### PR TITLE
fix: [BUG] #25 -Edit & Remove Buttons stay active after category switch

### DIFF
--- a/frontend/src/components/visual-editor/v2/Diagrams.tsx
+++ b/frontend/src/components/visual-editor/v2/Diagrams.tsx
@@ -48,7 +48,6 @@ import { IBlock } from "@/types/block.types";
 import { ICategory } from "@/types/category.types";
 import { BlockPorts } from "@/types/visual-editor.types";
 
-
 import BlockDialog from "../BlockDialog";
 import { ZOOM_LEVEL } from "../constants";
 import { useVisualEditor } from "../hooks/useVisualEditor";
@@ -141,6 +140,7 @@ const Diagrams = () => {
 
       if (id) {
         setSelectedCategoryId?.(id);
+        setSelectedBlockId(undefined); // Reset selected block when switching categories, resetting edit & remove buttons
       }
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "hexabot",
       "version": "2.0.0",
-      "license": "AGPL-3.0-only",
       "workspaces": [
         "frontend",
         "widget"
@@ -20,8 +19,7 @@
     },
     "frontend": {
       "name": "hexabot-ui",
-      "version": "2.0.0",
-      "license": "AGPL-3.0-only",
+      "version": "0.1.0",
       "dependencies": {
         "@chatscope/chat-ui-kit-react": "^2.0.3",
         "@chatscope/chat-ui-kit-styles": "^1.4.0",
@@ -9804,8 +9802,7 @@
     },
     "widget": {
       "name": "hexabot-widget",
-      "version": "2.0.0",
-      "license": "AGPL-3.0-only",
+      "version": "0.0.0",
       "dependencies": {
         "@types/emoji-js": "^3.5.2",
         "autolinker": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "hexabot",
       "version": "2.0.0",
+      "license": "AGPL-3.0-only",
       "workspaces": [
         "frontend",
         "widget"
@@ -19,7 +20,8 @@
     },
     "frontend": {
       "name": "hexabot-ui",
-      "version": "0.1.0",
+      "version": "2.0.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@chatscope/chat-ui-kit-react": "^2.0.3",
         "@chatscope/chat-ui-kit-styles": "^1.4.0",
@@ -9802,7 +9804,8 @@
     },
     "widget": {
       "name": "hexabot-widget",
-      "version": "0.0.0",
+      "version": "2.0.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@types/emoji-js": "^3.5.2",
         "autolinker": "^4.0.0",


### PR DESCRIPTION
# Motivation

Fixed the bug which caused edit and remove buttons to remain active when category was switched, now the buttons are reset when the caategory is switched

Fixes #25 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

Video of working proof:
https://www.loom.com/share/f3aff6514271415696145a0c47415206?sid=40577fab-3ba1-4734-bda9-3fae047b27a0