### PR TITLE
fix: remove extra rerendering when position changes

### DIFF
--- a/frontend/src/components/visual-editor/v2/Diagrams.tsx
+++ b/frontend/src/components/visual-editor/v2/Diagrams.tsx
@@ -48,7 +48,6 @@ import { IBlock } from "@/types/block.types";
 import { ICategory } from "@/types/category.types";
 import { BlockPorts } from "@/types/visual-editor.types";
 
-
 import BlockDialog from "../BlockDialog";
 import { ZOOM_LEVEL } from "../constants";
 import { useVisualEditor } from "../hooks/useVisualEditor";
@@ -273,7 +272,13 @@ const Diagrams = () => {
       zoomUpdated: debouncedZoomEvent,
       offsetUpdated: debouncedOffsetEvent,
     });
-  }, [JSON.stringify(blocks)]);
+  }, [
+    JSON.stringify(
+      blocks.map((b) => {
+        return { ...b, position: undefined, updatedAt: undefined };
+      }),
+    ),
+  ]);
 
   const handleDeleteButton = () => {
     const selectedEntities = engine?.getModel().getSelectedEntities();


### PR DESCRIPTION
# Motivation

All the problems described in the issue are the result of an extra rerendering when a position of a block changes

The rerendering is automatically triggered when any data of any block changes, witch is what we want except for the position change because we then overwrite the library's default behavior.

Fixes #24 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
