### PR TITLE
Fixed issue #16: Subscribers search input is too small

### DIFF
--- a/frontend/src/components/subscribers/index.tsx
+++ b/frontend/src/components/subscribers/index.tsx
@@ -178,7 +178,7 @@ export const Subscribers = () => {
           alignItems="center"
           flexShrink={0}
           flexWrap="nowrap"
-          width="max-content"
+          width="50%"
         >
           <FilterTextfield onChange={onSearch} fullWidth={true} />
           <Input


### PR DESCRIPTION
# Motivation
this pr fixes the issue of small input search bar in subscribers section raised in issue number #16 raised by @marrouchi  

Fixes # (issue)
Fixes #16 

## Type of change
eariler the parent grid of the input was give a width of max-content due to which it was taking only the space required to show the content hence the search input was soo small.

In the fix i have changed the width from max-content to 50% hence increasing the width to 50% of the screen size.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code

# Adding the screen short of the input after bug fix 
![Screenshot from 2024-09-22 00-45-02](https://github.com/user-attachments/assets/3ad9ee16-a116-4aed-aab5-230589f0408e)

