### PR TITLE
fix: remove duplicated label.type translation keys

### DIFF
--- a/frontend/src/i18n/en/translation.json
+++ b/frontend/src/i18n/en/translation.json
@@ -323,7 +323,6 @@
     "value": "Value",
     "synonyms": "Synonyms",
     "lookups": "Lookups",
-    "type": "Type",
     "lookup_strategies": "Lookup Strategy",
     "nlp_lookup_keywords": "Keywords/Free-Text",
     "nlp_lookup_trait": "Trait",

--- a/frontend/src/i18n/fr/translation.json
+++ b/frontend/src/i18n/fr/translation.json
@@ -323,7 +323,6 @@
     "nlp_entity_value": "Valeur TALN",
     "value": "Valeur",
     "lookups": "Stratégies",
-    "type": "Type",
     "lookup_strategies": "Stratégie de recherche",
     "nlp_lookup_keywords": "Mot-clés/Texte",
     "nlp_lookup_trait": "Trait",


### PR DESCRIPTION
# Motivation

The **en/translation.json** and **fr/translation.json** files situated under the **/frontend/src/i18n/** directory contains duplicated label.type keys.

Fixes #63

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
