### PR TITLE
fix: update package-lock file version and license values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "hexabot",
       "version": "2.0.0",
+      "license": "AGPL-3.0-only",
       "workspaces": [
         "frontend",
         "widget"
@@ -19,7 +20,8 @@
     },
     "frontend": {
       "name": "hexabot-ui",
-      "version": "0.1.0",
+      "version": "2.0.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@chatscope/chat-ui-kit-react": "^2.0.3",
         "@chatscope/chat-ui-kit-styles": "^1.4.0",
@@ -9802,7 +9804,8 @@
     },
     "widget": {
       "name": "hexabot-widget",
-      "version": "0.0.0",
+      "version": "2.0.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@types/emoji-js": "^3.5.2",
         "autolinker": "^4.0.0",


### PR DESCRIPTION
# Motivation
In the package-lock.json file, packages section, is missing a license field.
The frontend, widget packages license and version fields are not updated.

Fixes #74 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
