### PR TITLE
fix: added unit test case for permission deleteone api

### DIFF
--- a/api/src/user/repositories/permission.repository.spec.ts
+++ b/api/src/user/repositories/permission.repository.spec.ts
@@ -35,6 +35,7 @@ describe('PermissionRepository', () => {
   let permissionRepository: PermissionRepository;
   let permissionModel: Model<Permission>;
   let permission: Permission;
+  let permissionToDelete: Permission;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -58,6 +59,9 @@ describe('PermissionRepository', () => {
     );
     permission = await permissionRepository.findOne({
       action: Action.CREATE,
+    });
+    permissionToDelete = await permissionRepository.findOne({
+      action: Action.UPDATE,
     });
   });
 
@@ -110,6 +114,38 @@ describe('PermissionRepository', () => {
       );
       expect(permissionModel.find).toHaveBeenCalledWith({});
       expect(result).toEqualPayload(permissionsWithRolesAndModels);
+    });
+  });
+
+  describe('deleteOne', () => {
+    it('should delete a permission by id', async () => {
+      jest.spyOn(permissionModel, 'deleteOne');
+      const result = await permissionRepository.deleteOne(
+        permissionToDelete.id,
+      );
+
+      expect(permissionModel.deleteOne).toHaveBeenCalledWith({
+        _id: permissionToDelete.id,
+      });
+
+      expect(result).toEqual({
+        acknowledged: true,
+        deletedCount: 1,
+      });
+
+      const permissions = await permissionRepository.find({
+        role: permissionToDelete.id,
+      });
+      expect(permissions.length).toEqual(0);
+    });
+
+    it('should fail to delete a permission that does not exist', async () => {
+      expect(
+        await permissionRepository.deleteOne(permissionToDelete.id),
+      ).toEqual({
+        acknowledged: true,
+        deletedCount: 0,
+      });
     });
   });
 });


### PR DESCRIPTION
# Motivation

Add unit tests on deleteOne() in API user permission repository

Fixes https://github.com/Hexastack/Hexabot/issues/86

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
