### PR TITLE
fix: enhance self linked block curve

### DIFF
--- a/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
+++ b/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
@@ -13,11 +13,11 @@ interface Point {
   y: number;
 }
 
-const createCurvedPath = (start: Point, end: Point) => {
-  const controlPoint1X = start.x + 220;
-  const controlPoint1Y = start.y - 250;
-  const controlPoint2X = end.x - 250;
-  const controlPoint2Y = end.y - 250;
+const createCurvedPath = (start: Point, end: Point, nodeHeight: number) => {
+  const controlPoint1X = start.x + nodeHeight - 20;
+  const controlPoint1Y = start.y - nodeHeight;
+  const controlPoint2X = end.x - nodeHeight - 20;
+  const controlPoint2Y = end.y - nodeHeight;
 
   return `M ${start.x},${start.y} C ${controlPoint1X},${controlPoint1Y} ${controlPoint2X},${controlPoint2Y} ${end.x},${end.y}`;
 };
@@ -77,8 +77,14 @@ export class AdvancedLinkFactory extends DefaultLinkFactory {
         x: targetPortPosition.x + 20,
         y: targetPortPosition.y + 20,
       };
+      const targetPortHeight = model.getTargetPort().height;
+      const targetNdeHeight =
+        (model.getTargetPort().getPosition().y -
+          model.getTargetPort().getNode().getPosition().y) *
+          2 +
+        targetPortHeight;
 
-      path = createCurvedPath(startPoint, endPoint);
+      path = createCurvedPath(startPoint, endPoint, targetNdeHeight);
     }
 
     return (


### PR DESCRIPTION
# Motivation

The main motivation is to avoid having an intersection between the curved link and the blocks, especially for blocks with a large height..

Before the update:
![image](https://github.com/user-attachments/assets/e5f1e883-5abb-4a03-992e-e5434e6be509)

After the update:
![image](https://github.com/user-attachments/assets/ba4b3081-24c5-4edb-a00d-9ad85062b4df)

Fixes #103

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
