### PR TITLE
fix: cli extension npm preinstall

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -250,6 +250,10 @@ program
 
       console.log(chalk.cyan('Running npm install in the api/ folder...'));
       // Run npm install in the api folder to install dependencies
+      execSync('npm run preinstall', {
+        cwd: path.resolve(process.cwd(), 'api'),
+        stdio: 'inherit',
+      });
       execSync('npm install', {
         cwd: path.resolve(process.cwd(), 'api'),
         stdio: 'inherit',


### PR DESCRIPTION
# Motivation

For some reason, when using the cli to install an extension, the npm install doesn't update the package lock. 
"npm preinstall" which merges npm dependencies gets executed after the node modules are installed. This change makes sure preinstall is executed before the install.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
