### PR TITLE
fix(frontend): add reset selected

### DIFF
--- a/frontend/src/components/visual-editor/BlockDialog.tsx
+++ b/frontend/src/components/visual-editor/BlockDialog.tsx
@@ -42,6 +42,7 @@ import { TriggersForm } from "./form/TriggersForm";
 import { IBlockAttributes, IBlock } from "../../types/block.types";
 
 export type BlockDialogProps = DialogControlProps<IBlock>;
+type TSelectedTab = "triggers" | "options" | "messages";
 
 const BlockDialog: FC<BlockDialogProps> = ({
   open,
@@ -50,8 +51,11 @@ const BlockDialog: FC<BlockDialogProps> = ({
   ...rest
 }) => {
   const { t } = useTranslate();
-  const [selectedTab, setSelectedTab] = useState("triggers");
-  const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
+  const [selectedTab, setSelectedTab] = useState<TSelectedTab>("triggers");
+  const handleChange = (
+    _event: React.SyntheticEvent,
+    newValue: TSelectedTab,
+  ) => {
     setSelectedTab(newValue);
   };
   const { toast } = useToast();
@@ -102,7 +106,10 @@ const BlockDialog: FC<BlockDialogProps> = ({
   };
 
   useEffect(() => {
-    if (open) reset();
+    if (open) {
+      reset();
+      setSelectedTab("triggers");
+    }
   }, [open, reset]);
 
   useEffect(() => {


### PR DESCRIPTION
# Motivation
The main motivation of this change is to add the reset of the selected tabs tab when a user open to edit a block, 
which will make the mission easier to find the tab that he looking for.

Fixes #148 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
