### PR TITLE
feat: add bulk delete functionality

### DIFF
--- a/api/src/chat/controllers/category.controller.ts
+++ b/api/src/chat/controllers/category.controller.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -136,5 +137,30 @@ export class CategoryController extends BaseController<Category> {
       throw new NotFoundException(`Category with ID ${id} not found`);
     }
     return result;
+  }
+
+  /**
+   * Deletes multiple categories by their IDs.
+   * @param ids - IDs of categories to be deleted.
+   * @returns A Promise that resolves to the deletion result.
+   */
+  @CsrfCheck(true)
+  @Delete('')
+  @HttpCode(204)
+  async deleteMany(@Body('ids') ids: string[]): Promise<DeleteResult> {
+    if (!ids || ids.length === 0) {
+      throw new BadRequestException('No IDs provided for deletion.');
+    }
+    const deleteResult = await this.categoryService.deleteMany({
+      _id: { $in: ids },
+    });
+
+    if (deleteResult.deletedCount === 0) {
+      this.logger.warn(`Unable to delete categories with provided IDs: ${ids}`);
+      throw new NotFoundException('Categories with provided IDs not found');
+    }
+
+    this.logger.log(`Successfully deleted categories with IDs: ${ids}`);
+    return deleteResult;
   }
 }

--- a/api/src/chat/repositories/category.repository.ts
+++ b/api/src/chat/repositories/category.repository.ts
@@ -37,7 +37,7 @@ export class CategoryRepository extends BaseRepository<Category> {
    * @param criteria - The filter criteria for finding blocks to delete.
    */
   async preDelete(
-    _query: Query<
+    query: Query<
       DeleteResult,
       Document<Category, any, any>,
       unknown,
@@ -46,11 +46,18 @@ export class CategoryRepository extends BaseRepository<Category> {
     >,
     criteria: TFilterQuery<Category>,
   ) {
-    const associatedBlocks = await this.blockService.findOne({
-      category: criteria._id,
-    });
-    if (associatedBlocks) {
-      throw new ForbiddenException(`Category have blocks associated to it`);
+    criteria = query.getQuery();
+    const ids = Array.isArray(criteria._id) ? criteria._id : [criteria._id];
+
+    for (const id of ids) {
+      const associatedBlocks = await this.blockService.findOne({
+        category: id,
+      });
+      if (associatedBlocks) {
+        throw new ForbiddenException(
+          `Category ${id} has blocks associated with it`,
+        );
+      }
     }
   }
 }

--- a/frontend/src/components/categories/index.tsx
+++ b/frontend/src/components/categories/index.tsx
@@ -135,12 +135,14 @@ export const Categories = () => {
       <DeleteDialog
         {...deleteDialogCtl}
         callback={async () => {
+          if (selectedCategories.length > 0) {
+            deleteCategories(selectedCategories), setSelectedCategories([]);
+            deleteDialogCtl.closeDialog();
+          }
           if (deleteDialogCtl?.data) {
-            if (selectedCategories.length > 0) {
-              deleteCategories(selectedCategories), setSelectedCategories([]);
-              deleteDialogCtl.closeDialog();
-            } else {
+            {
               deleteCategory(deleteDialogCtl.data);
+              deleteDialogCtl.closeDialog();
             }
           }
         }}

--- a/frontend/src/components/categories/index.tsx
+++ b/frontend/src/components/categories/index.tsx
@@ -59,6 +59,7 @@ export const Categories = () => {
     },
     onSuccess: () => {
       deleteDialogCtl.closeDialog();
+      setSelectedCategories([]);
       toast.success(t("message.item_delete_success"));
     },
   });
@@ -68,6 +69,7 @@ export const Categories = () => {
     },
     onSuccess: () => {
       deleteDialogCtl.closeDialog();
+      setSelectedCategories([]);
       toast.success(t("message.item_delete_success"));
     },
   });
@@ -134,10 +136,12 @@ export const Categories = () => {
         {...deleteDialogCtl}
         callback={async () => {
           if (deleteDialogCtl?.data) {
-            deleteCategory(deleteDialogCtl.data);
-          } else if (selectedCategories.length > 0) {
-            deleteCategories(selectedCategories), setSelectedCategories([]);
-            deleteDialogCtl.closeDialog();
+            if (selectedCategories.length > 0) {
+              deleteCategories(selectedCategories), setSelectedCategories([]);
+              deleteDialogCtl.closeDialog();
+            } else {
+              deleteCategory(deleteDialogCtl.data);
+            }
           }
         }}
       />

--- a/frontend/src/hooks/crud/useDeleteMany.tsx
+++ b/frontend/src/hooks/crud/useDeleteMany.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2024 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { useMutation, useQueryClient } from "react-query";
+
+import { QueryType, TMutationOptions } from "@/services/types";
+import { IBaseSchema, IDynamicProps, TType } from "@/types/base.types";
+
+import { isSameEntity } from "./helpers";
+import { useEntityApiClient } from "../useApiClient";
+
+export const useDeleteMany = <
+  TEntity extends IDynamicProps["entity"],
+  TAttr = TType<TEntity>["attributes"],
+  TBasic extends IBaseSchema = TType<TEntity>["basic"],
+  TFull extends IBaseSchema = TType<TEntity>["full"],
+>(
+  entity: TEntity,
+  options?: Omit<
+    TMutationOptions<string, Error, string[], TBasic>,
+    "mutationFn" | "mutationKey"
+  > & {
+    invalidate?: boolean;
+  },
+) => {
+  const api = useEntityApiClient<TAttr, TBasic, TFull>(entity);
+  const queryClient = useQueryClient();
+  const { invalidate = true, ...otherOptions } = options || {};
+
+  return useMutation({
+    mutationFn: async (ids: string[]) => {
+      const result = await api.deleteMany(ids);
+
+      queryClient.removeQueries({
+        predicate: ({ queryKey }) => {
+          const [qType, qEntity, qId] = queryKey;
+
+          return (
+            qType === QueryType.item &&
+            isSameEntity(qEntity, entity) &&
+            ids.includes(qId as string)
+          );
+        },
+      });
+
+      if (invalidate) {
+        queryClient.invalidateQueries({
+          predicate: ({ queryKey }) => {
+            const [qType, qEntity] = queryKey;
+
+            return (
+              (qType === QueryType.count || qType === QueryType.collection) &&
+              isSameEntity(qEntity, entity)
+            );
+          },
+        });
+      }
+
+      return result;
+    },
+    ...otherOptions,
+  });
+};

--- a/frontend/src/services/api.class.ts
+++ b/frontend/src/services/api.class.ts
@@ -339,6 +339,21 @@ export class EntityApiClient<TAttr, TBasic, TFull> extends ApiClient {
   }
 
   /**
+   * Bulk Delete entries.
+   */
+  async deleteMany(ids: string[]) {
+    const { _csrf } = await this.getCsrf();
+    const { data } = await this.request.delete<string>(`${ROUTES[this.type]}`, {
+      data: {
+        _csrf,
+        ids,
+      },
+    });
+
+    return data;
+  }
+
+  /**
    * Count elements.
    */
   async count(params?: any) {


### PR DESCRIPTION
# Motivation

This PR includes the ability of performing a bulk delete operations on the flows:
Select multiple flows via check-boxes, and upon clicking "Delete," the selected categories should be removed from the list after confirmation.

Fixes # ([151](https://github.com/Hexastack/Hexabot/issues/151))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
