### PR TITLE
feat: [ContextVar]add bulk delete functionality

### DIFF
--- a/api/src/chat/controllers/context-var.controller.spec.ts
+++ b/api/src/chat/controllers/context-var.controller.spec.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Test } from '@nestjs/testing';
@@ -139,6 +139,44 @@ describe('ContextVarController', () => {
         new NotFoundException(
           `ContextVar with ID ${contextVarToDelete.id} not found`,
         ),
+      );
+    });
+  });
+
+  describe('deleteMany', () => {
+    const deleteResult = { acknowledged: true, deletedCount: 2 };
+
+    it('should delete contextVars when valid IDs are provided', async () => {
+      jest
+        .spyOn(contextVarService, 'deleteMany')
+        .mockResolvedValue(deleteResult);
+      const result = await contextVarController.deleteMany([
+        contextVarToDelete.id,
+        contextVar.id,
+      ]);
+
+      expect(contextVarService.deleteMany).toHaveBeenCalledWith({
+        _id: { $in: [contextVarToDelete.id, contextVar.id] },
+      });
+      expect(result).toEqual(deleteResult);
+    });
+
+    it('should throw BadRequestException when no IDs are provided', async () => {
+      await expect(contextVarController.deleteMany([])).rejects.toThrow(
+        new BadRequestException('No IDs provided for deletion.'),
+      );
+    });
+
+    it('should throw NotFoundException when no contextVars are deleted', async () => {
+      jest.spyOn(contextVarService, 'deleteMany').mockResolvedValue({
+        acknowledged: true,
+        deletedCount: 0,
+      });
+
+      await expect(
+        contextVarController.deleteMany([contextVarToDelete.id, contextVar.id]),
+      ).rejects.toThrow(
+        new NotFoundException('Context vars with provided IDs not found'),
       );
     });
   });


### PR DESCRIPTION
# Motivation

This PR includes the ability of performing a bulk delete operations on the context vars:
Select multiple context vars via check-boxes, and upon clicking "Delete," the selected context var should be removed from the list after confirmation.

Fixes [# (https://github.com/Hexastack/Hexabot/issues/151)](https://github.com/Hexastack/Hexabot/issues/174)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
