### PR TITLE
fix: autocomplete entity

### DIFF
--- a/frontend/src/app-components/inputs/AutoCompleteSelect.tsx
+++ b/frontend/src/app-components/inputs/AutoCompleteSelect.tsx
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { Box, Chip, ChipTypeMap } from "@mui/material";
+import { Box, Chip, ChipTypeMap, CircularProgress } from "@mui/material";
 import Autocomplete, {
   AutocompleteProps,
   AutocompleteValue,
@@ -185,6 +185,9 @@ const AutoCompleteSelect = <
                 {options.length === 0 && !loading && noOptionsWarning && (
                   <AlertAdornment title={noOptionsWarning} type="warning" />
                 )}
+                {loading ? (
+                  <CircularProgress color="inherit" size={20} />
+                ) : null}
                 {props.InputProps.endAdornment}
               </>
             ),

--- a/frontend/src/hooks/crud/useInfiniteFind.ts
+++ b/frontend/src/hooks/crud/useInfiniteFind.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2024 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { useInfiniteQuery, UseInfiniteQueryOptions } from "react-query";
+
+import {
+  EntityType,
+  Format,
+  QueryType,
+  TPopulateTypeFromFormat,
+} from "@/services/types";
+import {
+  IBaseSchema,
+  IDynamicProps,
+  IFindConfigProps,
+  POPULATE_BY_TYPE,
+  TAllowedFormat,
+  TType,
+} from "@/types/base.types";
+
+import { useNormalizeAndCache } from "./helpers";
+import { useGetFromCache } from "./useGet";
+import { useEntityApiClient } from "../useApiClient";
+
+export const useInfiniteFind = <
+  TDynamicProps extends IDynamicProps,
+  TAttr = TType<TDynamicProps["entity"]>["attributes"],
+  TBasic extends IBaseSchema = TType<TDynamicProps["entity"]>["basic"],
+  TFull extends IBaseSchema = TType<TDynamicProps["entity"]>["full"],
+  P = TPopulateTypeFromFormat<TDynamicProps>,
+>(
+  { entity, format }: TDynamicProps & TAllowedFormat<TDynamicProps["entity"]>,
+  config?: IFindConfigProps,
+  options?: Omit<
+    UseInfiniteQueryOptions<
+      string[],
+      Error,
+      string[],
+      [QueryType, EntityType, any]
+    >,
+    "queryFn" | "onSuccess"
+  > & { onSuccess?: (result: TBasic[]) => void },
+) => {
+  const { onSuccess, queryKey, ...otherOptions } = options || {};
+  const api = useEntityApiClient<TAttr, TBasic, TFull>(entity);
+  const normalizeAndCache = useNormalizeAndCache<TBasic | TFull, string[]>(
+    entity,
+  );
+  const getFromCache = useGetFromCache(entity);
+  // @TODO : fix the following
+  // @ts-ignore
+  const { data: infiniteData, ...infiniteQuery } = useInfiniteQuery({
+    queryKey,
+    queryFn: async () => {
+      const data = await api.find(
+        {
+          ...(config?.params || {}),
+        },
+        format === Format.FULL && (POPULATE_BY_TYPE[entity] as P),
+      );
+      const { entities, result } = normalizeAndCache(data);
+
+      if (onSuccess) {
+        onSuccess(
+          Object.values(entities[entity] as unknown as Record<string, TBasic>),
+        );
+      }
+
+      return result;
+    },
+    ...(otherOptions || {}),
+  });
+
+  return {
+    ...infiniteQuery,
+    data: infiniteData
+      ? {
+          ...infiniteData,
+          pages: (infiniteData?.pages || []).map((page) =>
+            page.map((id) => getFromCache(id) as unknown as TBasic),
+          ),
+        }
+      : undefined,
+  };
+};


### PR DESCRIPTION
# Motivation
While There is no strict limit on the maximum number of options you can provide to the Material-UI (MUI) Autocomplete control. However, performance may become an issue when dealing with a large number of options (e.g., thousands or more), as rendering and filtering so many options can cause lag in the UI. That's why we created the component "AutoCompleteEntitySelect" in the first place. If you have too many options, you can load the options asynchronously based on the user's input or scroll position, reducing the initial load.

This PR introduces the useInfiniteFind hook, which leverages react-query's useInfiniteQuery. It also updates AutoCompleteEntitySelect to use the new hook solving the racing condition between fetching VS rendering.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
