### PR TITLE
fix: content reload after import

### DIFF
--- a/frontend/src/app-components/attachment/AttachmentInput.tsx
+++ b/frontend/src/app-components/attachment/AttachmentInput.tsx
@@ -46,7 +46,7 @@ const AttachmentInput = forwardRef<HTMLDivElement, AttachmentThumbnailProps>(
     ref,
   ) => {
     const hasPermission = useHasPermission();
-    const handleChange = (attachment: IAttachment | null) => {
+    const handleChange = (attachment?: IAttachment | null) => {
       onChange && onChange(attachment?.id || null, attachment?.type || null);
     };
 

--- a/frontend/src/app-components/attachment/AttachmentUploader.tsx
+++ b/frontend/src/app-components/attachment/AttachmentUploader.tsx
@@ -65,7 +65,7 @@ export type FileUploadProps = {
   imageButton?: boolean;
   accept: string;
   enableMediaLibrary?: boolean;
-  onChange?: (data: IAttachment | null) => void;
+  onChange?: (data?: IAttachment | null) => void;
 };
 
 const AttachmentUploader: FC<FileUploadProps> = ({
@@ -99,15 +99,16 @@ const AttachmentUploader: FC<FileUploadProps> = ({
       const file = event.target.files.item(0);
 
       if (file) {
-        const acceptedTypes = accept.split(',');
-        const isValidType = acceptedTypes.some((type) =>
-          file.type === type || file.name.endsWith(type.replace('.*', ''))
+        const acceptedTypes = accept.split(",");
+        const isValidType = acceptedTypes.some(
+          (type) =>
+            file.type === type || file.name.endsWith(type.replace(".*", "")),
         );
 
         if (!isValidType) {
           toast.error(t("message.invalid_file_type"));
-          
-return;
+
+          return;
         }
 
         uploadAttachment(file);

--- a/frontend/src/app-components/dialogs/DeleteDialog.tsx
+++ b/frontend/src/app-components/dialogs/DeleteDialog.tsx
@@ -43,7 +43,16 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
         </Grid>
       </DialogContent>
       <DialogActions>
-        <Button variant="contained" color="error" onClick={callback} autoFocus>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={() => {
+            if (callback) {
+              callback();
+            }
+          }}
+          autoFocus
+        >
           {t("button.yes")}
         </Button>
         <Button variant="outlined" onClick={closeFunction}>

--- a/frontend/src/components/contents/ContentImportDialog.tsx
+++ b/frontend/src/components/contents/ContentImportDialog.tsx
@@ -38,17 +38,23 @@ export const ContentImportDialog: FC<ContentImportDialogProps> = ({
   const { refetch, isFetching } = useQuery(
     ["importContent", data?.contentType?.id, attachmentId],
     async () => {
-      await apiClient.importContent(data?.contentType?.id!, attachmentId!)},
+      if (data?.contentType?.id && attachmentId) {
+        await apiClient.importContent(data.contentType.id, attachmentId);
+      }
+    },
     {
       enabled: false,
       onSuccess: () => {
         handleCloseDialog();
         toast.success(t("message.success_save"));
+        if (rest.callback) {
+          rest.callback();
+        }
       },
       onError: () => {
         toast.error(t("message.internal_server_error"));
       },
-    }
+    },
   );
   const handleCloseDialog = () => {
     closeDialog();

--- a/frontend/src/components/contents/index.tsx
+++ b/frontend/src/components/contents/index.tsx
@@ -67,7 +67,7 @@ export const Contents = () => {
   const { data: contentType } = useGet(String(query.id), {
     entity: EntityType.CONTENT_TYPE,
   });
-  const { dataGridProps } = useFind(
+  const { dataGridProps, refetch } = useFind(
     { entity: EntityType.CONTENT, format: Format.FULL },
     {
       params: searchPayload,
@@ -161,7 +161,12 @@ export const Contents = () => {
         <Paper>
           <ContentDialog {...getDisplayDialogs(addDialogCtl)} />
           <ContentDialog {...getDisplayDialogs(editDialogCtl)} />
-          <ContentImportDialog {...getDisplayDialogs(importDialogCtl)} />
+          <ContentImportDialog
+            {...getDisplayDialogs(importDialogCtl)}
+            callback={() => {
+              refetch();
+            }}
+          />
           <DeleteDialog
             {...deleteDialogCtl}
             callback={() => {

--- a/frontend/src/hooks/useDialog.tsx
+++ b/frontend/src/hooks/useDialog.tsx
@@ -15,7 +15,7 @@ export type DialogControlProps<T, C = never> = Omit<
 >;
 export type DialogControl<T = null, C = never> = DialogProps & {
   data?: T;
-  callback?: (data: C) => void;
+  callback?: (data?: C) => void;
   openDialog: (data?: T) => void;
   closeDialog: () => void;
 };


### PR DESCRIPTION
# Motivation

This PR resolves the issue where the content list does not automatically refresh after importing a new CSV file. With this fix, the content will now update immediately following the CSV upload, eliminating the need for a manual page reload.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
