### PR TITLE
fix(frontend): refesh count after nlp sample import

### DIFF
--- a/frontend/src/components/nlp/NlpImportDialog.tsx
+++ b/frontend/src/components/nlp/NlpImportDialog.tsx
@@ -39,8 +39,8 @@ export const NlpImportDialog: FC<NlpImportDialogProps> = ({
       mutationFn: async (attachmentId: string | null) => {
         attachmentId && (await apiClient.importNlpSamples(attachmentId));
       },
-      onSuccess: () => {
-        queryClient.removeQueries({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
           predicate: ({ queryKey }) => {
             const [qType, qEntity] = queryKey;
 


### PR DESCRIPTION
# Motivation
The main motivation is to make the count counter updates automatically after the import of nlp sample csv file
  
Fixes #185 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
