### PR TITLE
fix(api): remove duplicated populate methods

### DIFF
--- a/api/src/chat/repositories/conversation.repository.ts
+++ b/api/src/chat/repositories/conversation.repository.ts
@@ -9,7 +9,7 @@
 import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectModel } from '@nestjs/mongoose';
-import { FilterQuery, Model } from 'mongoose';
+import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
@@ -48,21 +48,5 @@ export class ConversationRepository extends BaseRepository<
    */
   async end(convo: Conversation | ConversationFull) {
     return await this.updateOne(convo.id, { active: false });
-  }
-
-  /**
-   * Finds a single conversation by a given criteria and populates the related fields: `sender`, `current`, and `next`.
-   *
-   * @param criteria The search criteria, either a string or a filter query.
-   *
-   * @returns A promise resolving to the populated conversation full object.
-   */
-  async findOneAndPopulate(criteria: string | FilterQuery<Conversation>) {
-    const query = this.findOneQuery(criteria).populate([
-      'sender',
-      'current',
-      'next',
-    ]);
-    return await this.executeOne(query, ConversationFull);
   }
 }

--- a/api/src/user/repositories/permission.repository.ts
+++ b/api/src/user/repositories/permission.repository.ts
@@ -9,7 +9,7 @@
 import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model, TFilterQuery } from 'mongoose';
+import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
@@ -31,39 +31,5 @@ export class PermissionRepository extends BaseRepository<
     @InjectModel(Permission.name) readonly model: Model<Permission>,
   ) {
     super(eventEmitter, model, Permission, PERMISSION_POPULATE, PermissionFull);
-  }
-
-  /**
-   * Finds all permissions and populates the `model` and `role` relationships.
-   *
-   * @returns A list of populated permission entities.
-   */
-  async findAllAndPopulate() {
-    const query = this.findAllQuery().populate(['model', 'role']);
-    return await this.execute(query, PermissionFull);
-  }
-
-  /**
-   * Finds permissions based on the specified filter and populates the `model` and `role` relationships.
-   *
-   * @param filter - The filter query for finding permissions.
-   *
-   * @returns A list of populated permission entities matching the filter.
-   */
-  async findAndPopulate(filter: TFilterQuery<Permission>) {
-    const query = this.findQuery(filter).populate(['model', 'role']);
-    return await this.execute(query, PermissionFull);
-  }
-
-  /**
-   * Finds a single permission by its ID and populates the `model` and `role` relationships.
-   *
-   * @param id - The ID of the permission to find.
-   *
-   * @returns The populated permission entity.
-   */
-  async findOneAndPopulate(id: string) {
-    const query = this.findOneQuery(id).populate(['model', 'role']);
-    return await this.executeOne(query, PermissionFull);
   }
 }

--- a/api/src/user/repositories/role.repository.ts
+++ b/api/src/user/repositories/role.repository.ts
@@ -9,10 +9,9 @@
 import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model, TFilterQuery } from 'mongoose';
+import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
-import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 
 import { Permission } from '../schemas/permission.schema';
 import {
@@ -50,36 +49,5 @@ export class RoleRepository extends BaseRepository<
       await this.permissionModel.deleteMany({ role: id });
     }
     return result;
-  }
-
-  /**
-   * Finds and paginates Role entities based on filter criteria, and populates related fields.
-   *
-   * @param filter Filter criteria for querying Role entities.
-   * @param pageQuery Pagination details.
-   *
-   * @returns Paginated result of Role entities populated with related permissions and users.
-   */
-  async findPageAndPopulate(
-    filter: TFilterQuery<Role>,
-    pageQuery: PageQueryDto<Role>,
-  ) {
-    const query = this.findPageQuery(filter, pageQuery).populate([
-      'permissions',
-      'users',
-    ]);
-    return await this.execute(query, RoleFull);
-  }
-
-  /**
-   * Finds a single Role entity by its ID, and populates related fields.
-   *
-   * @param id The ID of the Role to find.
-   *
-   * @returns The found Role entity populated with related permissions and users.
-   */
-  async findOneAndPopulate(id: string) {
-    const query = this.findOneQuery(id).populate(['permissions', 'users']);
-    return await this.executeOne(query, RoleFull);
   }
 }


### PR DESCRIPTION
# Motivation
The main motivation is to removing the duplicated populate methods.

Fixes #199 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
