### PR TITLE
feat: add plugins settings i18n + typing

### DIFF
--- a/api/src/channel/channel.module.ts
+++ b/api/src/channel/channel.module.ts
@@ -24,7 +24,7 @@ export interface ChannelModuleOptions {
   folder: string;
 }
 
-@InjectDynamicProviders('dist/**/*.channel.js')
+@InjectDynamicProviders('dist/extensions/**/*.channel.js')
 @Module({
   controllers: [WebhookController, ChannelController],
   providers: [ChannelService],

--- a/api/src/channel/lib/Handler.ts
+++ b/api/src/channel/lib/Handler.ts
@@ -19,6 +19,7 @@ import { LoggerService } from '@/logger/logger.service';
 import BaseNlpHelper from '@/nlp/lib/BaseNlpHelper';
 import { NlpService } from '@/nlp/services/nlp.service';
 import { SettingService } from '@/setting/services/setting.service';
+import { hyphenToUnderscore } from '@/utils/helpers/misc';
 import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
 
@@ -56,7 +57,7 @@ export default abstract class ChannelHandler<N extends string = string> {
   }
 
   protected getGroup() {
-    return this.getChannel().replaceAll('-', '_') as ChannelSetting<N>['group'];
+    return hyphenToUnderscore(this.getChannel()) as ChannelSetting<N>['group'];
   }
 
   async setup() {

--- a/api/src/chat/controllers/block.controller.ts
+++ b/api/src/chat/controllers/block.controller.ts
@@ -59,7 +59,7 @@ export class BlockController extends BaseController<
     private readonly categoryService: CategoryService,
     private readonly labelService: LabelService,
     private readonly userService: UserService,
-    private pluginsService: PluginService<BaseBlockPlugin>,
+    private pluginsService: PluginService<BaseBlockPlugin<any>>,
   ) {
     super(blockService);
   }
@@ -122,8 +122,7 @@ export class BlockController extends BaseController<
       const plugins = this.pluginsService
         .getAllByType(PluginType.block)
         .map((p) => ({
-          title: p.title,
-          name: p.id,
+          id: p.id,
           template: {
             ...p.template,
             message: {

--- a/api/src/chat/services/message.service.ts
+++ b/api/src/chat/services/message.service.ts
@@ -116,4 +116,23 @@ export class MessageService extends BaseService<
       limit,
     );
   }
+
+  /**
+   * Retrieves the latest messages for a given subscriber
+   *
+   * @param subscriber - The subscriber whose message history is being retrieved.
+   * @param limit - The maximum number of messages to return (defaults to 5).
+   *
+   * @returns The message history since the specified date.
+   */
+  async findLastMessages(subscriber: Subscriber, limit: number = 5) {
+    const lastMessages = await this.findPage(
+      {
+        $or: [{ sender: subscriber.id }, { recipient: subscriber.id }],
+      },
+      { sort: ['createdAt', 'desc'], skip: 0, limit },
+    );
+
+    return lastMessages.reverse();
+  }
 }

--- a/api/src/i18n/services/i18n.service.ts
+++ b/api/src/i18n/services/i18n.service.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { promises as fs } from 'fs';
+import { existsSync, promises as fs } from 'fs';
 import * as path from 'path';
 
 import { Injectable, OnModuleInit } from '@nestjs/common';
@@ -86,11 +86,16 @@ export class I18nService<K = Record<string, unknown>>
 
   async loadExtensionI18nTranslations() {
     const baseDir = path.join(__dirname, '..', '..', 'extensions');
-    const extensionTypes = ['channels', 'plugins'];
+    const extensionTypes = ['channels', 'helpers', 'plugins'];
 
     try {
       for (const type of extensionTypes) {
         const extensionsDir = path.join(baseDir, type);
+
+        if (!existsSync(extensionsDir)) {
+          continue;
+        }
+
         const extensionFolders = await fs.readdir(extensionsDir, {
           withFileTypes: true,
         });

--- a/api/src/nlp/nlp.module.ts
+++ b/api/src/nlp/nlp.module.ts
@@ -33,7 +33,7 @@ import { NlpSampleService } from './services/nlp-sample.service';
 import { NlpValueService } from './services/nlp-value.service';
 import { NlpService } from './services/nlp.service';
 
-@InjectDynamicProviders('dist/**/*.nlp.helper.js')
+@InjectDynamicProviders('dist/extensions/**/*.nlp.helper.js')
 @Module({
   imports: [
     MongooseModule.forFeature([

--- a/api/src/plugins/base-block-plugin.ts
+++ b/api/src/plugins/base-block-plugin.ts
@@ -22,16 +22,21 @@ import {
 } from './types';
 
 @Injectable()
-export abstract class BaseBlockPlugin extends BasePlugin {
+export abstract class BaseBlockPlugin<
+  T extends PluginSetting[],
+> extends BasePlugin {
   public readonly type: PluginType = PluginType.block;
 
-  constructor(id: string, pluginService: PluginService<BasePlugin>) {
+  public readonly settings: T;
+
+  constructor(
+    id: string,
+    settings: T,
+    pluginService: PluginService<BasePlugin>,
+  ) {
     super(id, pluginService);
+    this.settings = settings;
   }
-
-  title: string;
-
-  settings: PluginSetting[];
 
   template: PluginBlockTemplate;
 
@@ -42,4 +47,11 @@ export abstract class BaseBlockPlugin extends BasePlugin {
     context: Context,
     convId?: string,
   ): Promise<StdOutgoingEnvelope>;
+
+  protected getArguments(block: Block) {
+    if ('args' in block.message) {
+      return block.message.args as SettingObject<T>;
+    }
+    throw new Error(`Block "${block.name}" does not have any arguments.`);
+  }
 }

--- a/api/src/plugins/plugins.module.ts
+++ b/api/src/plugins/plugins.module.ts
@@ -20,7 +20,7 @@ import { ContentModel } from '@/cms/schemas/content.schema';
 
 import { PluginService } from './plugins.service';
 
-@InjectDynamicProviders('dist/**/*.plugin.js')
+@InjectDynamicProviders('dist/extensions/**/*.plugin.js')
 @Global()
 @Module({
   imports: [

--- a/api/src/plugins/plugins.service.spec.ts
+++ b/api/src/plugins/plugins.service.spec.ts
@@ -8,8 +8,8 @@
 
 import { Test } from '@nestjs/testing';
 
-import { DummyPlugin } from '@/extensions/plugins/dummy.plugin';
 import { LoggerModule } from '@/logger/logger.module';
+import { DummyPlugin } from '@/utils/test/dummy/dummy.plugin';
 
 import { BaseBlockPlugin } from './base-block-plugin';
 import { PluginService } from './plugins.service';

--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -22,7 +22,7 @@ export interface CustomBlocks {}
 type ChannelEvent = any;
 type BlockAttrs = Partial<BlockCreateDto> & { name: string };
 
-export type PluginSetting = SettingCreateDto;
+export type PluginSetting = Omit<SettingCreateDto, 'weight'>;
 
 export type PluginBlockTemplate = Omit<
   BlockAttrs,

--- a/api/src/utils/helpers/misc.ts
+++ b/api/src/utils/helpers/misc.ts
@@ -9,3 +9,7 @@
 export const isEmpty = (value: string): boolean => {
   return value === undefined || value === null || value === '';
 };
+
+export const hyphenToUnderscore = (str: string) => {
+  return str.replaceAll('-', '_');
+};

--- a/api/src/utils/test/dummy/dummy.plugin.ts
+++ b/api/src/utils/test/dummy/dummy.plugin.ts
@@ -15,18 +15,15 @@ import {
 import { LoggerService } from '@/logger/logger.service';
 import { BaseBlockPlugin } from '@/plugins/base-block-plugin';
 import { PluginService } from '@/plugins/plugins.service';
+import { PluginSetting } from '@/plugins/types';
 
 @Injectable()
-export class DummyPlugin extends BaseBlockPlugin {
+export class DummyPlugin extends BaseBlockPlugin<PluginSetting[]> {
   constructor(
     pluginService: PluginService,
     private logger: LoggerService,
   ) {
-    super('dummy', pluginService);
-
-    this.title = 'Dummy';
-
-    this.settings = [];
+    super('dummy', [], pluginService);
 
     this.template = { name: 'Dummy Plugin' };
 

--- a/frontend/src/components/settings/SettingInput.tsx
+++ b/frontend/src/components/settings/SettingInput.tsx
@@ -25,15 +25,17 @@ import { MIME_TYPES } from "@/utils/attachment";
 interface RenderSettingInputProps {
   setting: ISetting;
   field: ControllerRenderProps<any, string>;
+  ns: string;
   isDisabled?: (setting: ISetting) => boolean;
 }
 
 const SettingInput: React.FC<RenderSettingInputProps> = ({
   setting,
   field,
+  ns,
   isDisabled = () => false,
 }) => {
-  const { t } = useTranslate(setting.group);
+  const { t } = useTranslate(ns);
   const label = t(`label.${setting.label}`, {
     defaultValue: setting.label,
   });

--- a/frontend/src/components/settings/index.tsx
+++ b/frontend/src/components/settings/index.tsx
@@ -186,6 +186,7 @@ export const Settings = () => {
                           <SettingInput
                             setting={setting}
                             field={field}
+                            ns={setting.group}
                             isDisabled={isDisabled}
                           />
                         </FormControl>

--- a/frontend/src/components/visual-editor/CustomBlocks.tsx
+++ b/frontend/src/components/visual-editor/CustomBlocks.tsx
@@ -30,8 +30,8 @@ export const CustomBlocks = () => {
       <Grid container>
         {customBlocks?.map((customBlock) => (
           <Block
-            key={customBlock.name}
-            title={customBlock.title}
+            key={customBlock.id}
+            title={t(`title.${customBlock.id}`, { ns: customBlock.id })}
             Icon={PluginIcon}
             blockTemplate={customBlock.template}
             name={customBlock.template.name}

--- a/frontend/src/components/visual-editor/form/OptionsForm.tsx
+++ b/frontend/src/components/visual-editor/form/OptionsForm.tsx
@@ -109,16 +109,19 @@ export const OptionsForm = () => {
             const { onChange, ...rest } = field;
 
             return (
-              <AutoCompleteEntitySelect<ICustomBlockTemplate, "title">
-                searchFields={["title", "name"]}
+              <AutoCompleteEntitySelect<ICustomBlockTemplate, "id">
+                searchFields={["id"]}
                 entity={EntityType.CUSTOM_BLOCK}
                 format={Format.BASIC}
-                idKey="name"
-                labelKey="title"
+                idKey="id"
+                labelKey="id"
                 label={t("label.effects")}
                 multiple={true}
+                getOptionLabel={(option) => {
+                  return t(`title.${option.id}`, { ns: option.id });
+                }}
                 onChange={(_e, selected) =>
-                  onChange(selected.map(({ name }) => name))
+                  onChange(selected.map(({ id }) => id))
                 }
                 preprocess={(options) => {
                   return options.filter(({ effects }) => effects.length > 0);

--- a/frontend/src/components/visual-editor/form/PluginMessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/PluginMessageForm.tsx
@@ -60,7 +60,11 @@ const PluginMessageForm = () => {
             defaultValue={message.args?.[setting.label] || setting.value}
             render={({ field }) => (
               <FormControl fullWidth sx={{ paddingTop: ".75rem" }}>
-                <SettingInput setting={setting} field={field} />
+                <SettingInput
+                  setting={setting}
+                  field={field}
+                  ns={message.plugin}
+                />
               </FormControl>
             )}
           />

--- a/frontend/src/services/entities.ts
+++ b/frontend/src/services/entities.ts
@@ -268,7 +268,7 @@ export const CustomBlockEntity = new schema.Entity(
   EntityType.CUSTOM_BLOCK,
   undefined,
   {
-    idAttribute: ({ name }) => name,
+    idAttribute: ({ id }) => id,
   },
 );
 

--- a/frontend/src/types/block.types.ts
+++ b/frontend/src/types/block.types.ts
@@ -11,15 +11,15 @@ import { EntityType, Format } from "@/services/types";
 import { IBaseSchema, IFormat, OmitPopulate } from "./base.types";
 import { ILabel } from "./label.types";
 import {
-  StdOutgoingQuickRepliesMessage,
+  AttachmentForeignKey,
+  ContentOptions,
+  PayloadType,
   StdOutgoingAttachmentMessage,
   StdOutgoingButtonsMessage,
   StdOutgoingListMessage,
+  StdOutgoingQuickRepliesMessage,
   StdOutgoingTextMessage,
-  AttachmentForeignKey,
   StdPluginMessage,
-  ContentOptions,
-  PayloadType,
 } from "./message.types";
 import { IUser } from "./user.types";
 
@@ -132,8 +132,6 @@ export interface IBlockFull extends IBlockStub, IFormat<Format.FULL> {
 }
 
 export interface ICustomBlockTemplateAttributes {
-  title: string;
-  name: string;
   template: IBlockAttributes;
   effects: string[];
 }


### PR DESCRIPTION
# Motivation

In this PR : 
- We introduce i18n for plugins 
- Enforce typing for plugin settings (arguments)
- Remove dummy plugin (keep it only for unit tests)

# Related PRs:
- https://github.com/Hexastack/hexabot-plugin-chatgpt/pull/2
- https://github.com/Hexastack/hexabot-plugin-gemini/pull/1

# How to test:
- Install chatgpt plugin as an example 
- Add a block, check the block message form : inputs should be translated (including helper text)
- Test the block

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
