### PR TITLE
fix(frontend): regex input control

### DIFF
--- a/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
@@ -266,9 +266,16 @@ const PatternInput: FC<PatternInputProps> = ({
         {typeof value === "string" && patternType === "regex" ? (
           <RegexInput
             {...registerInput(t("message.regex_is_invalid"), idx, {
-              validate: (value) =>
-                (value.trim() !== "" && value !== "/") ??
-                t("message.regex_is_invalid"),
+              validate: (pattern) => {
+                try {
+                  if (typeof pattern === "string")
+                    new RegExp(pattern.slice(1, -1));
+
+                  return true;
+                } catch (_e) {
+                  return t("message.regex_is_invalid");
+                }
+              },
               setValueAs: (v) => `/${v}/`,
             })}
             label={t("label.regex")}

--- a/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
@@ -268,7 +268,11 @@ const PatternInput: FC<PatternInputProps> = ({
             {...registerInput(t("message.regex_is_invalid"), idx, {
               validate: (pattern) => {
                 try {
-                  if (typeof pattern === "string")
+                  if (
+                    pattern.at(0) === "/" &&
+                    pattern.at(-1) === "/" &&
+                    typeof pattern === "string"
+                  )
                     new RegExp(pattern.slice(1, -1));
 
                   return true;


### PR DESCRIPTION
# Motivation
the main motivation of this update is to fix the input regex control in the block form triggers section

Fixes #167 

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
