### PR TITLE
fix: clear setting cache once seeded

### DIFF
--- a/api/src/setting/seeds/setting.seed.ts
+++ b/api/src/setting/seeds/setting.seed.ts
@@ -6,8 +6,11 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { Injectable } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable } from '@nestjs/common';
+import { Cache } from 'cache-manager';
 
+import { SETTING_CACHE_KEY } from '@/utils/constants/cache';
 import { BaseSchema } from '@/utils/generics/base-schema';
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
@@ -16,7 +19,10 @@ import { Setting } from '../schemas/setting.schema';
 
 @Injectable()
 export class SettingSeeder extends BaseSeeder<Setting> {
-  constructor(private readonly settingRepository: SettingRepository) {
+  constructor(
+    private readonly settingRepository: SettingRepository,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+  ) {
     super(settingRepository);
   }
 
@@ -35,6 +41,9 @@ export class SettingSeeder extends BaseSeeder<Setting> {
       if ((await this.repository.count({ group })) === 0)
         await this.repository.createMany(models);
     });
+
+    await this.cacheManager.del(SETTING_CACHE_KEY);
+
     return true;
   }
 }

--- a/api/src/setting/services/setting.service.ts
+++ b/api/src/setting/services/setting.service.ts
@@ -106,12 +106,19 @@ export class SettingService extends BaseService<Setting> {
   }
 
   /**
+   * Clears the settings cache
+   */
+  async clearCache() {
+    this.cacheManager.del(SETTING_CACHE_KEY);
+  }
+
+  /**
    * Event handler for setting updates. Listens to 'hook:setting:*' events
    * and invalidates the cache for settings when triggered.
    */
   @OnEvent('hook:setting:*')
   async handleSettingUpdateEvent() {
-    this.cacheManager.del(SETTING_CACHE_KEY);
+    this.clearCache();
   }
 
   /**


### PR DESCRIPTION
# Motivation

This PR fixes an issue with the settings cache : Once settings is seeded (insertMany), it doesn't invalidate the cache. This is causing an issue on app init (api sometimes fails to start and sometimes add duplicate settingss)

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
