### PR TITLE
fix(frontend): visual editor pattern UI representation

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -100,6 +100,7 @@
     "no_content_type": "No content type available, please create one first",
     "invalid_max_fallback_attempt_limit": "Max fallback attempt limit must have positive value",
     "regex_is_invalid": "Regex is invalid",
+    "regex_is_empty": "Regex cannot be empty",
     "attachment_not_found": "Attachment is not found",
     "title_length_exceeded": "You have reached the maximum length",
     "no_label_found": "No label found",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -100,6 +100,7 @@
     "no_content_type": "Il n'y a aucun type de contenu pour le moment, veuillez en ajouter un.",
     "invalid_max_fallback_attempt_limit": "La limite des tentatives de secours doit être un nombre positif.",
     "regex_is_invalid": "Le regex est invalide",
+    "regex_is_empty": "Le regex ne peut pas être vide",
     "attachment_not_found": "La pièce jointe est introuvable",
     "title_length_exceeded": "Vous avez atteint la longueur maximale",
     "no_label_found": "Aucune étiquette trouvée",

--- a/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
@@ -32,7 +32,12 @@ import { ContentPostbackInput } from "./ContentPostbackInput";
 import { PostbackInput } from "./PostbackInput";
 
 const isRegex = (str: Pattern) => {
-  return typeof str === "string" && str.startsWith("/") && str.endsWith("/");
+  return (
+    typeof str === "string" &&
+    str.startsWith("/") &&
+    str.endsWith("/") &&
+    str.length > 1
+  );
 };
 const getType = (pattern: Pattern): PatternType => {
   if (isRegex(pattern)) {

--- a/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
@@ -268,19 +268,14 @@ const PatternInput: FC<PatternInputProps> = ({
             {...registerInput(t("message.regex_is_invalid"), idx, {
               validate: (pattern) => {
                 try {
-                  if (
-                    pattern.at(0) === "/" &&
-                    pattern.at(-1) === "/" &&
-                    typeof pattern === "string"
-                  )
-                    new RegExp(pattern.slice(1, -1));
+                  if (isRegex(pattern)) new RegExp(pattern.slice(1, -1));
 
                   return true;
                 } catch (_e) {
                   return t("message.regex_is_invalid");
                 }
               },
-              setValueAs: (v) => `/${v}/`,
+              setValueAs: (v) => (isRegex(v) ? v : `/${v}/`),
             })}
             label={t("label.regex")}
             value={value.slice(1, -1)}

--- a/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
@@ -268,7 +268,7 @@ const PatternInput: FC<PatternInputProps> = ({
             {...registerInput(t("message.regex_is_invalid"), idx, {
               validate: (pattern) => {
                 try {
-                  if (isRegex(pattern)) new RegExp(pattern.slice(1, -1));
+                  new RegExp(pattern.slice(1, -1));
 
                   return true;
                 } catch (_e) {

--- a/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
@@ -32,12 +32,7 @@ import { ContentPostbackInput } from "./ContentPostbackInput";
 import { PostbackInput } from "./PostbackInput";
 
 const isRegex = (str: Pattern) => {
-  return (
-    typeof str === "string" &&
-    str.startsWith("/") &&
-    str.endsWith("/") &&
-    str.length > 1
-  );
+  return typeof str === "string" && str.startsWith("/") && str.endsWith("/");
 };
 const getType = (pattern: Pattern): PatternType => {
   if (isRegex(pattern)) {
@@ -270,10 +265,14 @@ const PatternInput: FC<PatternInputProps> = ({
         ) : null}
         {typeof value === "string" && patternType === "regex" ? (
           <RegexInput
-            {...registerInput(t("message.regex_is_invalid"), idx, {
+            {...registerInput(t("message.regex_is_empty"), idx, {
               validate: (pattern) => {
                 try {
-                  new RegExp(pattern.slice(1, -1));
+                  const parsedPattern = new RegExp(pattern.slice(1, -1));
+
+                  if (String(parsedPattern) !== pattern) {
+                    throw t("message.regex_is_invalid");
+                  }
 
                   return true;
                 } catch (_e) {
@@ -285,6 +284,7 @@ const PatternInput: FC<PatternInputProps> = ({
             label={t("label.regex")}
             value={value.slice(1, -1)}
             onChange={(v) => onChange(v)}
+            required
           />
         ) : null}
         {typeof value === "string" && patternType === "text" ? (


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to fix a bug existing actually in the Visual Editor. 
The block pattern field is displayed incorrectly in the UI.
More details are attached to the issue related to this PR.

Fixes #270

# Screenshots:
Cases fully support by this proposed change :
- Invalid regex case
![image](https://github.com/user-attachments/assets/e4be8c19-d487-45cd-ac56-aa8c9156425f)
- Empty regex case
![image](https://github.com/user-attachments/assets/13a25663-5282-40f3-85f8-e6bfd98b5250)
- Edge case pattern that can bypass the check logic
![image](https://github.com/user-attachments/assets/1bc38d44-b96b-4640-a90e-4ee5ca8a6fbd)

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code