### PR TITLE
fix(api): schema support attachment_id nullable value

### DIFF
--- a/api/src/chat/repositories/block.repository.ts
+++ b/api/src/chat/repositories/block.repository.ts
@@ -53,6 +53,7 @@ export class BlockRepository extends BaseRepository<
     if (
       block.message &&
       'attachment' in block.message &&
+      block.message.attachment.payload &&
       'url' in block.message.attachment.payload
     ) {
       this.logger.error(

--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -409,6 +409,7 @@ export class BlockService extends BaseService<Block, BlockPopulate, BlockFull> {
     if (
       block.message &&
       'attachment' in block.message &&
+      block.message.attachment.payload &&
       'url' in block.message.attachment.payload
     ) {
       this.logger.error(

--- a/api/src/chat/validation-rules/is-message.ts
+++ b/api/src/chat/validation-rules/is-message.ts
@@ -71,7 +71,7 @@ export function isValidMessage(msg: any) {
             .required(),
           payload: Joi.object().keys({
             url: Joi.string().uri(),
-            attachment_id: Joi.string(),
+            attachment_id: Joi.string().allow(null),
           }),
         }),
         elements: Joi.boolean(),


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to support block.message.payload.attachment_id to fix the attachment block edit form submit issue.
More details are attached to the issue related to this PR.

Fixes #276 

# Demo after the fix:
<video src="https://github.com/user-attachments/assets/903c5819-39ef-4320-8b84-28f3c74c4b95" />

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
