### PR TITLE
fix: missing nlu dockerfile expose port

### DIFF
--- a/nlu/Dockerfile
+++ b/nlu/Dockerfile
@@ -15,5 +15,7 @@ RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 # Copy source code
 COPY . .
 
+EXPOSE 5000
+
 # Entrypoint
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5000"]


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to fix NLU dockerfile missing expose port.

Fixes # (issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes