### PR TITLE
Autofix: 🐛 [BUG] - fix ILanguageStub type issue

### DIFF
--- a/frontend/src/types/language.types.ts
+++ b/frontend/src/types/language.types.ts
@@ -8,7 +8,7 @@
 
 import { EntityType, Format } from "@/services/types";
 
-import { IBaseSchema, IFormat, OmitPopulate } from "./base.types";
+import { IBaseSchema, IFormat } from "./base.types";
 
 export type ILanguages = Record<string, string>;
 
@@ -19,8 +19,6 @@ export interface ILanguageAttributes {
   isRTL: boolean;
 }
 
-export interface ILanguageStub
-  extends IBaseSchema,
-    OmitPopulate<ILanguageAttributes, EntityType.TRANSLATION> {}
+export interface ILanguageStub extends IBaseSchema, ILanguageAttributes {}
 
 export interface ILanguage extends ILanguageStub, IFormat<Format.BASIC> {}


### PR DESCRIPTION
I have identified an inconsistency in the `ILanguageStub` interface definition. The `ILanguageStub` interface extends `IBaseSchema` and `OmitPopulate<ILanguageAttributes, EntityType.TRANSLATION>`, but `EntityType.TRANSLATION` is not a property of `ILanguageAttributes`. To fix this, I've updated the `ILanguageStub` interface to remove the unnecessary `OmitPopulate` usage. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission