### PR TITLE
fix(api): exclude functions as nested types

### DIFF
--- a/api/src/utils/types/filter.types.ts
+++ b/api/src/utils/types/filter.types.ts
@@ -16,11 +16,14 @@ export type TFilterKeysOfNeverType<T> = Omit<T, TFilterKeysOfType<T, []>>;
 
 export type NestedKeys<T> = T extends object
   ? {
-      [K in keyof T]: Array<any> extends T[K]
-        ? Exclude<K, symbol>
-        : K extends symbol
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      [K in keyof T]: T[K] extends Function
+        ? never
+        : Array<any> extends T[K]
           ? Exclude<K, symbol>
-          : `${Exclude<K, symbol>}${'' | `.${NestedKeys<T[K]>}`}`;
+          : K extends symbol
+            ? Exclude<K, symbol>
+            : `${Exclude<K, symbol>}${'' | `.${NestedKeys<T[K]>}`}`;
     }[keyof T]
   : never;
 


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to remove nested types having function type from the nested queries autocomplete.
More details are attached to the issue related to this PR.

Fixes #314

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes