### PR TITLE
fix: restrict paste content to have text format+don't lose old text

### DIFF
--- a/widget/src/components/UserInput.tsx
+++ b/widget/src/components/UserInput.tsx
@@ -181,10 +181,20 @@ const UserInput: React.FC = () => {
           onBlur={() => setInputActive(false)}
           onKeyDown={handleKey}
           onInput={handleInput}
-          onPaste={(e) => {
+          onPaste={async (e) => {
             e.preventDefault();
-            (e.target as HTMLInputElement).innerText =
-              e.clipboardData.getData('text/plain');
+
+            const text = await navigator.clipboard.readText();
+            const range = window.getSelection()?.getRangeAt(0);
+
+            if (range && text) {
+              const node = document.createTextNode(text);
+
+              range.deleteContents();
+              range.insertNode(node);
+              range.collapse(false);
+            }
+
             handleInput();
           }}
           contentEditable


### PR DESCRIPTION
# Motivation
The main motivation of this update is to fix the issue happening the text field of the widget
More details are attached to the issue related to this PR.

Fixes #242

# Fix demonstration 
<video src="https://github.com/user-attachments/assets/67664797-43e5-4fb1-881b-8d65fd83fbba" />

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
