### PR TITLE
fix(frontend): contextVar edit dialog states

### DIFF
--- a/frontend/src/components/context-vars/ContextVarDialog.tsx
+++ b/frontend/src/components/context-vars/ContextVarDialog.tsx
@@ -66,7 +66,11 @@ export const ContextVarDialog: FC<ContextVarDialogProps> = ({
     formState: { errors },
     control,
   } = useForm<IContextVarAttributes>({
-    defaultValues: { name: data?.name || "", label: data?.label || "" },
+    defaultValues: {
+      name: data?.name || "",
+      label: data?.label || "",
+      permanent: data?.permanent,
+    },
   });
   const validationRules = {
     label: {
@@ -96,6 +100,7 @@ export const ContextVarDialog: FC<ContextVarDialogProps> = ({
       reset({
         label: data.label,
         name: data.name,
+        permanent: data.permanent,
       });
     } else {
       reset();

--- a/frontend/src/components/context-vars/ContextVarDialog.tsx
+++ b/frontend/src/components/context-vars/ContextVarDialog.tsx
@@ -69,7 +69,7 @@ export const ContextVarDialog: FC<ContextVarDialogProps> = ({
     defaultValues: {
       name: data?.name || "",
       label: data?.label || "",
-      permanent: data?.permanent,
+      permanent: data?.permanent || false,
     },
   });
   const validationRules = {


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to fix an issue situated in the ContextVar edit dialog component.
More details are attached to the issue related to this PR.

Fixes #338

# Fix demonstration
<video src="https://github.com/user-attachments/assets/8d0f70eb-5db2-44dd-a9ef-38068cad5187" />

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes