### PR TITLE
fix: content vs element

### DIFF
--- a/api/src/channel/lib/__test__/common.mock.ts
+++ b/api/src/channel/lib/__test__/common.mock.ts
@@ -120,7 +120,6 @@ export const contentMessage: StdOutgoingListMessage = {
       id: '1',
       entity: 'rank',
       title: 'First',
-      // @ts-expect-error Necessary workaround
       desc: 'About being first',
       thumbnail: {
         payload: attachmentWithUrl,
@@ -136,7 +135,6 @@ export const contentMessage: StdOutgoingListMessage = {
       id: '2',
       entity: 'rank',
       title: 'Second',
-      // @ts-expect-error Necessary workaround
       desc: 'About being second',
       thumbnail: {
         payload: attachmentWithUrl,

--- a/api/src/chat/schemas/types/message.ts
+++ b/api/src/chat/schemas/types/message.ts
@@ -7,7 +7,6 @@
  */
 
 import { Attachment } from '@/attachment/schemas/attachment.schema';
-import { Content } from '@/cms/schemas/content.schema';
 
 import { Message } from '../message.schema';
 
@@ -84,9 +83,14 @@ export type StdOutgoingButtonsMessage = {
   buttons: Button[];
 };
 
+export type ContentElement = { id: string; title: string } & Record<
+  string,
+  any
+>;
+
 export type StdOutgoingListMessage = {
   options: ContentOptions;
-  elements: Content[];
+  elements: ContentElement[];
   pagination: {
     total: number;
     skip: number;

--- a/api/src/chat/services/block.service.spec.ts
+++ b/api/src/chat/services/block.service.spec.ts
@@ -442,9 +442,7 @@ describe('BlockService', () => {
         { status: true, entity: contentType.id },
         { skip: 0, limit: 2, sort: ['createdAt', 'desc'] },
       );
-      const flattenedElements = elements.map((element) =>
-        Content.flatDynamicFields(element),
-      );
+      const flattenedElements = elements.map(Content.toElement);
       expect(result.format).toEqualPayload(
         blockProductListMock.options.content?.display,
       );
@@ -476,9 +474,7 @@ describe('BlockService', () => {
         { status: true, entity: contentType.id },
         { skip: 2, limit: 2, sort: ['createdAt', 'desc'] },
       );
-      const flattenedElements = elements.map((element) =>
-        Content.flatDynamicFields(element),
-      );
+      const flattenedElements = elements.map(Content.toElement);
       expect(result.format).toEqual(
         blockProductListMock.options.content?.display,
       );

--- a/api/src/extensions/channels/web/base-web-channel.ts
+++ b/api/src/extensions/channels/web/base-web-channel.ts
@@ -31,6 +31,7 @@ import { WithUrl } from '@/chat/schemas/types/attachment';
 import { Button, ButtonType } from '@/chat/schemas/types/button';
 import {
   AnyMessage,
+  ContentElement,
   FileType,
   IncomingMessage,
   OutgoingMessage,
@@ -963,7 +964,10 @@ export default abstract class BaseWebChannelHandler<
    *
    * @returns An array of elements object
    */
-  _formatElements(data: any[], options: BlockOptions): Web.MessageElement[] {
+  _formatElements(
+    data: ContentElement[],
+    options: BlockOptions,
+  ): Web.MessageElement[] {
     if (!options.content || !options.content.fields) {
       throw new Error('Content options are missing the fields');
     }


### PR DESCRIPTION
# Motivation

This PR fixes things about lists and carousel. We have now : 
1. Content (that is the object as stored in DB - with dynamicFields)
2. ContentElement which is a flattened form of the content. It would be used in list / carousel ("elements" attribute)

This should solve the confusion around both, both in channel and plugins.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
