### PR TITLE
fix: pagination

### DIFF
--- a/api/src/chat/controllers/block.controller.spec.ts
+++ b/api/src/chat/controllers/block.controller.spec.ts
@@ -48,13 +48,13 @@ import { BlockCreateDto, BlockUpdateDto } from '../dto/block.dto';
 import { BlockRepository } from '../repositories/block.repository';
 import { CategoryRepository } from '../repositories/category.repository';
 import { LabelRepository } from '../repositories/label.repository';
-import { BlockModel, Block } from '../schemas/block.schema';
+import { Block, BlockModel } from '../schemas/block.schema';
 import { LabelModel } from '../schemas/label.schema';
 import { BlockService } from '../services/block.service';
 import { CategoryService } from '../services/category.service';
 import { LabelService } from '../services/label.service';
 
-import { CategoryModel, Category } from './../schemas/category.schema';
+import { Category, CategoryModel } from './../schemas/category.schema';
 import { BlockController } from './block.controller';
 
 describe('BlockController', () => {
@@ -167,7 +167,7 @@ describe('BlockController', () => {
           blockFixture.name === 'hasNextBlocks' ? [hasPreviousBlocks.id] : [],
       }));
 
-      expect(blockService.find).toHaveBeenCalledWith({});
+      expect(blockService.find).toHaveBeenCalledWith({}, undefined);
       expect(result).toEqualPayload(blocksWithCategory, [
         ...IGNORED_TEST_FIELDS,
         'attachedToBlock',
@@ -187,7 +187,7 @@ describe('BlockController', () => {
           blockFixture.name === 'hasNextBlocks' ? [hasPreviousBlocks] : [],
       }));
 
-      expect(blockService.findAndPopulate).toHaveBeenCalledWith({});
+      expect(blockService.findAndPopulate).toHaveBeenCalledWith({}, undefined);
       expect(result).toEqualPayload(blocksWithCategory);
     });
   });

--- a/api/src/chat/controllers/category.controller.ts
+++ b/api/src/chat/controllers/category.controller.ts
@@ -57,7 +57,11 @@ export class CategoryController extends BaseController<Category> {
     @Query(new SearchFilterPipe<Category>({ allowedFields: ['label'] }))
     filters: TFilterQuery<Category>,
   ) {
-    return await this.categoryService.findPage(filters, pageQuery);
+    if (pageQuery.limit) {
+      return await this.categoryService.findPage(filters, pageQuery);
+    }
+
+    return await this.categoryService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/chat/controllers/context-var.controller.ts
+++ b/api/src/chat/controllers/context-var.controller.ts
@@ -60,7 +60,11 @@ export class ContextVarController extends BaseController<ContextVar> {
     @Query(new SearchFilterPipe<ContextVar>({ allowedFields: ['label'] }))
     filters: TFilterQuery<ContextVar>,
   ): Promise<ContextVar[]> {
-    return await this.contextVarService.findPage(filters, pageQuery);
+    if (pageQuery.limit) {
+      return await this.contextVarService.findPage(filters, pageQuery);
+    }
+
+    return await this.contextVarService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/chat/controllers/label.controller.ts
+++ b/api/src/chat/controllers/label.controller.ts
@@ -62,9 +62,15 @@ export class LabelController extends BaseController<
     @Query(new SearchFilterPipe<Label>({ allowedFields: ['name', 'title'] }))
     filters: TFilterQuery<Label>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.labelService.findPageAndPopulate(filters, pageQuery)
+        : await this.labelService.findPage(filters, pageQuery);
+    }
+
     return this.canPopulate(populate)
-      ? await this.labelService.findPageAndPopulate(filters, pageQuery)
-      : await this.labelService.findPage(filters, pageQuery);
+      ? await this.labelService.findAndPopulate(filters, pageQuery.sort)
+      : await this.labelService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/chat/controllers/message.controller.ts
+++ b/api/src/chat/controllers/message.controller.ts
@@ -42,6 +42,7 @@ import {
   MessageStub,
 } from '../schemas/message.schema';
 import {
+  AnyMessage,
   OutgoingMessage,
   OutgoingMessageFormat,
   StdOutgoingEnvelope,
@@ -71,7 +72,7 @@ export class MessageController extends BaseController<
 
   @Get()
   async findPage(
-    @Query(PageQueryPipe) pageQuery: PageQueryDto<Message>,
+    @Query(PageQueryPipe) pageQuery: PageQueryDto<AnyMessage>,
     @Query(PopulatePipe)
     populate: string[],
     @Query(
@@ -79,9 +80,15 @@ export class MessageController extends BaseController<
     )
     filters: TFilterQuery<Message>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.messageService.findPageAndPopulate(filters, pageQuery)
+        : await this.messageService.findPage(filters, pageQuery);
+    }
+
     return this.canPopulate(populate)
-      ? await this.messageService.findPageAndPopulate(filters, pageQuery)
-      : await this.messageService.findPage(filters, pageQuery);
+      ? await this.messageService.findAndPopulate(filters, pageQuery.sort)
+      : await this.messageService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/chat/controllers/subscriber.controller.ts
+++ b/api/src/chat/controllers/subscriber.controller.ts
@@ -73,9 +73,15 @@ export class SubscriberController extends BaseController<
     )
     filters: TFilterQuery<Subscriber>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.subscriberService.findPageAndPopulate(filters, pageQuery)
+        : await this.subscriberService.findPage(filters, pageQuery);
+    }
+
     return this.canPopulate(populate)
-      ? await this.subscriberService.findPageAndPopulate(filters, pageQuery)
-      : await this.subscriberService.findPage(filters, pageQuery);
+      ? await this.subscriberService.findAndPopulate(filters, pageQuery.sort)
+      : await this.subscriberService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/cms/controllers/content-type.controller.ts
+++ b/api/src/cms/controllers/content-type.controller.ts
@@ -75,7 +75,11 @@ export class ContentTypeController extends BaseController<ContentType> {
     @Query(new SearchFilterPipe<ContentType>({ allowedFields: ['name'] }))
     filters: TFilterQuery<ContentType>,
   ) {
-    return await this.contentTypeService.findPage(filters, pageQuery);
+    if (pageQuery.limit) {
+      return await this.contentTypeService.findPage(filters, pageQuery);
+    }
+
+    return await this.contentTypeService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/cms/controllers/content.controller.ts
+++ b/api/src/cms/controllers/content.controller.ts
@@ -194,9 +194,14 @@ export class ContentController extends BaseController<
     )
     filters: TFilterQuery<Content>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.contentService.findPageAndPopulate(filters, pageQuery)
+        : await this.contentService.findPage(filters, pageQuery);
+    }
     return this.canPopulate(populate)
-      ? await this.contentService.findPageAndPopulate(filters, pageQuery)
-      : await this.contentService.findPage(filters, pageQuery);
+      ? await this.contentService.findAndPopulate(filters, pageQuery.sort)
+      : await this.contentService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/cms/controllers/menu.controller.ts
+++ b/api/src/cms/controllers/menu.controller.ts
@@ -76,7 +76,11 @@ export class MenuController extends BaseController<
     @Query(new SearchFilterPipe<Menu>({ allowedFields: ['parent'] }))
     filters: TFilterQuery<Menu>,
   ) {
-    return await this.menuService.findPage(filters, pageQuery);
+    if (pageQuery.limit) {
+      return await this.menuService.findPage(filters, pageQuery);
+    }
+
+    return await this.menuService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/i18n/controllers/language.controller.ts
+++ b/api/src/i18n/controllers/language.controller.ts
@@ -57,7 +57,11 @@ export class LanguageController extends BaseController<Language> {
     @Query(new SearchFilterPipe<Language>({ allowedFields: ['title', 'code'] }))
     filters: TFilterQuery<Language>,
   ) {
-    return await this.languageService.findPage(filters, pageQuery);
+    if (pageQuery.limit) {
+      return await this.languageService.findPage(filters, pageQuery);
+    }
+
+    return await this.languageService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/i18n/controllers/translation.controller.ts
+++ b/api/src/i18n/controllers/translation.controller.ts
@@ -55,7 +55,10 @@ export class TranslationController extends BaseController<Translation> {
     @Query(new SearchFilterPipe<Translation>({ allowedFields: ['str'] }))
     filters: TFilterQuery<Translation>,
   ) {
-    return await this.translationService.findPage(filters, pageQuery);
+    if (pageQuery.limit) {
+      return await this.translationService.findPage(filters, pageQuery);
+    }
+    return await this.translationService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/nlp/controllers/nlp-entity.controller.ts
+++ b/api/src/nlp/controllers/nlp-entity.controller.ts
@@ -135,9 +135,15 @@ export class NlpEntityController extends BaseController<
     @Query(new SearchFilterPipe<NlpEntity>({ allowedFields: ['name', 'doc'] }))
     filters: TFilterQuery<NlpEntity>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.nlpEntityService.findPageAndPopulate(filters, pageQuery)
+        : await this.nlpEntityService.findPage(filters, pageQuery);
+    }
+
     return this.canPopulate(populate)
-      ? await this.nlpEntityService.findPageAndPopulate(filters, pageQuery)
-      : await this.nlpEntityService.findPage(filters, pageQuery);
+      ? await this.nlpEntityService.findAndPopulate(filters)
+      : await this.nlpEntityService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/nlp/controllers/nlp-sample.controller.ts
+++ b/api/src/nlp/controllers/nlp-sample.controller.ts
@@ -280,9 +280,15 @@ export class NlpSampleController extends BaseController<
     )
     filters: TFilterQuery<NlpSample>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.nlpSampleService.findPageAndPopulate(filters, pageQuery)
+        : await this.nlpSampleService.findPage(filters, pageQuery);
+    }
+
     return this.canPopulate(populate)
-      ? await this.nlpSampleService.findPageAndPopulate(filters, pageQuery)
-      : await this.nlpSampleService.findPage(filters, pageQuery);
+      ? await this.nlpSampleService.findAndPopulate(filters, pageQuery.sort)
+      : await this.nlpSampleService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/nlp/controllers/nlp-value.controller.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.ts
@@ -146,9 +146,15 @@ export class NlpValueController extends BaseController<
     )
     filters: TFilterQuery<NlpValue>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.nlpValueService.findPageAndPopulate(filters, pageQuery)
+        : await this.nlpValueService.findPage(filters, pageQuery);
+    }
+
     return this.canPopulate(populate)
-      ? await this.nlpValueService.findPageAndPopulate(filters, pageQuery)
-      : await this.nlpValueService.findPage(filters, pageQuery);
+      ? await this.nlpValueService.findAndPopulate(filters, pageQuery.sort)
+      : await this.nlpValueService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/user/controllers/role.controller.ts
+++ b/api/src/user/controllers/role.controller.ts
@@ -68,9 +68,15 @@ export class RoleController extends BaseController<
     @Query(new SearchFilterPipe<Role>({ allowedFields: ['name'] }))
     filters: TFilterQuery<Role>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.roleService.findPageAndPopulate(filters, pageQuery)
+        : await this.roleService.findPage(filters, pageQuery);
+    }
+
     return this.canPopulate(populate)
-      ? await this.roleService.findPageAndPopulate(filters, pageQuery)
-      : await this.roleService.findPage(filters, pageQuery);
+      ? await this.roleService.findAndPopulate(filters, pageQuery.sort)
+      : await this.roleService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/user/controllers/user.controller.ts
+++ b/api/src/user/controllers/user.controller.ts
@@ -168,9 +168,15 @@ export class ReadOnlyUserController extends BaseController<
     )
     filters: TFilterQuery<User>,
   ) {
+    if (pageQuery.limit) {
+      return this.canPopulate(populate)
+        ? await this.userService.findPageAndPopulate(filters, pageQuery)
+        : await this.userService.findPage(filters, pageQuery);
+    }
+
     return this.canPopulate(populate)
-      ? await this.userService.findPageAndPopulate(filters, pageQuery)
-      : await this.userService.find(filters);
+      ? await this.userService.findAndPopulate(filters, pageQuery.sort)
+      : await this.userService.find(filters, pageQuery.sort);
   }
 
   /**

--- a/api/src/utils/pagination/pagination-query.dto.ts
+++ b/api/src/utils/pagination/pagination-query.dto.ts
@@ -16,7 +16,7 @@ export type QuerySortDto<T> = [
 ];
 
 export type PageQueryDto<T> = {
-  skip: number;
-  limit: number;
+  skip: number | undefined;
+  limit: number | undefined;
   sort: QuerySortDto<T>;
 };

--- a/api/src/utils/pagination/pagination-query.pipe.ts
+++ b/api/src/utils/pagination/pagination-query.pipe.ts
@@ -14,19 +14,21 @@ import { PageQueryDto } from './pagination-query.dto';
 
 const sortTypes = ['asc', 'desc'];
 
+export type PageQueryParams = { skip?: string; limit?: string; sort?: string };
+
 export class PageQueryPipe<T>
-  implements
-    PipeTransform<
-      { skip: string; limit: string; sort: string },
-      PageQueryDto<T>
-    >
+  implements PipeTransform<PageQueryParams, PageQueryDto<T>>
 {
-  transform(value: { skip: string; limit: string; sort: string }) {
-    const skip = parseInt(value.skip) > -1 ? parseInt(value.skip) : 0;
-    const limit =
-      parseInt(value.limit) > 0
-        ? parseInt(value.limit)
-        : config.pagination.limit;
+  transform(value: PageQueryParams) {
+    let skip: number | undefined = undefined;
+    let limit: number | undefined = undefined;
+    if ('limit' in value) {
+      skip = parseInt(value.skip) > -1 ? parseInt(value.skip) : 0;
+      limit =
+        parseInt(value.limit) > 0
+          ? parseInt(value.limit)
+          : config.pagination.limit;
+    }
     const [sortName = 'createdAt', sortType = 'desc'] =
       value.sort?.split(' ') || [];
 


### PR DESCRIPTION
# Motivation
This PR addresses an issue where the hasCount parameter in the API does not properly disable the query limit for the Visual Editor. Despite passing hasCount as false, the API still applies a limit to the find query, causing unexpected behavior when managing a large number of flows.

A temporary fix was previously applied for the Visual Editor case in PR #357. This update ensures the hasCount parameter functions as intended across all relevant components, removing the reliance on temporary solutions.

ISSUE #358 

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
