### PR TITLE
fix: add null checks for plugin and settings to prevent TypeError

### DIFF
--- a/api/src/i18n/services/translation.service.ts
+++ b/api/src/i18n/services/translation.service.ts
@@ -59,7 +59,7 @@ export class TranslationService extends BaseService<Translation> {
 
         // plugin
         Object.entries(block.message.args).forEach(([l, arg]) => {
-          const setting = plugin.settings.find(({ label }) => label === l);
+          const setting = plugin?.settings.find(({ label }) => label === l);
           if (setting?.translatable) {
             if (Array.isArray(arg)) {
               // array of text


### PR DESCRIPTION
# Motivation

Fixes an API crash caused by accessing properties on an undefined plugin object when processing translations.

- Added optional chaining to safely access plugin and `plugin.settings` properties.

Fixes # (issue)

# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code

