### PR TITLE
fix: fix trimming for input text before model inference

### DIFF
--- a/api/src/extensions/helpers/core-nlu/index.helper.ts
+++ b/api/src/extensions/helpers/core-nlu/index.helper.ts
@@ -258,11 +258,18 @@ export default class CoreNluHelper extends BaseNlpHelper<
   ): Promise<Nlp.ParseEntities> {
     try {
       const settings = await this.getSettings();
+      const trimmedText = text.trim().replace(/\s+/g, ' ');
+
+      // Check if the trimmed text is empty
+      if (!trimmedText) {
+        this.logger.warn('Input text is empty after trimming.');
+        return { entities: [] };
+      }
       const { data: nlp } =
         await this.httpService.axiosRef.post<NlpParseResultType>(
           buildURL(settings.endpoint, '/parse'),
           {
-            q: text,
+            q: trimmedText,
             project,
           },
           {


### PR DESCRIPTION
# Motivation

The following PR fixes text trimming issues during NLU model's inference. Example: whitespaces are being predicted and infered which shouldn't happen
Fixes # (issue)

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
