### PR TITLE
fix: add console-channel before filtering

### DIFF
--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -608,8 +608,4 @@ export class BlockService extends BaseService<Block, BlockPopulate, BlockFull> {
       throw new Error('Invalid message format.');
     }
   }
-
-  getCategoryBlocks(categoryId: string) {
-    return this.repository.model.find({ category: categoryId });
-  }
 }


### PR DESCRIPTION
# Motivation

This PR ensures that all blocks include the `console-channel` in their trigger_channel attribute. Previously, blocks were filtered based on their `trigger_channel`, but not all blocks had `console-channel` specified, leading to potential filtering issues.

Fixes # ( )

- [x] Bug fix (non-breaking change which fixes an issue)
