### PR TITLE
Update config to use env var when defining the apiUrl and appUrl

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -75,7 +75,7 @@ const i18nOptions: I18nOptions = {
               options: {
                 context: {
                   appName: config.parameters.appName,
-                  appUrl: config.parameters.appUrl,
+                  appUrl: config.frontendPath,
                 },
               },
             },

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -75,7 +75,7 @@ const i18nOptions: I18nOptions = {
               options: {
                 context: {
                   appName: config.parameters.appName,
-                  appUrl: config.frontendPath,
+                  appUrl: config.uiBaseUrl,
                 },
               },
             },

--- a/api/src/attachment/schemas/attachment.schema.ts
+++ b/api/src/attachment/schemas/attachment.schema.ts
@@ -91,7 +91,7 @@ export class Attachment extends BaseSchema {
     attachmentName: string = '',
   ): string {
     return buildURL(
-      config.parameters.apiUrl,
+      config.apiPath,
       `/attachment/download/${attachmentId}/${attachmentName}`,
     );
   }

--- a/api/src/attachment/schemas/attachment.schema.ts
+++ b/api/src/attachment/schemas/attachment.schema.ts
@@ -91,7 +91,7 @@ export class Attachment extends BaseSchema {
     attachmentName: string = '',
   ): string {
     return buildURL(
-      config.apiPath,
+      config.apiBaseUrl,
       `/attachment/download/${attachmentId}/${attachmentName}`,
     );
   }
@@ -124,7 +124,7 @@ export const AttachmentModel: ModelDefinition = LifecycleHookManager.attach({
 AttachmentModel.schema.virtual('url').get(function () {
   if (this._id && this.name)
     return buildURL(
-      config.apiPath,
+      config.apiBaseUrl,
       `/attachment/download/${this._id}/${this.name}`,
     );
 

--- a/api/src/cms/schemas/content.schema.ts
+++ b/api/src/cms/schemas/content.schema.ts
@@ -53,7 +53,7 @@ export class ContentStub extends BaseSchema {
    * Helper to return the internal url of this content.
    */
   static getUrl(item: ContentElement): string {
-    return new URL('/content/view/' + item.id, config.apiPath).toString();
+    return new URL('/content/view/' + item.id, config.apiBaseUrl).toString();
   }
 
   /**

--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -112,7 +112,6 @@ export const config: Config = {
       ? Number(process.env.UPLOAD_MAX_SIZE_IN_BYTES)
       : 2000000,
     appName: 'Hexabot.ai',
-    apiUrl: 'http://localhost:4000',
     appUrl: 'http://localhost:8081',
   },
   pagination: {

--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -15,8 +15,8 @@ export const config: Config = {
     translationFilename: process.env.I18N_TRANSLATION_FILENAME || 'messages',
   },
   appPath: process.cwd(),
-  apiPath: process.env.API_ORIGIN || 'http://localhost:4000',
-  frontendPath: process.env.FRONTEND_ORIGIN
+  apiBaseUrl: process.env.API_ORIGIN || 'http://localhost:4000',
+  uiBaseUrl: process.env.FRONTEND_ORIGIN
     ? process.env.FRONTEND_ORIGIN.split(',')[0]
     : 'http://localhost:8080',
   security: {

--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -112,7 +112,6 @@ export const config: Config = {
       ? Number(process.env.UPLOAD_MAX_SIZE_IN_BYTES)
       : 2000000,
     appName: 'Hexabot.ai',
-    appUrl: 'http://localhost:8081',
   },
   pagination: {
     limit: 10,

--- a/api/src/config/types.ts
+++ b/api/src/config/types.ts
@@ -27,8 +27,8 @@ type TCacheConfig = {
 export type Config = {
   i18n: { translationFilename: string };
   appPath: string;
-  apiPath: string;
-  frontendPath: string;
+  apiBaseUrl: string;
+  uiBaseUrl: string;
   security: {
     httpsEnabled: boolean;
     trustProxy: boolean;

--- a/api/src/config/types.ts
+++ b/api/src/config/types.ts
@@ -81,7 +81,6 @@ export type Config = {
     storageMode: 'disk' | 'memory';
     maxUploadSize: number;
     appName: string;
-    appUrl: string;
   };
   pagination: {
     limit: number;

--- a/api/src/config/types.ts
+++ b/api/src/config/types.ts
@@ -81,7 +81,6 @@ export type Config = {
     storageMode: 'disk' | 'memory';
     maxUploadSize: number;
     appName: string;
-    apiUrl: string;
     appUrl: string;
   };
   pagination: {

--- a/api/src/extensions/channels/console/settings.ts
+++ b/api/src/extensions/channels/console/settings.ts
@@ -20,7 +20,7 @@ export default [
   {
     group: CONSOLE_CHANNEL_NAMESPACE,
     label: Web.SettingLabel.allowed_domains,
-    value: config.frontendPath,
+    value: config.uiBaseUrl,
     type: SettingType.text,
   },
   {

--- a/api/src/websocket/pipes/io-message.pipe.ts
+++ b/api/src/websocket/pipes/io-message.pipe.ts
@@ -49,7 +49,7 @@ export class IOMessagePipe implements PipeTransform<string, IOIncomingMessage> {
 
     const url = message.url.startsWith('http')
       ? message.url
-      : `${config.apiPath}${message.url}`;
+      : `${config.apiBaseUrl}${message.url}`;
 
     if (!URL.canParse(url)) {
       throw new BadRequestException('Cannot parse url');

--- a/api/src/websocket/pipes/io-message.pipe.ts
+++ b/api/src/websocket/pipes/io-message.pipe.ts
@@ -49,7 +49,7 @@ export class IOMessagePipe implements PipeTransform<string, IOIncomingMessage> {
 
     const url = message.url.startsWith('http')
       ? message.url
-      : `${config.parameters.apiUrl}${message.url}`;
+      : `${config.apiPath}${message.url}`;
 
     if (!URL.canParse(url)) {
       throw new BadRequestException('Cannot parse url');

--- a/api/src/websocket/utils/socket-request.ts
+++ b/api/src/websocket/utils/socket-request.ts
@@ -90,9 +90,7 @@ export class SocketRequest {
 
     // Resolve the URL and path
     const urlObj = new URL(
-      this.url.startsWith('http')
-        ? this.url
-        : `${config.parameters.apiUrl}${this.url}`,
+      this.url.startsWith('http') ? this.url : `${config.apiPath}${this.url}`,
     );
     this.path = urlObj.pathname || '/';
 

--- a/api/src/websocket/utils/socket-request.ts
+++ b/api/src/websocket/utils/socket-request.ts
@@ -90,7 +90,9 @@ export class SocketRequest {
 
     // Resolve the URL and path
     const urlObj = new URL(
-      this.url.startsWith('http') ? this.url : `${config.apiPath}${this.url}`,
+      this.url.startsWith('http')
+        ? this.url
+        : `${config.apiBaseUrl}${this.url}`,
     );
     this.path = urlObj.pathname || '/';
 


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to refactor the current logic to centralize apiUrl and appUrl environment variables.

Fixes #390 

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes