### PR TITLE
fix: attach botStats and nlpSampleEnitity to the lifecyclehook

### DIFF
--- a/api/src/analytics/schemas/bot-stats.schema.ts
+++ b/api/src/analytics/schemas/bot-stats.schema.ts
@@ -9,6 +9,7 @@
 import { ModelDefinition, Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 
 import { BaseSchema } from '@/utils/generics/base-schema';
+import { LifecycleHookManager } from '@/utils/generics/lifecycle-hook-manager';
 import { THydratedDocument } from '@/utils/types/filter.types';
 
 export enum BotStatsType {
@@ -115,9 +116,9 @@ export class BotStats extends BaseSchema {
 
 export type BotStatsDocument = THydratedDocument<BotStats>;
 
-export const BotStatsModel: ModelDefinition = {
+export const BotStatsModel: ModelDefinition = LifecycleHookManager.attach({
   name: BotStats.name,
   schema: SchemaFactory.createForClass(BotStats),
-};
+});
 
 export default BotStatsModel.schema;

--- a/api/src/nlp/schemas/nlp-sample-entity.schema.ts
+++ b/api/src/nlp/schemas/nlp-sample-entity.schema.ts
@@ -11,6 +11,7 @@ import { Transform, Type } from 'class-transformer';
 import { Schema as MongooseSchema } from 'mongoose';
 
 import { BaseSchema } from '@/utils/generics/base-schema';
+import { LifecycleHookManager } from '@/utils/generics/lifecycle-hook-manager';
 import {
   TFilterPopulateFields,
   THydratedDocument,
@@ -103,10 +104,11 @@ export class NlpSampleEntityFull extends NlpSampleEntityStub {
 
 export type NlpSampleEntityDocument = THydratedDocument<NlpSampleEntity>;
 
-export const NlpSampleEntityModel: ModelDefinition = {
-  name: NlpSampleEntity.name,
-  schema: SchemaFactory.createForClass(NlpSampleEntityStub),
-};
+export const NlpSampleEntityModel: ModelDefinition =
+  LifecycleHookManager.attach({
+    name: NlpSampleEntity.name,
+    schema: SchemaFactory.createForClass(NlpSampleEntityStub),
+  });
 
 export default NlpSampleEntityModel.schema;
 


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to attach botStats and nlpSampleEnitity models to the lifecyclehook

Fixes #401

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
