### PR TITLE
fix: synchronized sended messages for the same accounts

### DIFF
--- a/api/src/chat/services/chat.service.ts
+++ b/api/src/chat/services/chat.service.ts
@@ -253,6 +253,11 @@ export class ChatService {
         // Already existing user profile
         // Exec lastvisit hook
         this.eventEmitter.emit('hook:user:lastvisit', subscriber);
+        this.websocketGateway.broadcast(
+          subscriber,
+          event.getEventType(),
+          event._adapter.raw,
+        );
       }
 
       this.websocketGateway.broadcastSubscriberUpdate(subscriber);

--- a/widget/src/providers/ChatProvider.tsx
+++ b/widget/src/providers/ChatProvider.tsx
@@ -250,7 +250,7 @@ const ChatProvider: React.FC<{
       }
 
       setMessages((prevMessages) => [
-        ...prevMessages,
+        ...prevMessages.filter((message) => message.mid !== newIOMessage.mid),
         newIOMessage as TMessage,
       ]);
       setScroll(0);


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to make synchronized the sent message for the same account.
More details are attached to the issue related to this PR.

Fixes #392

# Fix Demonstration 
<video src="https://github.com/user-attachments/assets/211241a1-f7b5-4156-9638-1860f4b17cb8" />
 
# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes