### PR TITLE
refactor: hard coded direction values with enum

### DIFF
--- a/widget/src/components/messages/FileMessage.tsx
+++ b/widget/src/components/messages/FileMessage.tsx
@@ -10,7 +10,7 @@ import React from "react";
 
 import { useTranslation } from "../../hooks/useTranslation";
 import { useColors } from "../../providers/ColorProvider";
-import { TMessage } from "../../types/message.types";
+import { Direction, TMessage } from "../../types/message.types";
 import FileIcon from "../icons/FileIcon";
 
 import "./FileMessage.scss";
@@ -22,7 +22,7 @@ interface FileMessageProps {
 const FileMessage: React.FC<FileMessageProps> = ({ message }) => {
   const { t } = useTranslation();
   const { colors: allColors } = useColors();
-  const colors = allColors[message.direction || "received"];
+  const colors = allColors[message.direction || Direction.received];
 
   if (!("type" in message.data)) {
     throw new Error("Unable to detect type for file message");

--- a/widget/src/components/messages/GeolocationMessage.tsx
+++ b/widget/src/components/messages/GeolocationMessage.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 import { useColors } from "../../providers/ColorProvider";
 import { useWidget } from "../../providers/WidgetProvider";
-import { TMessage } from "../../types/message.types";
+import { Direction, TMessage } from "../../types/message.types";
 
 import "./GeolocationMessage.scss";
 
@@ -58,7 +58,7 @@ const GeolocationMessage: React.FC<GeolocationMessageProps> = ({ message }) => {
   },${coordinates.lat - 0.1},${coordinates.lng + 0.1},${
     coordinates.lat + 0.1
   }&layer=mapnik&marker=${coordinates.lat},${coordinates.lng}`;
-  const colors = allColors[message.direction || "received"];
+  const colors = allColors[message.direction || Direction.received];
 
   return (
     <div

--- a/widget/src/components/messages/ListMessage.tsx
+++ b/widget/src/components/messages/ListMessage.tsx
@@ -9,7 +9,7 @@
 import React from "react";
 
 import { useColors } from "../../providers/ColorProvider";
-import { TMessage } from "../../types/message.types";
+import { Direction, TMessage } from "../../types/message.types";
 
 import ButtonsMessage from "./ButtonMessage";
 
@@ -39,7 +39,7 @@ const ListMessage: React.FC<ListMessageProps> = ({ messageList }) => {
     throw new Error("Unable to find elements");
   }
 
-  const colors = allColors[messageList.direction || "received"];
+  const colors = allColors[messageList.direction || Direction.received];
 
   return (
     <div

--- a/widget/src/components/messages/TextMessage.tsx
+++ b/widget/src/components/messages/TextMessage.tsx
@@ -10,7 +10,7 @@ import Autolinker from "autolinker";
 import React, { useEffect, useRef } from "react";
 
 import { useColors } from "../../providers/ColorProvider";
-import { TMessage } from "../../types/message.types";
+import { Direction, TMessage } from "../../types/message.types";
 
 import "./TextMessage.scss";
 
@@ -28,7 +28,7 @@ const TextMessage: React.FC<TextMessageProps> = ({ message }) => {
   }, [message]);
 
   const autoLink = () => {
-    if (message.direction === "received" && messageTextRef.current) {
+    if (message.direction === Direction.received && messageTextRef.current) {
       const text = messageTextRef.current.innerText;
 
       messageTextRef.current.innerHTML = Autolinker.link(text, {
@@ -42,7 +42,7 @@ const TextMessage: React.FC<TextMessageProps> = ({ message }) => {
     throw new Error("Unable to find text.");
   }
 
-  const colors = allColors[message.direction || "received"];
+  const colors = allColors[message.direction || Direction.received];
 
   return (
     <div


### PR DESCRIPTION
# Motivation

This PR refactors the widget application to replace hard-coded 'received' with Direction enum, improving maintainability and reducing the risk of errors. 

Fixes #411