### PR TITLE
fix: add retro compatibility for find and findAndPopulate methods

### DIFF
--- a/api/src/attachment/controllers/attachment.controller.ts
+++ b/api/src/attachment/controllers/attachment.controller.ts
@@ -94,7 +94,7 @@ export class AttachmentController extends BaseController<Attachment> {
     )
     filters: TFilterQuery<Attachment>,
   ) {
-    return await this.attachmentService.findPage(filters, pageQuery);
+    return await this.attachmentService.find(filters, pageQuery);
   }
 
   /**

--- a/api/src/chat/controllers/message.controller.ts
+++ b/api/src/chat/controllers/message.controller.ts
@@ -55,7 +55,7 @@ import { SubscriberService } from '../services/subscriber.service';
 @UseInterceptors(CsrfInterceptor)
 @Controller('message')
 export class MessageController extends BaseController<
-  Message,
+  AnyMessage,
   MessageStub,
   MessagePopulate,
   MessageFull

--- a/api/src/chat/repositories/message.repository.ts
+++ b/api/src/chat/repositories/message.repository.ts
@@ -72,7 +72,7 @@ export class MessageRepository extends BaseRepository<
     until = new Date(),
     limit: number = 30,
   ) {
-    return await this.findPage(
+    return await this.find(
       {
         $or: [{ recipient: subscriber.id }, { sender: subscriber.id }],
         createdAt: { $lt: until },
@@ -96,7 +96,7 @@ export class MessageRepository extends BaseRepository<
     since = new Date(),
     limit: number = 30,
   ) {
-    return await this.findPage(
+    return await this.find(
       {
         $or: [{ recipient: subscriber.id }, { sender: subscriber.id }],
         createdAt: { $gt: since },

--- a/api/src/chat/repositories/subscriber.repository.ts
+++ b/api/src/chat/repositories/subscriber.repository.ts
@@ -106,7 +106,7 @@ export class SubscriberRepository extends BaseRepository<
    * @returns The constructed query object.
    */
   findByForeignIdQuery(id: string) {
-    return this.findPageQuery(
+    return this.findQuery(
       { foreign_id: id },
       { skip: 0, limit: 1, sort: ['lastvisit', 'desc'] },
     );

--- a/api/src/chat/services/message.service.ts
+++ b/api/src/chat/services/message.service.ts
@@ -126,7 +126,7 @@ export class MessageService extends BaseService<
    * @returns The message history since the specified date.
    */
   async findLastMessages(subscriber: Subscriber, limit: number = 5) {
-    const lastMessages = await this.findPage(
+    const lastMessages = await this.find(
       {
         $or: [{ sender: subscriber.id }, { recipient: subscriber.id }],
       },

--- a/api/src/cms/controllers/content.controller.ts
+++ b/api/src/cms/controllers/content.controller.ts
@@ -283,10 +283,7 @@ export class ContentController extends BaseController<
       );
       throw new NotFoundException(`ContentType of id ${contentType} not found`);
     }
-    return await this.contentService.findPage(
-      { entity: contentType },
-      pageQuery,
-    );
+    return await this.contentService.find({ entity: contentType }, pageQuery);
   }
 
   /**

--- a/api/src/cms/services/content.service.ts
+++ b/api/src/cms/services/content.service.ts
@@ -170,7 +170,7 @@ export class ContentService extends BaseService<
       }
 
       try {
-        const contents = await this.findPage(query, {
+        const contents = await this.find(query, {
           skip,
           limit,
           sort: ['createdAt', 'desc'],

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -275,12 +275,26 @@ export abstract class BaseRepository<
     }
   }
 
+  /**
+   * @deprecated
+   */
   async find(
     filter: TFilterQuery<T>,
-    // TODO: QuerySortDto<T> type need to be removed
+    pageQuery?: QuerySortDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<T[]>;
+
+  async find(
+    filter: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
-  ) {
+  ): Promise<T[]>;
+
+  async find(
+    filter: TFilterQuery<T>,
+    pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<T[]> {
     const query = this.findQuery(filter, pageQuery, projection);
     return await this.execute(query, this.cls);
   }
@@ -291,12 +305,26 @@ export abstract class BaseRepository<
     }
   }
 
+  /**
+   * @deprecated
+   */
   async findAndPopulate(
     filters: TFilterQuery<T>,
-    // TODO: QuerySortDto<T> need to be removed
+    pageQuery?: QuerySortDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<TFull[]>;
+
+  async findAndPopulate(
+    filters: TFilterQuery<T>,
+    pageQuery?: PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<TFull[]>;
+
+  async findAndPopulate(
+    filters: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
-  ) {
+  ): Promise<TFull[]> {
     this.ensureCanPopulate();
     const query = this.findQuery(filters, pageQuery, projection).populate(
       this.populate,

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -279,18 +279,18 @@ export abstract class BaseRepository<
     if (Array.isArray(pageQuery)) {
       const query = this.model.find<T>(filter, projection);
       return query.sort([pageQuery] as [string, SortOrder][]);
-    } else {
-      const {
-        skip = 0,
-        limit = 0,
-        sort = ['createdAt', 'asc'],
-      } = pageQuery || {};
-      const query = this.model.find<T>(filter, projection);
-      return query
-        .skip(skip)
-        .limit(limit)
-        .sort([sort] as [string, SortOrder][]);
     }
+
+    const {
+      skip = 0,
+      limit = 0,
+      sort = ['createdAt', 'asc'],
+    } = pageQuery || {};
+    const query = this.model.find<T>(filter, projection);
+    return query
+      .skip(skip)
+      .limit(limit)
+      .sort([sort] as [string, SortOrder][]);
   }
 
   async find(
@@ -354,12 +354,12 @@ export abstract class BaseRepository<
         this.populate,
       );
       return await this.execute(query, this.clsPopulate);
-    } else {
-      const query = this.findQuery(filters, pageQuery, projection).populate(
-        this.populate,
-      );
-      return await this.execute(query, this.clsPopulate);
     }
+
+    const query = this.findQuery(filters, pageQuery, projection).populate(
+      this.populate,
+    );
+    return await this.execute(query, this.clsPopulate);
   }
 
   protected findAllQuery(

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -362,11 +362,11 @@ export abstract class BaseRepository<
   }
 
   protected findAllQuery(sort?: QuerySortDto<T>) {
-    return this.findQuery({}, { limit: 0, skip: undefined, sort });
+    return this.findQuery({}, { limit: 0, skip: 0, sort });
   }
 
   async findAll(sort?: QuerySortDto<T>) {
-    return await this.find({}, { limit: 0, skip: undefined, sort });
+    return await this.find({}, { limit: 0, skip: 0, sort });
   }
 
   async findAllAndPopulate(sort?: QuerySortDto<T>) {

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -257,20 +257,28 @@ export abstract class BaseRepository<
 
   protected findQuery(
     filter: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
+    // TODO: QuerySortDto<T> type need to be removed
+    pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ) {
-    const { skip = 0, limit, sort = ['createdAt', 'asc'] } = pageQuery || {};
-    const query = this.model.find<T>(filter, projection);
-    return query
-      .skip(skip)
-      .limit(limit)
-      .sort([sort] as [string, SortOrder][]);
+    // TODO: current block need to be removed
+    if (Array.isArray(pageQuery)) {
+      const query = this.model.find<T>(filter, projection);
+      return query.sort([pageQuery] as [string, SortOrder][]);
+    } else {
+      const { skip = 0, limit, sort = ['createdAt', 'asc'] } = pageQuery || {};
+      const query = this.model.find<T>(filter, projection);
+      return query
+        .skip(skip)
+        .limit(limit)
+        .sort([sort] as [string, SortOrder][]);
+    }
   }
 
   async find(
     filter: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
+    // TODO: QuerySortDto<T> type need to be removed
+    pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ) {
     const query = this.findQuery(filter, pageQuery, projection);
@@ -285,7 +293,8 @@ export abstract class BaseRepository<
 
   async findAndPopulate(
     filters: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
+    // TODO: QuerySortDto<T> need to be removed
+    pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ) {
     this.ensureCanPopulate();

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -256,18 +256,18 @@ export abstract class BaseRepository<
     return await this.executeOne(query, this.clsPopulate);
   }
 
+  protected findQuery(
+    filter: TFilterQuery<T>,
+    pageQuery?: PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Query<T[], T, object, T, 'find', object>;
+
   /**
    * @deprecated
    */
   protected findQuery(
     filter: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T>,
-    projection?: ProjectionType<T>,
-  ): Query<T[], T, object, T, 'find', object>;
-
-  protected findQuery(
-    filter: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ): Query<T[], T, object, T, 'find', object>;
 
@@ -293,18 +293,18 @@ export abstract class BaseRepository<
     }
   }
 
+  async find(
+    filter: TFilterQuery<T>,
+    pageQuery?: PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<T[]>;
+
   /**
    * @deprecated
    */
   async find(
     filter: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T>,
-    projection?: ProjectionType<T>,
-  ): Promise<T[]>;
-
-  async find(
-    filter: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ): Promise<T[]>;
 
@@ -328,18 +328,18 @@ export abstract class BaseRepository<
     }
   }
 
+  async findAndPopulate(
+    filters: TFilterQuery<T>,
+    pageQuery?: PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<TFull[]>;
+
   /**
    * @deprecated
    */
   async findAndPopulate(
     filters: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T>,
-    projection?: ProjectionType<T>,
-  ): Promise<TFull[]>;
-
-  async findAndPopulate(
-    filters: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ): Promise<TFull[]>;
 

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -279,7 +279,11 @@ export abstract class BaseRepository<
       const query = this.model.find<T>(filter, projection);
       return query.sort([pageQuery] as [string, SortOrder][]);
     } else {
-      const { skip = 0, limit, sort = ['createdAt', 'asc'] } = pageQuery || {};
+      const {
+        skip = 0,
+        limit = 0,
+        sort = ['createdAt', 'asc'],
+      } = pageQuery || {};
       const query = this.model.find<T>(filter, projection);
       return query
         .skip(skip)
@@ -358,11 +362,11 @@ export abstract class BaseRepository<
   }
 
   protected findAllQuery(sort?: QuerySortDto<T>) {
-    return this.findQuery({}, { limit: undefined, skip: undefined, sort });
+    return this.findQuery({}, { limit: 0, skip: undefined, sort });
   }
 
   async findAll(sort?: QuerySortDto<T>) {
-    return await this.find({}, { limit: undefined, skip: undefined, sort });
+    return await this.find({}, { limit: 0, skip: undefined, sort });
   }
 
   async findAllAndPopulate(sort?: QuerySortDto<T>) {

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -44,18 +44,18 @@ export abstract class BaseService<
     return await this.repository.findOneAndPopulate(criteria, projection);
   }
 
+  async find(
+    filter: TFilterQuery<T>,
+    pageQuery?: PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<T[]>;
+
   /**
    * @deprecated
    */
   async find(
     filter: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T>,
-    projection?: ProjectionType<T>,
-  ): Promise<T[]>;
-
-  async find(
-    filter: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ): Promise<T[]>;
 
@@ -70,18 +70,18 @@ export abstract class BaseService<
     return await this.repository.find(filter, pageQuery, projection);
   }
 
+  async findAndPopulate(
+    filters: TFilterQuery<T>,
+    pageQuery?: PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<TFull[]>;
+
   /**
    * @deprecated
    */
   async findAndPopulate(
     filters: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T>,
-    projection?: ProjectionType<T>,
-  ): Promise<TFull[]>;
-
-  async findAndPopulate(
-    filters: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ): Promise<TFull[]>;
 

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -44,21 +44,59 @@ export abstract class BaseService<
     return await this.repository.findOneAndPopulate(criteria, projection);
   }
 
+  /**
+   * @deprecated
+   */
   async find(
     filter: TFilterQuery<T>,
-    // TODO: QuerySortDto<T> type need to be removed
+    pageQuery?: QuerySortDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<T[]>;
+
+  async find(
+    filter: TFilterQuery<T>,
+    pageQuery?: PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<T[]>;
+
+  async find(
+    filter: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ): Promise<T[]> {
+    if (Array.isArray(pageQuery))
+      return await this.repository.find(filter, pageQuery, projection);
+
     return await this.repository.find(filter, pageQuery, projection);
   }
 
+  /**
+   * @deprecated
+   */
   async findAndPopulate(
     filters: TFilterQuery<T>,
-    // TODO: QuerySortDto<T> type need to be removed
+    pageQuery?: QuerySortDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<TFull[]>;
+
+  async findAndPopulate(
+    filters: TFilterQuery<T>,
+    pageQuery?: PageQueryDto<T>,
+    projection?: ProjectionType<T>,
+  ): Promise<TFull[]>;
+
+  async findAndPopulate(
+    filters: TFilterQuery<T>,
     pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
-  ) {
+  ): Promise<TFull[]> {
+    if (Array.isArray(pageQuery))
+      return await this.repository.findAndPopulate(
+        filters,
+        pageQuery,
+        projection,
+      );
+
     return await this.repository.findAndPopulate(
       filters,
       pageQuery,

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -46,7 +46,8 @@ export abstract class BaseService<
 
   async find(
     filter: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
+    // TODO: QuerySortDto<T> type need to be removed
+    pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ): Promise<T[]> {
     return await this.repository.find(filter, pageQuery, projection);
@@ -54,7 +55,8 @@ export abstract class BaseService<
 
   async findAndPopulate(
     filters: TFilterQuery<T>,
-    pageQuery?: PageQueryDto<T>,
+    // TODO: QuerySortDto<T> type need to be removed
+    pageQuery?: QuerySortDto<T> | PageQueryDto<T>,
     projection?: ProjectionType<T>,
   ) {
     return await this.repository.findAndPopulate(


### PR DESCRIPTION
# Motivation
The motivation of this PR is to add retro compatibility for find and findAndPopulate methods.

![image](https://github.com/user-attachments/assets/d044bec2-19f4-44ca-b306-6cafd59623e3)
reference: https://www.mongodb.com/docs/manual/reference/method/cursor.limit/

Fixes #418

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes