### PR TITLE
fix: sync UI button max number validation with the API validation

### DIFF
--- a/frontend/src/components/visual-editor/form/inputs/message/ButtonsInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/message/ButtonsInput.tsx
@@ -32,7 +32,7 @@ const ButtonsInput: FC<ButtonsInput> = ({
   value,
   onChange,
   minInput = 1,
-  maxInput = 13,
+  maxInput = 3,
   disablePayload = false,
   fieldPath,
 }) => {


### PR DESCRIPTION
# Motivation
The motivation of this PR is to make equal the validation of the max number of buttons between API and the UI.

Fixes #321

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes