### PR TITLE
Fix : Number settings gets saved as strings in MongoDB

### DIFF
--- a/api/src/setting/repositories/setting.repository.ts
+++ b/api/src/setting/repositories/setting.repository.ts
@@ -150,7 +150,7 @@ export class SettingRepository extends BaseRepository<Setting> {
     } else if (type === SettingType.secret && typeof value !== 'string') {
       throw new Error('Setting Model (secret) : Value must be a string');
     } else if (type === SettingType.select && typeof value !== 'string') {
-      throw new Error('Setting Model (select): Value must be a string array!');
+      throw new Error('Setting Model (select): Value must be a string!');
     }
   }
 

--- a/api/src/setting/repositories/setting.repository.ts
+++ b/api/src/setting/repositories/setting.repository.ts
@@ -118,13 +118,10 @@ export class SettingRepository extends BaseRepository<Setting> {
     ) {
       throw new Error('Setting Model : Value must be a string!');
     } else if (type === SettingType.multiple_text) {
-      const isStringArray =
-        Array.isArray(value) &&
-        value.every((v) => {
-          return typeof v === 'string';
-        });
-      if (!isStringArray) {
-        throw new Error('Setting Model : Value must be a string array!');
+      if (!this.isArrayOfString(value)) {
+        throw new Error(
+          'Setting Model (Multiple Text) : Value must be a string array!',
+        );
       }
     } else if (
       type === SettingType.checkbox &&
@@ -138,6 +135,26 @@ export class SettingRepository extends BaseRepository<Setting> {
       value !== null
     ) {
       throw new Error('Setting Model : Value must be a number!');
+    } else if (type === SettingType.multiple_attachment) {
+      if (!this.isArrayOfString(value)) {
+        throw new Error(
+          'Setting Model (Multiple Attachement): Value must be a string array!',
+        );
+      }
+    } else if (type === SettingType.attachment) {
+      if (typeof value !== 'string' && typeof value !== null) {
+        throw new Error(
+          'Setting Model (attachement): Value must be a string or null !',
+        );
+      }
+    } else if (type === SettingType.secret && typeof value !== 'string') {
+      throw new Error('Setting Model (secret) : Value must be a string');
+    } else if (type === SettingType.select && typeof value !== 'string') {
+      throw new Error('Setting Model (select): Value must be a string array!');
     }
+  }
+
+  private isArrayOfString(value: any): boolean {
+    return Array.isArray(value) && value.every((v) => typeof v === 'string');
   }
 }

--- a/api/src/setting/repositories/setting.repository.ts
+++ b/api/src/setting/repositories/setting.repository.ts
@@ -40,7 +40,7 @@ export class SettingRepository extends BaseRepository<Setting> {
    *
    * @param setting The `Setting` document to be validated.
    */
-  async postValidate(
+  async preCreateValidate(
     setting: Document<unknown, unknown, Setting> &
       Setting & { _id: Types.ObjectId },
   ) {

--- a/api/src/utils/generics/base-repository.spec.ts
+++ b/api/src/utils/generics/base-repository.spec.ts
@@ -209,14 +209,10 @@ describe('BaseRepository', () => {
       await dummyRepository.updateOne(created.id, mockUpdate);
 
       expect(spyPreUpdateValidate).toHaveBeenCalledWith(
-        created.id,
-        mockUpdate,
         mockGetFilterValue,
         mockGetUpdateValue,
       );
       expect(spyPostUpdateValidate).toHaveBeenCalledWith(
-        created.id,
-        mockUpdate,
         mockGetFilterValue,
         mockGetUpdateValue,
       );
@@ -261,8 +257,6 @@ describe('BaseRepository', () => {
       ).rejects.toThrow('Mocked error while validating dummy');
 
       expect(spyPreUpdateValidate).toHaveBeenCalledWith(
-        created.id,
-        mockUpdate,
         mockGetFilterValue,
         mockGetUpdateValue,
       );

--- a/api/src/utils/generics/base-repository.spec.ts
+++ b/api/src/utils/generics/base-repository.spec.ts
@@ -6,22 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-/*
- * Copyright © 2024 Hexastack. All rights reserved.
- *
- * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
- * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
- * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
- */
-
-/*
- * Copyright © 2024 Hexastack. All rights reserved.
- *
- * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
- * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
- * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
- */
-
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Model, Types } from 'mongoose';

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -14,6 +14,7 @@ import {
 import { ClassTransformOptions, plainToClass } from 'class-transformer';
 import {
   Document,
+  FilterQuery,
   FlattenMaps,
   HydratedDocument,
   Model,
@@ -48,6 +49,8 @@ export enum EHook {
   postUpdateMany = 'postUpdateMany',
   postDelete = 'postDelete',
   postCreateValidate = 'postCreateValidate',
+  preUpdateValidate = 'preUpdateValidate',
+  postUpdateValidate = 'postUpdateValidate',
 }
 
 export abstract class BaseRepository<
@@ -460,6 +463,10 @@ export abstract class BaseRepository<
         new: true,
       },
     );
+    const filterCriteria = query.getFilter();
+    const queryUpdates = query.getUpdate();
+    await this.preUpdateValidate(criteria, dto, filterCriteria, queryUpdates);
+    await this.postUpdateValidate(criteria, dto, filterCriteria, queryUpdates);
     return await this.executeOne(query, this.cls);
   }
 
@@ -482,11 +489,33 @@ export abstract class BaseRepository<
     return await this.model.deleteMany(criteria);
   }
 
-  async preCreateValidate(_doc: HydratedDocument<T>): Promise<void> {
+  async preCreateValidate(
+    _doc: HydratedDocument<T>,
+    _filterCriteria?: FilterQuery<T>,
+    _updates?: UpdateWithAggregationPipeline | UpdateQuery<T>,
+  ): Promise<void> {
     // Nothing ...
   }
 
   async postCreateValidate(_validated: HydratedDocument<T>): Promise<void> {
+    // Nothing ...
+  }
+
+  async preUpdateValidate<D extends Partial<U>>(
+    _criteria: string | TFilterQuery<T>,
+    _dto: UpdateQuery<D>,
+    _filterCriteria: FilterQuery<T>,
+    _updates: UpdateWithAggregationPipeline | UpdateQuery<T>,
+  ): Promise<void> {
+    // Nothing ...
+  }
+
+  async postUpdateValidate<D extends Partial<U>>(
+    _criteria: string | TFilterQuery<T>,
+    _dto: UpdateQuery<D>,
+    _filterCriteria: FilterQuery<T>,
+    _updates: UpdateWithAggregationPipeline | UpdateQuery<T>,
+  ): Promise<void> {
     // Nothing ...
   }
 

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -52,6 +52,17 @@ export enum EHook {
   preUpdateValidate = 'preUpdateValidate',
   postUpdateValidate = 'postUpdateValidate',
 }
+// ! ------------------------------------ Note --------------------------------------------
+// Methods like `update()`, `updateOne()`, `updateMany()`, `findOneAndUpdate()`,
+// `findByIdAndUpdate()`, `findOneAndReplace()`, `findOneAndDelete()`, and `findByIdAndDelete()`
+// do not trigger Mongoose validation hooks by default. This is because these methods do not
+// return Mongoose Documents but plain JavaScript objects (POJOs), which do not have Mongoose
+// instance methods like `validate()` attached.
+//
+// Be cautious when using the `.lean()` function as well. It returns POJOs instead of Mongoose
+// Documents, so methods and hooks like `validate()` will not be available when working with
+// the returned data. If you need validation, ensure that you're working with a Mongoose Document
+// or explicitly use `runValidators: true` in the options for update operations.
 
 export abstract class BaseRepository<
   T extends FlattenMaps<unknown>,

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -42,12 +42,12 @@ export enum EHook {
   preUpdate = 'preUpdate',
   preUpdateMany = 'preUpdateMany',
   preDelete = 'preDelete',
-  preValidate = 'preValidate',
+  preCreateValidate = 'preCreateValidate',
   postCreate = 'postCreate',
   postUpdate = 'postUpdate',
   postUpdateMany = 'postUpdateMany',
   postDelete = 'postDelete',
-  postValidate = 'postValidate',
+  postCreateValidate = 'postCreateValidate',
 }
 
 export abstract class BaseRepository<
@@ -87,13 +87,16 @@ export abstract class BaseRepository<
     hooks?.validate.pre.execute(async function () {
       const doc = this as HydratedDocument<T>;
       await repository.preCreateValidate(doc);
-      repository.emitter.emit(repository.getEventName(EHook.preValidate), doc);
+      repository.emitter.emit(
+        repository.getEventName(EHook.preCreateValidate),
+        doc,
+      );
     });
 
     hooks?.validate.post.execute(async function (created: HydratedDocument<T>) {
       await repository.postCreateValidate(created);
       repository.emitter.emit(
-        repository.getEventName(EHook.postValidate),
+        repository.getEventName(EHook.postCreateValidate),
         created,
       );
     });

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -86,12 +86,12 @@ export abstract class BaseRepository<
 
     hooks?.validate.pre.execute(async function () {
       const doc = this as HydratedDocument<T>;
-      await repository.preValidate(doc);
+      await repository.preCreateValidate(doc);
       repository.emitter.emit(repository.getEventName(EHook.preValidate), doc);
     });
 
     hooks?.validate.post.execute(async function (created: HydratedDocument<T>) {
-      await repository.postValidate(created);
+      await repository.postCreateValidate(created);
       repository.emitter.emit(
         repository.getEventName(EHook.postValidate),
         created,
@@ -479,11 +479,11 @@ export abstract class BaseRepository<
     return await this.model.deleteMany(criteria);
   }
 
-  async preValidate(_doc: HydratedDocument<T>): Promise<void> {
+  async preCreateValidate(_doc: HydratedDocument<T>): Promise<void> {
     // Nothing ...
   }
 
-  async postValidate(_validated: HydratedDocument<T>): Promise<void> {
+  async postCreateValidate(_validated: HydratedDocument<T>): Promise<void> {
     // Nothing ...
   }
 

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -39,19 +39,20 @@ export type DeleteResult = {
 };
 
 export enum EHook {
+  preCreateValidate = 'preCreateValidate',
   preCreate = 'preCreate',
+  preUpdateValidate = 'preUpdateValidate',
   preUpdate = 'preUpdate',
   preUpdateMany = 'preUpdateMany',
   preDelete = 'preDelete',
-  preCreateValidate = 'preCreateValidate',
+  postCreateValidate = 'postCreateValidate',
   postCreate = 'postCreate',
+  postUpdateValidate = 'postUpdateValidate',
   postUpdate = 'postUpdate',
   postUpdateMany = 'postUpdateMany',
   postDelete = 'postDelete',
-  postCreateValidate = 'postCreateValidate',
-  preUpdateValidate = 'preUpdateValidate',
-  postUpdateValidate = 'postUpdateValidate',
 }
+
 // ! ------------------------------------ Note --------------------------------------------
 // Methods like `update()`, `updateOne()`, `updateMany()`, `findOneAndUpdate()`,
 // `findByIdAndUpdate()`, `findOneAndReplace()`, `findOneAndDelete()`, and `findByIdAndDelete()`
@@ -476,8 +477,21 @@ export abstract class BaseRepository<
     );
     const filterCriteria = query.getFilter();
     const queryUpdates = query.getUpdate();
-    await this.preUpdateValidate(criteria, dto, filterCriteria, queryUpdates);
-    await this.postUpdateValidate(criteria, dto, filterCriteria, queryUpdates);
+
+    await this.preUpdateValidate(filterCriteria, queryUpdates);
+    this.emitter.emit(
+      this.getEventName(EHook.preUpdateValidate),
+      filterCriteria,
+      queryUpdates,
+    );
+
+    await this.postUpdateValidate(filterCriteria, queryUpdates);
+    this.emitter.emit(
+      this.getEventName(EHook.postUpdateValidate),
+      filterCriteria,
+      queryUpdates,
+    );
+
     return await this.executeOne(query, this.cls);
   }
 
@@ -512,18 +526,14 @@ export abstract class BaseRepository<
     // Nothing ...
   }
 
-  async preUpdateValidate<D extends Partial<U>>(
-    _criteria: string | TFilterQuery<T>,
-    _dto: UpdateQuery<D>,
+  async preUpdateValidate(
     _filterCriteria: FilterQuery<T>,
     _updates: UpdateWithAggregationPipeline | UpdateQuery<T>,
   ): Promise<void> {
     // Nothing ...
   }
 
-  async postUpdateValidate<D extends Partial<U>>(
-    _criteria: string | TFilterQuery<T>,
-    _dto: UpdateQuery<D>,
+  async postUpdateValidate(
     _filterCriteria: FilterQuery<T>,
     _updates: UpdateWithAggregationPipeline | UpdateQuery<T>,
   ): Promise<void> {

--- a/api/types/event-emitter.d.ts
+++ b/api/types/event-emitter.d.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import type { Document, FilterQuery, Query } from 'mongoose';
+import type { Document, Query } from 'mongoose';
 import { type Socket } from 'socket.io';
 
 import { type BotStats } from '@/analytics/schemas/bot-stats.schema';
@@ -179,11 +179,13 @@ declare module '@nestjs/event-emitter' {
   type EventNamespaces = keyof IHookEntityOperationMap;
 
   /* pre hooks */
-  type TPreValidate<T> = THydratedDocument<T>;
+  type TPreCreateValidate<T> = THydratedDocument<T>;
 
   type TPreCreate<T> = THydratedDocument<T>;
 
-  type TPreUpdate<T> = TFilterQuery<T> & object;
+  type TPreUpdateValidate<T> = FilterQuery<T>;
+
+  type TPreUpdate<T> = TFilterQuery<T>;
 
   type TPreDelete<T> = Query<
     DeleteResult,
@@ -195,27 +197,27 @@ declare module '@nestjs/event-emitter' {
   >;
 
   type TPreUnion<T> =
-    | TPreValidate<T>
+    | TPreCreateValidate<T>
     | TPreCreate<T>
+    | TPreUpdateValidate<T>
     | TPreUpdate<T>
     | TPreDelete<T>;
 
   /* post hooks */
-  type TPostValidate<T> = THydratedDocument<T>;
+  type TPostCreateValidate<T> = THydratedDocument<T>;
 
   type TPostCreate<T> = THydratedDocument<T>;
 
+  type TPostUpdateValidate<T> = FilterQuery<T>;
+
   type TPostUpdate<T> = THydratedDocument<T>;
-
-  type TPreUpdateValidate<T> = FilterQuery<T>;
-
-  type TPostUpdateValidate<T> = THydratedDocument<T>;
 
   type TPostDelete = DeleteResult;
 
   type TPostUnion<T> =
-    | TPostValidate<T>
+    | TPostCreateValidate<T>
     | TPostCreate<T>
+    | TPostUpdateValidate<T>
     | TPostUpdate<T>
     | TPostDelete;
 
@@ -251,10 +253,13 @@ declare module '@nestjs/event-emitter' {
     T = IHookEntityOperationMap[E]['schema'],
   > =
     | {
-        [EHook.preCreateValidate]: TPreValidate<T>;
+        [EHook.preCreateValidate]: TPreCreateValidate<T>;
       }
     | {
         [EHook.preCreate]: TPreCreate<T>;
+      }
+    | {
+        [EHook.preUpdateValidate]: TPreUpdateValidate<T>;
       }
     | {
         [EHook.preUpdate]: TPreUpdate<T>;
@@ -263,22 +268,19 @@ declare module '@nestjs/event-emitter' {
         [EHook.preDelete]: TPreDelete<T>;
       }
     | {
-        [EHook.postCreateValidate]: TPostValidate<T>;
+        [EHook.postCreateValidate]: TPostCreateValidate<T>;
       }
     | {
         [EHook.postCreate]: TPostCreate<T>;
+      }
+    | {
+        [EHook.postUpdateValidate]: TPostUpdateValidate<T>;
       }
     | {
         [EHook.postUpdate]: TPostUpdate<T>;
       }
     | {
         [EHook.postDelete]: TPostDelete;
-      }
-    | {
-        [EHook.preUpdateValidate]: TPreUpdateValidate<T>;
-      }
-    | {
-        [EHook.postUpdateValidate]: TPostUpdateValidate<T>;
       };
 
   type TNormalizedHook<E extends keyof IHookEntityOperationMap, O> = Extract<

--- a/api/types/event-emitter.d.ts
+++ b/api/types/event-emitter.d.ts
@@ -247,7 +247,7 @@ declare module '@nestjs/event-emitter' {
     T = IHookEntityOperationMap[E]['schema'],
   > =
     | {
-        [EHook.preValidate]: TPreValidate<T>;
+        [EHook.preCreateValidate]: TPreValidate<T>;
       }
     | {
         [EHook.preCreate]: TPreCreate<T>;
@@ -259,7 +259,7 @@ declare module '@nestjs/event-emitter' {
         [EHook.preDelete]: TPreDelete<T>;
       }
     | {
-        [EHook.postValidate]: TPostValidate<T>;
+        [EHook.postCreateValidate]: TPostValidate<T>;
       }
     | {
         [EHook.postCreate]: TPostCreate<T>;

--- a/api/types/event-emitter.d.ts
+++ b/api/types/event-emitter.d.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import type { Document, Query } from 'mongoose';
+import type { Document, FilterQuery, Query } from 'mongoose';
 import { type Socket } from 'socket.io';
 
 import { type BotStats } from '@/analytics/schemas/bot-stats.schema';
@@ -207,6 +207,10 @@ declare module '@nestjs/event-emitter' {
 
   type TPostUpdate<T> = THydratedDocument<T>;
 
+  type TPreUpdateValidate<T> = FilterQuery<T>;
+
+  type TPostUpdateValidate<T> = THydratedDocument<T>;
+
   type TPostDelete = DeleteResult;
 
   type TPostUnion<T> =
@@ -269,6 +273,12 @@ declare module '@nestjs/event-emitter' {
       }
     | {
         [EHook.postDelete]: TPostDelete;
+      }
+    | {
+        [EHook.preUpdateValidate]: TPreUpdateValidate<T>;
+      }
+    | {
+        [EHook.postUpdateValidate]: TPostUpdateValidate<T>;
       };
 
   type TNormalizedHook<E extends keyof IHookEntityOperationMap, O> = Extract<

--- a/frontend/src/components/settings/SettingInput.tsx
+++ b/frontend/src/components/settings/SettingInput.tsx
@@ -95,6 +95,7 @@ const SettingInput: React.FC<RenderSettingInputProps> = ({
           label={label}
           helperText={helperText}
           {...field}
+          onChange={(e) => field.onChange(Number(e.target.value))}
           disabled={isDisabled(setting)}
         />
       );

--- a/frontend/src/components/settings/index.tsx
+++ b/frontend/src/components/settings/index.tsx
@@ -133,14 +133,8 @@ export const Settings = () => {
   useEffect(() => {
     const subscription = watch((values, { name }) => {
       const [group, label] = (name as string).split(".");
-      const currentSettingValue = values[group][label] as any;
-      // if setting value is Number but typed string convert it to number
-      const settingValue =
-        typeof values[group][label] === "string" && isNaN(currentSettingValue)
-          ? values[group][label]
-          : Number(values[group][label]);
 
-      debouncedUpdate(group, label, settingValue);
+      debouncedUpdate(group, label, values[group][label]);
     });
 
     return () => {

--- a/frontend/src/components/settings/index.tsx
+++ b/frontend/src/components/settings/index.tsx
@@ -133,8 +133,14 @@ export const Settings = () => {
   useEffect(() => {
     const subscription = watch((values, { name }) => {
       const [group, label] = (name as string).split(".");
+      const currentSettingValue = values[group][label] as any;
+      // if setting value is Number but typed string convert it to number
+      const settingValue =
+        typeof values[group][label] === "string" && isNaN(currentSettingValue)
+          ? values[group][label]
+          : Number(values[group][label]);
 
-      debouncedUpdate(group, label, values[group][label]);
+      debouncedUpdate(group, label, settingValue);
     });
 
     return () => {


### PR DESCRIPTION
# Motivation

This PR fixes the issue when updating a setting field that should be saved as Number and saved as String in MongoDB because mongoose middleware/hooks does not run by default on findOneAndUpdate

Fixes #427

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas