### PR TITLE
fix: display contentType text-area fields in list block

### DIFF
--- a/frontend/src/components/visual-editor/form/ListMessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/ListMessageForm.tsx
@@ -172,7 +172,6 @@ const ListMessageForm = () => {
         <FormLabel component="h4" sx={{ marginBottom: "1rem" }}>
           {t("title.fields_map")}
         </FormLabel>
-        {/* here! */}
         <ContentItem>
           <Controller
             name="options.content.fields.title"

--- a/frontend/src/components/visual-editor/form/ListMessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/ListMessageForm.tsx
@@ -172,6 +172,7 @@ const ListMessageForm = () => {
         <FormLabel component="h4" sx={{ marginBottom: "1rem" }}>
           {t("title.fields_map")}
         </FormLabel>
+        {/* here! */}
         <ContentItem>
           <Controller
             name="options.content.fields.title"
@@ -186,7 +187,9 @@ const ListMessageForm = () => {
               return (
                 <AutoCompleteSelect<ContentField, "label", false>
                   options={(contentType?.fields || []).filter(
-                    ({ type }) => ContentFieldType.TEXT === type,
+                    ({ type }) =>
+                      ContentFieldType.TEXT === type ||
+                      ContentFieldType.TEXTAREA === type,
                   )}
                   idKey="name"
                   labelKey="label"
@@ -214,7 +217,9 @@ const ListMessageForm = () => {
               return (
                 <AutoCompleteSelect<ContentField, "label", false>
                   options={(contentType?.fields || []).filter(
-                    ({ type }) => ContentFieldType.TEXT === type,
+                    ({ type }) =>
+                      ContentFieldType.TEXT === type ||
+                      ContentFieldType.TEXTAREA === type,
                   )}
                   idKey="name"
                   labelKey="label"

--- a/frontend/src/components/visual-editor/form/ListMessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/ListMessageForm.tsx
@@ -186,9 +186,7 @@ const ListMessageForm = () => {
               return (
                 <AutoCompleteSelect<ContentField, "label", false>
                   options={(contentType?.fields || []).filter(
-                    ({ type }) =>
-                      ContentFieldType.TEXT === type ||
-                      ContentFieldType.TEXTAREA === type,
+                    ({ type }) => ContentFieldType.TEXT === type,
                   )}
                   idKey="name"
                   labelKey="label"


### PR DESCRIPTION
# Motivation

This PR addresses the issue in List Block contentTypes of type text-area aren't displayed as an option 
Fixes #452

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
