### PR TITLE
fix(frontend): add missing autofocus for content add edit dialogs

### DIFF
--- a/frontend/src/components/contents/ContentDialog.tsx
+++ b/frontend/src/components/contents/ContentDialog.tsx
@@ -68,6 +68,7 @@ const ContentFieldInput: React.FC<ContentFieldInput> = ({
     case ContentFieldType.URL:
       return (
         <Input
+          autoFocus
           multiline={contentField.type === ContentFieldType.TEXTAREA}
           rows={contentField.type === ContentFieldType.TEXTAREA ? 5 : 1}
           label={t(`label.${contentField.name}`, {


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to add the missing autofocus attribute to the content add/edit dialog's component.

Fixes #457

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes