### PR TITLE
feat: change scope

### DIFF
--- a/api/src/logger/logger.service.ts
+++ b/api/src/logger/logger.service.ts
@@ -6,6 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { ConsoleLogger } from '@nestjs/common';
+import { ConsoleLogger, Injectable, Scope } from '@nestjs/common';
 
+@Injectable({ scope: Scope.TRANSIENT })
 export class LoggerService extends ConsoleLogger {}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -84,9 +84,9 @@ async function bootstrap() {
     app.useWebSocketAdapter(redisIoAdapter);
   }
 
-  process.on('uncaughtException', (error) => {
+  process.on('uncaughtException', async (error) => {
     if (error.stack.toLowerCase().includes('smtp'))
-      app.get(LoggerService).error('SMTP error', error.stack);
+      (await app.resolve(LoggerService)).error('SMTP error', error.stack);
     else throw error;
   });
 
@@ -95,7 +95,7 @@ async function bootstrap() {
     swagger(app);
   }
 
-  await app.listen(3000);
+  await app.listen(4001);
 }
 
 bootstrap();

--- a/api/src/seeder.ts
+++ b/api/src/seeder.ts
@@ -33,7 +33,7 @@ import { UserSeeder } from './user/seeds/user.seed';
 import { userModels } from './user/seeds/user.seed-model';
 
 export async function seedDatabase(app: INestApplicationContext) {
-  const logger = app.get(LoggerService);
+  const logger = await app.resolve(LoggerService);
   const modelSeeder = app.get(ModelSeeder);
   const categorySeeder = app.get(CategorySeeder);
   const contextVarSeeder = app.get(ContextVarSeeder);


### PR DESCRIPTION

This PR changes the `LoggerService` scope from `singleton` to `transient`. The main motivation for this change is to allow adding context-specific data for each class that uses the `LoggerService`.By making the service `transient`, a new instance of `LoggerService` will be created for each injection, enabling us to set a unique context for logging per class.**Implications**  
- **Pros** :
  - Enables class-specific logging contexts, improving traceability and debugging.

  - More flexible for future logging enhancements.
 
- **Cons** :
  - Loss of singleton behavior means there will be multiple instances, potentially increasing memory usage slightly.