### PR TITLE
fix: utilities decorators IsLessThanDate, IsObjectId

### DIFF
--- a/api/src/analytics/validation-rules/is-less-than-date.ts
+++ b/api/src/analytics/validation-rules/is-less-than-date.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,15 +8,15 @@
 
 import {
   registerDecorator,
-  ValidationOptions,
   ValidationArguments,
+  ValidationOptions,
 } from 'class-validator';
 
 export function IsLessThanDate(
   property: string,
   validationOptions?: ValidationOptions,
 ) {
-  return (object: unknown, propertyName: string) => {
+  return (object: object, propertyName: string) => {
     registerDecorator({
       target: object.constructor,
       propertyName,

--- a/api/src/utils/validation-rules/is-object-id.ts
+++ b/api/src/utils/validation-rules/is-object-id.ts
@@ -11,7 +11,7 @@ import { Types } from 'mongoose';
 
 export const IsObjectId =
   (validationOptions?: ValidationOptions) =>
-  (object: unknown, propertyName: string) =>
+  (object: object, propertyName: string) =>
     registerDecorator({
       target: object.constructor,
       propertyName,


### PR DESCRIPTION
# Motivation

This PR fixes Decorator  IsLessThanDate and IsObjectId to comply with strict null check

Fixes # (issue)

# Type of change:

Please delete options that are not relevant.

- [x Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
