### PR TITLE
fix: disabled tsconfig strict Property Initialization

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -14,6 +14,7 @@
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
+    "strictPropertyInitialization": false,
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to disable strict Property Initialization

Fixes #525 

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes