### PR TITLE
fix: add missing add-extra-deps script to production Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -38,6 +38,8 @@ WORKDIR /app
 
 COPY package*.json ./
 
+COPY add-extra-deps.js ./
+
 COPY --from=builder /app/src/extensions ./src/extensions
 
 COPY --from=builder /app/patches ./patches


### PR DESCRIPTION
This pull request includes a change to the `api/Dockerfile` to add the missing extra dependency script to the production target Docker image.

* [`api/Dockerfile`](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47R41-R42): Added `add-extra-deps.js` to the Docker image to ensure additional dependencies are included during the build process.