### PR TITLE
feat: support dynamic DTOs: controller, service, repository and seed

### DIFF
--- a/api/src/channel/channel.service.ts
+++ b/api/src/channel/channel.service.ts
@@ -161,7 +161,6 @@ export class ChannelService {
         foreign_id: req.session.passport.user.id,
       },
       {
-        id: req.session.passport.user.id,
         foreign_id: req.session.passport.user.id,
         first_name: req.session.passport.user.first_name,
         last_name: req.session.passport.user.last_name,

--- a/api/src/chat/dto/block.dto.ts
+++ b/api/src/chat/dto/block.dto.ts
@@ -21,6 +21,7 @@ import {
   IsString,
 } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 import { CaptureVar } from '../schemas/types/capture-var';
@@ -146,3 +147,7 @@ export class BlockUpdateDto extends PartialType(
   @IsOptional()
   trigger_channels?: string[];
 }
+
+export type BlockDTOMap = DtoConfig<{
+  create: BlockCreateDto;
+}>;

--- a/api/src/chat/dto/block.dto.ts
+++ b/api/src/chat/dto/block.dto.ts
@@ -148,6 +148,6 @@ export class BlockUpdateDto extends PartialType(
   trigger_channels?: string[];
 }
 
-export type BlockDTOMap = DtoConfig<{
+export type BlockDTOMapActions = DtoConfig<{
   create: BlockCreateDto;
 }>;

--- a/api/src/chat/dto/block.dto.ts
+++ b/api/src/chat/dto/block.dto.ts
@@ -148,6 +148,6 @@ export class BlockUpdateDto extends PartialType(
   trigger_channels?: string[];
 }
 
-export type BlockDTOMapActions = DtoConfig<{
+export type BlockDto = DtoConfig<{
   create: BlockCreateDto;
 }>;

--- a/api/src/chat/dto/category.dto.ts
+++ b/api/src/chat/dto/category.dto.ts
@@ -8,13 +8,15 @@
 
 import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import {
+  IsArray,
   IsBoolean,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
   IsString,
-  IsNumber,
-  IsArray,
 } from 'class-validator';
+
+import { DtoConfig } from '@/utils/types/dto.types';
 
 export class CategoryCreateDto {
   @ApiProperty({ description: 'Category label', type: String })
@@ -39,3 +41,7 @@ export class CategoryCreateDto {
 }
 
 export class CategoryUpdateDto extends PartialType(CategoryCreateDto) {}
+
+export type CategoryDTOMapActions = DtoConfig<{
+  create: CategoryCreateDto;
+}>;

--- a/api/src/chat/dto/category.dto.ts
+++ b/api/src/chat/dto/category.dto.ts
@@ -42,6 +42,6 @@ export class CategoryCreateDto {
 
 export class CategoryUpdateDto extends PartialType(CategoryCreateDto) {}
 
-export type CategoryDTOMapActions = DtoConfig<{
+export type CategoryDto = DtoConfig<{
   create: CategoryCreateDto;
 }>;

--- a/api/src/chat/dto/context-var.dto.ts
+++ b/api/src/chat/dto/context-var.dto.ts
@@ -30,6 +30,6 @@ export class ContextVarCreateDto {
 
 export class ContextVarUpdateDto extends PartialType(ContextVarCreateDto) {}
 
-export type ContextVarDTOMapActions = DtoConfig<{
+export type ContextVarDto = DtoConfig<{
   create: ContextVarCreateDto;
 }>;

--- a/api/src/chat/dto/context-var.dto.ts
+++ b/api/src/chat/dto/context-var.dto.ts
@@ -9,6 +9,8 @@
 import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
+
 export class ContextVarCreateDto {
   @ApiProperty({ description: 'Context var label', type: String })
   @IsNotEmpty()
@@ -27,3 +29,7 @@ export class ContextVarCreateDto {
 }
 
 export class ContextVarUpdateDto extends PartialType(ContextVarCreateDto) {}
+
+export type ContextVarDTOMapActions = DtoConfig<{
+  create: ContextVarCreateDto;
+}>;

--- a/api/src/chat/dto/conversation.dto.ts
+++ b/api/src/chat/dto/conversation.dto.ts
@@ -58,6 +58,6 @@ export class ConversationCreateDto {
   next?: string[];
 }
 
-export type ConversationDTOCruds = DtoConfig<{
+export type ConversationDtoMapActions = DtoConfig<{
   create: ConversationCreateDto;
 }>;

--- a/api/src/chat/dto/conversation.dto.ts
+++ b/api/src/chat/dto/conversation.dto.ts
@@ -16,6 +16,7 @@ import {
   IsString,
 } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 import { Context } from './../schemas/types/context';
@@ -45,7 +46,7 @@ export class ConversationCreateDto {
   @IsObjectId({
     message: 'Current must be a valid objectId',
   })
-  current: string;
+  current?: string;
 
   @ApiProperty({ description: 'next conversation', type: Array })
   @IsOptional()
@@ -54,5 +55,9 @@ export class ConversationCreateDto {
     each: true,
     message: 'next must be a valid objectId',
   })
-  next: string[];
+  next?: string[];
 }
+
+export type IConversationDto = DtoConfig<{
+  create: ConversationCreateDto;
+}>;

--- a/api/src/chat/dto/conversation.dto.ts
+++ b/api/src/chat/dto/conversation.dto.ts
@@ -58,6 +58,6 @@ export class ConversationCreateDto {
   next?: string[];
 }
 
-export type TConversationCrudsDto = DtoConfig<{
+export type ConversationCrudsDto = DtoConfig<{
   create: ConversationCreateDto;
 }>;

--- a/api/src/chat/dto/conversation.dto.ts
+++ b/api/src/chat/dto/conversation.dto.ts
@@ -46,7 +46,7 @@ export class ConversationCreateDto {
   @IsObjectId({
     message: 'Current must be a valid objectId',
   })
-  current?: string;
+  current?: string | null;
 
   @ApiProperty({ description: 'next conversation', type: Array })
   @IsOptional()

--- a/api/src/chat/dto/conversation.dto.ts
+++ b/api/src/chat/dto/conversation.dto.ts
@@ -58,6 +58,6 @@ export class ConversationCreateDto {
   next?: string[];
 }
 
-export type ConversationCrudsDto = DtoConfig<{
+export type ConversationDTOCruds = DtoConfig<{
   create: ConversationCreateDto;
 }>;

--- a/api/src/chat/dto/conversation.dto.ts
+++ b/api/src/chat/dto/conversation.dto.ts
@@ -58,6 +58,6 @@ export class ConversationCreateDto {
   next?: string[];
 }
 
-export type ConversationDtoMapActions = DtoConfig<{
+export type ConversationDto = DtoConfig<{
   create: ConversationCreateDto;
 }>;

--- a/api/src/chat/dto/conversation.dto.ts
+++ b/api/src/chat/dto/conversation.dto.ts
@@ -58,6 +58,6 @@ export class ConversationCreateDto {
   next?: string[];
 }
 
-export type IConversationDto = DtoConfig<{
+export type TConversationCrudsDto = DtoConfig<{
   create: ConversationCreateDto;
 }>;

--- a/api/src/chat/dto/label.dto.ts
+++ b/api/src/chat/dto/label.dto.ts
@@ -9,11 +9,13 @@
 import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import {
   IsNotEmpty,
+  IsObject,
   IsOptional,
   IsString,
   Matches,
-  IsObject,
 } from 'class-validator';
+
+import { DtoConfig } from '@/utils/types/dto.types';
 
 export class LabelCreateDto {
   @ApiProperty({ description: 'Label title', type: String })
@@ -39,3 +41,7 @@ export class LabelCreateDto {
 }
 
 export class LabelUpdateDto extends PartialType(LabelCreateDto) {}
+
+export type LabelDtoMapActions = DtoConfig<{
+  create: LabelCreateDto;
+}>;

--- a/api/src/chat/dto/label.dto.ts
+++ b/api/src/chat/dto/label.dto.ts
@@ -42,6 +42,6 @@ export class LabelCreateDto {
 
 export class LabelUpdateDto extends PartialType(LabelCreateDto) {}
 
-export type LabelDtoMapActions = DtoConfig<{
+export type LabelDto = DtoConfig<{
   create: LabelCreateDto;
 }>;

--- a/api/src/chat/dto/subscriber.dto.ts
+++ b/api/src/chat/dto/subscriber.dto.ts
@@ -116,6 +116,6 @@ export class SubscriberCreateDto {
 
 export class SubscriberUpdateDto extends PartialType(SubscriberCreateDto) {}
 
-export type UserDto = DtoConfig<{
+export type SubscriberDto = DtoConfig<{
   create: SubscriberCreateDto;
 }>;

--- a/api/src/chat/dto/subscriber.dto.ts
+++ b/api/src/chat/dto/subscriber.dto.ts
@@ -17,6 +17,7 @@ import {
 } from 'class-validator';
 
 import { ChannelName } from '@/channel/types';
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 import { SubscriberChannelData } from '../schemas/types/channel';
@@ -36,7 +37,7 @@ export class SubscriberCreateDto {
   @ApiPropertyOptional({ description: 'Subscriber locale', type: String })
   @IsOptional()
   @IsString()
-  locale: string;
+  locale?: string;
 
   @ApiPropertyOptional({ description: 'Subscriber timezone', type: Number })
   @IsOptional()
@@ -51,17 +52,17 @@ export class SubscriberCreateDto {
   @ApiPropertyOptional({ description: 'Subscriber gender', type: String })
   @IsOptional()
   @IsString()
-  gender: string;
+  gender?: string;
 
   @ApiPropertyOptional({ description: 'Subscriber country', type: String })
   @IsOptional()
   @IsString()
-  country: string;
+  country?: string;
 
   @ApiPropertyOptional({ description: 'Subscriber foreign id', type: String })
   @IsOptional()
   @IsString()
-  foreign_id: string;
+  foreign_id?: string;
 
   @ApiProperty({ description: 'Subscriber labels', type: Array })
   @IsNotEmpty()
@@ -114,3 +115,7 @@ export class SubscriberCreateDto {
 }
 
 export class SubscriberUpdateDto extends PartialType(SubscriberCreateDto) {}
+
+export type UserDtoMapActions = DtoConfig<{
+  create: SubscriberCreateDto;
+}>;

--- a/api/src/chat/dto/subscriber.dto.ts
+++ b/api/src/chat/dto/subscriber.dto.ts
@@ -116,6 +116,6 @@ export class SubscriberCreateDto {
 
 export class SubscriberUpdateDto extends PartialType(SubscriberCreateDto) {}
 
-export type UserDtoMapActions = DtoConfig<{
+export type UserDto = DtoConfig<{
   create: SubscriberCreateDto;
 }>;

--- a/api/src/chat/repositories/block.repository.ts
+++ b/api/src/chat/repositories/block.repository.ts
@@ -22,7 +22,7 @@ import { LoggerService } from '@/logger/logger.service';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { BlockCreateDto, BlockUpdateDto } from '../dto/block.dto';
+import { BlockCreateDto, BlockDTOMap, BlockUpdateDto } from '../dto/block.dto';
 import {
   Block,
   BLOCK_POPULATE,
@@ -34,7 +34,8 @@ import {
 export class BlockRepository extends BaseRepository<
   Block,
   BlockPopulate,
-  BlockFull
+  BlockFull,
+  BlockDTOMap
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/block.repository.ts
+++ b/api/src/chat/repositories/block.repository.ts
@@ -22,11 +22,7 @@ import { LoggerService } from '@/logger/logger.service';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import {
-  BlockCreateDto,
-  BlockDTOMapActions,
-  BlockUpdateDto,
-} from '../dto/block.dto';
+import { BlockCreateDto, BlockDto, BlockUpdateDto } from '../dto/block.dto';
 import {
   Block,
   BLOCK_POPULATE,
@@ -39,7 +35,7 @@ export class BlockRepository extends BaseRepository<
   Block,
   BlockPopulate,
   BlockFull,
-  BlockDTOMapActions
+  BlockDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/block.repository.ts
+++ b/api/src/chat/repositories/block.repository.ts
@@ -22,7 +22,11 @@ import { LoggerService } from '@/logger/logger.service';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { BlockCreateDto, BlockDTOMap, BlockUpdateDto } from '../dto/block.dto';
+import {
+  BlockCreateDto,
+  BlockDTOMapActions,
+  BlockUpdateDto,
+} from '../dto/block.dto';
 import {
   Block,
   BLOCK_POPULATE,
@@ -35,7 +39,7 @@ export class BlockRepository extends BaseRepository<
   Block,
   BlockPopulate,
   BlockFull,
-  BlockDTOMap
+  BlockDTOMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/category.repository.ts
+++ b/api/src/chat/repositories/category.repository.ts
@@ -14,7 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { CategoryDTOMapActions } from '../dto/category.dto';
+import { CategoryDto } from '../dto/category.dto';
 import { Category } from '../schemas/category.schema';
 import { BlockService } from '../services/block.service';
 
@@ -23,7 +23,7 @@ export class CategoryRepository extends BaseRepository<
   Category,
   never,
   never,
-  CategoryDTOMapActions
+  CategoryDto
 > {
   private readonly blockService: BlockService;
 

--- a/api/src/chat/repositories/category.repository.ts
+++ b/api/src/chat/repositories/category.repository.ts
@@ -14,11 +14,17 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { CategoryDTOMapActions } from '../dto/category.dto';
 import { Category } from '../schemas/category.schema';
 import { BlockService } from '../services/block.service';
 
 @Injectable()
-export class CategoryRepository extends BaseRepository<Category> {
+export class CategoryRepository extends BaseRepository<
+  Category,
+  never,
+  never,
+  CategoryDTOMapActions
+> {
   private readonly blockService: BlockService;
 
   constructor(

--- a/api/src/chat/repositories/context-var.repository.ts
+++ b/api/src/chat/repositories/context-var.repository.ts
@@ -19,11 +19,17 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { ContextVarDTOMapActions } from '../dto/context-var.dto';
 import { ContextVar } from '../schemas/context-var.schema';
 import { BlockService } from '../services/block.service';
 
 @Injectable()
-export class ContextVarRepository extends BaseRepository<ContextVar> {
+export class ContextVarRepository extends BaseRepository<
+  ContextVar,
+  never,
+  never,
+  ContextVarDTOMapActions
+> {
   private readonly blockService: BlockService;
 
   constructor(

--- a/api/src/chat/repositories/context-var.repository.ts
+++ b/api/src/chat/repositories/context-var.repository.ts
@@ -19,7 +19,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { ContextVarDTOMapActions } from '../dto/context-var.dto';
+import { ContextVarDto } from '../dto/context-var.dto';
 import { ContextVar } from '../schemas/context-var.schema';
 import { BlockService } from '../services/block.service';
 
@@ -28,7 +28,7 @@ export class ContextVarRepository extends BaseRepository<
   ContextVar,
   never,
   never,
-  ContextVarDTOMapActions
+  ContextVarDto
 > {
   private readonly blockService: BlockService;
 

--- a/api/src/chat/repositories/conversation.repository.ts
+++ b/api/src/chat/repositories/conversation.repository.ts
@@ -13,7 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
-import { IConversationDto } from '../dto/conversation.dto';
+import { TConversationCrudsDto } from '../dto/conversation.dto';
 import {
   Conversation,
   CONVERSATION_POPULATE,
@@ -26,7 +26,7 @@ export class ConversationRepository extends BaseRepository<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  IConversationDto
+  TConversationCrudsDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/conversation.repository.ts
+++ b/api/src/chat/repositories/conversation.repository.ts
@@ -13,7 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
-import { ConversationDTOCruds } from '../dto/conversation.dto';
+import { ConversationDtoMapActions } from '../dto/conversation.dto';
 import {
   Conversation,
   CONVERSATION_POPULATE,
@@ -26,7 +26,7 @@ export class ConversationRepository extends BaseRepository<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  ConversationDTOCruds
+  ConversationDtoMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/conversation.repository.ts
+++ b/api/src/chat/repositories/conversation.repository.ts
@@ -13,6 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
+import { IConversationDto } from '../dto/conversation.dto';
 import {
   Conversation,
   CONVERSATION_POPULATE,
@@ -24,7 +25,8 @@ import {
 export class ConversationRepository extends BaseRepository<
   Conversation,
   ConversationPopulate,
-  ConversationFull
+  ConversationFull,
+  IConversationDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/conversation.repository.ts
+++ b/api/src/chat/repositories/conversation.repository.ts
@@ -13,7 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
-import { TConversationCrudsDto } from '../dto/conversation.dto';
+import { ConversationCrudsDto } from '../dto/conversation.dto';
 import {
   Conversation,
   CONVERSATION_POPULATE,
@@ -26,7 +26,7 @@ export class ConversationRepository extends BaseRepository<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  TConversationCrudsDto
+  ConversationCrudsDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/conversation.repository.ts
+++ b/api/src/chat/repositories/conversation.repository.ts
@@ -13,7 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
-import { ConversationCrudsDto } from '../dto/conversation.dto';
+import { ConversationDTOCruds } from '../dto/conversation.dto';
 import {
   Conversation,
   CONVERSATION_POPULATE,
@@ -26,7 +26,7 @@ export class ConversationRepository extends BaseRepository<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  ConversationCrudsDto
+  ConversationDTOCruds
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/conversation.repository.ts
+++ b/api/src/chat/repositories/conversation.repository.ts
@@ -13,7 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
-import { ConversationDtoMapActions } from '../dto/conversation.dto';
+import { ConversationDto } from '../dto/conversation.dto';
 import {
   Conversation,
   CONVERSATION_POPULATE,
@@ -26,7 +26,7 @@ export class ConversationRepository extends BaseRepository<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  ConversationDtoMapActions
+  ConversationDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/label.repository.ts
+++ b/api/src/chat/repositories/label.repository.ts
@@ -14,6 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { LabelDtoMapActions } from '../dto/label.dto';
 import {
   Label,
   LABEL_POPULATE,
@@ -26,7 +27,8 @@ import {
 export class LabelRepository extends BaseRepository<
   Label,
   LabelPopulate,
-  LabelFull
+  LabelFull,
+  LabelDtoMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/label.repository.ts
+++ b/api/src/chat/repositories/label.repository.ts
@@ -14,7 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { LabelDtoMapActions } from '../dto/label.dto';
+import { LabelDto } from '../dto/label.dto';
 import {
   Label,
   LABEL_POPULATE,
@@ -28,7 +28,7 @@ export class LabelRepository extends BaseRepository<
   Label,
   LabelPopulate,
   LabelFull,
-  LabelDtoMapActions
+  LabelDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/subscriber.repository.ts
+++ b/api/src/chat/repositories/subscriber.repository.ts
@@ -20,7 +20,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { SubscriberUpdateDto } from '../dto/subscriber.dto';
+import { SubscriberUpdateDto, UserDtoMapActions } from '../dto/subscriber.dto';
 import {
   Subscriber,
   SUBSCRIBER_POPULATE,
@@ -33,7 +33,8 @@ import {
 export class SubscriberRepository extends BaseRepository<
   Subscriber,
   SubscriberPopulate,
-  SubscriberFull
+  SubscriberFull,
+  UserDtoMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/subscriber.repository.ts
+++ b/api/src/chat/repositories/subscriber.repository.ts
@@ -20,7 +20,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { SubscriberUpdateDto, UserDto } from '../dto/subscriber.dto';
+import { SubscriberDto, SubscriberUpdateDto } from '../dto/subscriber.dto';
 import {
   Subscriber,
   SUBSCRIBER_POPULATE,
@@ -34,7 +34,7 @@ export class SubscriberRepository extends BaseRepository<
   Subscriber,
   SubscriberPopulate,
   SubscriberFull,
-  UserDto
+  SubscriberDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/repositories/subscriber.repository.ts
+++ b/api/src/chat/repositories/subscriber.repository.ts
@@ -20,7 +20,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { SubscriberUpdateDto, UserDtoMapActions } from '../dto/subscriber.dto';
+import { SubscriberUpdateDto, UserDto } from '../dto/subscriber.dto';
 import {
   Subscriber,
   SUBSCRIBER_POPULATE,
@@ -34,7 +34,7 @@ export class SubscriberRepository extends BaseRepository<
   Subscriber,
   SubscriberPopulate,
   SubscriberFull,
-  UserDtoMapActions
+  UserDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/chat/schemas/block.schema.ts
+++ b/api/src/chat/schemas/block.schema.ts
@@ -43,7 +43,7 @@ export class BlockStub extends BaseSchema {
     validate: isPatternList,
     default: [],
   })
-  patterns?: Pattern[];
+  patterns: Pattern[];
 
   @Prop([
     {
@@ -52,7 +52,7 @@ export class BlockStub extends BaseSchema {
       default: [],
     },
   ])
-  trigger_labels?: unknown;
+  trigger_labels: unknown;
 
   @Prop([
     {
@@ -61,19 +61,19 @@ export class BlockStub extends BaseSchema {
       default: [],
     },
   ])
-  assign_labels?: unknown;
+  assign_labels: unknown;
 
   @Prop({
     type: Object,
     default: [],
   })
-  trigger_channels?: string[];
+  trigger_channels: string[];
 
   @Prop({
     type: Object,
     default: {},
   })
-  options?: BlockOptions;
+  options: BlockOptions;
 
   @Prop({
     type: Object,
@@ -88,13 +88,13 @@ export class BlockStub extends BaseSchema {
       default: [],
     },
   ])
-  nextBlocks?: unknown;
+  nextBlocks: unknown;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Block',
   })
-  attachedBlock?: unknown;
+  attachedBlock: unknown;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
@@ -106,14 +106,14 @@ export class BlockStub extends BaseSchema {
     type: Boolean,
     default: false,
   })
-  starts_conversation?: boolean;
+  starts_conversation: boolean;
 
   @Prop({
     type: Object,
     validate: isValidVarCapture,
     default: [],
   })
-  capture_vars?: CaptureVar[];
+  capture_vars: CaptureVar[];
 
   @Prop({
     type: Object,
@@ -125,22 +125,22 @@ export class BlockStub extends BaseSchema {
     type: Boolean,
     default: false,
   })
-  builtin?: boolean;
+  builtin: boolean;
 }
 
 @Schema({ timestamps: true })
 export class Block extends BlockStub {
-  @Transform(({ obj }) => obj.trigger_labels?.map((elem) => elem.toString()))
-  trigger_labels?: string[];
+  @Transform(({ obj }) => obj.trigger_labels.map((elem) => elem.toString()))
+  trigger_labels: string[];
 
-  @Transform(({ obj }) => obj.assign_labels?.map((elem) => elem.toString()))
-  assign_labels?: string[];
+  @Transform(({ obj }) => obj.assign_labels.map((elem) => elem.toString()))
+  assign_labels: string[];
 
-  @Transform(({ obj }) => obj.nextBlocks?.map((elem) => elem.toString()))
-  nextBlocks?: string[];
+  @Transform(({ obj }) => obj.nextBlocks.map((elem) => elem.toString()))
+  nextBlocks: string[];
 
   @Transform(({ obj }) => obj.attachedBlock?.toString() || null)
-  attachedBlock?: string;
+  attachedBlock: string;
 
   @Transform(({ obj }) => obj.category.toString())
   category: string;
@@ -161,16 +161,16 @@ export class BlockFull extends BlockStub {
   assign_labels: Label[];
 
   @Type(() => Block)
-  nextBlocks?: Block[];
+  nextBlocks: Block[];
 
   @Type(() => Block)
-  attachedBlock?: Block;
+  attachedBlock: Block;
 
   @Type(() => Category)
   category: Category;
 
   @Type(() => Block)
-  previousBlocks: Block[];
+  previousBlocks?: Block[];
 
   @Type(() => Block)
   attachedToBlock?: Block;

--- a/api/src/chat/schemas/category.schema.ts
+++ b/api/src/chat/schemas/category.schema.ts
@@ -25,19 +25,19 @@ export class Category extends BaseSchema {
     type: Boolean,
     default: false,
   })
-  builtin?: boolean;
+  builtin: boolean;
 
   @Prop({
     type: Number,
     default: 100,
   })
-  zoom?: number;
+  zoom: number;
 
   @Prop({
     type: [Number, Number],
     default: [0, 0],
   })
-  offset?: [number, number];
+  offset: [number, number];
 }
 
 export const CategoryModel: ModelDefinition = LifecycleHookManager.attach({

--- a/api/src/chat/schemas/context-var.schema.ts
+++ b/api/src/chat/schemas/context-var.schema.ts
@@ -38,7 +38,7 @@ export class ContextVar extends BaseSchema {
     type: Boolean,
     default: false,
   })
-  permanent?: boolean;
+  permanent: boolean;
 }
 
 export const ContextVarModel: ModelDefinition = LifecycleHookManager.attach({

--- a/api/src/chat/schemas/conversation.schema.ts
+++ b/api/src/chat/schemas/conversation.schema.ts
@@ -51,19 +51,19 @@ class ConversationStub extends BaseSchema {
     type: Boolean,
     default: true,
   })
-  active?: boolean;
+  active: boolean;
 
   @Prop({
     type: Object,
     default: getDefaultConversationContext(),
   })
-  context?: Context;
+  context: Context;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: 'Block',
   })
-  current?: unknown;
+  current: unknown;
 
   @Prop([
     {
@@ -72,7 +72,7 @@ class ConversationStub extends BaseSchema {
       default: [],
     },
   ])
-  next?: unknown;
+  next: unknown;
 }
 
 @Schema({ timestamps: true })
@@ -81,10 +81,10 @@ export class Conversation extends ConversationStub {
   sender: string;
 
   @Transform(({ obj }) => obj.current.toString())
-  current?: string;
+  current: string;
 
   @Transform(({ obj }) => obj.next.map((elem) => elem.toString()))
-  next?: string[];
+  next: string[];
 }
 
 @Schema({ timestamps: true })

--- a/api/src/chat/schemas/conversation.schema.ts
+++ b/api/src/chat/schemas/conversation.schema.ts
@@ -80,8 +80,8 @@ export class Conversation extends ConversationStub {
   @Transform(({ obj }) => obj.sender.toString())
   sender: string;
 
-  @Transform(({ obj }) => obj.current.toString())
-  current: string;
+  @Transform(({ obj }) => (obj.current ? obj.current.toString() : null))
+  current: string | null;
 
   @Transform(({ obj }) => obj.next.map((elem) => elem.toString()))
   next: string[];

--- a/api/src/chat/schemas/label.schema.ts
+++ b/api/src/chat/schemas/label.schema.ts
@@ -43,13 +43,13 @@ export class LabelStub extends BaseSchema {
   @Prop({
     type: String,
   })
-  description?: string;
+  description: string;
 
   @Prop({
     type: Boolean,
     default: false,
   })
-  builtin?: boolean;
+  builtin: boolean;
 }
 
 @Schema({ timestamps: true })

--- a/api/src/chat/seeds/category.seed.ts
+++ b/api/src/chat/seeds/category.seed.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
+import { CategoryDTOMapActions } from '../dto/category.dto';
 import { CategoryRepository } from '../repositories/category.repository';
 import { Category } from '../schemas/category.schema';
 
 @Injectable()
-export class CategorySeeder extends BaseSeeder<Category> {
+export class CategorySeeder extends BaseSeeder<
+  Category,
+  never,
+  never,
+  CategoryDTOMapActions
+> {
   constructor(private readonly categoryRepository: CategoryRepository) {
     super(categoryRepository);
   }

--- a/api/src/chat/seeds/category.seed.ts
+++ b/api/src/chat/seeds/category.seed.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
-import { CategoryDTOMapActions } from '../dto/category.dto';
+import { CategoryDto } from '../dto/category.dto';
 import { CategoryRepository } from '../repositories/category.repository';
 import { Category } from '../schemas/category.schema';
 
@@ -19,7 +19,7 @@ export class CategorySeeder extends BaseSeeder<
   Category,
   never,
   never,
-  CategoryDTOMapActions
+  CategoryDto
 > {
   constructor(private readonly categoryRepository: CategoryRepository) {
     super(categoryRepository);

--- a/api/src/chat/seeds/context-var.seed.ts
+++ b/api/src/chat/seeds/context-var.seed.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
+import { ContextVarDTOMapActions } from '../dto/context-var.dto';
 import { ContextVarRepository } from '../repositories/context-var.repository';
 import { ContextVar } from '../schemas/context-var.schema';
 
 @Injectable()
-export class ContextVarSeeder extends BaseSeeder<ContextVar> {
+export class ContextVarSeeder extends BaseSeeder<
+  ContextVar,
+  never,
+  never,
+  ContextVarDTOMapActions
+> {
   constructor(private readonly contextVarRepository: ContextVarRepository) {
     super(contextVarRepository);
   }

--- a/api/src/chat/seeds/context-var.seed.ts
+++ b/api/src/chat/seeds/context-var.seed.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
-import { ContextVarDTOMapActions } from '../dto/context-var.dto';
+import { ContextVarDto } from '../dto/context-var.dto';
 import { ContextVarRepository } from '../repositories/context-var.repository';
 import { ContextVar } from '../schemas/context-var.schema';
 
@@ -19,7 +19,7 @@ export class ContextVarSeeder extends BaseSeeder<
   ContextVar,
   never,
   never,
-  ContextVarDTOMapActions
+  ContextVarDto
 > {
   constructor(private readonly contextVarRepository: ContextVarRepository) {
     super(contextVarRepository);

--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -22,7 +22,7 @@ import { SettingService } from '@/setting/services/setting.service';
 import { BaseService } from '@/utils/generics/base-service';
 import { getRandom } from '@/utils/helpers/safeRandom';
 
-import { BlockDTOMap } from '../dto/block.dto';
+import { BlockDTOMapActions } from '../dto/block.dto';
 import { BlockRepository } from '../repositories/block.repository';
 import { Block, BlockFull, BlockPopulate } from '../schemas/block.schema';
 import { Context } from '../schemas/types/context';
@@ -40,7 +40,7 @@ export class BlockService extends BaseService<
   Block,
   BlockPopulate,
   BlockFull,
-  BlockDTOMap
+  BlockDTOMapActions
 > {
   constructor(
     readonly repository: BlockRepository,

--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -22,7 +22,7 @@ import { SettingService } from '@/setting/services/setting.service';
 import { BaseService } from '@/utils/generics/base-service';
 import { getRandom } from '@/utils/helpers/safeRandom';
 
-import { BlockDTOMapActions } from '../dto/block.dto';
+import { BlockDto } from '../dto/block.dto';
 import { BlockRepository } from '../repositories/block.repository';
 import { Block, BlockFull, BlockPopulate } from '../schemas/block.schema';
 import { Context } from '../schemas/types/context';
@@ -40,7 +40,7 @@ export class BlockService extends BaseService<
   Block,
   BlockPopulate,
   BlockFull,
-  BlockDTOMapActions
+  BlockDto
 > {
   constructor(
     readonly repository: BlockRepository,

--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -22,6 +22,7 @@ import { SettingService } from '@/setting/services/setting.service';
 import { BaseService } from '@/utils/generics/base-service';
 import { getRandom } from '@/utils/helpers/safeRandom';
 
+import { BlockDTOMap } from '../dto/block.dto';
 import { BlockRepository } from '../repositories/block.repository';
 import { Block, BlockFull, BlockPopulate } from '../schemas/block.schema';
 import { Context } from '../schemas/types/context';
@@ -35,7 +36,12 @@ import { Payload, StdQuickReply } from '../schemas/types/quick-reply';
 import { SubscriberContext } from '../schemas/types/subscriberContext';
 
 @Injectable()
-export class BlockService extends BaseService<Block, BlockPopulate, BlockFull> {
+export class BlockService extends BaseService<
+  Block,
+  BlockPopulate,
+  BlockFull,
+  BlockDTOMap
+> {
   constructor(
     readonly repository: BlockRepository,
     private readonly contentService: ContentService,

--- a/api/src/chat/services/category.service.ts
+++ b/api/src/chat/services/category.service.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
+import { CategoryDTOMapActions } from '../dto/category.dto';
 import { CategoryRepository } from '../repositories/category.repository';
 import { Category } from '../schemas/category.schema';
 
 @Injectable()
-export class CategoryService extends BaseService<Category> {
+export class CategoryService extends BaseService<
+  Category,
+  never,
+  never,
+  CategoryDTOMapActions
+> {
   constructor(readonly repository: CategoryRepository) {
     super(repository);
   }

--- a/api/src/chat/services/category.service.ts
+++ b/api/src/chat/services/category.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { CategoryDTOMapActions } from '../dto/category.dto';
+import { CategoryDto } from '../dto/category.dto';
 import { CategoryRepository } from '../repositories/category.repository';
 import { Category } from '../schemas/category.schema';
 
@@ -19,7 +19,7 @@ export class CategoryService extends BaseService<
   Category,
   never,
   never,
-  CategoryDTOMapActions
+  CategoryDto
 > {
   constructor(readonly repository: CategoryRepository) {
     super(repository);

--- a/api/src/chat/services/context-var.service.ts
+++ b/api/src/chat/services/context-var.service.ts
@@ -10,12 +10,18 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
+import { ContextVarDTOMapActions } from '../dto/context-var.dto';
 import { ContextVarRepository } from '../repositories/context-var.repository';
 import { Block, BlockFull } from '../schemas/block.schema';
 import { ContextVar } from '../schemas/context-var.schema';
 
 @Injectable()
-export class ContextVarService extends BaseService<ContextVar> {
+export class ContextVarService extends BaseService<
+  ContextVar,
+  never,
+  never,
+  ContextVarDTOMapActions
+> {
   constructor(readonly repository: ContextVarRepository) {
     super(repository);
   }

--- a/api/src/chat/services/context-var.service.ts
+++ b/api/src/chat/services/context-var.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { ContextVarDTOMapActions } from '../dto/context-var.dto';
+import { ContextVarDto } from '../dto/context-var.dto';
 import { ContextVarRepository } from '../repositories/context-var.repository';
 import { Block, BlockFull } from '../schemas/block.schema';
 import { ContextVar } from '../schemas/context-var.schema';
@@ -20,7 +20,7 @@ export class ContextVarService extends BaseService<
   ContextVar,
   never,
   never,
-  ContextVarDTOMapActions
+  ContextVarDto
 > {
   constructor(readonly repository: ContextVarRepository) {
     super(repository);

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -12,7 +12,7 @@ import EventWrapper from '@/channel/lib/EventWrapper';
 import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { ConversationDTOCruds } from '../dto/conversation.dto';
+import { ConversationDtoMapActions } from '../dto/conversation.dto';
 import { VIEW_MORE_PAYLOAD } from '../helpers/constants';
 import { ConversationRepository } from '../repositories/conversation.repository';
 import { Block, BlockFull } from '../schemas/block.schema';
@@ -32,7 +32,7 @@ export class ConversationService extends BaseService<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  ConversationDTOCruds
+  ConversationDtoMapActions
 > {
   constructor(
     readonly repository: ConversationRepository,

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -12,6 +12,7 @@ import EventWrapper from '@/channel/lib/EventWrapper';
 import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 
+import { IConversationDto } from '../dto/conversation.dto';
 import { VIEW_MORE_PAYLOAD } from '../helpers/constants';
 import { ConversationRepository } from '../repositories/conversation.repository';
 import { Block, BlockFull } from '../schemas/block.schema';
@@ -30,7 +31,8 @@ import { SubscriberService } from './subscriber.service';
 export class ConversationService extends BaseService<
   Conversation,
   ConversationPopulate,
-  ConversationFull
+  ConversationFull,
+  IConversationDto
 > {
   constructor(
     readonly repository: ConversationRepository,

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -12,7 +12,7 @@ import EventWrapper from '@/channel/lib/EventWrapper';
 import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { ConversationCrudsDto } from '../dto/conversation.dto';
+import { ConversationDTOCruds } from '../dto/conversation.dto';
 import { VIEW_MORE_PAYLOAD } from '../helpers/constants';
 import { ConversationRepository } from '../repositories/conversation.repository';
 import { Block, BlockFull } from '../schemas/block.schema';
@@ -32,7 +32,7 @@ export class ConversationService extends BaseService<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  ConversationCrudsDto
+  ConversationDTOCruds
 > {
   constructor(
     readonly repository: ConversationRepository,

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -12,7 +12,7 @@ import EventWrapper from '@/channel/lib/EventWrapper';
 import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { TConversationCrudsDto } from '../dto/conversation.dto';
+import { ConversationCrudsDto } from '../dto/conversation.dto';
 import { VIEW_MORE_PAYLOAD } from '../helpers/constants';
 import { ConversationRepository } from '../repositories/conversation.repository';
 import { Block, BlockFull } from '../schemas/block.schema';
@@ -32,7 +32,7 @@ export class ConversationService extends BaseService<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  TConversationCrudsDto
+  ConversationCrudsDto
 > {
   constructor(
     readonly repository: ConversationRepository,

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -12,7 +12,7 @@ import EventWrapper from '@/channel/lib/EventWrapper';
 import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { IConversationDto } from '../dto/conversation.dto';
+import { TConversationCrudsDto } from '../dto/conversation.dto';
 import { VIEW_MORE_PAYLOAD } from '../helpers/constants';
 import { ConversationRepository } from '../repositories/conversation.repository';
 import { Block, BlockFull } from '../schemas/block.schema';
@@ -32,7 +32,7 @@ export class ConversationService extends BaseService<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  IConversationDto
+  TConversationCrudsDto
 > {
   constructor(
     readonly repository: ConversationRepository,

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -12,7 +12,7 @@ import EventWrapper from '@/channel/lib/EventWrapper';
 import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { ConversationDtoMapActions } from '../dto/conversation.dto';
+import { ConversationDto } from '../dto/conversation.dto';
 import { VIEW_MORE_PAYLOAD } from '../helpers/constants';
 import { ConversationRepository } from '../repositories/conversation.repository';
 import { Block, BlockFull } from '../schemas/block.schema';
@@ -32,7 +32,7 @@ export class ConversationService extends BaseService<
   Conversation,
   ConversationPopulate,
   ConversationFull,
-  ConversationDtoMapActions
+  ConversationDto
 > {
   constructor(
     readonly repository: ConversationRepository,

--- a/api/src/chat/services/label.service.ts
+++ b/api/src/chat/services/label.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { LabelDtoMapActions } from '../dto/label.dto';
+import { LabelDto } from '../dto/label.dto';
 import { LabelRepository } from '../repositories/label.repository';
 import { Label, LabelFull, LabelPopulate } from '../schemas/label.schema';
 
@@ -19,7 +19,7 @@ export class LabelService extends BaseService<
   Label,
   LabelPopulate,
   LabelFull,
-  LabelDtoMapActions
+  LabelDto
 > {
   constructor(readonly repository: LabelRepository) {
     super(repository);

--- a/api/src/chat/services/label.service.ts
+++ b/api/src/chat/services/label.service.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
+import { LabelDtoMapActions } from '../dto/label.dto';
 import { LabelRepository } from '../repositories/label.repository';
 import { Label, LabelFull, LabelPopulate } from '../schemas/label.schema';
 
 @Injectable()
-export class LabelService extends BaseService<Label, LabelPopulate, LabelFull> {
+export class LabelService extends BaseService<
+  Label,
+  LabelPopulate,
+  LabelFull,
+  LabelDtoMapActions
+> {
   constructor(readonly repository: LabelRepository) {
     super(repository);
   }

--- a/api/src/chat/services/subscriber.service.ts
+++ b/api/src/chat/services/subscriber.service.ts
@@ -28,7 +28,7 @@ import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
-import { SubscriberUpdateDto, UserDto } from '../dto/subscriber.dto';
+import { SubscriberDto, SubscriberUpdateDto } from '../dto/subscriber.dto';
 import { SubscriberRepository } from '../repositories/subscriber.repository';
 import {
   Subscriber,
@@ -41,7 +41,7 @@ export class SubscriberService extends BaseService<
   Subscriber,
   SubscriberPopulate,
   SubscriberFull,
-  UserDto
+  SubscriberDto
 > {
   private readonly gateway: WebsocketGateway;
 

--- a/api/src/chat/services/subscriber.service.ts
+++ b/api/src/chat/services/subscriber.service.ts
@@ -28,7 +28,7 @@ import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
-import { SubscriberUpdateDto, UserDtoMapActions } from '../dto/subscriber.dto';
+import { SubscriberUpdateDto, UserDto } from '../dto/subscriber.dto';
 import { SubscriberRepository } from '../repositories/subscriber.repository';
 import {
   Subscriber,
@@ -41,7 +41,7 @@ export class SubscriberService extends BaseService<
   Subscriber,
   SubscriberPopulate,
   SubscriberFull,
-  UserDtoMapActions
+  UserDto
 > {
   private readonly gateway: WebsocketGateway;
 

--- a/api/src/chat/services/subscriber.service.ts
+++ b/api/src/chat/services/subscriber.service.ts
@@ -28,7 +28,7 @@ import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
-import { SubscriberUpdateDto } from '../dto/subscriber.dto';
+import { SubscriberUpdateDto, UserDtoMapActions } from '../dto/subscriber.dto';
 import { SubscriberRepository } from '../repositories/subscriber.repository';
 import {
   Subscriber,
@@ -40,7 +40,8 @@ import {
 export class SubscriberService extends BaseService<
   Subscriber,
   SubscriberPopulate,
-  SubscriberFull
+  SubscriberFull,
+  UserDtoMapActions
 > {
   private readonly gateway: WebsocketGateway;
 

--- a/api/src/cms/dto/content.dto.ts
+++ b/api/src/cms/dto/content.dto.ts
@@ -9,6 +9,7 @@
 import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 export class ContentCreateDto {
@@ -34,3 +35,7 @@ export class ContentCreateDto {
 }
 
 export class ContentUpdateDto extends PartialType(ContentCreateDto) {}
+
+export type ContentDTOMapActions = DtoConfig<{
+  create: ContentCreateDto;
+}>;

--- a/api/src/cms/dto/content.dto.ts
+++ b/api/src/cms/dto/content.dto.ts
@@ -36,6 +36,6 @@ export class ContentCreateDto {
 
 export class ContentUpdateDto extends PartialType(ContentCreateDto) {}
 
-export type ContentDTOMapActions = DtoConfig<{
+export type ContentDto = DtoConfig<{
   create: ContentCreateDto;
 }>;

--- a/api/src/cms/dto/contentType.dto.ts
+++ b/api/src/cms/dto/contentType.dto.ts
@@ -9,15 +9,17 @@
 import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
-  IsString,
   IsArray,
-  ValidateNested,
-  IsOptional,
   IsEnum,
-  Matches,
   IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
   Validate,
+  ValidateNested,
 } from 'class-validator';
+
+import { DtoConfig } from '@/utils/types/dto.types';
 
 import { ValidateRequiredFields } from '../validators/validate-required-fields.validator';
 
@@ -55,3 +57,7 @@ export class ContentTypeCreateDto {
 }
 
 export class ContentTypeUpdateDto extends PartialType(ContentTypeCreateDto) {}
+
+export type ContentTypeDtoMapActions = DtoConfig<{
+  create: ContentTypeCreateDto;
+}>;

--- a/api/src/cms/dto/contentType.dto.ts
+++ b/api/src/cms/dto/contentType.dto.ts
@@ -58,6 +58,6 @@ export class ContentTypeCreateDto {
 
 export class ContentTypeUpdateDto extends PartialType(ContentTypeCreateDto) {}
 
-export type ContentTypeDtoMapActions = DtoConfig<{
+export type ContentTypeDto = DtoConfig<{
   create: ContentTypeCreateDto;
 }>;

--- a/api/src/cms/dto/menu.dto.ts
+++ b/api/src/cms/dto/menu.dto.ts
@@ -16,6 +16,7 @@ import {
   ValidateIf,
 } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 import { MenuType } from '../schemas/types/menu';
@@ -53,3 +54,7 @@ export class MenuCreateDto {
 }
 
 export class MenuQueryDto extends PartialType(MenuCreateDto) {}
+
+export type MenuDTOMapActions = DtoConfig<{
+  create: MenuCreateDto;
+}>;

--- a/api/src/cms/dto/menu.dto.ts
+++ b/api/src/cms/dto/menu.dto.ts
@@ -55,6 +55,6 @@ export class MenuCreateDto {
 
 export class MenuQueryDto extends PartialType(MenuCreateDto) {}
 
-export type MenuDTOMapActions = DtoConfig<{
+export type MenuDto = DtoConfig<{
   create: MenuCreateDto;
 }>;

--- a/api/src/cms/repositories/content-type.repository.ts
+++ b/api/src/cms/repositories/content-type.repository.ts
@@ -15,11 +15,17 @@ import { BlockService } from '@/chat/services/block.service';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { ContentTypeDtoMapActions } from '../dto/contentType.dto';
 import { ContentType } from '../schemas/content-type.schema';
 import { Content } from '../schemas/content.schema';
 
 @Injectable()
-export class ContentTypeRepository extends BaseRepository<ContentType> {
+export class ContentTypeRepository extends BaseRepository<
+  ContentType,
+  never,
+  never,
+  ContentTypeDtoMapActions
+> {
   constructor(
     readonly eventEmitter: EventEmitter2,
     @InjectModel(ContentType.name) readonly model: Model<ContentType>,

--- a/api/src/cms/repositories/content-type.repository.ts
+++ b/api/src/cms/repositories/content-type.repository.ts
@@ -15,7 +15,7 @@ import { BlockService } from '@/chat/services/block.service';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { ContentTypeDtoMapActions } from '../dto/contentType.dto';
+import { ContentTypeDto } from '../dto/contentType.dto';
 import { ContentType } from '../schemas/content-type.schema';
 import { Content } from '../schemas/content.schema';
 
@@ -24,7 +24,7 @@ export class ContentTypeRepository extends BaseRepository<
   ContentType,
   never,
   never,
-  ContentTypeDtoMapActions
+  ContentTypeDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/cms/repositories/content.repository.ts
+++ b/api/src/cms/repositories/content.repository.ts
@@ -21,6 +21,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { ContentDTOMapActions } from '../dto/content.dto';
 import {
   Content,
   CONTENT_POPULATE,
@@ -32,7 +33,8 @@ import {
 export class ContentRepository extends BaseRepository<
   Content,
   ContentPopulate,
-  ContentFull
+  ContentFull,
+  ContentDTOMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/cms/repositories/content.repository.ts
+++ b/api/src/cms/repositories/content.repository.ts
@@ -21,7 +21,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { ContentDTOMapActions } from '../dto/content.dto';
+import { ContentDto } from '../dto/content.dto';
 import {
   Content,
   CONTENT_POPULATE,
@@ -34,7 +34,7 @@ export class ContentRepository extends BaseRepository<
   Content,
   ContentPopulate,
   ContentFull,
-  ContentDTOMapActions
+  ContentDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/cms/repositories/menu.repository.ts
+++ b/api/src/cms/repositories/menu.repository.ts
@@ -13,7 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
-import { MenuDTOMapActions } from '../dto/menu.dto';
+import { MenuDto } from '../dto/menu.dto';
 import {
   Menu,
   MENU_POPULATE,
@@ -28,7 +28,7 @@ export class MenuRepository extends BaseRepository<
   Menu,
   MenuPopulate,
   MenuFull,
-  MenuDTOMapActions
+  MenuDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/cms/repositories/menu.repository.ts
+++ b/api/src/cms/repositories/menu.repository.ts
@@ -13,6 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
+import { MenuDTOMapActions } from '../dto/menu.dto';
 import {
   Menu,
   MENU_POPULATE,
@@ -26,7 +27,8 @@ import { MenuType } from '../schemas/types/menu';
 export class MenuRepository extends BaseRepository<
   Menu,
   MenuPopulate,
-  MenuFull
+  MenuFull,
+  MenuDTOMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/cms/schemas/content-type.schema.ts
+++ b/api/src/cms/schemas/content-type.schema.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { Prop, Schema, SchemaFactory, ModelDefinition } from '@nestjs/mongoose';
+import { ModelDefinition, Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import mongoose from 'mongoose';
 
 import { BaseSchema } from '@/utils/generics/base-schema';
@@ -39,7 +39,7 @@ export class ContentType extends BaseSchema {
       },
     ],
   })
-  fields?: {
+  fields: {
     name: string;
     label: string;
     type: string;

--- a/api/src/cms/schemas/content.schema.ts
+++ b/api/src/cms/schemas/content.schema.ts
@@ -41,7 +41,7 @@ export class ContentStub extends BaseSchema {
    * Either of not this content is active.
    */
   @Prop({ type: Boolean, default: true })
-  status?: boolean;
+  status: boolean;
 
   @Prop({ type: mongoose.Schema.Types.Mixed })
   dynamicFields: Record<string, any>;

--- a/api/src/cms/services/content-type.service.ts
+++ b/api/src/cms/services/content-type.service.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
+import { ContentTypeDtoMapActions } from '../dto/contentType.dto';
 import { ContentTypeRepository } from '../repositories/content-type.repository';
 import { ContentType } from '../schemas/content-type.schema';
 
 @Injectable()
-export class ContentTypeService extends BaseService<ContentType> {
+export class ContentTypeService extends BaseService<
+  ContentType,
+  never,
+  never,
+  ContentTypeDtoMapActions
+> {
   constructor(readonly repository: ContentTypeRepository) {
     super(repository);
   }

--- a/api/src/cms/services/content-type.service.ts
+++ b/api/src/cms/services/content-type.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { ContentTypeDtoMapActions } from '../dto/contentType.dto';
+import { ContentTypeDto } from '../dto/contentType.dto';
 import { ContentTypeRepository } from '../repositories/content-type.repository';
 import { ContentType } from '../schemas/content-type.schema';
 
@@ -19,7 +19,7 @@ export class ContentTypeService extends BaseService<
   ContentType,
   never,
   never,
-  ContentTypeDtoMapActions
+  ContentTypeDto
 > {
   constructor(readonly repository: ContentTypeRepository) {
     super(repository);

--- a/api/src/cms/services/content.service.ts
+++ b/api/src/cms/services/content.service.ts
@@ -19,6 +19,7 @@ import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { ContentDTOMapActions } from '../dto/content.dto';
 import { ContentRepository } from '../repositories/content.repository';
 import {
   Content,
@@ -30,7 +31,8 @@ import {
 export class ContentService extends BaseService<
   Content,
   ContentPopulate,
-  ContentFull
+  ContentFull,
+  ContentDTOMapActions
 > {
   constructor(
     readonly repository: ContentRepository,

--- a/api/src/cms/services/content.service.ts
+++ b/api/src/cms/services/content.service.ts
@@ -19,7 +19,7 @@ import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { ContentDTOMapActions } from '../dto/content.dto';
+import { ContentDto } from '../dto/content.dto';
 import { ContentRepository } from '../repositories/content.repository';
 import {
   Content,
@@ -32,7 +32,7 @@ export class ContentService extends BaseService<
   Content,
   ContentPopulate,
   ContentFull,
-  ContentDTOMapActions
+  ContentDto
 > {
   constructor(
     readonly repository: ContentRepository,

--- a/api/src/cms/services/menu.service.ts
+++ b/api/src/cms/services/menu.service.ts
@@ -20,13 +20,18 @@ import { MENU_CACHE_KEY } from '@/utils/constants/cache';
 import { Cacheable } from '@/utils/decorators/cacheable.decorator';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { MenuCreateDto } from '../dto/menu.dto';
+import { MenuCreateDto, MenuDTOMapActions } from '../dto/menu.dto';
 import { MenuRepository } from '../repositories/menu.repository';
 import { Menu, MenuFull, MenuPopulate } from '../schemas/menu.schema';
 import { AnyMenu, MenuTree, MenuType } from '../schemas/types/menu';
 
 @Injectable()
-export class MenuService extends BaseService<Menu, MenuPopulate, MenuFull> {
+export class MenuService extends BaseService<
+  Menu,
+  MenuPopulate,
+  MenuFull,
+  MenuDTOMapActions
+> {
   private RootSymbol: symbol = Symbol('RootMenu');
 
   constructor(

--- a/api/src/cms/services/menu.service.ts
+++ b/api/src/cms/services/menu.service.ts
@@ -20,7 +20,7 @@ import { MENU_CACHE_KEY } from '@/utils/constants/cache';
 import { Cacheable } from '@/utils/decorators/cacheable.decorator';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { MenuCreateDto, MenuDTOMapActions } from '../dto/menu.dto';
+import { MenuCreateDto, MenuDto } from '../dto/menu.dto';
 import { MenuRepository } from '../repositories/menu.repository';
 import { Menu, MenuFull, MenuPopulate } from '../schemas/menu.schema';
 import { AnyMenu, MenuTree, MenuType } from '../schemas/types/menu';
@@ -30,7 +30,7 @@ export class MenuService extends BaseService<
   Menu,
   MenuPopulate,
   MenuFull,
-  MenuDTOMapActions
+  MenuDto
 > {
   private RootSymbol: symbol = Symbol('RootMenu');
 

--- a/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
+++ b/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
@@ -137,12 +137,16 @@ describe('BaseNlpHelper', () => {
           name: 'intent',
           createdAt: new Date(),
           updatedAt: new Date(),
+          builtin: false,
+          lookups: [],
         },
         entity2: {
           id: new ObjectId().toString(),
           name: 'test-entity',
           createdAt: new Date(),
           updatedAt: new Date(),
+          builtin: false,
+          lookups: [],
         },
       });
       jest.spyOn(NlpValue, 'getValueMap').mockReturnValue({
@@ -152,6 +156,9 @@ describe('BaseNlpHelper', () => {
           entity: 'entity1', // Add the required entity field
           createdAt: new Date(),
           updatedAt: new Date(),
+          builtin: false,
+          expressions: [],
+          metadata: [],
         },
         value2: {
           id: new ObjectId().toString(),
@@ -159,6 +166,9 @@ describe('BaseNlpHelper', () => {
           entity: 'entity2', // Add the required entity field
           createdAt: new Date(),
           updatedAt: new Date(),
+          builtin: false,
+          expressions: [],
+          metadata: [],
         },
       });
 
@@ -195,6 +205,8 @@ describe('BaseNlpHelper', () => {
           name: 'test-entity',
           createdAt: new Date(),
           updatedAt: new Date(),
+          builtin: false,
+          lookups: [],
         },
       });
 

--- a/api/src/i18n/dto/language.dto.ts
+++ b/api/src/i18n/dto/language.dto.ts
@@ -35,6 +35,6 @@ export class LanguageCreateDto {
 
 export class LanguageUpdateDto extends PartialType(LanguageCreateDto) {}
 
-export type LanguageDTOMapActions = DtoConfig<{
+export type LanguageDto = DtoConfig<{
   create: LanguageCreateDto;
 }>;

--- a/api/src/i18n/dto/language.dto.ts
+++ b/api/src/i18n/dto/language.dto.ts
@@ -7,8 +7,10 @@
  */
 
 import { PartialType } from '@nestjs/mapped-types';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+import { DtoConfig } from '@/utils/types/dto.types';
 
 export class LanguageCreateDto {
   @ApiProperty({ description: 'Language Title', type: String })
@@ -25,10 +27,14 @@ export class LanguageCreateDto {
   @IsBoolean()
   isRTL: boolean;
 
-  @ApiProperty({ description: 'Is Default Language ?', type: Boolean })
+  @ApiPropertyOptional({ description: 'Is Default Language ?', type: Boolean })
   @IsOptional()
   @IsBoolean()
   isDefault?: boolean;
 }
 
 export class LanguageUpdateDto extends PartialType(LanguageCreateDto) {}
+
+export type LanguageDTOMapActions = DtoConfig<{
+  create: LanguageCreateDto;
+}>;

--- a/api/src/i18n/repositories/language.repository.ts
+++ b/api/src/i18n/repositories/language.repository.ts
@@ -14,7 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { LanguageDTOMapActions } from '../dto/language.dto';
+import { LanguageDto } from '../dto/language.dto';
 import { Language } from '../schemas/language.schema';
 
 @Injectable()
@@ -22,7 +22,7 @@ export class LanguageRepository extends BaseRepository<
   Language,
   never,
   never,
-  LanguageDTOMapActions
+  LanguageDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/i18n/repositories/language.repository.ts
+++ b/api/src/i18n/repositories/language.repository.ts
@@ -14,10 +14,16 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { LanguageDTOMapActions } from '../dto/language.dto';
 import { Language } from '../schemas/language.schema';
 
 @Injectable()
-export class LanguageRepository extends BaseRepository<Language> {
+export class LanguageRepository extends BaseRepository<
+  Language,
+  never,
+  never,
+  LanguageDTOMapActions
+> {
   constructor(
     readonly eventEmitter: EventEmitter2,
     @InjectModel(Language.name) readonly model: Model<Language>,

--- a/api/src/i18n/schemas/language.schema.ts
+++ b/api/src/i18n/schemas/language.schema.ts
@@ -32,13 +32,13 @@ export class Language extends BaseSchema {
     type: Boolean,
     default: false,
   })
-  isDefault?: boolean;
+  isDefault: boolean;
 
   @Prop({
     type: Boolean,
     default: false,
   })
-  isRTL?: boolean;
+  isRTL: boolean;
 }
 
 export const LanguageModel: ModelDefinition = LifecycleHookManager.attach({

--- a/api/src/i18n/seeds/language.seed.ts
+++ b/api/src/i18n/seeds/language.seed.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
+import { LanguageDTOMapActions } from '../dto/language.dto';
 import { LanguageRepository } from '../repositories/language.repository';
 import { Language } from '../schemas/language.schema';
 
 @Injectable()
-export class LanguageSeeder extends BaseSeeder<Language> {
+export class LanguageSeeder extends BaseSeeder<
+  Language,
+  never,
+  never,
+  LanguageDTOMapActions
+> {
   constructor(private readonly languageRepository: LanguageRepository) {
     super(languageRepository);
   }

--- a/api/src/i18n/seeds/language.seed.ts
+++ b/api/src/i18n/seeds/language.seed.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
-import { LanguageDTOMapActions } from '../dto/language.dto';
+import { LanguageDto } from '../dto/language.dto';
 import { LanguageRepository } from '../repositories/language.repository';
 import { Language } from '../schemas/language.schema';
 
@@ -19,7 +19,7 @@ export class LanguageSeeder extends BaseSeeder<
   Language,
   never,
   never,
-  LanguageDTOMapActions
+  LanguageDto
 > {
   constructor(private readonly languageRepository: LanguageRepository) {
     super(languageRepository);

--- a/api/src/i18n/services/language.service.ts
+++ b/api/src/i18n/services/language.service.ts
@@ -21,11 +21,17 @@ import {
 import { Cacheable } from '@/utils/decorators/cacheable.decorator';
 import { BaseService } from '@/utils/generics/base-service';
 
+import { LanguageDTOMapActions } from '../dto/language.dto';
 import { LanguageRepository } from '../repositories/language.repository';
 import { Language } from '../schemas/language.schema';
 
 @Injectable()
-export class LanguageService extends BaseService<Language> {
+export class LanguageService extends BaseService<
+  Language,
+  never,
+  never,
+  LanguageDTOMapActions
+> {
   constructor(
     readonly repository: LanguageRepository,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,

--- a/api/src/i18n/services/language.service.ts
+++ b/api/src/i18n/services/language.service.ts
@@ -21,7 +21,7 @@ import {
 import { Cacheable } from '@/utils/decorators/cacheable.decorator';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { LanguageDTOMapActions } from '../dto/language.dto';
+import { LanguageDto } from '../dto/language.dto';
 import { LanguageRepository } from '../repositories/language.repository';
 import { Language } from '../schemas/language.schema';
 
@@ -30,7 +30,7 @@ export class LanguageService extends BaseService<
   Language,
   never,
   never,
-  LanguageDTOMapActions
+  LanguageDto
 > {
   constructor(
     readonly repository: LanguageRepository,

--- a/api/src/i18n/services/translation.service.spec.ts
+++ b/api/src/i18n/services/translation.service.spec.ts
@@ -154,6 +154,7 @@ describe('TranslationService', () => {
         },
       },
       options: {},
+      attachedBlock: null,
     };
 
     const mockedPlugin: any = {

--- a/api/src/nlp/dto/nlp-entity.dto.ts
+++ b/api/src/nlp/dto/nlp-entity.dto.ts
@@ -8,14 +8,16 @@
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
-  IsString,
-  IsOptional,
-  IsBoolean,
   IsArray,
-  Matches,
+  IsBoolean,
   IsIn,
   IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
 } from 'class-validator';
+
+import { DtoConfig } from '@/utils/types/dto.types';
 
 export type Lookup = 'keywords' | 'trait' | 'free-text';
 
@@ -46,3 +48,7 @@ export class NlpEntityCreateDto {
   @IsOptional()
   builtin?: boolean;
 }
+
+export type NlpEntityDTOMapActions = DtoConfig<{
+  create: NlpEntityCreateDto;
+}>;

--- a/api/src/nlp/dto/nlp-entity.dto.ts
+++ b/api/src/nlp/dto/nlp-entity.dto.ts
@@ -49,6 +49,6 @@ export class NlpEntityCreateDto {
   builtin?: boolean;
 }
 
-export type NlpEntityDTOMapActions = DtoConfig<{
+export type NlpEntityDto = DtoConfig<{
   create: NlpEntityCreateDto;
 }>;

--- a/api/src/nlp/dto/nlp-sample.dto.ts
+++ b/api/src/nlp/dto/nlp-sample.dto.ts
@@ -15,6 +15,7 @@ import {
   IsString,
 } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 import { NlpSampleEntityValue, NlpSampleState } from '../schemas/types';
@@ -40,7 +41,7 @@ export class NlpSampleCreateDto {
   @IsString()
   @IsIn(Object.values(NlpSampleState))
   @IsOptional()
-  type?: NlpSampleState;
+  type?: keyof typeof NlpSampleState;
 
   @ApiProperty({ description: 'NLP sample language id', type: String })
   @IsString()
@@ -63,3 +64,7 @@ export class NlpSampleDto extends NlpSampleCreateDto {
 }
 
 export class NlpSampleUpdateDto extends PartialType(NlpSampleCreateDto) {}
+
+export type NlpSampleDTOMapActions = DtoConfig<{
+  create: NlpSampleCreateDto;
+}>;

--- a/api/src/nlp/dto/nlp-sample.dto.ts
+++ b/api/src/nlp/dto/nlp-sample.dto.ts
@@ -65,6 +65,6 @@ export class NlpSampleDto extends NlpSampleCreateDto {
 
 export class NlpSampleUpdateDto extends PartialType(NlpSampleCreateDto) {}
 
-export type NlpSampleDTOMapActions = DtoConfig<{
+export type TNlpSampleDto = DtoConfig<{
   create: NlpSampleCreateDto;
 }>;

--- a/api/src/nlp/dto/nlp-value.dto.ts
+++ b/api/src/nlp/dto/nlp-value.dto.ts
@@ -54,6 +54,6 @@ export class NlpValueCreateDto {
 
 export class NlpValueUpdateDto extends PartialType(NlpValueCreateDto) {}
 
-export type NlpValueDTOMapActions = DtoConfig<{
+export type NlpValueDto = DtoConfig<{
   create: NlpValueCreateDto;
 }>;

--- a/api/src/nlp/dto/nlp-value.dto.ts
+++ b/api/src/nlp/dto/nlp-value.dto.ts
@@ -9,14 +9,15 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
-  IsString,
-  IsBoolean,
   IsArray,
-  IsObject,
+  IsBoolean,
   IsNotEmpty,
+  IsObject,
   IsOptional,
+  IsString,
 } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 export class NlpValueCreateDto {
@@ -52,3 +53,7 @@ export class NlpValueCreateDto {
 }
 
 export class NlpValueUpdateDto extends PartialType(NlpValueCreateDto) {}
+
+export type NlpValueDTOMapActions = DtoConfig<{
+  create: NlpValueCreateDto;
+}>;

--- a/api/src/nlp/repositories/nlp-entity.repository.ts
+++ b/api/src/nlp/repositories/nlp-entity.repository.ts
@@ -14,6 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { NlpEntityDTOMapActions } from '../dto/nlp-entity.dto';
 import {
   NLP_ENTITY_POPULATE,
   NlpEntity,
@@ -29,7 +30,8 @@ import { NlpValueRepository } from './nlp-value.repository';
 export class NlpEntityRepository extends BaseRepository<
   NlpEntity,
   NlpEntityPopulate,
-  NlpEntityFull
+  NlpEntityFull,
+  NlpEntityDTOMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/nlp/repositories/nlp-entity.repository.ts
+++ b/api/src/nlp/repositories/nlp-entity.repository.ts
@@ -14,7 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { NlpEntityDTOMapActions } from '../dto/nlp-entity.dto';
+import { NlpEntityDto } from '../dto/nlp-entity.dto';
 import {
   NLP_ENTITY_POPULATE,
   NlpEntity,
@@ -31,7 +31,7 @@ export class NlpEntityRepository extends BaseRepository<
   NlpEntity,
   NlpEntityPopulate,
   NlpEntityFull,
-  NlpEntityDTOMapActions
+  NlpEntityDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/nlp/repositories/nlp-sample.repository.ts
+++ b/api/src/nlp/repositories/nlp-sample.repository.ts
@@ -14,7 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { NlpSampleDTOMapActions } from '../dto/nlp-sample.dto';
+import { TNlpSampleDto } from '../dto/nlp-sample.dto';
 import {
   NLP_SAMPLE_POPULATE,
   NlpSample,
@@ -29,7 +29,7 @@ export class NlpSampleRepository extends BaseRepository<
   NlpSample,
   NlpSamplePopulate,
   NlpSampleFull,
-  NlpSampleDTOMapActions
+  TNlpSampleDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/nlp/repositories/nlp-sample.repository.ts
+++ b/api/src/nlp/repositories/nlp-sample.repository.ts
@@ -14,6 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { NlpSampleDTOMapActions } from '../dto/nlp-sample.dto';
 import {
   NLP_SAMPLE_POPULATE,
   NlpSample,
@@ -27,7 +28,8 @@ import { NlpSampleEntityRepository } from './nlp-sample-entity.repository';
 export class NlpSampleRepository extends BaseRepository<
   NlpSample,
   NlpSamplePopulate,
-  NlpSampleFull
+  NlpSampleFull,
+  NlpSampleDTOMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -14,7 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { NlpValueDTOMapActions } from '../dto/nlp-value.dto';
+import { NlpValueDto } from '../dto/nlp-value.dto';
 import {
   NLP_VALUE_POPULATE,
   NlpValue,
@@ -30,7 +30,7 @@ export class NlpValueRepository extends BaseRepository<
   NlpValue,
   NlpValuePopulate,
   NlpValueFull,
-  NlpValueDTOMapActions
+  NlpValueDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -14,6 +14,7 @@ import { Document, Model, Query } from 'mongoose';
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { NlpValueDTOMapActions } from '../dto/nlp-value.dto';
 import {
   NLP_VALUE_POPULATE,
   NlpValue,
@@ -28,7 +29,8 @@ import { NlpSampleEntityRepository } from './nlp-sample-entity.repository';
 export class NlpValueRepository extends BaseRepository<
   NlpValue,
   NlpValuePopulate,
-  NlpValueFull
+  NlpValueFull,
+  NlpValueDTOMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/nlp/schemas/nlp-entity.schema.ts
+++ b/api/src/nlp/schemas/nlp-entity.schema.ts
@@ -44,7 +44,7 @@ export class NlpEntityStub extends BaseSchema {
    * Lookup strategy can contain : keywords, trait, free-text
    */
   @Prop({ type: [String], default: ['keywords'] })
-  lookups?: Lookup[];
+  lookups: Lookup[];
 
   /**
    * Description of the entity purpose.
@@ -56,7 +56,7 @@ export class NlpEntityStub extends BaseSchema {
    * Either or not this entity a built-in (either fixtures or shipped along with the 3rd party ai).
    */
   @Prop({ type: Boolean, default: false })
-  builtin?: boolean;
+  builtin: boolean;
 
   /**
    * Returns a map object for entities

--- a/api/src/nlp/schemas/nlp-sample.schema.ts
+++ b/api/src/nlp/schemas/nlp-sample.schema.ts
@@ -33,7 +33,7 @@ export class NlpSampleStub extends BaseSchema {
    * Either or not this sample was used for traning already.
    */
   @Prop({ type: Boolean, default: false })
-  trained?: boolean;
+  trained: boolean;
 
   /**
    * From where this sample was provided.
@@ -43,7 +43,7 @@ export class NlpSampleStub extends BaseSchema {
     enum: Object.values(NlpSampleState),
     default: NlpSampleState.train,
   })
-  type?: keyof typeof NlpSampleState;
+  type: keyof typeof NlpSampleState;
 
   /**
    * The language of the sample.

--- a/api/src/nlp/schemas/nlp-value.schema.ts
+++ b/api/src/nlp/schemas/nlp-value.schema.ts
@@ -38,19 +38,19 @@ export class NlpValueStub extends BaseSchema {
    * An array of synonyms or equivalent words that fits this value.
    */
   @Prop({ type: [String], default: [] })
-  expressions?: string[];
+  expressions: string[];
 
   /**
    * Metadata are additional data that can be associated to this values, most of the time, the metadata contains system values or ids (e.g: value: "coffee", metadata: "item_11") .
    */
   @Prop({ type: JSON, default: {} })
-  metadata?: Record<string, any>;
+  metadata: Record<string, any>;
 
   /**
    * Either or not this value a built-in (either fixtures or shipped along with the 3rd party ai).
    */
   @Prop({ type: Boolean, default: false })
-  builtin?: boolean;
+  builtin: boolean;
 
   /**
    * The entity to which this value belongs to.

--- a/api/src/nlp/seeds/nlp-entity.seed.ts
+++ b/api/src/nlp/seeds/nlp-entity.seed.ts
@@ -10,6 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
+import { NlpEntityDTOMapActions } from '../dto/nlp-entity.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import {
   NlpEntity,
@@ -21,7 +22,8 @@ import {
 export class NlpEntitySeeder extends BaseSeeder<
   NlpEntity,
   NlpEntityPopulate,
-  NlpEntityFull
+  NlpEntityFull,
+  NlpEntityDTOMapActions
 > {
   constructor(nlpEntityRepository: NlpEntityRepository) {
     super(nlpEntityRepository);

--- a/api/src/nlp/seeds/nlp-entity.seed.ts
+++ b/api/src/nlp/seeds/nlp-entity.seed.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
-import { NlpEntityDTOMapActions } from '../dto/nlp-entity.dto';
+import { NlpEntityDto } from '../dto/nlp-entity.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import {
   NlpEntity,
@@ -23,7 +23,7 @@ export class NlpEntitySeeder extends BaseSeeder<
   NlpEntity,
   NlpEntityPopulate,
   NlpEntityFull,
-  NlpEntityDTOMapActions
+  NlpEntityDto
 > {
   constructor(nlpEntityRepository: NlpEntityRepository) {
     super(nlpEntityRepository);

--- a/api/src/nlp/seeds/nlp-value.seed.ts
+++ b/api/src/nlp/seeds/nlp-value.seed.ts
@@ -8,9 +8,9 @@
 
 import { Injectable } from '@nestjs/common';
 
-import { BaseSchema } from '@/utils/generics/base-schema';
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
+import { NlpValueCreateDto, NlpValueDTOMapActions } from '../dto/nlp-value.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
 import {
@@ -23,7 +23,8 @@ import {
 export class NlpValueSeeder extends BaseSeeder<
   NlpValue,
   NlpValuePopulate,
-  NlpValueFull
+  NlpValueFull,
+  NlpValueDTOMapActions
 > {
   constructor(
     nlpValueRepository: NlpValueRepository,
@@ -32,7 +33,7 @@ export class NlpValueSeeder extends BaseSeeder<
     super(nlpValueRepository);
   }
 
-  async seed(models: Omit<NlpValue, keyof BaseSchema>[]): Promise<boolean> {
+  async seed(models: NlpValueCreateDto[]): Promise<boolean> {
     if (await this.isEmpty()) {
       const entities = await this.nlpEntityRepository.findAll();
       const modelDtos = models.map((v) => ({

--- a/api/src/nlp/seeds/nlp-value.seed.ts
+++ b/api/src/nlp/seeds/nlp-value.seed.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
-import { NlpValueCreateDto, NlpValueDTOMapActions } from '../dto/nlp-value.dto';
+import { NlpValueCreateDto, NlpValueDto } from '../dto/nlp-value.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
 import {
@@ -24,7 +24,7 @@ export class NlpValueSeeder extends BaseSeeder<
   NlpValue,
   NlpValuePopulate,
   NlpValueFull,
-  NlpValueDTOMapActions
+  NlpValueDto
 > {
   constructor(
     nlpValueRepository: NlpValueRepository,

--- a/api/src/nlp/services/nlp-entity.service.ts
+++ b/api/src/nlp/services/nlp-entity.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { Lookup, NlpEntityDTOMapActions } from '../dto/nlp-entity.dto';
+import { Lookup, NlpEntityDto } from '../dto/nlp-entity.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import {
   NlpEntity,
@@ -26,7 +26,7 @@ export class NlpEntityService extends BaseService<
   NlpEntity,
   NlpEntityPopulate,
   NlpEntityFull,
-  NlpEntityDTOMapActions
+  NlpEntityDto
 > {
   constructor(
     readonly repository: NlpEntityRepository,

--- a/api/src/nlp/services/nlp-entity.service.ts
+++ b/api/src/nlp/services/nlp-entity.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { Lookup } from '../dto/nlp-entity.dto';
+import { Lookup, NlpEntityDTOMapActions } from '../dto/nlp-entity.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import {
   NlpEntity,
@@ -25,7 +25,8 @@ import { NlpValueService } from './nlp-value.service';
 export class NlpEntityService extends BaseService<
   NlpEntity,
   NlpEntityPopulate,
-  NlpEntityFull
+  NlpEntityFull,
+  NlpEntityDTOMapActions
 > {
   constructor(
     readonly repository: NlpEntityRepository,

--- a/api/src/nlp/services/nlp-sample.service.ts
+++ b/api/src/nlp/services/nlp-sample.service.ts
@@ -21,7 +21,10 @@ import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 import { THydratedDocument } from '@/utils/types/filter.types';
 
-import { NlpSampleCreateDto } from '../dto/nlp-sample.dto';
+import {
+  NlpSampleCreateDto,
+  NlpSampleDTOMapActions,
+} from '../dto/nlp-sample.dto';
 import { NlpSampleRepository } from '../repositories/nlp-sample.repository';
 import {
   NlpSample,
@@ -37,7 +40,8 @@ import { NlpSampleEntityService } from './nlp-sample-entity.service';
 export class NlpSampleService extends BaseService<
   NlpSample,
   NlpSamplePopulate,
-  NlpSampleFull
+  NlpSampleFull,
+  NlpSampleDTOMapActions
 > {
   constructor(
     readonly repository: NlpSampleRepository,

--- a/api/src/nlp/services/nlp-sample.service.ts
+++ b/api/src/nlp/services/nlp-sample.service.ts
@@ -21,10 +21,7 @@ import { LoggerService } from '@/logger/logger.service';
 import { BaseService } from '@/utils/generics/base-service';
 import { THydratedDocument } from '@/utils/types/filter.types';
 
-import {
-  NlpSampleCreateDto,
-  NlpSampleDTOMapActions,
-} from '../dto/nlp-sample.dto';
+import { NlpSampleCreateDto, TNlpSampleDto } from '../dto/nlp-sample.dto';
 import { NlpSampleRepository } from '../repositories/nlp-sample.repository';
 import {
   NlpSample,
@@ -41,7 +38,7 @@ export class NlpSampleService extends BaseService<
   NlpSample,
   NlpSamplePopulate,
   NlpSampleFull,
-  NlpSampleDTOMapActions
+  TNlpSampleDto
 > {
   constructor(
     readonly repository: NlpSampleRepository,

--- a/api/src/nlp/services/nlp-value.service.ts
+++ b/api/src/nlp/services/nlp-value.service.ts
@@ -11,7 +11,11 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { DeleteResult } from '@/utils/generics/base-repository';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { NlpValueCreateDto, NlpValueUpdateDto } from '../dto/nlp-value.dto';
+import {
+  NlpValueCreateDto,
+  NlpValueDTOMapActions,
+  NlpValueUpdateDto,
+} from '../dto/nlp-value.dto';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
 import { NlpEntity } from '../schemas/nlp-entity.schema';
 import {
@@ -27,7 +31,8 @@ import { NlpEntityService } from './nlp-entity.service';
 export class NlpValueService extends BaseService<
   NlpValue,
   NlpValuePopulate,
-  NlpValueFull
+  NlpValueFull,
+  NlpValueDTOMapActions
 > {
   constructor(
     readonly repository: NlpValueRepository,

--- a/api/src/nlp/services/nlp-value.service.ts
+++ b/api/src/nlp/services/nlp-value.service.ts
@@ -13,7 +13,7 @@ import { BaseService } from '@/utils/generics/base-service';
 
 import {
   NlpValueCreateDto,
-  NlpValueDTOMapActions,
+  NlpValueDto,
   NlpValueUpdateDto,
 } from '../dto/nlp-value.dto';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
@@ -32,7 +32,7 @@ export class NlpValueService extends BaseService<
   NlpValue,
   NlpValuePopulate,
   NlpValueFull,
-  NlpValueDTOMapActions
+  NlpValueDto
 > {
   constructor(
     readonly repository: NlpValueRepository,

--- a/api/src/user/controllers/permission.controller.ts
+++ b/api/src/user/controllers/permission.controller.ts
@@ -47,10 +47,10 @@ export class PermissionController extends BaseController<
   PermissionFull
 > {
   constructor(
-    private readonly permissionService: PermissionService,
-    private readonly logger: LoggerService,
-    private readonly roleService: RoleService,
-    private readonly modelService: ModelService,
+    protected readonly permissionService: PermissionService,
+    protected readonly logger: LoggerService,
+    protected readonly roleService: RoleService,
+    protected readonly modelService: ModelService,
   ) {
     super(permissionService);
   }

--- a/api/src/user/controllers/permission.controller.ts
+++ b/api/src/user/controllers/permission.controller.ts
@@ -47,10 +47,10 @@ export class PermissionController extends BaseController<
   PermissionFull
 > {
   constructor(
-    protected readonly permissionService: PermissionService,
-    protected readonly logger: LoggerService,
-    protected readonly roleService: RoleService,
-    protected readonly modelService: ModelService,
+    private readonly permissionService: PermissionService,
+    private readonly logger: LoggerService,
+    private readonly roleService: RoleService,
+    private readonly modelService: ModelService,
   ) {
     super(permissionService);
   }

--- a/api/src/user/dto/permission.dto.ts
+++ b/api/src/user/dto/permission.dto.ts
@@ -42,6 +42,6 @@ export class PermissionCreateDto {
   relation?: TRelation;
 }
 
-export type PermissionDTOMapActions = DtoConfig<{
+export type PermissionDto = DtoConfig<{
   create: PermissionCreateDto;
 }>;

--- a/api/src/user/dto/permission.dto.ts
+++ b/api/src/user/dto/permission.dto.ts
@@ -7,8 +7,9 @@
  */
 
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsString, IsOptional } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 import { Action } from '../types/action.type';
@@ -40,3 +41,7 @@ export class PermissionCreateDto {
   @IsOptional()
   relation?: TRelation;
 }
+
+export type PermissionDTOMapActions = DtoConfig<{
+  create: PermissionCreateDto;
+}>;

--- a/api/src/user/dto/role.dto.ts
+++ b/api/src/user/dto/role.dto.ts
@@ -9,6 +9,8 @@
 import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
+
 export class RoleCreateDto {
   @ApiProperty({ description: 'Name of the role', type: String })
   @IsNotEmpty()
@@ -26,3 +28,7 @@ export class RoleCreateDto {
 }
 
 export class RoleUpdateDto extends PartialType(RoleCreateDto) {}
+
+export type RoleDTOMapActions = DtoConfig<{
+  create: RoleCreateDto;
+}>;

--- a/api/src/user/dto/role.dto.ts
+++ b/api/src/user/dto/role.dto.ts
@@ -29,6 +29,6 @@ export class RoleCreateDto {
 
 export class RoleUpdateDto extends PartialType(RoleCreateDto) {}
 
-export type RoleDTOMapActions = DtoConfig<{
+export type RoleDto = DtoConfig<{
   create: RoleCreateDto;
 }>;

--- a/api/src/user/dto/user.dto.ts
+++ b/api/src/user/dto/user.dto.ts
@@ -100,6 +100,6 @@ export class UserResetPasswordDto extends PickType(UserCreateDto, [
 
 export class UserRequestResetDto extends PickType(UserCreateDto, ['email']) {}
 
-export type UserCrudsDto = DtoConfig<{
+export type UserDTOCruds = DtoConfig<{
   create: UserCreateDto;
 }>;

--- a/api/src/user/dto/user.dto.ts
+++ b/api/src/user/dto/user.dto.ts
@@ -62,12 +62,21 @@ export class UserCreateDto {
   @IsString()
   @IsObjectId({ message: 'Avatar must be a valid ObjectId' })
   avatar: string | null = null;
+
+  @ApiPropertyOptional({
+    description: 'User state',
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  state?: boolean;
 }
 
 export class UserEditProfileDto extends OmitType(PartialType(UserCreateDto), [
   'username',
   'roles',
   'avatar',
+  'state',
 ]) {
   @ApiPropertyOptional({ description: 'User language', type: String })
   @IsOptional()

--- a/api/src/user/dto/user.dto.ts
+++ b/api/src/user/dto/user.dto.ts
@@ -109,6 +109,6 @@ export class UserResetPasswordDto extends PickType(UserCreateDto, [
 
 export class UserRequestResetDto extends PickType(UserCreateDto, ['email']) {}
 
-export type UserDTOCruds = DtoConfig<{
+export type UserDtoMapActions = DtoConfig<{
   create: UserCreateDto;
 }>;

--- a/api/src/user/dto/user.dto.ts
+++ b/api/src/user/dto/user.dto.ts
@@ -109,6 +109,6 @@ export class UserResetPasswordDto extends PickType(UserCreateDto, [
 
 export class UserRequestResetDto extends PickType(UserCreateDto, ['email']) {}
 
-export type UserDtoMapActions = DtoConfig<{
+export type UserDto = DtoConfig<{
   create: UserCreateDto;
 }>;

--- a/api/src/user/dto/user.dto.ts
+++ b/api/src/user/dto/user.dto.ts
@@ -22,6 +22,7 @@ import {
   IsString,
 } from 'class-validator';
 
+import { DtoConfig } from '@/utils/types/dto.types';
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
 
 export class UserCreateDto {
@@ -98,3 +99,7 @@ export class UserResetPasswordDto extends PickType(UserCreateDto, [
 ]) {}
 
 export class UserRequestResetDto extends PickType(UserCreateDto, ['email']) {}
+
+export type TUserCrudsDto = DtoConfig<{
+  create: UserCreateDto;
+}>;

--- a/api/src/user/dto/user.dto.ts
+++ b/api/src/user/dto/user.dto.ts
@@ -100,6 +100,6 @@ export class UserResetPasswordDto extends PickType(UserCreateDto, [
 
 export class UserRequestResetDto extends PickType(UserCreateDto, ['email']) {}
 
-export type TUserCrudsDto = DtoConfig<{
+export type UserCrudsDto = DtoConfig<{
   create: UserCreateDto;
 }>;

--- a/api/src/user/repositories/permission.repository.ts
+++ b/api/src/user/repositories/permission.repository.ts
@@ -13,7 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
-import { PermissionDTOMapActions } from '../dto/permission.dto';
+import { PermissionDto } from '../dto/permission.dto';
 import {
   Permission,
   PERMISSION_POPULATE,
@@ -26,7 +26,7 @@ export class PermissionRepository extends BaseRepository<
   Permission,
   PermissionPopulate,
   PermissionFull,
-  PermissionDTOMapActions
+  PermissionDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/user/repositories/permission.repository.ts
+++ b/api/src/user/repositories/permission.repository.ts
@@ -13,6 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository } from '@/utils/generics/base-repository';
 
+import { PermissionDTOMapActions } from '../dto/permission.dto';
 import {
   Permission,
   PERMISSION_POPULATE,
@@ -24,7 +25,8 @@ import {
 export class PermissionRepository extends BaseRepository<
   Permission,
   PermissionPopulate,
-  PermissionFull
+  PermissionFull,
+  PermissionDTOMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/user/repositories/role.repository.ts
+++ b/api/src/user/repositories/role.repository.ts
@@ -13,7 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 
-import { RoleDTOMapActions } from '../dto/role.dto';
+import { RoleDto } from '../dto/role.dto';
 import { Permission } from '../schemas/permission.schema';
 import {
   Role,
@@ -27,7 +27,7 @@ export class RoleRepository extends BaseRepository<
   Role,
   RolePopulate,
   RoleFull,
-  RoleDTOMapActions
+  RoleDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/user/repositories/role.repository.ts
+++ b/api/src/user/repositories/role.repository.ts
@@ -13,6 +13,7 @@ import { Model } from 'mongoose';
 
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 
+import { RoleDTOMapActions } from '../dto/role.dto';
 import { Permission } from '../schemas/permission.schema';
 import {
   Role,
@@ -25,7 +26,8 @@ import {
 export class RoleRepository extends BaseRepository<
   Role,
   RolePopulate,
-  RoleFull
+  RoleFull,
+  RoleDTOMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/user/repositories/user.repository.ts
+++ b/api/src/user/repositories/user.repository.ts
@@ -20,7 +20,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { UserEditProfileDto } from '../dto/user.dto';
+import { UserCrudsDto, UserEditProfileDto } from '../dto/user.dto';
 import {
   User,
   USER_POPULATE,
@@ -34,7 +34,8 @@ import { hash } from '../utilities/bcryptjs';
 export class UserRepository extends BaseRepository<
   User,
   UserPopulate,
-  UserFull
+  UserFull,
+  UserCrudsDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/user/repositories/user.repository.ts
+++ b/api/src/user/repositories/user.repository.ts
@@ -20,7 +20,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { UserDTOCruds, UserEditProfileDto } from '../dto/user.dto';
+import { UserDtoMapActions, UserEditProfileDto } from '../dto/user.dto';
 import {
   User,
   USER_POPULATE,
@@ -35,7 +35,7 @@ export class UserRepository extends BaseRepository<
   User,
   UserPopulate,
   UserFull,
-  UserDTOCruds
+  UserDtoMapActions
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/user/repositories/user.repository.ts
+++ b/api/src/user/repositories/user.repository.ts
@@ -20,7 +20,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { UserDtoMapActions, UserEditProfileDto } from '../dto/user.dto';
+import { UserDto, UserEditProfileDto } from '../dto/user.dto';
 import {
   User,
   USER_POPULATE,
@@ -35,7 +35,7 @@ export class UserRepository extends BaseRepository<
   User,
   UserPopulate,
   UserFull,
-  UserDtoMapActions
+  UserDto
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/user/repositories/user.repository.ts
+++ b/api/src/user/repositories/user.repository.ts
@@ -20,7 +20,7 @@ import {
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
-import { UserCrudsDto, UserEditProfileDto } from '../dto/user.dto';
+import { UserDTOCruds, UserEditProfileDto } from '../dto/user.dto';
 import {
   User,
   USER_POPULATE,
@@ -35,7 +35,7 @@ export class UserRepository extends BaseRepository<
   User,
   UserPopulate,
   UserFull,
-  UserCrudsDto
+  UserDTOCruds
 > {
   constructor(
     readonly eventEmitter: EventEmitter2,

--- a/api/src/user/schemas/permission.schema.ts
+++ b/api/src/user/schemas/permission.schema.ts
@@ -18,6 +18,7 @@ import {
 } from '@/utils/types/filter.types';
 
 import { Action } from '../types/action.type';
+import { TRelation } from '../types/index.type';
 
 import { Model } from './model.schema';
 import { Role } from './role.schema';
@@ -41,7 +42,7 @@ export class PermissionStub extends BaseSchema {
     type: String,
     default: 'role',
   })
-  relation?: string;
+  relation: TRelation;
 }
 
 @Schema({ timestamps: true })

--- a/api/src/user/schemas/role.schema.ts
+++ b/api/src/user/schemas/role.schema.ts
@@ -31,7 +31,7 @@ export class RoleStub extends BaseSchema {
   name: string;
 
   @Prop({ type: Boolean, default: true })
-  active?: boolean;
+  active: boolean;
 }
 
 @Schema({ timestamps: true })

--- a/api/src/user/schemas/user.schema.ts
+++ b/api/src/user/schemas/user.schema.ts
@@ -50,6 +50,16 @@ export class UserStub extends BaseSchema {
   })
   password: string;
 
+  @Prop([{ type: MongooseSchema.Types.ObjectId, ref: 'Role' }])
+  roles: unknown;
+
+  @Prop({
+    type: MongooseSchema.Types.ObjectId,
+    ref: 'Attachment',
+    default: null,
+  })
+  avatar: unknown;
+
   @Prop({
     type: Boolean,
     default: false,
@@ -82,16 +92,6 @@ export class UserStub extends BaseSchema {
     default: 0,
   })
   resetCount?: number;
-
-  @Prop([{ type: MongooseSchema.Types.ObjectId, ref: 'Role' }])
-  roles: unknown;
-
-  @Prop({
-    type: MongooseSchema.Types.ObjectId,
-    ref: 'Attachment',
-    default: null,
-  })
-  avatar: unknown;
 
   @Prop({
     type: String,

--- a/api/src/user/seeds/permission.seed.ts
+++ b/api/src/user/seeds/permission.seed.ts
@@ -10,6 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
+import { PermissionDTOMapActions } from '../dto/permission.dto';
 import { PermissionRepository } from '../repositories/permission.repository';
 import {
   Permission,
@@ -21,7 +22,8 @@ import {
 export class PermissionSeeder extends BaseSeeder<
   Permission,
   PermissionPopulate,
-  PermissionFull
+  PermissionFull,
+  PermissionDTOMapActions
 > {
   constructor(private readonly permissionRepository: PermissionRepository) {
     super(permissionRepository);

--- a/api/src/user/seeds/permission.seed.ts
+++ b/api/src/user/seeds/permission.seed.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
-import { PermissionDTOMapActions } from '../dto/permission.dto';
+import { PermissionDto } from '../dto/permission.dto';
 import { PermissionRepository } from '../repositories/permission.repository';
 import {
   Permission,
@@ -23,7 +23,7 @@ export class PermissionSeeder extends BaseSeeder<
   Permission,
   PermissionPopulate,
   PermissionFull,
-  PermissionDTOMapActions
+  PermissionDto
 > {
   constructor(private readonly permissionRepository: PermissionRepository) {
     super(permissionRepository);

--- a/api/src/user/seeds/role.seed.ts
+++ b/api/src/user/seeds/role.seed.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
-import { RoleDTOMapActions } from '../dto/role.dto';
+import { RoleDto } from '../dto/role.dto';
 import { RoleRepository } from '../repositories/role.repository';
 import { Role, RoleFull, RolePopulate } from '../schemas/role.schema';
 
@@ -19,7 +19,7 @@ export class RoleSeeder extends BaseSeeder<
   Role,
   RolePopulate,
   RoleFull,
-  RoleDTOMapActions
+  RoleDto
 > {
   constructor(private readonly roleRepository: RoleRepository) {
     super(roleRepository);

--- a/api/src/user/seeds/role.seed.ts
+++ b/api/src/user/seeds/role.seed.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseSeeder } from '@/utils/generics/base-seeder';
 
+import { RoleDTOMapActions } from '../dto/role.dto';
 import { RoleRepository } from '../repositories/role.repository';
 import { Role, RoleFull, RolePopulate } from '../schemas/role.schema';
 
 @Injectable()
-export class RoleSeeder extends BaseSeeder<Role, RolePopulate, RoleFull> {
+export class RoleSeeder extends BaseSeeder<
+  Role,
+  RolePopulate,
+  RoleFull,
+  RoleDTOMapActions
+> {
   constructor(private readonly roleRepository: RoleRepository) {
     super(roleRepository);
   }

--- a/api/src/user/services/permission.service.ts
+++ b/api/src/user/services/permission.service.ts
@@ -15,6 +15,7 @@ import { PERMISSION_CACHE_KEY } from '@/utils/constants/cache';
 import { Cacheable } from '@/utils/decorators/cacheable.decorator';
 import { BaseService } from '@/utils/generics/base-service';
 
+import { PermissionDTOMapActions } from '../dto/permission.dto';
 import { PermissionRepository } from '../repositories/permission.repository';
 import {
   Permission,
@@ -27,7 +28,8 @@ import { PermissionsTree } from '../types/permission.type';
 export class PermissionService extends BaseService<
   Permission,
   PermissionPopulate,
-  PermissionFull
+  PermissionFull,
+  PermissionDTOMapActions
 > {
   constructor(
     readonly repository: PermissionRepository,

--- a/api/src/user/services/permission.service.ts
+++ b/api/src/user/services/permission.service.ts
@@ -15,7 +15,7 @@ import { PERMISSION_CACHE_KEY } from '@/utils/constants/cache';
 import { Cacheable } from '@/utils/decorators/cacheable.decorator';
 import { BaseService } from '@/utils/generics/base-service';
 
-import { PermissionDTOMapActions } from '../dto/permission.dto';
+import { PermissionDto } from '../dto/permission.dto';
 import { PermissionRepository } from '../repositories/permission.repository';
 import {
   Permission,
@@ -29,7 +29,7 @@ export class PermissionService extends BaseService<
   Permission,
   PermissionPopulate,
   PermissionFull,
-  PermissionDTOMapActions
+  PermissionDto
 > {
   constructor(
     readonly repository: PermissionRepository,

--- a/api/src/user/services/role.service.ts
+++ b/api/src/user/services/role.service.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
+import { RoleDTOMapActions } from '../dto/role.dto';
 import { RoleRepository } from '../repositories/role.repository';
 import { Role, RoleFull, RolePopulate } from '../schemas/role.schema';
 
 @Injectable()
-export class RoleService extends BaseService<Role, RolePopulate, RoleFull> {
+export class RoleService extends BaseService<
+  Role,
+  RolePopulate,
+  RoleFull,
+  RoleDTOMapActions
+> {
   constructor(readonly repository: RoleRepository) {
     super(repository);
   }

--- a/api/src/user/services/role.service.ts
+++ b/api/src/user/services/role.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { RoleDTOMapActions } from '../dto/role.dto';
+import { RoleDto } from '../dto/role.dto';
 import { RoleRepository } from '../repositories/role.repository';
 import { Role, RoleFull, RolePopulate } from '../schemas/role.schema';
 
@@ -19,7 +19,7 @@ export class RoleService extends BaseService<
   Role,
   RolePopulate,
   RoleFull,
-  RoleDTOMapActions
+  RoleDto
 > {
   constructor(readonly repository: RoleRepository) {
     super(repository);

--- a/api/src/user/services/user.service.ts
+++ b/api/src/user/services/user.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { UserCrudsDto } from '../dto/user.dto';
+import { UserDTOCruds } from '../dto/user.dto';
 import { UserRepository } from '../repositories/user.repository';
 import { User, UserFull, UserPopulate } from '../schemas/user.schema';
 
@@ -19,7 +19,7 @@ export class UserService extends BaseService<
   User,
   UserPopulate,
   UserFull,
-  UserCrudsDto
+  UserDTOCruds
 > {
   constructor(readonly repository: UserRepository) {
     super(repository);

--- a/api/src/user/services/user.service.ts
+++ b/api/src/user/services/user.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { TUserCrudsDto } from '../dto/user.dto';
+import { UserCrudsDto } from '../dto/user.dto';
 import { UserRepository } from '../repositories/user.repository';
 import { User, UserFull, UserPopulate } from '../schemas/user.schema';
 
@@ -19,7 +19,7 @@ export class UserService extends BaseService<
   User,
   UserPopulate,
   UserFull,
-  TUserCrudsDto
+  UserCrudsDto
 > {
   constructor(readonly repository: UserRepository) {
     super(repository);

--- a/api/src/user/services/user.service.ts
+++ b/api/src/user/services/user.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { UserDTOCruds } from '../dto/user.dto';
+import { UserDtoMapActions } from '../dto/user.dto';
 import { UserRepository } from '../repositories/user.repository';
 import { User, UserFull, UserPopulate } from '../schemas/user.schema';
 
@@ -19,7 +19,7 @@ export class UserService extends BaseService<
   User,
   UserPopulate,
   UserFull,
-  UserDTOCruds
+  UserDtoMapActions
 > {
   constructor(readonly repository: UserRepository) {
     super(repository);

--- a/api/src/user/services/user.service.ts
+++ b/api/src/user/services/user.service.ts
@@ -10,11 +10,17 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
+import { TUserCrudsDto } from '../dto/user.dto';
 import { UserRepository } from '../repositories/user.repository';
 import { User, UserFull, UserPopulate } from '../schemas/user.schema';
 
 @Injectable()
-export class UserService extends BaseService<User, UserPopulate, UserFull> {
+export class UserService extends BaseService<
+  User,
+  UserPopulate,
+  UserFull,
+  TUserCrudsDto
+> {
   constructor(readonly repository: UserRepository) {
     super(repository);
   }

--- a/api/src/user/services/user.service.ts
+++ b/api/src/user/services/user.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@nestjs/common';
 
 import { BaseService } from '@/utils/generics/base-service';
 
-import { UserDtoMapActions } from '../dto/user.dto';
+import { UserDto } from '../dto/user.dto';
 import { UserRepository } from '../repositories/user.repository';
 import { User, UserFull, UserPopulate } from '../schemas/user.schema';
 
@@ -19,7 +19,7 @@ export class UserService extends BaseService<
   User,
   UserPopulate,
   UserFull,
-  UserDtoMapActions
+  UserDto
 > {
   constructor(readonly repository: UserRepository) {
     super(repository);

--- a/api/src/utils/generics/base-controller.ts
+++ b/api/src/utils/generics/base-controller.ts
@@ -10,6 +10,7 @@ import { NotFoundException } from '@nestjs/common';
 
 import { TFilterQuery } from '@/utils/types/filter.types';
 
+import { DtoConfig } from '../types/dto.types';
 import { TValidateProps } from '../types/filter.types';
 
 import { BaseSchema } from './base-schema';
@@ -20,8 +21,9 @@ export abstract class BaseController<
   TStub = never,
   P extends string = never,
   TFull extends Omit<T, P> = never,
+  Dto extends DtoConfig = object,
 > {
-  constructor(protected readonly service: BaseService<T, P, TFull>) {}
+  constructor(protected readonly service: BaseService<T, P, TFull, Dto>) {}
 
   /**
    * Checks if the given populate fields are allowed based on the allowed fields list.

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -30,6 +30,7 @@ import {
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
+import { DtoInfer, DtoOperations, DtoProps } from '../types/dto.types';
 
 import { BaseSchema } from './base-schema';
 import { LifecycleHookManager } from './lifecycle-hook-manager';
@@ -70,6 +71,7 @@ export abstract class BaseRepository<
   T extends FlattenMaps<unknown>,
   P extends string = never,
   TFull extends Omit<T, P> = never,
+  DTO extends DtoProps<T> = unknown,
   U = Omit<T, keyof BaseSchema>,
   D = Document<T>,
 > {
@@ -454,7 +456,7 @@ export abstract class BaseRepository<
     return await this.model.countDocuments(criteria).exec();
   }
 
-  async create(dto: U): Promise<T> {
+  async create(dto: DtoInfer<DtoOperations.Create, DTO, U>): Promise<T> {
     const doc = await this.model.create(dto);
 
     return plainToClass(

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -71,7 +71,7 @@ export abstract class BaseRepository<
   T extends FlattenMaps<unknown>,
   P extends string = never,
   TFull extends Omit<T, P> = never,
-  DTO extends DtoProps<T> = unknown,
+  DTOCruds extends DtoProps<T> = unknown,
   U = Omit<T, keyof BaseSchema>,
   D = Document<T>,
 > {
@@ -456,7 +456,7 @@ export abstract class BaseRepository<
     return await this.model.countDocuments(criteria).exec();
   }
 
-  async create(dto: DtoInfer<DtoOperations.Create, DTO, U>): Promise<T> {
+  async create(dto: DtoInfer<DtoOperations.Create, DTOCruds, U>): Promise<T> {
     const doc = await this.model.create(dto);
 
     return plainToClass(

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -30,7 +30,7 @@ import {
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
-import { DtoActions, DtoInfer, DtoProps } from '../types/dto.types';
+import { DtoAction, DtoInfer, DtoProps } from '../types/dto.types';
 
 import { BaseSchema } from './base-schema';
 import { LifecycleHookManager } from './lifecycle-hook-manager';
@@ -456,7 +456,7 @@ export abstract class BaseRepository<
     return await this.model.countDocuments(criteria).exec();
   }
 
-  async create(dto: DtoInfer<DtoActions.Create, DTOCruds, U>): Promise<T> {
+  async create(dto: DtoInfer<DtoAction.Create, DTOCruds, U>): Promise<T> {
     const doc = await this.model.create(dto);
 
     return plainToClass(
@@ -467,7 +467,7 @@ export abstract class BaseRepository<
   }
 
   async createMany(
-    dtoArray: DtoInfer<DtoActions.Create, DTOCruds, U>[],
+    dtoArray: DtoInfer<DtoAction.Create, DTOCruds, U>[],
   ): Promise<T[]> {
     const docs = await this.model.create(dtoArray);
 

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -466,7 +466,9 @@ export abstract class BaseRepository<
     );
   }
 
-  async createMany(dtoArray: U[]): Promise<T[]> {
+  async createMany(
+    dtoArray: DtoInfer<DtoOperations.Create, DTOCruds, U>[],
+  ): Promise<T[]> {
     const docs = await this.model.create(dtoArray);
 
     return docs.map((doc) =>

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -30,7 +30,7 @@ import {
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
-import { DtoInfer, DtoOperations, DtoProps } from '../types/dto.types';
+import { DtoActions, DtoInfer, DtoProps } from '../types/dto.types';
 
 import { BaseSchema } from './base-schema';
 import { LifecycleHookManager } from './lifecycle-hook-manager';
@@ -456,7 +456,7 @@ export abstract class BaseRepository<
     return await this.model.countDocuments(criteria).exec();
   }
 
-  async create(dto: DtoInfer<DtoOperations.Create, DTOCruds, U>): Promise<T> {
+  async create(dto: DtoInfer<DtoActions.Create, DTOCruds, U>): Promise<T> {
     const doc = await this.model.create(dto);
 
     return plainToClass(
@@ -467,7 +467,7 @@ export abstract class BaseRepository<
   }
 
   async createMany(
-    dtoArray: DtoInfer<DtoOperations.Create, DTOCruds, U>[],
+    dtoArray: DtoInfer<DtoActions.Create, DTOCruds, U>[],
   ): Promise<T[]> {
     const docs = await this.model.create(dtoArray);
 

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -30,7 +30,7 @@ import {
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
-import { DtoAction, DtoInfer, DtoProps } from '../types/dto.types';
+import { DtoAction, DtoConfig, DtoInfer } from '../types/dto.types';
 
 import { BaseSchema } from './base-schema';
 import { LifecycleHookManager } from './lifecycle-hook-manager';
@@ -71,7 +71,7 @@ export abstract class BaseRepository<
   T extends FlattenMaps<unknown>,
   P extends string = never,
   TFull extends Omit<T, P> = never,
-  DTOCruds extends DtoProps<T> = unknown,
+  Dto extends DtoConfig = object,
   U = Omit<T, keyof BaseSchema>,
   D = Document<T>,
 > {
@@ -456,7 +456,7 @@ export abstract class BaseRepository<
     return await this.model.countDocuments(criteria).exec();
   }
 
-  async create(dto: DtoInfer<DtoAction.Create, DTOCruds, U>): Promise<T> {
+  async create(dto: DtoInfer<DtoAction.Create, Dto, U>): Promise<T> {
     const doc = await this.model.create(dto);
 
     return plainToClass(
@@ -467,7 +467,7 @@ export abstract class BaseRepository<
   }
 
   async createMany(
-    dtoArray: DtoInfer<DtoAction.Create, DTOCruds, U>[],
+    dtoArray: DtoInfer<DtoAction.Create, Dto, U>[],
   ): Promise<T[]> {
     const docs = await this.model.create(dtoArray);
 

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -72,7 +72,7 @@ export abstract class BaseRepository<
   P extends string = never,
   TFull extends Omit<T, P> = never,
   Dto extends DtoConfig = object,
-  U = Omit<T, keyof BaseSchema>,
+  U extends Omit<T, keyof BaseSchema> = Omit<T, keyof BaseSchema>,
   D = Document<T>,
 > {
   private readonly transformOpts = { excludePrefixes: ['_', 'password'] };

--- a/api/src/utils/generics/base-seeder.ts
+++ b/api/src/utils/generics/base-seeder.ts
@@ -8,6 +8,8 @@
 
 import { FlattenMaps } from 'mongoose';
 
+import { DtoActions, DtoInfer, DtoProps } from '../types/dto.types';
+
 import { BaseRepository } from './base-repository';
 import { BaseSchema } from './base-schema';
 
@@ -15,6 +17,7 @@ export abstract class BaseSeeder<
   T extends FlattenMaps<unknown>,
   P extends string = never,
   TFull extends Omit<T, P> = never,
+  DTOCruds extends DtoProps<any> = unknown,
 > {
   constructor(protected readonly repository: BaseRepository<T, P, TFull>) {}
 
@@ -27,7 +30,9 @@ export abstract class BaseSeeder<
     return count === 0;
   }
 
-  async seed(models: Omit<T, keyof BaseSchema>[]): Promise<boolean> {
+  async seed<D extends Omit<T, keyof BaseSchema>>(
+    models: DtoInfer<DtoActions.Create, DTOCruds, D>[],
+  ): Promise<boolean> {
     if (await this.isEmpty()) {
       await this.repository.createMany(models);
       return true;

--- a/api/src/utils/generics/base-seeder.ts
+++ b/api/src/utils/generics/base-seeder.ts
@@ -18,6 +18,7 @@ export abstract class BaseSeeder<
   P extends string = never,
   TFull extends Omit<T, P> = never,
   Dto extends DtoConfig = object,
+  U extends Omit<T, keyof BaseSchema> = Omit<T, keyof BaseSchema>,
 > {
   constructor(
     protected readonly repository: BaseRepository<T, P, TFull, Dto>,
@@ -32,9 +33,7 @@ export abstract class BaseSeeder<
     return count === 0;
   }
 
-  async seed<D extends Omit<T, keyof BaseSchema>>(
-    models: DtoInfer<DtoAction.Create, Dto, D>[],
-  ): Promise<boolean> {
+  async seed(models: DtoInfer<DtoAction.Create, Dto, U>[]): Promise<boolean> {
     if (await this.isEmpty()) {
       await this.repository.createMany(models);
       return true;

--- a/api/src/utils/generics/base-seeder.ts
+++ b/api/src/utils/generics/base-seeder.ts
@@ -8,7 +8,7 @@
 
 import { FlattenMaps } from 'mongoose';
 
-import { DtoAction, DtoInfer, DtoProps } from '../types/dto.types';
+import { DtoAction, DtoConfig, DtoInfer } from '../types/dto.types';
 
 import { BaseRepository } from './base-repository';
 import { BaseSchema } from './base-schema';
@@ -17,10 +17,10 @@ export abstract class BaseSeeder<
   T extends FlattenMaps<unknown>,
   P extends string = never,
   TFull extends Omit<T, P> = never,
-  DTOCruds extends DtoProps<any> = unknown,
+  Dto extends DtoConfig = object,
 > {
   constructor(
-    protected readonly repository: BaseRepository<T, P, TFull, DTOCruds>,
+    protected readonly repository: BaseRepository<T, P, TFull, Dto>,
   ) {}
 
   async findAll(): Promise<T[]> {
@@ -33,7 +33,7 @@ export abstract class BaseSeeder<
   }
 
   async seed<D extends Omit<T, keyof BaseSchema>>(
-    models: DtoInfer<DtoAction.Create, DTOCruds, D>[],
+    models: DtoInfer<DtoAction.Create, Dto, D>[],
   ): Promise<boolean> {
     if (await this.isEmpty()) {
       await this.repository.createMany(models);

--- a/api/src/utils/generics/base-seeder.ts
+++ b/api/src/utils/generics/base-seeder.ts
@@ -19,7 +19,9 @@ export abstract class BaseSeeder<
   TFull extends Omit<T, P> = never,
   DTOCruds extends DtoProps<any> = unknown,
 > {
-  constructor(protected readonly repository: BaseRepository<T, P, TFull>) {}
+  constructor(
+    protected readonly repository: BaseRepository<T, P, TFull, DTOCruds>,
+  ) {}
 
   async findAll(): Promise<T[]> {
     return await this.repository.findAll();

--- a/api/src/utils/generics/base-seeder.ts
+++ b/api/src/utils/generics/base-seeder.ts
@@ -8,7 +8,7 @@
 
 import { FlattenMaps } from 'mongoose';
 
-import { DtoActions, DtoInfer, DtoProps } from '../types/dto.types';
+import { DtoAction, DtoInfer, DtoProps } from '../types/dto.types';
 
 import { BaseRepository } from './base-repository';
 import { BaseSchema } from './base-schema';
@@ -33,7 +33,7 @@ export abstract class BaseSeeder<
   }
 
   async seed<D extends Omit<T, keyof BaseSchema>>(
-    models: DtoInfer<DtoActions.Create, DTOCruds, D>[],
+    models: DtoInfer<DtoAction.Create, DTOCruds, D>[],
   ): Promise<boolean> {
     if (await this.isEmpty()) {
       await this.repository.createMany(models);

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -24,6 +24,7 @@ export abstract class BaseService<
   P extends string = never,
   TFull extends Omit<T, P> = never,
   Dto extends DtoConfig = object,
+  U extends Omit<T, keyof BaseSchema> = Omit<T, keyof BaseSchema>,
 > {
   constructor(
     protected readonly repository: BaseRepository<T, P, TFull, Dto>,
@@ -144,9 +145,7 @@ export abstract class BaseService<
     return await this.repository.count(criteria);
   }
 
-  async create<D extends Omit<T, keyof BaseSchema>>(
-    dto: DtoInfer<DtoAction.Create, Dto, D>,
-  ): Promise<T> {
+  async create(dto: DtoInfer<DtoAction.Create, Dto, U>): Promise<T> {
     try {
       return await this.repository.create(dto);
     } catch (error) {
@@ -159,9 +158,9 @@ export abstract class BaseService<
     }
   }
 
-  async findOneOrCreate<D extends Omit<T, keyof BaseSchema>>(
+  async findOneOrCreate(
     criteria: string | TFilterQuery<T>,
-    dto: DtoInfer<DtoAction.Create, Dto, D>,
+    dto: DtoInfer<DtoAction.Create, Dto, U>,
   ): Promise<T> {
     const result = await this.findOne(criteria);
     if (!result) {
@@ -170,24 +169,21 @@ export abstract class BaseService<
     return result;
   }
 
-  async createMany<D extends Omit<T, keyof BaseSchema>>(
-    dtoArray: DtoInfer<DtoAction.Create, Dto, D>[],
+  async createMany(
+    dtoArray: DtoInfer<DtoAction.Create, Dto, U>[],
   ): Promise<T[]> {
     return await this.repository.createMany(dtoArray);
   }
 
-  async updateOne<D extends Partial<Omit<T, keyof BaseSchema>>>(
+  async updateOne(
     criteria: string | TFilterQuery<T>,
-    dto: D,
-    options?: QueryOptions<D> | null,
+    dto: Partial<U>,
+    options?: QueryOptions<Partial<U>> | null,
   ): Promise<T | null> {
     return await this.repository.updateOne(criteria, dto, options);
   }
 
-  async updateMany<D extends Partial<Omit<T, keyof BaseSchema>>>(
-    filter: TFilterQuery<T>,
-    dto: D,
-  ) {
+  async updateMany(filter: TFilterQuery<T>, dto: Partial<U>) {
     return await this.repository.updateMany(filter, dto);
   }
 

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -25,7 +25,9 @@ export abstract class BaseService<
   TFull extends Omit<T, P> = never,
   DTO extends DtoProps<any> = unknown,
 > {
-  constructor(protected readonly repository: BaseRepository<T, P, TFull>) {}
+  constructor(
+    protected readonly repository: BaseRepository<T, P, TFull, DTO>,
+  ) {}
 
   getRepository() {
     return this.repository;

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -14,6 +14,7 @@ import { ProjectionType, QueryOptions } from 'mongoose';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
+import { DtoInfer, DtoOperations, DtoProps } from '../types/dto.types';
 
 import { BaseRepository } from './base-repository';
 import { BaseSchema } from './base-schema';
@@ -22,6 +23,7 @@ export abstract class BaseService<
   T extends BaseSchema,
   P extends string = never,
   TFull extends Omit<T, P> = never,
+  DTO extends DtoProps<any> = unknown,
 > {
   constructor(protected readonly repository: BaseRepository<T, P, TFull>) {}
 
@@ -140,7 +142,9 @@ export abstract class BaseService<
     return await this.repository.count(criteria);
   }
 
-  async create<D extends Omit<T, keyof BaseSchema>>(dto: D): Promise<T> {
+  async create<
+    D extends DtoInfer<DtoOperations.Create, DTO, Omit<T, keyof BaseSchema>>,
+  >(dto: D): Promise<T> {
     try {
       return await this.repository.create(dto);
     } catch (error) {
@@ -153,10 +157,9 @@ export abstract class BaseService<
     }
   }
 
-  async findOneOrCreate<D extends Omit<T, keyof BaseSchema>>(
-    criteria: string | TFilterQuery<T>,
-    dto: D,
-  ): Promise<T> {
+  async findOneOrCreate<
+    D extends DtoInfer<DtoOperations.Create, DTO, Omit<T, keyof BaseSchema>>,
+  >(criteria: string | TFilterQuery<T>, dto: D): Promise<T> {
     const result = await this.findOne(criteria);
     if (!result) {
       return await this.create(dto);

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -23,10 +23,10 @@ export abstract class BaseService<
   T extends BaseSchema,
   P extends string = never,
   TFull extends Omit<T, P> = never,
-  DTO extends DtoProps<any> = unknown,
+  DTOCruds extends DtoProps<any> = unknown,
 > {
   constructor(
-    protected readonly repository: BaseRepository<T, P, TFull, DTO>,
+    protected readonly repository: BaseRepository<T, P, TFull, DTOCruds>,
   ) {}
 
   getRepository() {
@@ -145,7 +145,11 @@ export abstract class BaseService<
   }
 
   async create<
-    D extends DtoInfer<DtoOperations.Create, DTO, Omit<T, keyof BaseSchema>>,
+    D extends DtoInfer<
+      DtoOperations.Create,
+      DTOCruds,
+      Omit<T, keyof BaseSchema>
+    >,
   >(dto: D): Promise<T> {
     try {
       return await this.repository.create(dto);
@@ -160,7 +164,11 @@ export abstract class BaseService<
   }
 
   async findOneOrCreate<
-    D extends DtoInfer<DtoOperations.Create, DTO, Omit<T, keyof BaseSchema>>,
+    D extends DtoInfer<
+      DtoOperations.Create,
+      DTOCruds,
+      Omit<T, keyof BaseSchema>
+    >,
   >(criteria: string | TFilterQuery<T>, dto: D): Promise<T> {
     const result = await this.findOne(criteria);
     if (!result) {

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -14,7 +14,7 @@ import { ProjectionType, QueryOptions } from 'mongoose';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
-import { DtoActions, DtoInfer, DtoProps } from '../types/dto.types';
+import { DtoAction, DtoInfer, DtoProps } from '../types/dto.types';
 
 import { BaseRepository } from './base-repository';
 import { BaseSchema } from './base-schema';
@@ -145,7 +145,7 @@ export abstract class BaseService<
   }
 
   async create<D extends Omit<T, keyof BaseSchema>>(
-    dto: DtoInfer<DtoActions.Create, DTOCruds, D>,
+    dto: DtoInfer<DtoAction.Create, DTOCruds, D>,
   ): Promise<T> {
     try {
       return await this.repository.create(dto);
@@ -161,7 +161,7 @@ export abstract class BaseService<
 
   async findOneOrCreate<D extends Omit<T, keyof BaseSchema>>(
     criteria: string | TFilterQuery<T>,
-    dto: DtoInfer<DtoActions.Create, DTOCruds, D>,
+    dto: DtoInfer<DtoAction.Create, DTOCruds, D>,
   ): Promise<T> {
     const result = await this.findOne(criteria);
     if (!result) {
@@ -171,7 +171,7 @@ export abstract class BaseService<
   }
 
   async createMany<D extends Omit<T, keyof BaseSchema>>(
-    dtoArray: DtoInfer<DtoActions.Create, DTOCruds, D>[],
+    dtoArray: DtoInfer<DtoAction.Create, DTOCruds, D>[],
   ): Promise<T[]> {
     return await this.repository.createMany(dtoArray);
   }

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -144,13 +144,9 @@ export abstract class BaseService<
     return await this.repository.count(criteria);
   }
 
-  async create<
-    D extends DtoInfer<
-      DtoOperations.Create,
-      DTOCruds,
-      Omit<T, keyof BaseSchema>
-    >,
-  >(dto: D): Promise<T> {
+  async create<D extends Omit<T, keyof BaseSchema>>(
+    dto: DtoInfer<DtoOperations.Create, DTOCruds, D>,
+  ): Promise<T> {
     try {
       return await this.repository.create(dto);
     } catch (error) {
@@ -163,13 +159,10 @@ export abstract class BaseService<
     }
   }
 
-  async findOneOrCreate<
-    D extends DtoInfer<
-      DtoOperations.Create,
-      DTOCruds,
-      Omit<T, keyof BaseSchema>
-    >,
-  >(criteria: string | TFilterQuery<T>, dto: D): Promise<T> {
+  async findOneOrCreate<D extends Omit<T, keyof BaseSchema>>(
+    criteria: string | TFilterQuery<T>,
+    dto: DtoInfer<DtoOperations.Create, DTOCruds, D>,
+  ): Promise<T> {
     const result = await this.findOne(criteria);
     if (!result) {
       return await this.create(dto);
@@ -178,7 +171,7 @@ export abstract class BaseService<
   }
 
   async createMany<D extends Omit<T, keyof BaseSchema>>(
-    dtoArray: D[],
+    dtoArray: DtoInfer<DtoOperations.Create, DTOCruds, D>[],
   ): Promise<T[]> {
     return await this.repository.createMany(dtoArray);
   }

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -14,7 +14,7 @@ import { ProjectionType, QueryOptions } from 'mongoose';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
-import { DtoInfer, DtoOperations, DtoProps } from '../types/dto.types';
+import { DtoActions, DtoInfer, DtoProps } from '../types/dto.types';
 
 import { BaseRepository } from './base-repository';
 import { BaseSchema } from './base-schema';
@@ -145,7 +145,7 @@ export abstract class BaseService<
   }
 
   async create<D extends Omit<T, keyof BaseSchema>>(
-    dto: DtoInfer<DtoOperations.Create, DTOCruds, D>,
+    dto: DtoInfer<DtoActions.Create, DTOCruds, D>,
   ): Promise<T> {
     try {
       return await this.repository.create(dto);
@@ -161,7 +161,7 @@ export abstract class BaseService<
 
   async findOneOrCreate<D extends Omit<T, keyof BaseSchema>>(
     criteria: string | TFilterQuery<T>,
-    dto: DtoInfer<DtoOperations.Create, DTOCruds, D>,
+    dto: DtoInfer<DtoActions.Create, DTOCruds, D>,
   ): Promise<T> {
     const result = await this.findOne(criteria);
     if (!result) {
@@ -171,7 +171,7 @@ export abstract class BaseService<
   }
 
   async createMany<D extends Omit<T, keyof BaseSchema>>(
-    dtoArray: DtoInfer<DtoOperations.Create, DTOCruds, D>[],
+    dtoArray: DtoInfer<DtoActions.Create, DTOCruds, D>[],
   ): Promise<T[]> {
     return await this.repository.createMany(dtoArray);
   }

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -14,7 +14,7 @@ import { ProjectionType, QueryOptions } from 'mongoose';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
-import { DtoAction, DtoInfer, DtoProps } from '../types/dto.types';
+import { DtoAction, DtoConfig, DtoInfer } from '../types/dto.types';
 
 import { BaseRepository } from './base-repository';
 import { BaseSchema } from './base-schema';
@@ -23,10 +23,10 @@ export abstract class BaseService<
   T extends BaseSchema,
   P extends string = never,
   TFull extends Omit<T, P> = never,
-  DTOCruds extends DtoProps<any> = unknown,
+  Dto extends DtoConfig = object,
 > {
   constructor(
-    protected readonly repository: BaseRepository<T, P, TFull, DTOCruds>,
+    protected readonly repository: BaseRepository<T, P, TFull, Dto>,
   ) {}
 
   getRepository() {
@@ -145,7 +145,7 @@ export abstract class BaseService<
   }
 
   async create<D extends Omit<T, keyof BaseSchema>>(
-    dto: DtoInfer<DtoAction.Create, DTOCruds, D>,
+    dto: DtoInfer<DtoAction.Create, Dto, D>,
   ): Promise<T> {
     try {
       return await this.repository.create(dto);
@@ -161,7 +161,7 @@ export abstract class BaseService<
 
   async findOneOrCreate<D extends Omit<T, keyof BaseSchema>>(
     criteria: string | TFilterQuery<T>,
-    dto: DtoInfer<DtoAction.Create, DTOCruds, D>,
+    dto: DtoInfer<DtoAction.Create, Dto, D>,
   ): Promise<T> {
     const result = await this.findOne(criteria);
     if (!result) {
@@ -171,7 +171,7 @@ export abstract class BaseService<
   }
 
   async createMany<D extends Omit<T, keyof BaseSchema>>(
-    dtoArray: DtoInfer<DtoAction.Create, DTOCruds, D>[],
+    dtoArray: DtoInfer<DtoAction.Create, Dto, D>[],
   ): Promise<T[]> {
     return await this.repository.createMany(dtoArray);
   }

--- a/api/src/utils/test/fixtures/block.ts
+++ b/api/src/utils/test/fixtures/block.ts
@@ -26,6 +26,7 @@ export const blockDefaultValues: TBlockFixtures['defaultValues'] = {
   capture_vars: [],
   assign_labels: [],
   trigger_labels: [],
+  trigger_channels: [],
   builtin: false,
   starts_conversation: false,
   attachedBlock: null,
@@ -36,7 +37,6 @@ export const blocks: TBlockFixtures['values'][] = [
   {
     name: 'hasNextBlocks',
     patterns: ['Hi'],
-    trigger_channels: [],
     category: null,
     options: {
       typing: 0,
@@ -55,7 +55,6 @@ export const blocks: TBlockFixtures['values'][] = [
   {
     name: 'hasPreviousBlocks',
     patterns: ['colors'],
-    trigger_channels: [],
     category: null,
     options: {
       typing: 0,
@@ -93,7 +92,6 @@ export const blocks: TBlockFixtures['values'][] = [
   {
     name: 'buttons',
     patterns: ['about'],
-    trigger_channels: [],
     category: null,
     options: {
       typing: 0,
@@ -131,7 +129,6 @@ export const blocks: TBlockFixtures['values'][] = [
   {
     name: 'attachment',
     patterns: ['image'],
-    trigger_channels: [],
     category: null,
     options: {
       typing: 0,
@@ -158,7 +155,6 @@ export const blocks: TBlockFixtures['values'][] = [
   {
     name: 'test',
     patterns: ['yes'],
-    trigger_channels: [],
     category: null,
     //to be verified
     options: {

--- a/api/src/utils/test/fixtures/block.ts
+++ b/api/src/utils/test/fixtures/block.ts
@@ -8,16 +8,19 @@
 
 import mongoose from 'mongoose';
 
+import { BlockCreateDto } from '@/chat/dto/block.dto';
 import { Block, BlockModel } from '@/chat/schemas/block.schema';
 import { CategoryModel } from '@/chat/schemas/category.schema';
 import { FileType } from '@/chat/schemas/types/attachment';
 import { ButtonType } from '@/chat/schemas/types/button';
 import { QuickReplyType } from '@/chat/schemas/types/quick-reply';
-import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
+import { FixturesTypeBuilder } from '../types';
 
-export const fieldsWithDefaultValues = {
+type TBlockFixtures = FixturesTypeBuilder<Block, BlockCreateDto>;
+
+export const blockDefaultValues: TBlockFixtures['defaultValues'] = {
   options: {},
   nextBlocks: [],
   capture_vars: [],
@@ -27,16 +30,9 @@ export const fieldsWithDefaultValues = {
   starts_conversation: false,
   attachedBlock: null,
   attachedToBlock: null,
-} satisfies Partial<Block>;
+};
 
-type TFieldWithDefaultValues =
-  | keyof typeof fieldsWithDefaultValues
-  | keyof BaseSchema;
-type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
-  Partial<Pick<Block, TFieldWithDefaultValues>>;
-type TBlock = TTransformedField<Block>;
-
-export const blocks: TBlock[] = [
+export const blocks: TBlockFixtures['values'][] = [
   {
     name: 'hasNextBlocks',
     patterns: ['Hi'],
@@ -181,9 +177,11 @@ export const blocks: TBlock[] = [
   },
 ];
 
-export const blockFixtures = getFixturesWithDefaultValues<TBlock>({
+export const blockFixtures = getFixturesWithDefaultValues<
+  TBlockFixtures['values']
+>({
   fixtures: blocks,
-  defaultValues: fieldsWithDefaultValues,
+  defaultValues: blockDefaultValues,
 });
 
 export const installBlockFixtures = async () => {

--- a/api/src/utils/test/fixtures/block.ts
+++ b/api/src/utils/test/fixtures/block.ts
@@ -8,17 +8,35 @@
 
 import mongoose from 'mongoose';
 
-import { BlockCreateDto } from '@/chat/dto/block.dto';
-import { BlockModel, Block } from '@/chat/schemas/block.schema';
+import { Block, BlockModel } from '@/chat/schemas/block.schema';
 import { CategoryModel } from '@/chat/schemas/category.schema';
 import { FileType } from '@/chat/schemas/types/attachment';
 import { ButtonType } from '@/chat/schemas/types/button';
 import { QuickReplyType } from '@/chat/schemas/types/quick-reply';
+import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
-import { TFixturesDefaultValues } from '../types';
 
-export const blocks: BlockCreateDto[] = [
+export const fieldsWithDefaultValues = {
+  options: {},
+  nextBlocks: [],
+  capture_vars: [],
+  assign_labels: [],
+  trigger_labels: [],
+  builtin: false,
+  starts_conversation: false,
+  attachedBlock: null,
+  attachedToBlock: null,
+} satisfies Partial<Block>;
+
+type TFieldWithDefaultValues =
+  | keyof typeof fieldsWithDefaultValues
+  | keyof BaseSchema;
+type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
+  Partial<Pick<Block, TFieldWithDefaultValues>>;
+type TBlock = TTransformedField<Block>;
+
+export const blocks: TBlock[] = [
   {
     name: 'hasNextBlocks',
     patterns: ['Hi'],
@@ -163,20 +181,9 @@ export const blocks: BlockCreateDto[] = [
   },
 ];
 
-export const blockDefaultValues: TFixturesDefaultValues<Block> = {
-  options: {},
-  builtin: false,
-  nextBlocks: [],
-  capture_vars: [],
-  assign_labels: [],
-  trigger_labels: [],
-  starts_conversation: false,
-  attachedToBlock: null,
-};
-
-export const blockFixtures = getFixturesWithDefaultValues<Block>({
+export const blockFixtures = getFixturesWithDefaultValues<TBlock>({
   fixtures: blocks,
-  defaultValues: blockDefaultValues,
+  defaultValues: fieldsWithDefaultValues,
 });
 
 export const installBlockFixtures = async () => {

--- a/api/src/utils/test/fixtures/category.ts
+++ b/api/src/utils/test/fixtures/category.ts
@@ -8,25 +8,24 @@
 
 import mongoose from 'mongoose';
 
+import { CategoryCreateDto } from '@/chat/dto/category.dto';
 import { Category, CategoryModel } from '@/chat/schemas/category.schema';
-import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
+import { FixturesTypeBuilder } from '../types';
 
-export const fieldsWithDefaultValues = {
+export type TCategoryFixtures = FixturesTypeBuilder<
+  Category,
+  CategoryCreateDto
+>;
+
+export const fieldsWithDefaultValues: TCategoryFixtures['defaultValues'] = {
   builtin: false,
   zoom: 100,
   offset: [0, 0],
-} satisfies Partial<Category>;
+};
 
-type TFieldWithDefaultValues =
-  | keyof typeof fieldsWithDefaultValues
-  | keyof BaseSchema;
-type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
-  Partial<Pick<Category, TFieldWithDefaultValues>>;
-type TCategory = TTransformedField<Category>;
-
-export const categories: TCategory[] = [
+export const categories: TCategoryFixtures['values'][] = [
   {
     label: 'test category 1',
   },
@@ -35,7 +34,9 @@ export const categories: TCategory[] = [
   },
 ];
 
-export const categoryFixtures = getFixturesWithDefaultValues<TCategory>({
+export const categoryFixtures = getFixturesWithDefaultValues<
+  TCategoryFixtures['values']
+>({
   fixtures: categories,
   defaultValues: fieldsWithDefaultValues,
 });

--- a/api/src/utils/test/fixtures/category.ts
+++ b/api/src/utils/test/fixtures/category.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -19,7 +19,7 @@ export type TCategoryFixtures = FixturesTypeBuilder<
   CategoryCreateDto
 >;
 
-export const fieldsWithDefaultValues: TCategoryFixtures['defaultValues'] = {
+export const categoryDefaultValues: TCategoryFixtures['defaultValues'] = {
   builtin: false,
   zoom: 100,
   offset: [0, 0],
@@ -38,7 +38,7 @@ export const categoryFixtures = getFixturesWithDefaultValues<
   TCategoryFixtures['values']
 >({
   fixtures: categories,
-  defaultValues: fieldsWithDefaultValues,
+  defaultValues: categoryDefaultValues,
 });
 
 export const installCategoryFixtures = async () => {

--- a/api/src/utils/test/fixtures/category.ts
+++ b/api/src/utils/test/fixtures/category.ts
@@ -8,13 +8,25 @@
 
 import mongoose from 'mongoose';
 
-import { CategoryCreateDto } from '@/chat/dto/category.dto';
-import { CategoryModel, Category } from '@/chat/schemas/category.schema';
+import { Category, CategoryModel } from '@/chat/schemas/category.schema';
+import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
-import { TFixturesDefaultValues } from '../types';
 
-export const categories: CategoryCreateDto[] = [
+export const fieldsWithDefaultValues = {
+  builtin: false,
+  zoom: 100,
+  offset: [0, 0],
+} satisfies Partial<Category>;
+
+type TFieldWithDefaultValues =
+  | keyof typeof fieldsWithDefaultValues
+  | keyof BaseSchema;
+type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
+  Partial<Pick<Category, TFieldWithDefaultValues>>;
+type TCategory = TTransformedField<Category>;
+
+export const categories: TCategory[] = [
   {
     label: 'test category 1',
   },
@@ -23,15 +35,9 @@ export const categories: CategoryCreateDto[] = [
   },
 ];
 
-export const categoryDefaultValues: TFixturesDefaultValues<Category> = {
-  builtin: false,
-  zoom: 100,
-  offset: [0, 0],
-};
-
-export const categoryFixtures = getFixturesWithDefaultValues<Category>({
+export const categoryFixtures = getFixturesWithDefaultValues<TCategory>({
   fixtures: categories,
-  defaultValues: categoryDefaultValues,
+  defaultValues: fieldsWithDefaultValues,
 });
 
 export const installCategoryFixtures = async () => {

--- a/api/src/utils/test/fixtures/content.ts
+++ b/api/src/utils/test/fixtures/content.ts
@@ -8,16 +8,26 @@
 
 import mongoose from 'mongoose';
 
-import { ContentCreateDto } from '@/cms/dto/content.dto';
 import { Content, ContentModel } from '@/cms/schemas/content.schema';
+import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
-import { TFixturesDefaultValues } from '../types';
 
 import { installAttachmentFixtures } from './attachment';
 import { installContentTypeFixtures } from './contenttype';
 
-const contents: ContentCreateDto[] = [
+export const fieldsWithDefaultValues = {
+  status: true,
+} satisfies Partial<Content>;
+
+type TFieldWithDefaultValues =
+  | keyof typeof fieldsWithDefaultValues
+  | keyof BaseSchema;
+type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
+  Partial<Pick<Content, TFieldWithDefaultValues>>;
+type TContent = TTransformedField<Content>;
+
+const contents: TContent[] = [
   {
     title: 'Jean',
     dynamicFields: {
@@ -131,14 +141,9 @@ const contents: ContentCreateDto[] = [
   },
 ];
 
-export const categoryDefaultValues: TFixturesDefaultValues<Content> = {
-  status: true,
-  createdAt: undefined,
-};
-
-export const contentFixtures = getFixturesWithDefaultValues<Content>({
+export const contentFixtures = getFixturesWithDefaultValues<TContent>({
   fixtures: contents,
-  defaultValues: categoryDefaultValues,
+  defaultValues: fieldsWithDefaultValues,
 });
 
 export const installContentFixtures = async () => {

--- a/api/src/utils/test/fixtures/content.ts
+++ b/api/src/utils/test/fixtures/content.ts
@@ -8,26 +8,22 @@
 
 import mongoose from 'mongoose';
 
+import { ContentCreateDto } from '@/cms/dto/content.dto';
 import { Content, ContentModel } from '@/cms/schemas/content.schema';
-import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
+import { FixturesTypeBuilder } from '../types';
 
 import { installAttachmentFixtures } from './attachment';
 import { installContentTypeFixtures } from './contenttype';
 
-export const fieldsWithDefaultValues = {
+type TContentFixtures = FixturesTypeBuilder<Content, ContentCreateDto>;
+
+export const fieldsWithDefaultValues: TContentFixtures['defaultValues'] = {
   status: true,
-} satisfies Partial<Content>;
+};
 
-type TFieldWithDefaultValues =
-  | keyof typeof fieldsWithDefaultValues
-  | keyof BaseSchema;
-type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
-  Partial<Pick<Content, TFieldWithDefaultValues>>;
-type TContent = TTransformedField<Content>;
-
-const contents: TContent[] = [
+const contents: TContentFixtures['values'][] = [
   {
     title: 'Jean',
     dynamicFields: {
@@ -141,7 +137,9 @@ const contents: TContent[] = [
   },
 ];
 
-export const contentFixtures = getFixturesWithDefaultValues<TContent>({
+export const contentFixtures = getFixturesWithDefaultValues<
+  TContentFixtures['values']
+>({
   fixtures: contents,
   defaultValues: fieldsWithDefaultValues,
 });

--- a/api/src/utils/test/fixtures/content.ts
+++ b/api/src/utils/test/fixtures/content.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -19,7 +19,7 @@ import { installContentTypeFixtures } from './contenttype';
 
 type TContentFixtures = FixturesTypeBuilder<Content, ContentCreateDto>;
 
-export const fieldsWithDefaultValues: TContentFixtures['defaultValues'] = {
+export const contentDefaultValues: TContentFixtures['defaultValues'] = {
   status: true,
 };
 
@@ -141,7 +141,7 @@ export const contentFixtures = getFixturesWithDefaultValues<
   TContentFixtures['values']
 >({
   fixtures: contents,
-  defaultValues: fieldsWithDefaultValues,
+  defaultValues: contentDefaultValues,
 });
 
 export const installContentFixtures = async () => {

--- a/api/src/utils/test/fixtures/contenttype.ts
+++ b/api/src/utils/test/fixtures/contenttype.ts
@@ -8,15 +8,21 @@
 
 import mongoose from 'mongoose';
 
+import { ContentTypeCreateDto } from '@/cms/dto/contentType.dto';
 import {
   ContentType,
   ContentTypeModel,
 } from '@/cms/schemas/content-type.schema';
-import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
+import { FixturesTypeBuilder } from '../types';
 
-export const fieldsWithDefaultValues = {
+type TContentTypeFixtures = FixturesTypeBuilder<
+  ContentType,
+  ContentTypeCreateDto
+>;
+
+export const fieldsWithDefaultValues: TContentTypeFixtures['defaultValues'] = {
   fields: [
     {
       name: 'title',
@@ -29,16 +35,9 @@ export const fieldsWithDefaultValues = {
       type: 'checkbox',
     },
   ],
-} satisfies Partial<ContentType>;
+};
 
-type TFieldWithDefaultValues =
-  | keyof typeof fieldsWithDefaultValues
-  | keyof BaseSchema;
-type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
-  Partial<Pick<ContentType, TFieldWithDefaultValues>>;
-type TContentType = TTransformedField<ContentType>;
-
-const contentTypes: TContentType[] = [
+const contentTypes: TContentTypeFixtures['values'][] = [
   {
     name: 'Product',
     fields: [
@@ -121,7 +120,9 @@ const contentTypes: TContentType[] = [
   },
 ];
 
-export const contentTypeFixtures = getFixturesWithDefaultValues<TContentType>({
+export const contentTypeFixtures = getFixturesWithDefaultValues<
+  TContentTypeFixtures['values']
+>({
   fixtures: contentTypes,
   defaultValues: fieldsWithDefaultValues,
 });

--- a/api/src/utils/test/fixtures/contenttype.ts
+++ b/api/src/utils/test/fixtures/contenttype.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -22,7 +22,7 @@ type TContentTypeFixtures = FixturesTypeBuilder<
   ContentTypeCreateDto
 >;
 
-export const fieldsWithDefaultValues: TContentTypeFixtures['defaultValues'] = {
+export const contentTypeDefaultValues: TContentTypeFixtures['defaultValues'] = {
   fields: [
     {
       name: 'title',
@@ -124,7 +124,7 @@ export const contentTypeFixtures = getFixturesWithDefaultValues<
   TContentTypeFixtures['values']
 >({
   fixtures: contentTypes,
-  defaultValues: fieldsWithDefaultValues,
+  defaultValues: contentTypeDefaultValues,
 });
 
 export const installContentTypeFixtures = async () => {

--- a/api/src/utils/test/fixtures/contenttype.ts
+++ b/api/src/utils/test/fixtures/contenttype.ts
@@ -8,16 +8,37 @@
 
 import mongoose from 'mongoose';
 
-import { ContentTypeCreateDto } from '@/cms/dto/contentType.dto';
 import {
   ContentType,
   ContentTypeModel,
 } from '@/cms/schemas/content-type.schema';
+import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
-import { TFixturesDefaultValues } from '../types';
 
-const contentTypes: ContentTypeCreateDto[] = [
+export const fieldsWithDefaultValues = {
+  fields: [
+    {
+      name: 'title',
+      label: 'Title',
+      type: 'text',
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'checkbox',
+    },
+  ],
+} satisfies Partial<ContentType>;
+
+type TFieldWithDefaultValues =
+  | keyof typeof fieldsWithDefaultValues
+  | keyof BaseSchema;
+type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
+  Partial<Pick<ContentType, TFieldWithDefaultValues>>;
+type TContentType = TTransformedField<ContentType>;
+
+const contentTypes: TContentType[] = [
   {
     name: 'Product',
     fields: [
@@ -100,24 +121,9 @@ const contentTypes: ContentTypeCreateDto[] = [
   },
 ];
 
-export const contentTypeDefaultValues: TFixturesDefaultValues<ContentType> = {
-  fields: [
-    {
-      name: 'title',
-      label: 'Title',
-      type: 'text',
-    },
-    {
-      name: 'status',
-      label: 'Status',
-      type: 'checkbox',
-    },
-  ],
-};
-
-export const contentTypeFixtures = getFixturesWithDefaultValues<ContentType>({
+export const contentTypeFixtures = getFixturesWithDefaultValues<TContentType>({
   fixtures: contentTypes,
-  defaultValues: contentTypeDefaultValues,
+  defaultValues: fieldsWithDefaultValues,
 });
 
 export const installContentTypeFixtures = async () => {

--- a/api/src/utils/test/fixtures/contextvar.ts
+++ b/api/src/utils/test/fixtures/contextvar.ts
@@ -8,23 +8,19 @@
 
 import mongoose from 'mongoose';
 
+import { ContextVarCreateDto } from '@/chat/dto/context-var.dto';
 import { ContextVar, ContextVarModel } from '@/chat/schemas/context-var.schema';
-import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
+import { FixturesTypeBuilder } from '../types';
 
-export const fieldsWithDefaultValues = {
+type TContentVarFixtures = FixturesTypeBuilder<ContextVar, ContextVarCreateDto>;
+
+export const fieldsWithDefaultValues: TContentVarFixtures['defaultValues'] = {
   permanent: false,
-} satisfies Partial<ContextVar>;
+};
 
-type TFieldWithDefaultValues =
-  | keyof typeof fieldsWithDefaultValues
-  | keyof BaseSchema;
-type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
-  Partial<Pick<ContextVar, TFieldWithDefaultValues>>;
-type TContextVar = TTransformedField<ContextVar>;
-
-const contextVars: TContextVar[] = [
+const contextVars: TContentVarFixtures['values'][] = [
   {
     label: 'test context var 1',
     name: 'test1',
@@ -35,7 +31,9 @@ const contextVars: TContextVar[] = [
   },
 ];
 
-export const contextVarFixtures = getFixturesWithDefaultValues<TContextVar>({
+export const contextVarFixtures = getFixturesWithDefaultValues<
+  TContentVarFixtures['values']
+>({
   fixtures: contextVars,
   defaultValues: fieldsWithDefaultValues,
 });

--- a/api/src/utils/test/fixtures/contextvar.ts
+++ b/api/src/utils/test/fixtures/contextvar.ts
@@ -8,26 +8,36 @@
 
 import mongoose from 'mongoose';
 
-import { ContextVarCreateDto } from '@/chat/dto/context-var.dto';
-import { ContextVarModel, ContextVar } from '@/chat/schemas/context-var.schema';
+import { ContextVar, ContextVarModel } from '@/chat/schemas/context-var.schema';
+import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
 
-const contextVars: ContextVarCreateDto[] = [
+export const fieldsWithDefaultValues = {
+  permanent: false,
+} satisfies Partial<ContextVar>;
+
+type TFieldWithDefaultValues =
+  | keyof typeof fieldsWithDefaultValues
+  | keyof BaseSchema;
+type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
+  Partial<Pick<ContextVar, TFieldWithDefaultValues>>;
+type TContextVar = TTransformedField<ContextVar>;
+
+const contextVars: TContextVar[] = [
   {
     label: 'test context var 1',
     name: 'test1',
-    permanent: false,
   },
   {
     label: 'test context var 2',
     name: 'test2',
-    permanent: false,
   },
 ];
 
-export const contextVarFixtures = getFixturesWithDefaultValues<ContextVar>({
+export const contextVarFixtures = getFixturesWithDefaultValues<TContextVar>({
   fixtures: contextVars,
+  defaultValues: fieldsWithDefaultValues,
 });
 
 export const installContextVarFixtures = async () => {

--- a/api/src/utils/test/fixtures/contextvar.ts
+++ b/api/src/utils/test/fixtures/contextvar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -16,7 +16,7 @@ import { FixturesTypeBuilder } from '../types';
 
 type TContentVarFixtures = FixturesTypeBuilder<ContextVar, ContextVarCreateDto>;
 
-export const fieldsWithDefaultValues: TContentVarFixtures['defaultValues'] = {
+export const contentVarDefaultValues: TContentVarFixtures['defaultValues'] = {
   permanent: false,
 };
 
@@ -35,7 +35,7 @@ export const contextVarFixtures = getFixturesWithDefaultValues<
   TContentVarFixtures['values']
 >({
   fixtures: contextVars,
-  defaultValues: fieldsWithDefaultValues,
+  defaultValues: contentVarDefaultValues,
 });
 
 export const installContextVarFixtures = async () => {

--- a/api/src/utils/test/fixtures/conversation.ts
+++ b/api/src/utils/test/fixtures/conversation.ts
@@ -9,10 +9,7 @@
 import mongoose from 'mongoose';
 
 import { ConversationCreateDto } from '@/chat/dto/conversation.dto';
-import {
-  Conversation,
-  ConversationModel,
-} from '@/chat/schemas/conversation.schema';
+import { ConversationModel } from '@/chat/schemas/conversation.schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
 import { TFixturesDefaultValues } from '../types';
@@ -116,14 +113,16 @@ const conversations: ConversationCreateDto[] = [
   },
 ];
 
-export const conversationDefaultValues: TFixturesDefaultValues<Conversation> = {
-  active: false,
-};
+export const conversationDefaultValues: TFixturesDefaultValues<ConversationCreateDto> =
+  {
+    active: false,
+  };
 
-export const conversationFixtures = getFixturesWithDefaultValues<Conversation>({
-  fixtures: conversations,
-  defaultValues: conversationDefaultValues,
-});
+export const conversationFixtures =
+  getFixturesWithDefaultValues<ConversationCreateDto>({
+    fixtures: conversations,
+    defaultValues: conversationDefaultValues,
+  });
 
 export const installConversationTypeFixtures = async () => {
   const subscribers = await installSubscriberFixtures();

--- a/api/src/utils/test/fixtures/label.ts
+++ b/api/src/utils/test/fixtures/label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -16,7 +16,7 @@ import { FixturesTypeBuilder } from '../types';
 
 type TLabelFixtures = FixturesTypeBuilder<Label, LabelCreateDto>;
 
-export const fieldsWithDefaultValues: TLabelFixtures['defaultValues'] = {
+export const contentLabelDefaultValues: TLabelFixtures['defaultValues'] = {
   builtin: false,
 };
 
@@ -49,7 +49,7 @@ export const labelFixtures = getFixturesWithDefaultValues<
   TLabelFixtures['values']
 >({
   fixtures: labels,
-  defaultValues: fieldsWithDefaultValues,
+  defaultValues: contentLabelDefaultValues,
 });
 
 export const installLabelFixtures = async () => {

--- a/api/src/utils/test/fixtures/label.ts
+++ b/api/src/utils/test/fixtures/label.ts
@@ -8,23 +8,19 @@
 
 import mongoose from 'mongoose';
 
+import { LabelCreateDto } from '@/chat/dto/label.dto';
 import { Label, LabelModel } from '@/chat/schemas/label.schema';
-import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
+import { FixturesTypeBuilder } from '../types';
 
-export const fieldsWithDefaultValues = {
+type TLabelFixtures = FixturesTypeBuilder<Label, LabelCreateDto>;
+
+export const fieldsWithDefaultValues: TLabelFixtures['defaultValues'] = {
   builtin: false,
-} satisfies Partial<Label>;
+};
 
-type TFieldWithDefaultValues =
-  | keyof typeof fieldsWithDefaultValues
-  | keyof BaseSchema;
-type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
-  Partial<Pick<Label, TFieldWithDefaultValues>>;
-type TLabel = TTransformedField<Label>;
-
-export const labels: TLabel[] = [
+export const labels: TLabelFixtures['values'][] = [
   {
     description: 'test description 1',
     label_id: {
@@ -49,7 +45,9 @@ export const labels: TLabel[] = [
   },
 ];
 
-export const labelFixtures = getFixturesWithDefaultValues<TLabel>({
+export const labelFixtures = getFixturesWithDefaultValues<
+  TLabelFixtures['values']
+>({
   fixtures: labels,
   defaultValues: fieldsWithDefaultValues,
 });

--- a/api/src/utils/test/fixtures/label.ts
+++ b/api/src/utils/test/fixtures/label.ts
@@ -8,13 +8,23 @@
 
 import mongoose from 'mongoose';
 
-import { LabelCreateDto } from '@/chat/dto/label.dto';
 import { Label, LabelModel } from '@/chat/schemas/label.schema';
+import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
-import { TFixturesDefaultValues } from '../types';
 
-export const labels: LabelCreateDto[] = [
+export const fieldsWithDefaultValues = {
+  builtin: false,
+} satisfies Partial<Label>;
+
+type TFieldWithDefaultValues =
+  | keyof typeof fieldsWithDefaultValues
+  | keyof BaseSchema;
+type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
+  Partial<Pick<Label, TFieldWithDefaultValues>>;
+type TLabel = TTransformedField<Label>;
+
+export const labels: TLabel[] = [
   {
     description: 'test description 1',
     label_id: {
@@ -39,13 +49,9 @@ export const labels: LabelCreateDto[] = [
   },
 ];
 
-export const labelDefaultValues: TFixturesDefaultValues<Label> = {
-  builtin: false,
-};
-
-export const labelFixtures = getFixturesWithDefaultValues<Label>({
+export const labelFixtures = getFixturesWithDefaultValues<TLabel>({
   fixtures: labels,
-  defaultValues: labelDefaultValues,
+  defaultValues: fieldsWithDefaultValues,
 });
 
 export const installLabelFixtures = async () => {

--- a/api/src/utils/test/fixtures/nlpsample.ts
+++ b/api/src/utils/test/fixtures/nlpsample.ts
@@ -8,27 +8,23 @@
 
 import mongoose from 'mongoose';
 
+import { NlpSampleCreateDto } from '@/nlp/dto/nlp-sample.dto';
 import { NlpSample, NlpSampleModel } from '@/nlp/schemas/nlp-sample.schema';
 import { NlpSampleState } from '@/nlp/schemas/types';
-import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
+import { FixturesTypeBuilder } from '../types';
 
 import { installLanguageFixtures } from './language';
 
-export const fieldsWithDefaultValues = {
+type TNlpSampleFixtures = FixturesTypeBuilder<NlpSample, NlpSampleCreateDto>;
+
+export const fieldsWithDefaultValues: TNlpSampleFixtures['defaultValues'] = {
   type: NlpSampleState.train,
   trained: false,
-} satisfies Partial<NlpSample>;
+};
 
-type TFieldWithDefaultValues =
-  | keyof typeof fieldsWithDefaultValues
-  | keyof BaseSchema;
-type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
-  Partial<Pick<NlpSample, TFieldWithDefaultValues>>;
-type TNlpSample = TTransformedField<NlpSample>;
-
-const nlpSamples: TNlpSample[] = [
+const nlpSamples: TNlpSampleFixtures['values'][] = [
   {
     text: 'yess',
     language: '0',
@@ -49,7 +45,9 @@ const nlpSamples: TNlpSample[] = [
   },
 ];
 
-export const nlpSampleFixtures = getFixturesWithDefaultValues<TNlpSample>({
+export const nlpSampleFixtures = getFixturesWithDefaultValues<
+  TNlpSampleFixtures['values']
+>({
   fixtures: nlpSamples,
   defaultValues: fieldsWithDefaultValues,
 });

--- a/api/src/utils/test/fixtures/nlpsample.ts
+++ b/api/src/utils/test/fixtures/nlpsample.ts
@@ -8,16 +8,27 @@
 
 import mongoose from 'mongoose';
 
-import { NlpSampleCreateDto } from '@/nlp/dto/nlp-sample.dto';
-import { NlpSampleModel, NlpSample } from '@/nlp/schemas/nlp-sample.schema';
+import { NlpSample, NlpSampleModel } from '@/nlp/schemas/nlp-sample.schema';
 import { NlpSampleState } from '@/nlp/schemas/types';
+import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
-import { TFixturesDefaultValues } from '../types';
 
 import { installLanguageFixtures } from './language';
 
-const nlpSamples: NlpSampleCreateDto[] = [
+export const fieldsWithDefaultValues = {
+  type: NlpSampleState.train,
+  trained: false,
+} satisfies Partial<NlpSample>;
+
+type TFieldWithDefaultValues =
+  | keyof typeof fieldsWithDefaultValues
+  | keyof BaseSchema;
+type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
+  Partial<Pick<NlpSample, TFieldWithDefaultValues>>;
+type TNlpSample = TTransformedField<NlpSample>;
+
+const nlpSamples: TNlpSample[] = [
   {
     text: 'yess',
     language: '0',
@@ -38,14 +49,9 @@ const nlpSamples: NlpSampleCreateDto[] = [
   },
 ];
 
-export const nlpSampleDefaultValues: TFixturesDefaultValues<NlpSample> = {
-  type: NlpSampleState.train,
-  trained: false,
-};
-
-export const nlpSampleFixtures = getFixturesWithDefaultValues<NlpSample>({
+export const nlpSampleFixtures = getFixturesWithDefaultValues<TNlpSample>({
   fixtures: nlpSamples,
-  defaultValues: nlpSampleDefaultValues,
+  defaultValues: fieldsWithDefaultValues,
 });
 
 export const installNlpSampleFixtures = async () => {

--- a/api/src/utils/test/fixtures/nlpsample.ts
+++ b/api/src/utils/test/fixtures/nlpsample.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -19,7 +19,7 @@ import { installLanguageFixtures } from './language';
 
 type TNlpSampleFixtures = FixturesTypeBuilder<NlpSample, NlpSampleCreateDto>;
 
-export const fieldsWithDefaultValues: TNlpSampleFixtures['defaultValues'] = {
+export const nlpSampleDefaultValues: TNlpSampleFixtures['defaultValues'] = {
   type: NlpSampleState.train,
   trained: false,
 };
@@ -49,7 +49,7 @@ export const nlpSampleFixtures = getFixturesWithDefaultValues<
   TNlpSampleFixtures['values']
 >({
   fixtures: nlpSamples,
-  defaultValues: fieldsWithDefaultValues,
+  defaultValues: nlpSampleDefaultValues,
 });
 
 export const installNlpSampleFixtures = async () => {

--- a/api/src/utils/test/fixtures/subscriber.ts
+++ b/api/src/utils/test/fixtures/subscriber.ts
@@ -8,31 +8,26 @@
 
 import mongoose from 'mongoose';
 
+import { SubscriberCreateDto } from '@/chat/dto/subscriber.dto';
 import { Subscriber, SubscriberModel } from '@/chat/schemas/subscriber.schema';
-import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
-import { TFixturesDefaultValues } from '../types';
+import { FixturesTypeBuilder, TFixturesDefaultValues } from '../types';
 
 import { installLabelFixtures } from './label';
 import { installUserFixtures } from './user';
 
-export const fieldsWithDefaultValues = {
+type TSubscriberFixtures = FixturesTypeBuilder<Subscriber, SubscriberCreateDto>;
+
+export const fieldsWithDefaultValues: TSubscriberFixtures['defaultValues'] = {
   context: {},
   avatar: null,
   assignedAt: null,
   assignedTo: null,
   timezone: 0,
-} satisfies Partial<Subscriber>;
+};
 
-type TFieldWithDefaultValues =
-  | keyof typeof fieldsWithDefaultValues
-  | keyof BaseSchema;
-type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
-  Partial<Pick<Subscriber, TFieldWithDefaultValues>>;
-type TSubscriber = TTransformedField<Subscriber>;
-
-const subscribers: TSubscriber[] = [
+const subscribers: TSubscriberFixtures['values'][] = [
   {
     foreign_id: 'foreign-id-messenger',
     first_name: 'Jhon',
@@ -104,7 +99,9 @@ export const subscriberDefaultValues: TFixturesDefaultValues<Subscriber> = {
   avatar: null,
 };
 
-export const subscriberFixtures = getFixturesWithDefaultValues<Subscriber>({
+export const subscriberFixtures = getFixturesWithDefaultValues<
+  TSubscriberFixtures['values']
+>({
   fixtures: subscribers,
   defaultValues: subscriberDefaultValues,
 });

--- a/api/src/utils/test/fixtures/subscriber.ts
+++ b/api/src/utils/test/fixtures/subscriber.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -12,19 +12,20 @@ import { SubscriberCreateDto } from '@/chat/dto/subscriber.dto';
 import { Subscriber, SubscriberModel } from '@/chat/schemas/subscriber.schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
-import { FixturesTypeBuilder, TFixturesDefaultValues } from '../types';
+import { FixturesTypeBuilder } from '../types';
 
 import { installLabelFixtures } from './label';
 import { installUserFixtures } from './user';
 
 type TSubscriberFixtures = FixturesTypeBuilder<Subscriber, SubscriberCreateDto>;
 
-export const fieldsWithDefaultValues: TSubscriberFixtures['defaultValues'] = {
-  context: {},
-  avatar: null,
-  assignedAt: null,
-  assignedTo: null,
+export const subscriberDefaultValues: TSubscriberFixtures['defaultValues'] = {
   timezone: 0,
+  assignedTo: null,
+  assignedAt: null,
+  lastvisit: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  retainedFrom: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  avatar: null,
 };
 
 const subscribers: TSubscriberFixtures['values'][] = [
@@ -89,15 +90,6 @@ const subscribers: TSubscriberFixtures['values'][] = [
     retainedFrom: new Date('2024-01-02T20:40:03.249Z'),
   },
 ];
-
-export const subscriberDefaultValues: TFixturesDefaultValues<Subscriber> = {
-  timezone: 0,
-  assignedTo: null,
-  assignedAt: null,
-  lastvisit: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-  retainedFrom: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-  avatar: null,
-};
 
 export const subscriberFixtures = getFixturesWithDefaultValues<
   TSubscriberFixtures['values']

--- a/api/src/utils/test/fixtures/subscriber.ts
+++ b/api/src/utils/test/fixtures/subscriber.ts
@@ -8,8 +8,8 @@
 
 import mongoose from 'mongoose';
 
-import { SubscriberCreateDto } from '@/chat/dto/subscriber.dto';
 import { Subscriber, SubscriberModel } from '@/chat/schemas/subscriber.schema';
+import { BaseSchema } from '@/utils/generics/base-schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
 import { TFixturesDefaultValues } from '../types';
@@ -17,7 +17,22 @@ import { TFixturesDefaultValues } from '../types';
 import { installLabelFixtures } from './label';
 import { installUserFixtures } from './user';
 
-const subscribers: SubscriberCreateDto[] = [
+export const fieldsWithDefaultValues = {
+  context: {},
+  avatar: null,
+  assignedAt: null,
+  assignedTo: null,
+  timezone: 0,
+} satisfies Partial<Subscriber>;
+
+type TFieldWithDefaultValues =
+  | keyof typeof fieldsWithDefaultValues
+  | keyof BaseSchema;
+type TTransformedField<T> = Omit<T, TFieldWithDefaultValues> &
+  Partial<Pick<Subscriber, TFieldWithDefaultValues>>;
+type TSubscriber = TTransformedField<Subscriber>;
+
+const subscribers: TSubscriber[] = [
   {
     foreign_id: 'foreign-id-messenger',
     first_name: 'Jhon',
@@ -30,7 +45,6 @@ const subscribers: SubscriberCreateDto[] = [
       name: 'messenger-channel',
     },
     labels: [],
-    assignedAt: null,
     lastvisit: new Date('2020-01-01T20:40:03.249Z'),
     retainedFrom: new Date('2020-01-01T20:40:03.249Z'),
   },
@@ -46,7 +60,6 @@ const subscribers: SubscriberCreateDto[] = [
       name: 'web-channel',
     },
     labels: [],
-    assignedAt: null,
     lastvisit: new Date('2021-01-01T20:40:03.249Z'),
     retainedFrom: new Date('2021-01-02T20:40:03.249Z'),
   },
@@ -62,7 +75,6 @@ const subscribers: SubscriberCreateDto[] = [
       name: 'web-channel',
     },
     labels: [],
-    assignedAt: null,
     lastvisit: new Date('2022-01-01T20:40:03.249Z'),
     retainedFrom: new Date('2022-01-02T20:40:03.249Z'),
   },
@@ -78,7 +90,6 @@ const subscribers: SubscriberCreateDto[] = [
       name: 'web-channel',
     },
     labels: [],
-    assignedAt: null,
     lastvisit: new Date('2024-01-01T20:40:03.249Z'),
     retainedFrom: new Date('2024-01-02T20:40:03.249Z'),
   },

--- a/api/src/utils/test/mocks/block.ts
+++ b/api/src/utils/test/mocks/block.ts
@@ -95,6 +95,7 @@ export const baseBlockInstance = {
   category: undefined,
   previousBlocks: [],
   trigger_channels: [],
+  nextBlocks: [],
   ...modelInstance,
 };
 
@@ -103,6 +104,7 @@ export const blockEmpty: BlockFull = {
   name: 'Empty',
   patterns: [],
   message: [''],
+  nextBlocks: [],
 };
 
 // Translation Data

--- a/api/src/utils/test/types.ts
+++ b/api/src/utils/test/types.ts
@@ -8,7 +8,7 @@
 
 import { BaseSchema } from '../generics/base-schema';
 
-type TOptionalPropertyOf<T> = Exclude<
+export type TOptionalPropertyOf<T> = Exclude<
   {
     [K in keyof T]: T extends Record<K, T[K]> ? never : K;
   }[keyof T],
@@ -23,3 +23,25 @@ export type TFixtures<T> = Omit<T, keyof BaseSchema> & {
 export type TFixturesDefaultValues<T, S = TFixtures<T>> = {
   [key in TOptionalPropertyOf<S>]?: S[key];
 } & { createdAt?: BaseSchema['createdAt'] };
+
+export type TOptionalPropertyFrom<O extends object, O1 extends object> = Pick<
+  O1,
+  Exclude<keyof O1, keyof O>
+> &
+  Pick<O, Exclude<keyof O, keyof O1>>;
+
+export type OptionalProperties<T, K extends keyof T> = Omit<
+  T,
+  K | keyof BaseSchema
+> &
+  Partial<Pick<T, K>>;
+
+export type FixturesTypeBuilder<
+  S extends object,
+  D extends object,
+  DO = TFixturesDefaultValues<D>,
+  U = Partial<TFixtures<TOptionalPropertyFrom<D, S>>>,
+> = {
+  defaultValues: DO & U;
+  values: OptionalProperties<S, keyof S & keyof (DO & U)>;
+};

--- a/api/src/utils/types/dto.types.ts
+++ b/api/src/utils/types/dto.types.ts
@@ -6,17 +6,17 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-export enum DtoOperations {
+export enum DtoActions {
   Create = 'create',
   Read = 'read',
   Update = 'update',
   Delete = 'delete',
 }
 
-export type DtoConfig<T extends Partial<Record<DtoOperations, object>>> = T;
+export type DtoConfig<T extends Partial<Record<DtoActions, object>>> = T;
 
 export type DtoProps<T extends Record<string, unknown>> = {
-  [K in DtoOperations]?: T[K];
+  [K in DtoActions]?: T[K];
 };
 
 export type DtoInfer<K extends keyof DTO, DTO, T> = DTO[K] extends object

--- a/api/src/utils/types/dto.types.ts
+++ b/api/src/utils/types/dto.types.ts
@@ -13,12 +13,12 @@ export enum DtoAction {
   Delete = 'delete',
 }
 
-export type DtoConfig<T extends Partial<Record<DtoAction, object>>> = T;
+export type DtoConfig<
+  C extends Partial<Record<DtoAction, object>> = Partial<
+    Record<DtoAction, object>
+  >,
+> = C;
 
-export type DtoProps<T extends Record<string, unknown>> = {
-  [K in DtoAction]?: T[K];
-};
-
-export type DtoInfer<K extends keyof DTO, DTO, T> = DTO[K] extends object
-  ? DTO[K]
-  : T;
+export type DtoInfer<K extends keyof Dto, Dto, I> = Dto[K] extends object
+  ? Dto[K]
+  : I;

--- a/api/src/utils/types/dto.types.ts
+++ b/api/src/utils/types/dto.types.ts
@@ -6,17 +6,17 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-export enum DtoActions {
+export enum DtoAction {
   Create = 'create',
   Read = 'read',
   Update = 'update',
   Delete = 'delete',
 }
 
-export type DtoConfig<T extends Partial<Record<DtoActions, object>>> = T;
+export type DtoConfig<T extends Partial<Record<DtoAction, object>>> = T;
 
 export type DtoProps<T extends Record<string, unknown>> = {
-  [K in DtoActions]?: T[K];
+  [K in DtoAction]?: T[K];
 };
 
 export type DtoInfer<K extends keyof DTO, DTO, T> = DTO[K] extends object

--- a/api/src/utils/types/dto.types.ts
+++ b/api/src/utils/types/dto.types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+export enum DtoOperations {
+  Create = 'create',
+  Read = 'read',
+  Update = 'update',
+  Delete = 'delete',
+}
+
+export type DtoConfig<T extends Partial<Record<DtoOperations, object>>> = T;
+
+export type DtoProps<T extends Record<string, unknown>> = {
+  [K in DtoOperations]?: T[K];
+};
+
+export type DtoInfer<K extends keyof DTO, DTO, T> = DTO[K] extends object
+  ? DTO[K]
+  : T;


### PR DESCRIPTION
# Motivation
The idea of this PR is to propose a solution for the payload type restriction inferred from the schema, gives the possibility to define custom DTO per action (CRUD)  if needed, otherwise preserving the old way of handling data types (retro compatibility).

Fixes #548

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes