### PR TITLE
fix(frontend): allow fallback block to be empty

### DIFF
--- a/frontend/src/components/settings/SettingInput.tsx
+++ b/frontend/src/components/settings/SettingInput.tsx
@@ -6,7 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-
 import KeyIcon from "@mui/icons-material/Key";
 import { FormControlLabel, MenuItem, Switch } from "@mui/material";
 import { ControllerRenderProps } from "react-hook-form";

--- a/frontend/src/components/settings/SettingInput.tsx
+++ b/frontend/src/components/settings/SettingInput.tsx
@@ -1,10 +1,11 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
+
 
 import KeyIcon from "@mui/icons-material/Key";
 import { FormControlLabel, MenuItem, Switch } from "@mui/material";
@@ -120,7 +121,7 @@ const SettingInput: React.FC<RenderSettingInputProps> = ({
             label={t("label.fallback_block")}
             helperText={t("help.fallback_block")}
             multiple={false}
-            onChange={(_e, selected, ..._) => onChange(selected?.id || null)}
+            onChange={(_e, selected, ..._) => onChange(selected?.id || "")}
             {...rest}
           />
         );


### PR DESCRIPTION
The backend does not allow fallback_block to be null it only allows it to be a string.

Fixes #553 

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the behavior of the settings input so that when no valid selection is made, it now returns an empty value for improved consistency in state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->