### PR TITLE
Enhance CORS configuration with allowed domains from settings

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -47,25 +47,10 @@ async function bootstrap() {
   // Retrieve the SettingService instance
   const settingService = app.get<SettingService>(SettingService);
 
-  // Fetch allowed domains from the settings collection
-  const settingsAllowedDomains = await settingService.getAllowedDomains();
-
-  // Get allowed origins from .env configuration
-  const configAllowedOrigins = config.security.cors.allowOrigins
-    ? config.security.cors.allowOrigins.map((origin) => origin.trim())
-    : [];
-
-  // Combine both settings and config allowed domains
-  const combinedAllowedDomains = [
-    ...settingsAllowedDomains,
-    ...configAllowedOrigins,
-  ];
-  const allowedDomains = Array.from(new Set(combinedAllowedDomains));
-
   // Enable CORS with the combined allowed domains
   app.enableCors({
     origin: (origin, callback) => {
-      if (!origin || allowedDomains.includes(origin)) {
+      if (!origin || settingService.isOriginAllowed(origin)) {
         callback(null, true);
       } else {
         callback(new Error('Not allowed by CORS'));

--- a/api/src/setting/services/setting.service.ts
+++ b/api/src/setting/services/setting.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -9,7 +9,9 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import { InjectModel } from '@nestjs/mongoose';
 import { Cache } from 'cache-manager';
+import { Model } from 'mongoose';
 
 import { config } from '@/config';
 import { Config } from '@/config/types';
@@ -30,6 +32,7 @@ export class SettingService extends BaseService<Setting> {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly logger: LoggerService,
     private readonly seeder: SettingSeeder,
+    @InjectModel(Setting.name) private settingModel: Model<Setting>,
   ) {
     super(repository);
   }
@@ -131,5 +134,18 @@ export class SettingService extends BaseService<Setting> {
   async getSettings(): Promise<Settings> {
     const settings = await this.findAll();
     return this.buildTree(settings);
+  }
+
+  /**
+   * Fetches all settings labeled as 'allowed_domains'.
+   * @returns An array of allowed domains.
+   */
+  async getAllowedDomains(): Promise<string[]> {
+    const settings = await this.settingModel
+      .find({ label: 'allowed_domains' })
+      .exec();
+    return settings
+      .map((setting) => setting.value.split(',').map((domain) => domain.trim()))
+      .flat();
   }
 }

--- a/api/src/websocket/utils/gateway-options.ts
+++ b/api/src/websocket/utils/gateway-options.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,65 +8,72 @@
 
 import util from 'util';
 
+import { Injectable } from '@nestjs/common';
 import type { ServerOptions } from 'socket.io';
 
 import { config } from '@/config';
+import { SettingService } from '@/setting/services/setting.service';
 
-export const buildWebSocketGatewayOptions = (): Partial<ServerOptions> => {
-  const opts: Partial<ServerOptions> = {
-    allowEIO3: true, // Allows support for Engine.io v3 clients.
-    path: config.sockets.path,
-    ...(typeof config.sockets.serveClient !== 'undefined' && {
-      serveClient: config.sockets.serveClient,
-    }),
-    ...(config.sockets.beforeConnect && {
-      allowRequest: (handshake, cb) => {
-        try {
-          const result = config.sockets.beforeConnect(handshake);
-          return cb(null, result);
-        } catch (e) {
-          // eslint-disable-next-line no-console
-          console.log(
-            `A socket was rejected via the config.sockets.beforeConnect function.\n` +
-              `It attempted to connect with headers:\n` +
-              `${util.inspect(handshake.headers, { depth: null })}\n` +
-              `Details: ${e}`,
-          );
-          return cb(e, false);
-        }
-      },
-    }),
-    ...(config.sockets.pingTimeout && {
-      pingTimeout: config.sockets.pingTimeout,
-    }),
-    ...(config.sockets.pingInterval && {
-      pingInterval: config.sockets.pingInterval,
-    }),
-    ...(config.sockets.maxHttpBufferSize && {
-      maxHttpBufferSize: config.sockets.maxHttpBufferSize,
-    }),
-    ...(config.sockets.transports && { transports: config.sockets.transports }),
-    ...(config.sockets.allowUpgrades && {
-      allowUpgrades: config.sockets.allowUpgrades,
-    }),
-    ...(config.sockets.cookie && { cookie: config.sockets.cookie }),
-    ...(config.sockets.onlyAllowOrigins && {
+@Injectable()
+export class WebSocketGatewayOptionsService {
+  constructor(private readonly settingsService: SettingService) {}
+
+  buildWebSocketGatewayOptions(): Partial<ServerOptions> {
+    const opts: Partial<ServerOptions> = {
+      allowEIO3: true, // Allows support for Engine.io v3 clients.
+      path: config.sockets.path,
+      ...(typeof config.sockets.serveClient !== 'undefined' && {
+        serveClient: config.sockets.serveClient,
+      }),
+      ...(config.sockets.beforeConnect && {
+        allowRequest: (handshake, cb) => {
+          try {
+            const result = config.sockets.beforeConnect(handshake);
+            return cb(null, result);
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.log(
+              `A socket was rejected via the config.sockets.beforeConnect function.\n` +
+                `It attempted to connect with headers:\n` +
+                `${util.inspect(handshake.headers, { depth: null })}\n` +
+                `Details: ${e}`,
+            );
+            return cb(e, false);
+          }
+        },
+      }),
+      ...(config.sockets.pingTimeout && {
+        pingTimeout: config.sockets.pingTimeout,
+      }),
+      ...(config.sockets.pingInterval && {
+        pingInterval: config.sockets.pingInterval,
+      }),
+      ...(config.sockets.maxHttpBufferSize && {
+        maxHttpBufferSize: config.sockets.maxHttpBufferSize,
+      }),
+      ...(config.sockets.transports && {
+        transports: config.sockets.transports,
+      }),
+      ...(config.sockets.allowUpgrades && {
+        allowUpgrades: config.sockets.allowUpgrades,
+      }),
+      ...(config.sockets.cookie && { cookie: config.sockets.cookie }),
       cors: {
         origin: (origin, cb) => {
-          if (origin && config.sockets.onlyAllowOrigins.includes(origin)) {
+          if (origin && this.settingsService.isOriginAllowed(origin)) {
             cb(null, true);
           } else {
             // eslint-disable-next-line no-console
             console.log(
-              `A socket was rejected via the config.sockets.onlyAllowOrigins array.\n` +
+              `A socket was rejected via the SettingsService.allowedOriginDomains array.\n` +
                 `It attempted to connect with origin: ${origin}`,
             );
             cb(new Error('Origin not allowed'), false);
           }
         },
       },
-    }),
-  };
+    };
 
-  return opts;
-};
+    return opts;
+  }
+}

--- a/api/src/websocket/websocket.module.ts
+++ b/api/src/websocket/websocket.module.ts
@@ -8,12 +8,20 @@
 
 import { Global, Module } from '@nestjs/common';
 
+import { SettingModule } from '@/setting/setting.module';
+
 import { SocketEventDispatcherService } from './services/socket-event-dispatcher.service';
+import { WebSocketGatewayOptionsService } from './utils/gateway-options';
 import { WebsocketGateway } from './websocket.gateway';
 
 @Global()
 @Module({
-  providers: [WebsocketGateway, SocketEventDispatcherService],
+  imports: [SettingModule],
+  providers: [
+    WebsocketGateway,
+    SocketEventDispatcherService,
+    WebSocketGatewayOptionsService,
+  ],
   exports: [WebsocketGateway],
 })
 export class WebsocketModule {}


### PR DESCRIPTION
Introduce a method to fetch allowed domains from settings and enhance CORS configuration by combining these domains with those specified in the environment.

## Important considerations : 
### Issue 1 : 
- The current implementation fetches allowed domains from the settings service synchronously during the application bootstrap. While this works for initial loading, it doesn't inherently support real-time updates if the settings change after the server has started.
- To achieve truly dynamic CORS configurations that reflect real-time changes in the settings, consider implementing a mechanism to update the allowed domains without restarting the server. This can be done using:
  - Event Emitters: Emit an event whenever the settings related to allowed_domains are updated, and update the CORS configuration accordingly.
  - Polling: Periodically fetch the latest settings and update the allowed domains.

### Issue 2 : 
- Mixing configuration sources (settings service and .env) can lead to inconsistencies and make it harder to track where specific configurations originate.

### Issue 3 : 
- Fetching allowed domains from the database can introduce latency, especially if the database is under heavy load.
- Implement caching mechanisms to store allowed domains in memory, reducing the need for frequent database queries.