### PR TITLE
fix: patch-lock-file error in dev & prod mode

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -52,6 +52,9 @@ COPY ./widget ./widget
 
 RUN npm install
 
+
+# used to by pass Next.js paching lock file
+ENV NEXT_IGNORE_INCORRECT_LOCKFILE=true 
 ENV NODE_ENV=development
 ENV CHOKIDAR_USEPOLLING=true
 ENV WATCHPACK_POLLING=true
@@ -64,6 +67,8 @@ CMD ["npm", "run", "dev", "--", "-p", "8080"]
 FROM base AS production
 WORKDIR /app
 
+# used to by pass Next.js paching lock file 
+ENV NEXT_IGNORE_INCORRECT_LOCKFILE=true 
 ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1


### PR DESCRIPTION
# Motivation

This PR addresses the issue when running in dev/prod mode the frontend gets error trying to patch package.lockfile.json

Fixes #607

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)