### PR TITLE
fix: remove unnecessary state change

### DIFF
--- a/frontend/src/app-components/inputs/PasswordInput.tsx
+++ b/frontend/src/app-components/inputs/PasswordInput.tsx
@@ -1,30 +1,24 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
+
 import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
 import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 import { IconButton, InputAdornment, TextFieldProps } from "@mui/material";
-import React, { forwardRef, useState } from "react";
+import { forwardRef, useState } from "react";
 
 import { Input } from "./Input";
 
 export const PasswordInput = forwardRef<any, TextFieldProps>(
   ({ onChange, InputProps, value, ...rest }, ref) => {
-    const [password, setPassword] = useState<string>(value as string);
     const [showPassword, setShowPassword] = useState(false);
     const handleTogglePasswordVisibility = () => {
       setShowPassword(!showPassword);
-    };
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      setPassword(event.target.value);
-      if (onChange) {
-        onChange(event);
-      }
     };
 
     return (
@@ -33,10 +27,10 @@ export const PasswordInput = forwardRef<any, TextFieldProps>(
         type={showPassword ? "text" : "password"}
         {...rest}
         defaultValue={value}
-        onChange={handleChange}
+        onChange={onChange}
         InputProps={{
           ...InputProps,
-          endAdornment: password && (
+          endAdornment: (
             <InputAdornment position="end">
               <IconButton onClick={handleTogglePasswordVisibility} edge="end">
                 {showPassword ? (

--- a/frontend/src/app-components/inputs/PasswordInput.tsx
+++ b/frontend/src/app-components/inputs/PasswordInput.tsx
@@ -6,7 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-
 import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
 import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 import { IconButton, InputAdornment, TextFieldProps } from "@mui/material";
@@ -15,7 +14,7 @@ import { forwardRef, useState } from "react";
 import { Input } from "./Input";
 
 export const PasswordInput = forwardRef<any, TextFieldProps>(
-  ({ onChange, InputProps, value, ...rest }, ref) => {
+  ({ onChange, InputProps, ...rest }, ref) => {
     const [showPassword, setShowPassword] = useState(false);
     const handleTogglePasswordVisibility = () => {
       setShowPassword(!showPassword);
@@ -26,7 +25,6 @@ export const PasswordInput = forwardRef<any, TextFieldProps>(
         ref={ref}
         type={showPassword ? "text" : "password"}
         {...rest}
-        defaultValue={value}
         onChange={onChange}
         InputProps={{
           ...InputProps,


### PR DESCRIPTION
# Motivation

React's focus behavior can be affected when a component re-renders due to state changes. In this case, updating the local password state caused the PasswordInput component to re-render unnecessarily. This re-render could interfere with the input field's focus.

Fixes https://github.com/Hexastack/Hexabot/issues/593

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
