### PR TITLE
fix: remove duplicate emitted event 'new_users'

### DIFF
--- a/api/src/chat/services/chat.service.ts
+++ b/api/src/chat/services/chat.service.ts
@@ -258,7 +258,6 @@ export class ChatService {
 
       if (!subscriber) {
         const subscriberData = await handler.getSubscriberData(event);
-        this.eventEmitter.emit('hook:stats:entry', 'new_users', 'New users');
         subscriberData.channel = event.getChannelData();
         subscriber = await this.subscriberService.create(subscriberData);
 


### PR DESCRIPTION
# Motivation

This PR addresses the issue of duplicate event emitted `new_users` and removes it  (event is already emitted in the subscriber postCreate() hook)

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code