### PR TITLE
feat: update block plugin settings visibility

### DIFF
--- a/api/src/chat/controllers/block.controller.ts
+++ b/api/src/chat/controllers/block.controller.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -110,7 +110,7 @@ export class BlockController extends BaseController<
         throw new NotFoundException('Plugin Not Found');
       }
 
-      return plugin.settings;
+      return plugin.getDefaultSettings();
     } catch (e) {
       this.logger.error('Unable to fetch plugin settings', e);
       throw e;
@@ -134,7 +134,7 @@ export class BlockController extends BaseController<
             ...p.template,
             message: {
               plugin: p.name,
-              args: p.settings.reduce(
+              args: p.getDefaultSettings().reduce(
                 (acc, setting) => {
                   acc[setting.label] = setting.value;
                   return acc;

--- a/api/src/i18n/services/translation.service.spec.ts
+++ b/api/src/i18n/services/translation.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -10,7 +10,9 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { I18nService } from '@/i18n/services/i18n.service';
+import { BasePlugin } from '@/plugins/base-plugin.service';
 import { PluginService } from '@/plugins/plugins.service';
+import { PluginBlockTemplate } from '@/plugins/types';
 import { SettingType } from '@/setting/schemas/types';
 import { SettingService } from '@/setting/services/setting.service';
 
@@ -157,26 +159,56 @@ describe('TranslationService', () => {
       attachedBlock: null,
     };
 
-    const mockedPlugin: any = {
-      name: 'ollama-plugin',
-      type: 'block',
-      settings: [
-        {
-          label: 'model',
-          group: 'default',
-          type: SettingType.text,
-          value: 'llama3.2',
-          translatable: false,
-        },
-        {
-          label: 'context',
-          group: 'default',
-          type: SettingType.multiple_text,
-          value: ['Answer the user QUESTION using the DOCUMENTS text above.'],
-          translatable: true,
-        },
-      ],
-    };
+    class MockPlugin extends BasePlugin {
+      template: PluginBlockTemplate = { name: 'Ollama Plugin' };
+
+      name: `${string}-plugin`;
+
+      type: any;
+
+      private settings: {
+        label: string;
+        group: string;
+        type: SettingType;
+        value: any;
+        translatable: boolean;
+      }[];
+
+      constructor() {
+        super('ollama-plugin', pluginService);
+        this.name = 'ollama-plugin';
+        this.type = 'block';
+        this.settings = [
+          {
+            label: 'model',
+            group: 'default',
+            type: SettingType.text,
+            value: 'llama3.2',
+            translatable: false,
+          },
+          {
+            label: 'context',
+            group: 'default',
+            type: SettingType.multiple_text,
+            value: ['Answer the user QUESTION using the DOCUMENTS text above.'],
+            translatable: true,
+          },
+        ];
+      }
+
+      // Implementing the 'getPath' method (with a mock return value)
+      getPath() {
+        // Return a mock path
+        return '/mock/path';
+      }
+
+      getDefaultSettings() {
+        return this.settings;
+      }
+    }
+
+    // Create an instance of the mock plugin
+    const mockedPlugin = new MockPlugin();
 
     jest
       .spyOn(pluginService, 'getPlugin')

--- a/api/src/i18n/services/translation.service.ts
+++ b/api/src/i18n/services/translation.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -59,7 +59,9 @@ export class TranslationService extends BaseService<Translation> {
 
         // plugin
         Object.entries(block.message.args).forEach(([l, arg]) => {
-          const setting = plugin?.settings.find(({ label }) => label === l);
+          const setting = plugin
+            ?.getDefaultSettings()
+            .find(({ label }) => label === l);
           if (setting?.translatable) {
             if (Array.isArray(arg)) {
               // array of text


### PR DESCRIPTION
# Motivation

The following PR updates block settings visibility to private in order to avoid confusion between default block settings and block args.

Fixes # ([598](https://github.com/Hexastack/Hexabot/issues/598))

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
