### PR TITLE
fix: re-subscribe on ws reconnect

### DIFF
--- a/widget/src/components/UserSubscription.tsx
+++ b/widget/src/components/UserSubscription.tsx
@@ -1,10 +1,11 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
+
 
 import React, {
   SyntheticEvent,
@@ -75,7 +76,7 @@ const UserSubscription: React.FC = () => {
         });
         setMessages(messages);
         setParticipants([
-          ...participants,
+          participants[0],
           {
             id: profile.foreign_id,
             foreign_id: profile.foreign_id,

--- a/widget/src/utils/SocketIoClient.ts
+++ b/widget/src/utils/SocketIoClient.ts
@@ -57,8 +57,6 @@ export class SocketIoClient {
 
   private config: SocketIoClientConfig;
 
-  public id: string;
-
   constructor(
     apiUrl: string,
     socketConfig: SocketIoClientConfig,

--- a/widget/src/utils/SocketIoClient.ts
+++ b/widget/src/utils/SocketIoClient.ts
@@ -1,10 +1,11 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
+
 
 import { io, ManagerOptions, Socket, SocketOptions } from "socket.io-client";
 
@@ -56,6 +57,8 @@ export class SocketIoClient {
 
   private config: SocketIoClientConfig;
 
+  public id: string;
+
   constructor(
     apiUrl: string,
     socketConfig: SocketIoClientConfig,
@@ -70,6 +73,10 @@ export class SocketIoClient {
 
     this.socket = io(url.origin, this.config);
     this.init(handlers);
+  }
+
+  get io() {
+    return this.socket.io;
   }
 
   /**


### PR DESCRIPTION
# Motivation

This PR fixes an issue where a user loses their subscription (e.g., joining the correct IO room) after losing internet connectivity and reconnecting. The added functionality ensures that users are automatically re-subscribed upon reconnection to maintain seamless functionality.

# How to test locally
- Use the chat widget
- Restart the API 
- Use the chat again, it should respond to messages 

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
