### PR TITLE
fix: update return type of findOneByForeignId to include null

### DIFF
--- a/api/src/chat/repositories/subscriber.repository.ts
+++ b/api/src/chat/repositories/subscriber.repository.ts
@@ -123,7 +123,7 @@ export class SubscriberRepository extends BaseRepository<
    *
    * @param id - The foreign ID of the subscriber.
    *
-   * @returns The found subscriber entity.
+   * @returns The found subscriber entity, or `null` if no subscriber is found.
    */
   async findOneByForeignId(id: string): Promise<Subscriber | null> {
     const query = this.findByForeignIdQuery(id);

--- a/api/src/chat/repositories/subscriber.repository.ts
+++ b/api/src/chat/repositories/subscriber.repository.ts
@@ -125,10 +125,10 @@ export class SubscriberRepository extends BaseRepository<
    *
    * @returns The found subscriber entity.
    */
-  async findOneByForeignId(id: string): Promise<Subscriber> {
+  async findOneByForeignId(id: string): Promise<Subscriber | null> {
     const query = this.findByForeignIdQuery(id);
     const [result] = await this.execute(query, Subscriber);
-    return result;
+    return result || null;
   }
 
   /**


### PR DESCRIPTION
# Motivation

This change ensures that the `findOneByForeignId()` method behaves consistently by returning `Subscriber | null`, just like the `findOne()` method. Adding a `null` check increases reliability and prevents potential errors when the method is called with a foreign ID that doesn't exist. This update improves the code's robustness and aligns with best practices.

Fixes #614 

# Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added unit tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.