### PR TITLE
Feat/transient logger

### DIFF
--- a/api/src/analytics/analytics.module.ts
+++ b/api/src/analytics/analytics.module.ts
@@ -10,13 +10,19 @@ import { Module } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
 
+import { LoggerModule } from '@/logger/logger.module';
+
 import { BotStatsController } from './controllers/bot-stats.controller';
 import { BotStatsRepository } from './repositories/bot-stats.repository';
 import { BotStatsModel } from './schemas/bot-stats.schema';
 import { BotStatsService } from './services/bot-stats.service';
 
 @Module({
-  imports: [MongooseModule.forFeature([BotStatsModel]), EventEmitter2],
+  imports: [
+    MongooseModule.forFeature([BotStatsModel]),
+    EventEmitter2,
+    LoggerModule.register('AnalyticsModule'),
+  ],
   controllers: [BotStatsController],
   providers: [BotStatsService, BotStatsRepository],
 })

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -97,6 +97,7 @@ const i18nOptions: I18nOptions = {
         return connection;
       },
     }),
+    LoggerModule.register('AppModule'),
     NlpModule,
     CmsModule,
     UserModule,
@@ -107,7 +108,6 @@ const i18nOptions: I18nOptions = {
     ChannelModule,
     PluginsModule,
     HelperModule,
-    LoggerModule,
     WebsocketModule,
     EventEmitterModule.forRoot({
       // set this to `true` to use wildcards

--- a/api/src/attachment/attachment.module.ts
+++ b/api/src/attachment/attachment.module.ts
@@ -13,6 +13,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { PassportModule } from '@nestjs/passport';
 
 import { config } from '@/config';
+import { LoggerModule } from '@/logger/logger.module';
 import { UserModule } from '@/user/user.module';
 
 import { AttachmentController } from './controllers/attachment.controller';
@@ -22,6 +23,7 @@ import { AttachmentService } from './services/attachment.service';
 
 @Module({
   imports: [
+    LoggerModule.register('AttachmentModule'),
     MongooseModule.forFeature([AttachmentModel]),
     PassportModule.register({
       session: true,

--- a/api/src/channel/channel.module.ts
+++ b/api/src/channel/channel.module.ts
@@ -19,6 +19,7 @@ import { InjectDynamicProviders } from 'nestjs-dynamic-providers';
 import { AttachmentModule } from '@/attachment/attachment.module';
 import { ChatModule } from '@/chat/chat.module';
 import { CmsModule } from '@/cms/cms.module';
+import { LoggerModule } from '@/logger/logger.module';
 
 import { ChannelController } from './channel.controller';
 import { ChannelMiddleware } from './channel.middleware';
@@ -39,7 +40,14 @@ export interface ChannelModuleOptions {
   'dist/.hexabot/custom/extensions/channels/**/*.channel.js',
 )
 @Module({
-  imports: [ChatModule, AttachmentModule, CmsModule, HttpModule, JwtModule],
+  imports: [
+    ChatModule,
+    AttachmentModule,
+    CmsModule,
+    HttpModule,
+    JwtModule,
+    LoggerModule.register('ChannelModule'),
+  ],
   controllers: [WebhookController, ChannelController],
   providers: [ChannelService],
   exports: [ChannelService],

--- a/api/src/chat/chat.module.ts
+++ b/api/src/chat/chat.module.ts
@@ -13,6 +13,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { AttachmentModule } from '@/attachment/attachment.module';
 import { ChannelModule } from '@/channel/channel.module';
 import { CmsModule } from '@/cms/cms.module';
+import { LoggerModule } from '@/logger/logger.module';
 import { UserModule } from '@/user/user.module';
 
 import { BlockController } from './controllers/block.controller';
@@ -64,6 +65,7 @@ import { SubscriberService } from './services/subscriber.service';
     AttachmentModule,
     EventEmitter2,
     UserModule,
+    LoggerModule.register('ChatModule'),
   ],
   controllers: [
     CategoryController,

--- a/api/src/chat/controllers/block.controller.ts
+++ b/api/src/chat/controllers/block.controller.ts
@@ -23,6 +23,7 @@ import {
 import { CsrfCheck } from '@tekuconcept/nestjs-csrf';
 
 import { CsrfInterceptor } from '@/interceptors/csrf.interceptor';
+import { LogClass } from '@/logger/logger.decorator';
 import { LoggerService } from '@/logger/logger.service';
 import { BaseBlockPlugin } from '@/plugins/base-block-plugin';
 import { PluginService } from '@/plugins/plugins.service';
@@ -48,6 +49,7 @@ import { CategoryService } from '../services/category.service';
 import { LabelService } from '../services/label.service';
 
 @UseInterceptors(CsrfInterceptor)
+@LogClass()
 @Controller('Block')
 export class BlockController extends BaseController<
   Block,

--- a/api/src/chat/services/bot.service.ts
+++ b/api/src/chat/services/bot.service.ts
@@ -10,6 +10,7 @@ import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import EventWrapper from '@/channel/lib/EventWrapper';
+import { LogClass } from '@/logger/logger.decorator';
 import { LoggerService } from '@/logger/logger.service';
 import { SettingService } from '@/setting/services/setting.service';
 
@@ -29,6 +30,7 @@ import { ConversationService } from './conversation.service';
 import { SubscriberService } from './subscriber.service';
 
 @Injectable()
+@LogClass()
 export class BotService {
   constructor(
     private readonly eventEmitter: EventEmitter2,

--- a/api/src/cms/cms.module.ts
+++ b/api/src/cms/cms.module.ts
@@ -11,6 +11,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 
 import { AttachmentModule } from '@/attachment/attachment.module';
 import { ChatModule } from '@/chat/chat.module';
+import { LoggerModule } from '@/logger/logger.module';
 
 import { AttachmentModel } from '../attachment/schemas/attachment.schema';
 
@@ -29,6 +30,7 @@ import { MenuService } from './services/menu.service';
 
 @Module({
   imports: [
+    LoggerModule.register('CMSModule'),
     MongooseModule.forFeature([
       ContentModel,
       ContentTypeModel,

--- a/api/src/helper/helper.module.ts
+++ b/api/src/helper/helper.module.ts
@@ -10,6 +10,7 @@ import { HttpModule } from '@nestjs/axios';
 import { Global, Module } from '@nestjs/common';
 import { InjectDynamicProviders } from 'nestjs-dynamic-providers';
 
+import { LoggerModule } from '@/logger/logger.module';
 import { NlpModule } from '@/nlp/nlp.module';
 
 import { HelperController } from './helper.controller';
@@ -25,7 +26,7 @@ import { HelperService } from './helper.service';
   'dist/.hexabot/custom/extensions/helpers/**/*.helper.js',
 )
 @Module({
-  imports: [HttpModule, NlpModule],
+  imports: [LoggerModule.register('SettingModule'), HttpModule, NlpModule],
   controllers: [HelperController],
   providers: [HelperService],
   exports: [HelperService],

--- a/api/src/i18n/controllers/language.controller.ts
+++ b/api/src/i18n/controllers/language.controller.ts
@@ -23,7 +23,6 @@ import {
 import { CsrfCheck } from '@tekuconcept/nestjs-csrf';
 
 import { CsrfInterceptor } from '@/interceptors/csrf.interceptor';
-import { LoggerService } from '@/logger/logger.service';
 import { BaseController } from '@/utils/generics/base-controller';
 import { DeleteResult } from '@/utils/generics/base-repository';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
@@ -40,7 +39,7 @@ import { LanguageService } from '../services/language.service';
 export class LanguageController extends BaseController<Language> {
   constructor(
     private readonly languageService: LanguageService,
-    private readonly logger: LoggerService,
+    // private readonly logger: LoggerService,
   ) {
     super(languageService);
   }
@@ -85,7 +84,7 @@ export class LanguageController extends BaseController<Language> {
   async findOne(@Param('id') id: string): Promise<Language> {
     const doc = await this.languageService.findOne(id);
     if (!doc) {
-      this.logger.warn(`Unable to find Language by id ${id}`);
+      // this.logger.warn(`Unable to find Language by id ${id}`);
       throw new NotFoundException(`Language with ID ${id} not found`);
     }
     return doc;
@@ -140,7 +139,7 @@ export class LanguageController extends BaseController<Language> {
       _id: id,
     });
     if (result.deletedCount === 0) {
-      this.logger.warn(`Unable to delete Language by id ${id}`);
+      // this.logger.warn(`Unable to delete Language by id ${id}`);
       throw new BadRequestException(`Unable to delete Language with ID ${id}`);
     }
     return result;

--- a/api/src/i18n/controllers/translation.controller.ts
+++ b/api/src/i18n/controllers/translation.controller.ts
@@ -23,7 +23,6 @@ import {
 import { CsrfCheck } from '@tekuconcept/nestjs-csrf';
 
 import { CsrfInterceptor } from '@/interceptors/csrf.interceptor';
-import { LoggerService } from '@/logger/logger.service';
 import { SettingService } from '@/setting/services/setting.service';
 import { BaseController } from '@/utils/generics/base-controller';
 import { DeleteResult } from '@/utils/generics/base-repository';
@@ -44,7 +43,7 @@ export class TranslationController extends BaseController<Translation> {
     private readonly languageService: LanguageService,
     private readonly translationService: TranslationService,
     private readonly settingService: SettingService,
-    private readonly logger: LoggerService,
+    // private readonly logger: LoggerService,
   ) {
     super(translationService);
   }
@@ -78,7 +77,7 @@ export class TranslationController extends BaseController<Translation> {
   async findOne(@Param('id') id: string) {
     const doc = await this.translationService.findOne(id);
     if (!doc) {
-      this.logger.warn(`Unable to find Translation by id ${id}`);
+      // this.logger.warn(`Unable to find Translation by id ${id}`);
       throw new NotFoundException(`Translation with ID ${id} not found`);
     }
     return doc;
@@ -145,7 +144,7 @@ export class TranslationController extends BaseController<Translation> {
   async deleteOne(@Param('id') id: string): Promise<DeleteResult> {
     const result = await this.translationService.deleteOne(id);
     if (result.deletedCount === 0) {
-      this.logger.warn(`Unable to delete Translation by id ${id}`);
+      // this.logger.warn(`Unable to delete Translation by id ${id}`);
       throw new BadRequestException(
         `Unable to delete Translation with ID ${id}`,
       );

--- a/api/src/i18n/i18n.module.ts
+++ b/api/src/i18n/i18n.module.ts
@@ -60,9 +60,11 @@ export class I18nModule extends NativeI18nModule {
         'I18n: Unable to find providers and/or exports forRoot()',
       );
     }
+
     return {
       module: I18nModule,
       imports: (imports || []).concat([
+        // LoggerModule.register('I18nModule'),
         MongooseModule.forFeature([LanguageModel, TranslationModel]),
         forwardRef(() => ChatModule),
       ]),

--- a/api/src/i18n/services/language.service.ts
+++ b/api/src/i18n/services/language.service.ts
@@ -15,7 +15,6 @@ import {
 } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 
-import { LoggerService } from '@/logger/logger.service';
 import {
   DEFAULT_LANGUAGE_CACHE_KEY,
   LANGUAGES_CACHE_KEY,
@@ -37,7 +36,7 @@ export class LanguageService extends BaseService<
   constructor(
     readonly repository: LanguageRepository,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
-    private readonly logger: LoggerService,
+    // private readonly logger: LoggerService,
   ) {
     super(repository);
   }
@@ -84,7 +83,7 @@ export class LanguageService extends BaseService<
     const language = await this.findOne({ code });
 
     if (!language) {
-      this.logger.warn(`Unable to Language by languageCode ${code}`);
+      // this.logger.warn(`Unable to Language by languageCode ${code}`);
       throw new NotFoundException(
         `Language with languageCode ${code} not found`,
       );

--- a/api/src/logger/logger.context.ts
+++ b/api/src/logger/logger.context.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { AsyncLocalStorage } from 'async_hooks';
+
+export interface LogContext {
+  className: string;
+  methodName: string;
+}
+
+export const loggingStorage = new AsyncLocalStorage<LogContext>();

--- a/api/src/logger/logger.decorator.ts
+++ b/api/src/logger/logger.decorator.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { loggingStorage } from './logger.context';
+
+export function LogClass() {
+  return function <T extends { new (...args: any[]): {} }>(constructor: T) {
+    const prototype = constructor.prototype;
+    const methodNames = Object.getOwnPropertyNames(prototype).filter(
+      (name) => name !== 'constructor' && typeof prototype[name] === 'function',
+    );
+
+    for (const methodName of methodNames) {
+      const originalMethod = prototype[methodName];
+      const className = constructor.name;
+
+      // Preserve all metadata
+      const metadataKeys = Reflect.getMetadataKeys(originalMethod);
+      const metadata = metadataKeys.reduce((acc, key) => {
+        acc[key] = Reflect.getMetadata(key, originalMethod);
+        return acc;
+      }, {});
+
+      prototype[methodName] = function (...args: any[]) {
+        return loggingStorage.run({ className, methodName }, () => {
+          const result = originalMethod.apply(this, args);
+          return result instanceof Promise
+            ? result.catch((e) => {
+                loggingStorage.disable();
+                throw e;
+              })
+            : result;
+        });
+      };
+
+      // Restore metadata
+      Object.entries(metadata).forEach(([key, value]) => {
+        Reflect.defineMetadata(key, value, prototype[methodName]);
+      });
+    }
+
+    return constructor;
+  };
+}
+
+// Optional method decorator for explicit control
+export function LogMethod() {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const originalMethod = descriptor.value;
+    const className = target.constructor.name;
+
+    descriptor.value = function (...args: any[]) {
+      return loggingStorage.run({ className, methodName: propertyKey }, () =>
+        originalMethod.apply(this, args),
+      );
+    };
+  };
+}

--- a/api/src/logger/logger.module.ts
+++ b/api/src/logger/logger.module.ts
@@ -6,13 +6,30 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { Global, Module } from '@nestjs/common';
+import { DynamicModule, Module, Scope } from '@nestjs/common';
 
 import { LoggerService } from './logger.service';
 
-@Global()
-@Module({
-  providers: [LoggerService],
-  exports: [LoggerService],
-})
-export class LoggerModule {}
+const LOGGER_CONTEXT = 'LOGGER_CONTEXT';
+
+@Module({})
+export class LoggerModule {
+  static register(context: string): DynamicModule {
+    return {
+      module: LoggerModule,
+      providers: [
+        {
+          provide: LOGGER_CONTEXT, // Provide the context as a separate injectable
+          useValue: context,
+        },
+        {
+          provide: LoggerService,
+          useFactory: () => new LoggerService(context),
+          inject: [LOGGER_CONTEXT], // Inject the context into the factory
+          scope: Scope.TRANSIENT,
+        },
+      ],
+      exports: [LoggerService],
+    };
+  }
+}

--- a/api/src/logger/logger.service.ts
+++ b/api/src/logger/logger.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,9 +8,50 @@
 
 import { ConsoleLogger, Injectable, Scope } from '@nestjs/common';
 
+import { loggingStorage } from './logger.context';
+
 @Injectable({ scope: Scope.TRANSIENT })
 export class LoggerService extends ConsoleLogger {
-  constructor(context: string) {
-    super(context); // Pass the context to the parent class
+  constructor(private readonly moduleContext: string) {
+    super(moduleContext);
+  }
+
+  private getCallerContext(): string[] {
+    const store = loggingStorage.getStore();
+    const classMethod = store ? `${store.className}.${store.methodName}` : null;
+    return [this.moduleContext, classMethod].filter(Boolean) as string[];
+  }
+
+  private buildContext(): string {
+    return [...this.getCallerContext()].filter(Boolean).join('::');
+  }
+
+  log(message: any, ...args: any) {
+    super.setContext(this.buildContext());
+    super.log(message, ...args);
+  }
+
+  error(message: any, ...args: any) {
+    super.setContext(this.buildContext());
+    super.error(message, ...args);
+  }
+
+  warn(message: any, ...args: any) {
+    super.setContext(this.buildContext());
+    super.warn(message, ...args);
+
+    // super.warn(message, this.buildContext(), ...args);
+  }
+
+  debug(message: any, ...args: any) {
+    super.setContext(this.buildContext());
+    // super.debug(message, this.buildContext(), ...args);
+    super.debug(message, ...args);
+  }
+
+  verbose(message: any, ...args: any) {
+    super.setContext(this.buildContext());
+    super.verbose(message, ...args);
+    // super.verbose(message, this.buildContext(), ...args);
   }
 }

--- a/api/src/logger/logger.service.ts
+++ b/api/src/logger/logger.service.ts
@@ -6,6 +6,11 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { ConsoleLogger } from '@nestjs/common';
+import { ConsoleLogger, Injectable, Scope } from '@nestjs/common';
 
-export class LoggerService extends ConsoleLogger {}
+@Injectable({ scope: Scope.TRANSIENT })
+export class LoggerService extends ConsoleLogger {
+  constructor(context: string) {
+    super(context); // Pass the context to the parent class
+  }
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -34,6 +34,7 @@ async function bootstrap() {
   const app = await NestFactory.create(HexabotModule, {
     bodyParser: false,
   });
+  app.useLogger(await app.resolve(LoggerService));
 
   const rawBodyBuffer = (req, res, buf, encoding) => {
     if (buf?.length) {
@@ -84,9 +85,9 @@ async function bootstrap() {
     app.useWebSocketAdapter(redisIoAdapter);
   }
 
-  process.on('uncaughtException', (error) => {
+  process.on('uncaughtException', async (error) => {
     if (error.stack?.toLowerCase().includes('smtp'))
-      app.get(LoggerService).error('SMTP error', error.stack);
+      (await app.resolve(LoggerService)).error('SMTP error', error.stack);
     else throw error;
   });
 

--- a/api/src/migration/migration.module.ts
+++ b/api/src/migration/migration.module.ts
@@ -22,7 +22,7 @@ import { MigrationService } from './migration.service';
 @Module({
   imports: [
     MongooseModule.forFeature([MigrationModel]),
-    LoggerModule,
+    LoggerModule.register('MigrationModule'),
     HttpModule,
     AttachmentModule,
   ],

--- a/api/src/nlp/nlp.module.ts
+++ b/api/src/nlp/nlp.module.ts
@@ -11,6 +11,7 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { AttachmentModule } from '@/attachment/attachment.module';
+import { LoggerModule } from '@/logger/logger.module';
 
 import { NlpEntityController } from './controllers/nlp-entity.controller';
 import { NlpSampleController } from './controllers/nlp-sample.controller';
@@ -33,6 +34,7 @@ import { NlpService } from './services/nlp.service';
 
 @Module({
   imports: [
+    LoggerModule.register('NlpModule'),
     MongooseModule.forFeature([
       NlpEntityModel,
       NlpValueModel,

--- a/api/src/plugins/plugins.module.ts
+++ b/api/src/plugins/plugins.module.ts
@@ -18,6 +18,7 @@ import { BlockModel } from '@/chat/schemas/block.schema';
 import { CmsModule } from '@/cms/cms.module';
 import { ContentTypeModel } from '@/cms/schemas/content-type.schema';
 import { ContentModel } from '@/cms/schemas/content.schema';
+import { LoggerModule } from '@/logger/logger.module';
 
 import { PluginService } from './plugins.service';
 
@@ -32,6 +33,7 @@ import { PluginService } from './plugins.service';
 @Global()
 @Module({
   imports: [
+    LoggerModule.register('PluginModule'),
     MongooseModule.forFeature([
       BlockModel,
       AttachmentModel,

--- a/api/src/seeder.ts
+++ b/api/src/seeder.ts
@@ -37,7 +37,7 @@ import { UserSeeder } from './user/seeds/user.seed';
 import { userModels } from './user/seeds/user.seed-model';
 
 export async function seedDatabase(app: INestApplicationContext) {
-  const logger = app.get(LoggerService);
+  const logger = await app.resolve(LoggerService);
   const modelSeeder = app.get(ModelSeeder);
   const categorySeeder = app.get(CategorySeeder);
   const contextVarSeeder = app.get(ContextVarSeeder);

--- a/api/src/setting/setting.module.ts
+++ b/api/src/setting/setting.module.ts
@@ -10,6 +10,8 @@ import { Global, Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { PassportModule } from '@nestjs/passport';
 
+import { LoggerModule } from '@/logger/logger.module';
+
 import { SettingController } from './controllers/setting.controller';
 import { MetadataRepository } from './repositories/metadata.repository';
 import { SettingRepository } from './repositories/setting.repository';
@@ -23,6 +25,7 @@ import { SettingService } from './services/setting.service';
 @Global()
 @Module({
   imports: [
+    LoggerModule.register('SettingModule'),
     MongooseModule.forFeature([SettingModel, MetadataModel]),
     PassportModule.register({
       session: true,

--- a/api/src/user/user.module.ts
+++ b/api/src/user/user.module.ts
@@ -13,6 +13,7 @@ import { PassportModule } from '@nestjs/passport';
 
 import { AttachmentModule } from '@/attachment/attachment.module';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
+import { LoggerModule } from '@/logger/logger.module';
 
 import { LocalAuthController } from './controllers/auth.controller';
 import { ModelController } from './controllers/model.controller';
@@ -47,6 +48,7 @@ import { ValidateAccountService } from './services/validate-account.service';
 
 @Module({
   imports: [
+    LoggerModule.register('UserModule'),
     MongooseModule.forFeature([
       UserModel,
       ModelModel,

--- a/api/src/websocket/websocket.module.ts
+++ b/api/src/websocket/websocket.module.ts
@@ -8,11 +8,14 @@
 
 import { Global, Module } from '@nestjs/common';
 
+import { LoggerModule } from '@/logger/logger.module';
+
 import { SocketEventDispatcherService } from './services/socket-event-dispatcher.service';
 import { WebsocketGateway } from './websocket.gateway';
 
 @Global()
 @Module({
+  imports: [LoggerModule.register('WebsocketModule')],
   providers: [WebsocketGateway, SocketEventDispatcherService],
   exports: [WebsocketGateway],
 })


### PR DESCRIPTION
# Motivation

# This PR is WIP. 
- This PR allows us to define transient loggerService with module context utilizing dynamic modules. E.g output : `[Nest] 3999  - 01/24/2025, 4:44:37 PM VERBOSE [WebsocketModule] Retrieved socket session`
- We also can attach `LogClass` decorator to a class to enrich the logger.context to know which class and method called the loggerService methods. Example output `DEBUG [ChatModule::BotService.findBlockAndSendReply] No attached/next blocks to execute ...`
 - As an alternative to  `LogClass` we have another decroator `LogMethod` which allows to do the same thing but on method level E.g use case when a class have multiple methods but we only care about giving context to a one of them or a few (to reduce overhead) 


## How to Test : 
- you can trigger any module that has logger methods called & it should display  the log with name module attached as context
- you can also test BotService or BlockController to see the log context displayed in this format [Module::class.name.method.name]
- you can also test `LogMethod` decorator by adding it on a method that contains loggerService methods & it should display the log context in this format [Module::class.name.method.name]
 
Fixes # (issue)

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
