### PR TITLE
fix: hook stats entry event

### DIFF
--- a/api/src/analytics/services/bot-stats.service.ts
+++ b/api/src/analytics/services/bot-stats.service.ts
@@ -93,8 +93,9 @@ export class BotStatsService extends BaseService<BotStats> {
     ) {
       this.eventEmitter.emit(
         'hook:stats:entry',
-        'retention',
+        BotStatsType.retention,
         'Retentioned users',
+        subscriber,
       );
     }
   }
@@ -106,7 +107,11 @@ export class BotStatsService extends BaseService<BotStats> {
    * @param name - The name or identifier of the statistics entry (e.g., a specific feature or component being tracked).
    */
   @OnEvent('hook:stats:entry')
-  async handleStatEntry(type: BotStatsType, name: string): Promise<void> {
+  async handleStatEntry(
+    type: BotStatsType,
+    name: string,
+    _subscriber: Subscriber,
+  ): Promise<void> {
     const day = new Date();
     day.setMilliseconds(0);
     day.setSeconds(0);

--- a/api/src/chat/repositories/subscriber.repository.ts
+++ b/api/src/chat/repositories/subscriber.repository.ts
@@ -16,6 +16,7 @@ import {
   UpdateWithAggregationPipeline,
 } from 'mongoose';
 
+import { BotStatsType } from '@/analytics/schemas/bot-stats.schema';
 import { BaseRepository } from '@/utils/generics/base-repository';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
@@ -47,7 +48,7 @@ export class SubscriberRepository extends BaseRepository<
   async postCreate(created: SubscriberDocument): Promise<void> {
     this.eventEmitter.emit(
       'hook:stats:entry',
-      'new_users',
+      BotStatsType.new_users,
       'New users',
       created,
     );

--- a/api/src/chat/services/bot.service.spec.ts
+++ b/api/src/chat/services/bot.service.spec.ts
@@ -243,8 +243,8 @@ describe('BlockService', () => {
     await botService.startConversation(event, block);
     expect(hasBotSpoken).toEqual(true);
     expect(triggeredEvents).toEqual([
-      ['popular', 'hasNextBlocks'],
-      ['new_conversations', 'New conversations'],
+      ['popular', 'hasNextBlocks', webSubscriber],
+      ['new_conversations', 'New conversations', webSubscriber],
     ]);
     clearMock.mockClear();
   });
@@ -301,7 +301,7 @@ describe('BlockService', () => {
     const captured = await botService.processConversationMessage(event);
     expect(captured).toBe(true);
     expect(triggeredEvents).toEqual([
-      ['existing_conversations', 'Existing conversations'],
+      ['existing_conversations', 'Existing conversations', webSubscriber],
     ]);
     clearMock.mockClear();
   });

--- a/api/src/chat/services/chat.service.ts
+++ b/api/src/chat/services/chat.service.ts
@@ -11,6 +11,7 @@ import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import mime from 'mime';
 import { v4 as uuidv4 } from 'uuid';
 
+import { BotStatsType } from '@/analytics/schemas/bot-stats.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
 import {
   AttachmentAccess,
@@ -149,11 +150,17 @@ export class ChatService {
       }
 
       this.websocketGateway.broadcastMessageReceived(populatedMsg, subscriber);
-      this.eventEmitter.emit('hook:stats:entry', 'incoming', 'Incoming');
       this.eventEmitter.emit(
         'hook:stats:entry',
-        'all_messages',
+        BotStatsType.incoming,
+        'Incoming',
+        subscriber,
+      );
+      this.eventEmitter.emit(
+        'hook:stats:entry',
+        BotStatsType.all_messages,
         'All Messages',
+        subscriber,
       );
     } catch (err) {
       this.logger.error('Unable to log received message.', err, event);
@@ -248,7 +255,7 @@ export class ChatService {
         };
 
         this.eventEmitter.emit('hook:chatbot:sent', sentMessage, event);
-        this.eventEmitter.emit('hook:stats:entry', 'echo', 'Echo');
+        this.eventEmitter.emit('hook:stats:entry', 'echo', 'Echo', recipient);
       } catch (err) {
         this.logger.error('Unable to log echo message', err, event);
       }


### PR DESCRIPTION
# Motivation

This PR includes adding missing subscriber when emitting 'hook:stats:entry' event.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced analytics tracking with refined event processing, now incorporating additional subscriber information to improve data consistency and overall insights.

- **Refactor**
  - Standardized event emissions across messaging and conversation services for more coherent and accurate statistics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->