### PR TITLE
fix: broadcast channel provider missing for widget

### DIFF
--- a/widget/src/ChatWidget.tsx
+++ b/widget/src/ChatWidget.tsx
@@ -1,15 +1,17 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
+
 import "normalize.css";
 import "./ChatWidget.css";
 import Launcher from "./components/Launcher";
 import UserSubscription from "./components/UserSubscription";
+import BroadcastChannelProvider from "./providers/BroadcastChannelProvider";
 import ChatProvider from "./providers/ChatProvider";
 import { ColorProvider } from "./providers/ColorProvider";
 import { ConfigProvider } from "./providers/ConfigProvider";
@@ -29,9 +31,11 @@ function ChatWidget(props: Partial<Config>) {
             <SettingsProvider>
               <ColorProvider>
                 <WidgetProvider>
-                  <ChatProvider>
-                    <Launcher PreChat={UserSubscription} />
-                  </ChatProvider>
+                  <BroadcastChannelProvider channelName="main-channel">
+                    <ChatProvider>
+                      <Launcher PreChat={UserSubscription} />
+                    </ChatProvider>
+                  </BroadcastChannelProvider>
                 </WidgetProvider>
               </ColorProvider>
             </SettingsProvider>


### PR DESCRIPTION
# Motivation

This PR fixes a bug in widget project where it doesn't display the web-widget

![image](https://github.com/user-attachments/assets/e88e5a69-6085-4d56-94a0-8245c648d702)

Fixes #672

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code