### PR TITLE
refactor(frontend): update nlpSample dialogs

### DIFF
--- a/frontend/src/app-components/dialogs/FormDialog.tsx
+++ b/frontend/src/app-components/dialogs/FormDialog.tsx
@@ -20,16 +20,18 @@ export const FormDialog = ({
   ...rest
 }: FormDialogProps) => {
   const handleClose = () => rest.onClose?.({}, "backdropClick");
+  const dialogActions =
+    rest.hasButtons === false ? null : (
+      <DialogActions style={{ padding: "0.5rem" }}>
+        <DialogFormButtons onCancel={handleClose} onSubmit={onSubmit} />
+      </DialogActions>
+    );
 
   return (
     <Dialog fullWidth {...rest}>
       <DialogTitle onClose={handleClose}>{title}</DialogTitle>
       <DialogContent>{children}</DialogContent>
-      {rest.hasButtons === false ? null : (
-        <DialogActions style={{ padding: "0.5rem" }}>
-          <DialogFormButtons onCancel={handleClose} onSubmit={onSubmit} />
-        </DialogActions>
-      )}
+      {dialogActions}
     </Dialog>
   );
 };

--- a/frontend/src/app-components/dialogs/FormDialog.tsx
+++ b/frontend/src/app-components/dialogs/FormDialog.tsx
@@ -25,9 +25,11 @@ export const FormDialog = ({
     <Dialog fullWidth {...rest}>
       <DialogTitle onClose={handleClose}>{title}</DialogTitle>
       <DialogContent>{children}</DialogContent>
-      <DialogActions style={{ padding: "0.5rem" }}>
-        <DialogFormButtons onCancel={handleClose} onSubmit={onSubmit} />
-      </DialogActions>
+      {rest.hasButtons === false ? null : (
+        <DialogActions style={{ padding: "0.5rem" }}>
+          <DialogFormButtons onCancel={handleClose} onSubmit={onSubmit} />
+        </DialogActions>
+      )}
     </Dialog>
   );
 };

--- a/frontend/src/components/nlp/components/NlpSampleForm.tsx
+++ b/frontend/src/components/nlp/components/NlpSampleForm.tsx
@@ -1,38 +1,35 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { Dialog, DialogContent } from "@mui/material";
-import { FC } from "react";
+import { FC, Fragment } from "react";
 
-import { DialogTitle } from "@/app-components/dialogs/DialogTitle";
 import { useUpdate } from "@/hooks/crud/useUpdate";
-import { DialogControlProps } from "@/hooks/useDialog";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
+import { ComponentFormProps } from "@/types/common/dialogs.types";
 import {
   INlpDatasetSample,
   INlpDatasetSampleAttributes,
   INlpSampleFormAttributes,
 } from "@/types/nlp-sample.types";
 
-import NlpDatasetSample from "./components/NlpTrainForm";
+import NlpDatasetSample from "./NlpTrainForm";
 
-export type NlpSampleDialogProps = DialogControlProps<INlpDatasetSample>;
-export const NlpSampleDialog: FC<NlpSampleDialogProps> = ({
-  open,
-  data: sample,
-  closeDialog,
+export const NlpSampleForm: FC<ComponentFormProps<INlpDatasetSample>> = ({
+  data,
+  Wrapper = Fragment,
+  WrapperProps,
   ...rest
 }) => {
   const { t } = useTranslate();
   const { toast } = useToast();
-  const { mutateAsync: updateSample } = useUpdate<
+  const { mutate: updateSample } = useUpdate<
     EntityType.NLP_SAMPLE,
     INlpDatasetSampleAttributes
   >(EntityType.NLP_SAMPLE, {
@@ -44,10 +41,10 @@ export const NlpSampleDialog: FC<NlpSampleDialogProps> = ({
     },
   });
   const onSubmitForm = (form: INlpSampleFormAttributes) => {
-    if (sample?.id) {
+    if (data?.id) {
       updateSample(
         {
-          id: sample.id,
+          id: data.id,
           params: {
             text: form.text,
             type: form.type,
@@ -57,7 +54,7 @@ export const NlpSampleDialog: FC<NlpSampleDialogProps> = ({
         },
         {
           onSuccess: () => {
-            closeDialog();
+            rest.onSuccess?.();
           },
         },
       );
@@ -65,13 +62,13 @@ export const NlpSampleDialog: FC<NlpSampleDialogProps> = ({
   };
 
   return (
-    <Dialog open={open} fullWidth maxWidth="md" onClose={closeDialog} {...rest}>
-      <DialogTitle onClose={closeDialog}>
-        {t("title.edit_nlp_sample")}
-      </DialogTitle>
-      <DialogContent>
-        <NlpDatasetSample sample={sample} submitForm={onSubmitForm} />
-      </DialogContent>
-    </Dialog>
+    <Wrapper open={!!WrapperProps?.open} onSubmit={() => {}} {...WrapperProps}>
+      <form>
+        <NlpDatasetSample
+          sample={data || undefined}
+          submitForm={onSubmitForm}
+        />
+      </form>
+    </Wrapper>
   );
 };

--- a/frontend/src/components/nlp/components/NlpSampleFormDialog.tsx
+++ b/frontend/src/components/nlp/components/NlpSampleFormDialog.tsx
@@ -19,8 +19,7 @@ export const NlpSampleFormDialog = <
 ) => (
   <GenericFormDialog<T>
     Form={NlpSampleForm}
-    addText="title.new_category"
-    editText="title.edit_category"
+    editText="title.edit_nlp_sample"
     {...props}
   />
 );

--- a/frontend/src/components/nlp/components/NlpSampleFormDialog.tsx
+++ b/frontend/src/components/nlp/components/NlpSampleFormDialog.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { GenericFormDialog } from "@/app-components/dialogs";
+import { ComponentFormDialogProps } from "@/types/common/dialogs.types";
+import { INlpDatasetSample } from "@/types/nlp-sample.types";
+
+import { NlpSampleForm } from "./NlpSampleForm";
+
+export const NlpSampleFormDialog = <
+  T extends INlpDatasetSample = INlpDatasetSample,
+>(
+  props: ComponentFormDialogProps<T>,
+) => (
+  <GenericFormDialog<T>
+    Form={NlpSampleForm}
+    addText="title.new_category"
+    editText="title.edit_category"
+    {...props}
+  />
+);

--- a/frontend/src/contexts/dialogs.context.tsx
+++ b/frontend/src/contexts/dialogs.context.tsx
@@ -55,7 +55,7 @@ function DialogsProvider(props: DialogProviderProps) {
       payload: P,
       options: OpenDialogOptions<R> = {},
     ) {
-      const { onClose = async () => {} } = options;
+      const { onClose = async () => {}, ...rest } = options;
       let resolve: ((result: R) => void) | undefined;
       const promise = new Promise<R>((resolveImpl) => {
         resolve = resolveImpl;
@@ -77,7 +77,7 @@ function DialogsProvider(props: DialogProviderProps) {
         payload,
         onClose,
         resolve,
-        msgProps: { count: options.count, mode: options.mode },
+        msgProps: rest,
       };
 
       setStack((prevStack) => [...prevStack, newEntry]);

--- a/frontend/src/types/common/dialogs.types.ts
+++ b/frontend/src/types/common/dialogs.types.ts
@@ -9,12 +9,14 @@
 import { DialogProps as MuiDialogProps } from "@mui/material";
 import { BaseSyntheticEvent } from "react";
 
-interface ConfirmDialogExtraOptions {
+interface DialogExtraOptions {
   mode?: "click" | "selection";
   count?: number;
+  maxWidth?: MuiDialogProps["maxWidth"];
+  hasButtons?: boolean;
 }
 // context
-export interface OpenDialogOptions<R> extends ConfirmDialogExtraOptions {
+export interface OpenDialogOptions<R> extends DialogExtraOptions {
   /**
    * A function that is called before closing the dialog closes. The dialog
    * stays open as long as the returned promise is not resolved. Use this if
@@ -133,7 +135,7 @@ export interface DialogStackEntry<P, R> {
   payload: P;
   onClose: (result: R) => Promise<void>;
   resolve: (result: R) => void;
-  msgProps: ConfirmDialogExtraOptions;
+  msgProps: DialogExtraOptions;
 }
 
 export interface DialogProviderProps {
@@ -142,7 +144,7 @@ export interface DialogProviderProps {
 }
 
 // form dialog
-export interface FormDialogProps extends MuiDialogProps {
+export interface FormDialogProps extends MuiDialogProps, DialogExtraOptions {
   title?: string;
   children?: React.ReactNode;
   onSubmit: (e: BaseSyntheticEvent) => void;


### PR DESCRIPTION
# Motivation
The main motivation is to refactor the NlpSamples code base to use useDialogs hook instead of using useDialog hook.

Fixes #695

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
