### PR TITLE
fix: missing value in PayloadType enum

### DIFF
--- a/api/src/chat/controllers/block.controller.spec.ts
+++ b/api/src/chat/controllers/block.controller.spec.ts
@@ -53,6 +53,7 @@ import { CategoryRepository } from '../repositories/category.repository';
 import { LabelRepository } from '../repositories/label.repository';
 import { Block, BlockModel } from '../schemas/block.schema';
 import { LabelModel } from '../schemas/label.schema';
+import { PayloadType } from '../schemas/types/message';
 import { BlockService } from '../services/block.service';
 import { CategoryService } from '../services/category.service';
 import { LabelService } from '../services/label.service';
@@ -335,5 +336,22 @@ describe('BlockController', () => {
         blockController.updateOne(blockToDelete.id, updateBlock),
       ).rejects.toThrow(getUpdateOneError(Block.name, blockToDelete.id));
     });
+  });
+
+  it('should update block trigger to postback menu', async () => {
+    jest.spyOn(blockService, 'updateOne');
+    const updateBlock: BlockUpdateDto = {
+      patterns: [
+        {
+          label: 'postback123',
+          value: 'postback123',
+          type: PayloadType.menu,
+        },
+      ],
+    };
+    const result = await blockController.updateOne(block.id, updateBlock);
+    expect(blockService.updateOne).toHaveBeenCalledWith(block.id, updateBlock);
+
+    expect(result.patterns).toEqual(updateBlock.patterns);
   });
 });

--- a/api/src/chat/controllers/block.controller.spec.ts
+++ b/api/src/chat/controllers/block.controller.spec.ts
@@ -352,6 +352,15 @@ describe('BlockController', () => {
     const result = await blockController.updateOne(block.id, updateBlock);
     expect(blockService.updateOne).toHaveBeenCalledWith(block.id, updateBlock);
 
+    expect(
+      result.patterns.find(
+        (pattern) =>
+          typeof pattern === 'object' &&
+          'type' in pattern &&
+          pattern.type === PayloadType.menu &&
+          pattern,
+      ),
+    ).toBeDefined();
     expect(result.patterns).toEqual(updateBlock.patterns);
   });
 });

--- a/api/src/chat/controllers/block.controller.spec.ts
+++ b/api/src/chat/controllers/block.controller.spec.ts
@@ -53,7 +53,7 @@ import { CategoryRepository } from '../repositories/category.repository';
 import { LabelRepository } from '../repositories/label.repository';
 import { Block, BlockModel } from '../schemas/block.schema';
 import { LabelModel } from '../schemas/label.schema';
-import { PayloadType } from '../schemas/types/message';
+import { PayloadType } from '../schemas/types/button';
 import { BlockService } from '../services/block.service';
 import { CategoryService } from '../services/category.service';
 import { LabelService } from '../services/label.service';

--- a/api/src/chat/schemas/types/button.ts
+++ b/api/src/chat/schemas/types/button.ts
@@ -41,4 +41,5 @@ export enum PayloadType {
   quick_reply = 'quick_reply',
   button = 'button',
   outcome = 'outcome',
+  menu = 'menu',
 }


### PR DESCRIPTION
# Motivation

This PR fixes the issue where the PayloadType enum missing `menu` value

Fixes #716

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code