### PR TITLE
feat: change mid to string array

### DIFF
--- a/api/src/channel/lib/Handler.ts
+++ b/api/src/channel/lib/Handler.ts
@@ -214,7 +214,7 @@ export default abstract class ChannelHandler<
     envelope: StdOutgoingEnvelope,
     options: any,
     context: any,
-  ): Promise<{ mid: string }>;
+  ): Promise<{ mid: string | string[] }>;
 
   /**
    * Calls the channel handler to fetch attachments and stores them

--- a/api/src/chat/controllers/message.controller.spec.ts
+++ b/api/src/chat/controllers/message.controller.spec.ts
@@ -141,6 +141,10 @@ describe('MessageController', () => {
 
   afterAll(closeInMongodConnection);
 
+  function toArray(value?: string | string[]): string[] {
+    return value ? (Array.isArray(value) ? value : [value]) : [];
+  }
+
   describe('count', () => {
     it('should count messages', async () => {
       jest.spyOn(messageService, 'count');
@@ -162,8 +166,13 @@ describe('MessageController', () => {
       expect(messageService.findOneAndPopulate).toHaveBeenCalledWith(
         message.id,
       );
+      const expectedFixture = messageFixtures.find(
+        ({ mid }) =>
+          JSON.stringify(toArray(mid)) === JSON.stringify(message.mid),
+      );
       expect(result).toEqualPayload({
-        ...messageFixtures.find(({ mid }) => mid === message.mid),
+        ...expectedFixture,
+        mid: toArray(expectedFixture?.mid),
         sender,
         recipient,
         sentBy: user.id,
@@ -174,8 +183,13 @@ describe('MessageController', () => {
       const result = await messageController.findOne(message.id, []);
 
       expect(messageService.findOne).toHaveBeenCalledWith(message.id);
+      const expectedFixture = messageFixtures.find(
+        ({ mid }) =>
+          JSON.stringify(toArray(mid)) === JSON.stringify(message.mid),
+      );
       expect(result).toEqualPayload({
-        ...messageFixtures.find(({ mid }) => mid === message.mid),
+        ...expectedFixture,
+        mid: toArray(expectedFixture?.mid),
         sender: sender.id,
         recipient: recipient.id,
         sentBy: user.id,

--- a/api/src/chat/dto/message.dto.ts
+++ b/api/src/chat/dto/message.dto.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -11,8 +11,8 @@ import {
   IsBoolean,
   IsNotEmpty,
   IsObject,
-  IsString,
   IsOptional,
+  IsString,
 } from 'class-validator';
 
 import { IsObjectId } from '@/utils/validation-rules/is-object-id';
@@ -27,7 +27,7 @@ export class MessageCreateDto {
   @ApiProperty({ description: 'Message id', type: String })
   @IsOptional()
   @IsString()
-  mid?: string;
+  mid?: string | string[];
 
   @ApiProperty({ description: 'Reply to Message id', type: String })
   @IsOptional()

--- a/api/src/chat/schemas/message.schema.ts
+++ b/api/src/chat/schemas/message.schema.ts
@@ -96,9 +96,12 @@ export class MessageFull extends MessageStub {
   sentBy?: string; // sendBy is never populate
 }
 
+const MessageSchema = SchemaFactory.createForClass(MessageStub);
+MessageSchema.index({ mid: 1 });
+
 export const MessageModel: ModelDefinition = LifecycleHookManager.attach({
   name: Message.name,
-  schema: SchemaFactory.createForClass(MessageStub),
+  schema: MessageSchema,
 });
 
 export default MessageModel.schema;

--- a/api/src/chat/schemas/message.schema.ts
+++ b/api/src/chat/schemas/message.schema.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -20,11 +20,11 @@ import { StdIncomingMessage, StdOutgoingMessage } from './types/message';
 @Schema({ timestamps: true })
 export class MessageStub extends BaseSchema {
   @Prop({
-    type: String,
+    type: [String],
     required: false,
     //TODO : add default value for mid
   })
-  mid?: string;
+  mid?: string | string[];
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,

--- a/api/src/chat/services/message.service.spec.ts
+++ b/api/src/chat/services/message.service.spec.ts
@@ -105,6 +105,9 @@ describe('MessageService', () => {
   afterEach(jest.clearAllMocks);
   afterAll(closeInMongodConnection);
 
+  function toArray(value?: string | string[]): string[] {
+    return value ? (Array.isArray(value) ? value : [value]) : [];
+  }
   describe('findOneAndPopulate', () => {
     it('should find message by id, and populate its corresponding sender and recipient', async () => {
       jest.spyOn(messageRepository, 'findOneAndPopulate');
@@ -114,8 +117,13 @@ describe('MessageService', () => {
         message.id,
         undefined,
       );
+      const expectedFixture = messageFixtures.find(
+        ({ mid }) =>
+          JSON.stringify(toArray(mid)) === JSON.stringify(message.mid),
+      );
       expect(result).toEqualPayload({
-        ...messageFixtures.find(({ mid }) => mid === message.mid),
+        ...expectedFixture,
+        mid: toArray(expectedFixture?.mid),
         sender,
         recipient,
         sentBy: user.id,

--- a/api/src/extensions/channels/web/base-web-channel.ts
+++ b/api/src/extensions/channels/web/base-web-channel.ts
@@ -242,7 +242,7 @@ export default abstract class BaseWebChannelHandler<
           ...message,
           author: anyMessage.sender,
           read: true, // Temporary fix as read is false in the bd
-          mid: anyMessage.mid,
+          mid: anyMessage.mid?.[0],
           createdAt: anyMessage.createdAt,
         });
       } else {
@@ -251,7 +251,7 @@ export default abstract class BaseWebChannelHandler<
           ...message,
           author: 'chatbot',
           read: true, // Temporary fix as read is false in the bd
-          mid: anyMessage.mid || this.generateId(),
+          mid: anyMessage.mid?.[0] || this.generateId(),
           handover: !!anyMessage.handover,
           createdAt: anyMessage.createdAt,
         });

--- a/api/src/utils/test/fixtures/message.ts
+++ b/api/src/utils/test/fixtures/message.ts
@@ -9,7 +9,7 @@
 import mongoose from 'mongoose';
 
 import { MessageCreateDto } from '@/chat/dto/message.dto';
-import { MessageModel, Message } from '@/chat/schemas/message.schema';
+import { Message, MessageModel } from '@/chat/schemas/message.schema';
 
 import { getFixturesWithDefaultValues } from '../defaultValues';
 import { TFixturesDefaultValues } from '../types';
@@ -27,7 +27,7 @@ const messages: MessageCreateDto[] = [
     delivery: true,
   },
   {
-    mid: 'mid-2',
+    mid: ['mid-2', 'mid-2.1'],
     sender: '1',
     recipient: '1',
     sentBy: '0',


### PR DESCRIPTION
# Motivation

Changed the mid field in the Message schema from string to [string].

## Reason for the Change:
In some channels (like Slack), certain elements must be sent as multiple separate messages. For example:

- An attachment with a quick reply in Slack requires two separate messages, each with its own mid.

To handle this, we now store mid as an array of strings in our message object, allowing multiple message IDs to be linked to a single logical message in our database.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for message IDs to allow handling of multiple IDs (`mid` can now be a string or an array of strings) across message creation, storage, and retrieval.

* **Bug Fixes**
  * Improved consistency in processing and comparing message IDs, ensuring reliable handling whether `mid` is a string or an array.

* **Tests**
  * Updated and expanded test cases to cover scenarios where message IDs are arrays, ensuring robust validation of the new behavior.

* **Chores**
  * Updated copyright years.
  * Adjusted import ordering for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->