### PR TITLE
fix: non-block drop in visual editor

### DIFF
--- a/frontend/src/components/visual-editor/v2/Diagrams.tsx
+++ b/frontend/src/components/visual-editor/v2/Diagrams.tsx
@@ -519,9 +519,11 @@ const Diagrams = () => {
       className="visual-editor"
       id="visual-editor"
       onDrop={(event) => {
-        const data = JSON.parse(
-          event.dataTransfer.getData("storm-diagram-node"),
-        );
+        const stormDiagramNode =
+          event.dataTransfer.getData("storm-diagram-node");
+
+        if (!stormDiagramNode) return;
+        const data = JSON.parse(stormDiagramNode);
 
         if (!data) {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
# Motivation

The `visual editor` captures all `drag and drop events` within it, and handles only those of a `block`.
But when checking if an event is related to a block, `JSON parsing` of an empty string may happen, which causes an error.
This `PR` fixes this issue.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
