### PR TITLE
feat: add migration for message mid to array

### DIFF
--- a/api/src/migration/migrations/1739354541379-v-2-2-1.migration.ts
+++ b/api/src/migration/migrations/1739354541379-v-2-2-1.migration.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import mongoose from 'mongoose';
+
+import messageSchema, { Message } from '@/chat/schemas/message.schema';
+
+module.exports = {
+  async up() {
+    const MessageModel = mongoose.model<Message>(Message.name, messageSchema);
+    await MessageModel.updateMany({ mid: { $not: { $type: 'array' } } }, [
+      { $set: { mid: ['$mid'] } },
+    ]);
+    return true;
+  },
+  async down() {
+    const MessageModel = mongoose.model<Message>(Message.name, messageSchema);
+    await MessageModel.updateMany({ mid: { $type: 'array' } }, [
+      { $set: { mid: { $arrayElemAt: ['$mid', 0] } } },
+    ]);
+
+    return true;
+  },
+};


### PR DESCRIPTION
# Motivation

This PR introduces the migration necessary to support the changes made in [Previous PR #745 ]. The previous PR modified the `mid` field in the Message schema from a string to an array of strings to handle cases where multiple message IDs need to be linked to a single logical message (e.g., Slack messages requiring multiple separate messages for attachments and quick replies).
## Dependency:
This PR **depends on**  [Previous PR #745 ], and it **should not be merged before**  that PR is merged.
## Migration Details:
- **Up Migration:**  Converts existing `mid` fields (currently strings) into arrays containing the original value.
 
- **Down Migration:**  Reverts the change by extracting the first element from the array and setting it back as a string.


   
###  🚨 Note:
 **The migration version (present in the migration name) is arbitrary and must be corrected before merging.**