### PR TITLE
fix: make SettingType.select inferring options as type

### DIFF
--- a/api/src/setting/index.d.ts
+++ b/api/src/setting/index.d.ts
@@ -1,10 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
+
+import { SettingType } from '@/setting/schemas/types';
 
 import { SettingByType } from './schemas/types';
 import { DEFAULT_SETTINGS } from './seeds/setting.seed-model';
@@ -22,10 +24,14 @@ declare global {
             ? { [K in keyof T]: TNativeType<T[K]> }
             : T;
 
+  type SettingValue<K> = K['type'] extends SettingType.select
+    ? K['options'][number]
+    : TNativeType<K['value']>;
+
   type SettingObject<
     T extends Omit<Setting, 'id' | 'createdAt' | 'updatedAt'>[],
   > = {
-    [K in T[number] as K['label']]: TNativeType<K['value']>;
+    [K in T[number] as K['label']]: SettingValue<K>;
   };
 
   type SettingMapByType<
@@ -38,7 +44,7 @@ declare global {
     T extends Omit<Setting, 'id' | 'createdAt' | 'updatedAt'>[],
   > = {
     [G in T[number] as G['group']]: {
-      [K in T[number] as K['label']]: TNativeType<K['value']>;
+      [K in T[number] as K['label']]: SettingValue<K>;
     };
   };
 


### PR DESCRIPTION
# Motivation
The main motivation is to make setting with SettingType.select type inferring the options types.

Fixes #752

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
