### PR TITLE
fix(frontend): use short dialogs imports

### DIFF
--- a/frontend/src/components/Menu/MenuForm.tsx
+++ b/frontend/src/components/Menu/MenuForm.tsx
@@ -10,7 +10,7 @@ import { MenuItem } from "@mui/material";
 import { FC, Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import { ToggleableInput } from "@/app-components/inputs/ToggleableInput";
 import { useCreate } from "@/hooks/crud/useCreate";

--- a/frontend/src/components/categories/CategoryForm.tsx
+++ b/frontend/src/components/categories/CategoryForm.tsx
@@ -9,7 +9,7 @@
 import { FC, Fragment, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/content-types/ContentTypeForm.tsx
+++ b/frontend/src/components/content-types/ContentTypeForm.tsx
@@ -11,7 +11,7 @@ import { Button } from "@mui/material";
 import { FC, Fragment, useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/contents/ContentForm.tsx
+++ b/frontend/src/components/contents/ContentForm.tsx
@@ -17,7 +17,7 @@ import {
 } from "react-hook-form";
 
 import AttachmentInput from "@/app-components/attachment/AttachmentInput";
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Adornment } from "@/app-components/inputs/Adornment";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";

--- a/frontend/src/components/contents/ContentImportForm.tsx
+++ b/frontend/src/components/contents/ContentImportForm.tsx
@@ -10,7 +10,7 @@ import { FC, Fragment, useState } from "react";
 import { useQuery } from "react-query";
 
 import AttachmentInput from "@/app-components/attachment/AttachmentInput";
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { useApiClient } from "@/hooks/useApiClient";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";

--- a/frontend/src/components/context-vars/ContextVarForm.tsx
+++ b/frontend/src/components/context-vars/ContextVarForm.tsx
@@ -10,7 +10,7 @@ import { FormControlLabel, FormHelperText, Switch } from "@mui/material";
 import { FC, Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/labels/LabelForm.tsx
+++ b/frontend/src/components/labels/LabelForm.tsx
@@ -9,7 +9,7 @@
 import { FC, Fragment, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/languages/LanguageForm.tsx
+++ b/frontend/src/components/languages/LanguageForm.tsx
@@ -10,7 +10,7 @@ import { FormControlLabel, Switch } from "@mui/material";
 import { FC, Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/nlp/components/NlpEntityForm.tsx
+++ b/frontend/src/components/nlp/components/NlpEntityForm.tsx
@@ -16,7 +16,7 @@ import {
 import { FC, Fragment, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/nlp/components/NlpValueForm.tsx
+++ b/frontend/src/components/nlp/components/NlpValueForm.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 import { FC, Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import MultipleInput from "@/app-components/inputs/MultipleInput";
 import { useCreate } from "@/hooks/crud/useCreate";

--- a/frontend/src/components/profile/profile.tsx
+++ b/frontend/src/components/profile/profile.tsx
@@ -6,7 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-
 import CheckIcon from "@mui/icons-material/Check";
 import EmailIcon from "@mui/icons-material/Email";
 import KeyIcon from "@mui/icons-material/Key";
@@ -16,8 +15,7 @@ import { FC } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useQueryClient } from "react-query";
 
-import { ContentItem } from "@/app-components/dialogs";
-import { ContentContainer } from "@/app-components/dialogs/layouts/ContentContainer";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Adornment } from "@/app-components/inputs/Adornment";
 import AvatarInput from "@/app-components/inputs/AvatarInput";
 import { Input } from "@/app-components/inputs/Input";

--- a/frontend/src/components/roles/RoleForm.tsx
+++ b/frontend/src/components/roles/RoleForm.tsx
@@ -9,7 +9,7 @@
 import { FC, Fragment, useEffect } from "react";
 import { useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -10,7 +10,7 @@ import { Button, Grid, Link } from "@mui/material";
 import { FC, Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import { Input } from "@/app-components/inputs/Input";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/users/EditUserForm.tsx
+++ b/frontend/src/components/users/EditUserForm.tsx
@@ -10,7 +10,7 @@ import { Button, Grid, Link } from "@mui/material";
 import { FC, Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import { Input } from "@/app-components/inputs/Input";
 import { useUpdate } from "@/hooks/crud/useUpdate";

--- a/frontend/src/components/users/InviteUserForm.tsx
+++ b/frontend/src/components/users/InviteUserForm.tsx
@@ -9,7 +9,7 @@
 import { FC, Fragment } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import { Input } from "@/app-components/inputs/Input";
 import { useSendInvitation } from "@/hooks/entities/invitation-hooks";

--- a/frontend/src/components/visual-editor/BlockEditForm.tsx
+++ b/frontend/src/components/visual-editor/BlockEditForm.tsx
@@ -12,7 +12,7 @@ import { FormControlLabel, Grid, Switch, Tab, Tabs } from "@mui/material";
 import { FC, Fragment, useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs/";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
 import TriggerIcon from "@/app-components/svg/TriggerIcon";
 import { TabPanel } from "@/app-components/tabs/TabPanel";

--- a/frontend/src/components/visual-editor/BlockMoveForm.tsx
+++ b/frontend/src/components/visual-editor/BlockMoveForm.tsx
@@ -9,7 +9,7 @@
 import { MenuItem, Select } from "@mui/material";
 import { FC, Fragment, useState } from "react";
 
-import { ContentContainer } from "@/app-components/dialogs/";
+import { ContentContainer } from "@/app-components/dialogs";
 import { ICategory } from "@/types/category.types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
 

--- a/frontend/src/components/visual-editor/form/MessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/MessageForm.tsx
@@ -1,12 +1,13 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { ContentContainer } from "@/app-components/dialogs/layouts/ContentContainer";
+
+import { ContentContainer } from "@/app-components/dialogs";
 
 import AttachmentMessageForm from "./AttachmentMessageForm";
 import { useBlock } from "./BlockFormProvider";

--- a/frontend/src/components/visual-editor/form/MessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/MessageForm.tsx
@@ -6,7 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-
 import { ContentContainer } from "@/app-components/dialogs";
 
 import AttachmentMessageForm from "./AttachmentMessageForm";

--- a/frontend/src/components/visual-editor/form/OptionsForm.tsx
+++ b/frontend/src/components/visual-editor/form/OptionsForm.tsx
@@ -1,16 +1,16 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
+
 import { Typography } from "@mui/material";
 import { Controller, useFormContext } from "react-hook-form";
 
-import { ContentContainer } from "@/app-components/dialogs/layouts/ContentContainer";
-import { ContentItem } from "@/app-components/dialogs/layouts/ContentItem";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import { Input } from "@/app-components/inputs/Input";
 import { useTranslate } from "@/hooks/useTranslate";

--- a/frontend/src/components/visual-editor/form/OptionsForm.tsx
+++ b/frontend/src/components/visual-editor/form/OptionsForm.tsx
@@ -6,7 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-
 import { Typography } from "@mui/material";
 import { Controller, useFormContext } from "react-hook-form";
 

--- a/frontend/src/components/visual-editor/form/TriggersForm.tsx
+++ b/frontend/src/components/visual-editor/form/TriggersForm.tsx
@@ -6,7 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-
 import { Divider } from "@mui/material";
 import { Controller, useFormContext } from "react-hook-form";
 

--- a/frontend/src/components/visual-editor/form/TriggersForm.tsx
+++ b/frontend/src/components/visual-editor/form/TriggersForm.tsx
@@ -1,16 +1,16 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
+
 import { Divider } from "@mui/material";
 import { Controller, useFormContext } from "react-hook-form";
 
-import { ContentContainer } from "@/app-components/dialogs/layouts/ContentContainer";
-import { ContentItem } from "@/app-components/dialogs/layouts/ContentItem";
+import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType, Format } from "@/services/types";


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to introduce the using of the dialogs short imports.
For more details you can see the dedicated issue #762

Fixes #762

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
