### PR TITLE
Fixed carousel buttons not visible on dark image (black) and opening attachment from the inbox croping the image

### DIFF
--- a/frontend/src/components/inbox/components/AttachmentViewerForm.tsx
+++ b/frontend/src/components/inbox/components/AttachmentViewerForm.tsx
@@ -23,7 +23,7 @@ export const AttachmentViewerForm: FC<
     <Wrapper {...WrapperProps}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        width="auto"
+        width="100%"
         height={800}
         style={{
           cursor: "pointer",

--- a/frontend/src/components/inbox/components/AttachmentViewerForm.tsx
+++ b/frontend/src/components/inbox/components/AttachmentViewerForm.tsx
@@ -24,10 +24,10 @@ export const AttachmentViewerForm: FC<
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         width="100%"
-        height={400}
         style={{
           cursor: "pointer",
           objectFit: "contain",
+          maxHeight: "70vh",
         }}
         alt={data?.url}
         src={data?.url}

--- a/frontend/src/components/inbox/components/AttachmentViewerForm.tsx
+++ b/frontend/src/components/inbox/components/AttachmentViewerForm.tsx
@@ -24,7 +24,7 @@ export const AttachmentViewerForm: FC<
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         width="100%"
-        height={800}
+        height={400}
         style={{
           cursor: "pointer",
           objectFit: "contain",

--- a/frontend/src/components/inbox/components/Carousel.tsx
+++ b/frontend/src/components/inbox/components/Carousel.tsx
@@ -30,7 +30,7 @@ import {
 
 const CARD_WIDTH = 300;
 const StyledIconButton = styled(IconButton)({
-  opacity: 0.1,
+  opacity: 0.2,
   zIndex: 9999,
   position: "absolute",
   top: "50%",
@@ -38,7 +38,9 @@ const StyledIconButton = styled(IconButton)({
   transition: "all 0.1s",
   ".carousel-wrapper:hover &": {
     opacity: 1,
+    backgroundColor: "#fff"
   },
+  backgroundColor: "#fff"
 });
 const StyledCarouselDiv = styled("div")({
   display: "flex",


### PR DESCRIPTION
# Motivation

Carousel Buttons: Improved visibility of carousel navigation buttons when displayed over dark or black images by adding a contrasting background and hover effect.
Inbox Attachments: Resolved image cropping issue when opening attachments from the inbox by adjusting the container styling and ensuring proper aspect ratio.

Fixes #584

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
