### PR TITLE
fix: appropriate toast message on category bulk delete

### DIFF
--- a/api/src/chat/repositories/category.repository.ts
+++ b/api/src/chat/repositories/category.repository.ts
@@ -65,8 +65,9 @@ export class CategoryRepository extends BaseRepository<
         category: id,
       });
       if (associatedBlocks) {
+        const category = await this.findOne({ _id: id });
         throw new ForbiddenException(
-          `Category ${id} has blocks associated with it`,
+          `Category ${category?.label || id} has blocks associated with it`,
         );
       }
     }

--- a/api/src/chat/repositories/category.repository.ts
+++ b/api/src/chat/repositories/category.repository.ts
@@ -54,7 +54,11 @@ export class CategoryRepository extends BaseRepository<
     criteria: TFilterQuery<Category>,
   ) {
     criteria = query.getQuery();
-    const ids = Array.isArray(criteria._id) ? criteria._id : [criteria._id];
+    const ids = Array.isArray(criteria._id?.$in)
+      ? criteria._id.$in
+      : Array.isArray(criteria._id)
+        ? criteria._id
+        : [criteria._id];
 
     for (const id of ids) {
       const associatedBlocks = await this.blockService.findOne({


### PR DESCRIPTION
# Motivation

Error message of bulk Flow (categories) delete are now clear.
Associated to [Issue #740](https://github.com/Hexastack/Hexabot/issues/740)

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code