### PR TITLE
fix: assign null to nlp samples language on associated language delete

### DIFF
--- a/api/src/i18n/repositories/language.repository.ts
+++ b/api/src/i18n/repositories/language.repository.ts
@@ -48,10 +48,22 @@ export class LanguageRepository extends BaseRepository<
     _criteria: TFilterQuery<Language>,
   ): Promise<void> {
     if (_criteria._id) {
-      const language = await this.find(
-        typeof _criteria === 'string' ? { _id: _criteria } : _criteria,
-      );
-      this.eventEmitter.emit('hook:language:delete', language);
+      const ids = Array.isArray(_criteria._id?.$in)
+        ? _criteria._id.$in
+        : Array.isArray(_criteria._id)
+          ? _criteria._id
+          : [_criteria._id];
+
+      for (const id of ids) {
+        const language = await this.findOne({
+          _id: id,
+        });
+        if (language) {
+          this.eventEmitter.emit('hook:language:delete', language);
+        } else {
+          throw new Error(`Language with id ${id} not found`);
+        }
+      }
     } else {
       throw new Error('Attempted to delete language using unknown criteria');
     }


### PR DESCRIPTION
# Motivation

Null value is now assigned to nlp samples' language when deleting associated language.
[Issue #781](https://github.com/Hexastack/Hexabot/issues/781)

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
