### PR TITLE
Fix: train edit nlu sample

### DIFF
--- a/api/src/nlp/services/nlp-sample.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -12,10 +12,14 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { HelperService } from '@/helper/helper.service';
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
 import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
 import { LanguageService } from '@/i18n/services/language.service';
 import { LoggerService } from '@/logger/logger.service';
+import { SettingModel } from '@/setting/schemas/setting.schema';
+import { SettingSeeder } from '@/setting/seeds/setting.seed';
+import { SettingService } from '@/setting/services/setting.service';
 import { nlpSampleFixtures } from '@/utils/test/fixtures/nlpsample';
 import { installNlpSampleEntityFixtures } from '@/utils/test/fixtures/nlpsampleentity';
 import { getPageQuery } from '@/utils/test/pagination';
@@ -40,6 +44,7 @@ import {
 } from '../schemas/nlp-sample.schema';
 import { NlpValueModel } from '../schemas/nlp-value.schema';
 
+import { SettingRepository } from './../../setting/repositories/setting.repository';
 import { NlpEntityService } from './nlp-entity.service';
 import { NlpSampleEntityService } from './nlp-sample-entity.service';
 import { NlpSampleService } from './nlp-sample.service';
@@ -67,6 +72,7 @@ describe('NlpSampleService', () => {
           NlpValueModel,
           NlpEntityModel,
           LanguageModel,
+          SettingModel,
         ]),
       ],
       providers: [
@@ -90,6 +96,10 @@ describe('NlpSampleService', () => {
             set: jest.fn(),
           },
         },
+        HelperService,
+        SettingService,
+        SettingRepository,
+        SettingSeeder,
       ],
     }).compile();
     nlpEntityService = module.get<NlpEntityService>(NlpEntityService);

--- a/api/src/nlp/services/nlp-sample.service.ts
+++ b/api/src/nlp/services/nlp-sample.service.ts
@@ -51,7 +51,6 @@ export class NlpSampleService extends BaseService<
     private readonly logger: LoggerService,
     private readonly helperService: HelperService,
     private readonly settingService: SettingService,
-    private readonly loggerService: LoggerService,
   ) {
     super(repository);
   }
@@ -218,17 +217,14 @@ export class NlpSampleService extends BaseService<
   async handleInference(doc: THydratedDocument<Message>) {
     const settings = await this.settingService.getSettings();
     if (!settings.chatbot_settings.automate_inference) {
-      this.loggerService.log('Automated inference is disabled');
+      this.logger.log('Automated inference is disabled');
       return;
     }
-    this.loggerService.log('Automated inference running');
+    this.logger.log('Automated inference running');
     if ('text' in doc.message) {
       const helper = await this.helperService.getDefaultHelper(HelperType.NLU);
       const { entities = [] } = await helper.predict(doc.message.text);
-      this.loggerService.debug(
-        `${helper.getName()} infered these entites`,
-        entities,
-      );
+      this.logger.debug(`${helper.getName()} infered these entites`, entities);
 
       const foundSample = await this.repository.findOne({
         text: doc.message.text,

--- a/api/src/setting/seeds/setting.seed-model.ts
+++ b/api/src/setting/seeds/setting.seed-model.ts
@@ -86,6 +86,13 @@ export const DEFAULT_SETTINGS = [
     translatable: true,
   },
   {
+    group: 'chatbot_settings',
+    label: 'automate_inference',
+    value: true,
+    type: SettingType.checkbox,
+    weight: 7,
+  },
+  {
     group: 'contact',
     label: 'contact_email_recipient',
     value: 'admin@example.com',

--- a/frontend/public/locales/en/chatbot_settings.json
+++ b/frontend/public/locales/en/chatbot_settings.json
@@ -8,7 +8,8 @@
     "fallback_block": "Fallback Block",
     "default_nlu_helper": "Default NLU Helper",
     "default_llm_helper": "Default LLM Helper",
-    "default_storage_helper": "Default Storage Helper"
+    "default_storage_helper": "Default Storage Helper",
+    "automate_inference": "Automate Inference"
   },
   "help": {
     "global_fallback": "Global fallback allows you to send custom messages when user entry does not match any of the block messages.",

--- a/frontend/public/locales/fr/chatbot_settings.json
+++ b/frontend/public/locales/fr/chatbot_settings.json
@@ -8,7 +8,8 @@
     "fallback_block": "Bloc de secours",
     "default_nlu_helper": "Utilitaire NLU par défaut",
     "default_llm_helper": "Utilitaire LLM par défaut",
-    "default_storage_helper": "Utilitaire de stockage par défaut"
+    "default_storage_helper": "Utilitaire de stockage par défaut",
+    "automate_inference": "Inférence Automatisée"
   },
   "help": {
     "global_fallback": "La réponse de secours globale vous permet d'envoyer des messages personnalisés lorsque l'entrée de l'utilisateur ne correspond à aucun des messages des blocs.",

--- a/frontend/src/components/nlp/components/NlpSampleForm.tsx
+++ b/frontend/src/components/nlp/components/NlpSampleForm.tsx
@@ -29,7 +29,7 @@ export const NlpSampleForm: FC<ComponentFormProps<INlpDatasetSample>> = ({
 }) => {
   const { t } = useTranslate();
   const { toast } = useToast();
-  const { mutate: updateSample } = useUpdate<
+  const { mutate: updateSample, isLoading: isUpdatingSample } = useUpdate<
     EntityType.NLP_SAMPLE,
     INlpDatasetSampleAttributes
   >(EntityType.NLP_SAMPLE, {
@@ -63,7 +63,11 @@ export const NlpSampleForm: FC<ComponentFormProps<INlpDatasetSample>> = ({
 
   return (
     <Wrapper onSubmit={() => {}} {...WrapperProps}>
-      <NlpDatasetSample sample={data || undefined} submitForm={onSubmitForm} />
+      <NlpDatasetSample
+        sample={data || undefined}
+        submitForm={onSubmitForm}
+        isMutationLoading={isUpdatingSample}
+      />
     </Wrapper>
   );
 };

--- a/frontend/src/components/nlp/components/NlpTrainForm.tsx
+++ b/frontend/src/components/nlp/components/NlpTrainForm.tsx
@@ -49,11 +49,13 @@ import { INlpValue } from "@/types/nlp-value.types";
 type NlpDatasetSampleProps = {
   sample?: INlpDatasetSample;
   submitForm: (params: INlpSampleFormAttributes) => void;
+  isMutationLoading: boolean;
 };
 
 const NlpDatasetSample: FC<NlpDatasetSampleProps> = ({
   sample,
   submitForm,
+  isMutationLoading,
 }) => {
   const { t } = useTranslate();
   const { data: entities, refetch: refetchEntities } = useFind(
@@ -174,7 +176,8 @@ const NlpDatasetSample: FC<NlpDatasetSampleProps> = ({
     hasEmptyCurrentType ||
     hasEmptyCurrentText ||
     hasEmptyTraitEntitesValue ||
-    hasEmptyLanguage;
+    hasEmptyLanguage ||
+    isMutationLoading;
 
   return (
     <Box className="nlp-train" sx={{ position: "relative", p: 2 }}>

--- a/frontend/src/components/nlp/components/NlpTrainForm.tsx
+++ b/frontend/src/components/nlp/components/NlpTrainForm.tsx
@@ -98,7 +98,7 @@ const NlpDatasetSample: FC<NlpDatasetSampleProps> = ({
     });
   const currentText = watch("text");
   const currentType = watch("type");
-  const langauge = watch("language");
+  const language = watch("language");
   const { apiClient } = useApiClient();
   const { fields: traitEntities, update: updateTraitEntity } = useFieldArray({
     control,
@@ -170,7 +170,7 @@ const NlpDatasetSample: FC<NlpDatasetSampleProps> = ({
 
   const hasEmptyCurrentType = !currentType;
   const hasEmptyCurrentText = !currentText;
-  const hasEmptyLanguage = !langauge;
+  const hasEmptyLanguage = !language;
   const hasEmptyTraitEntitesValue = traitEntities.some((e) => !e.value);
   const shouldDisableValidateButton =
     hasEmptyCurrentType ||

--- a/frontend/src/components/nlp/components/NlpTrainForm.tsx
+++ b/frontend/src/components/nlp/components/NlpTrainForm.tsx
@@ -96,6 +96,7 @@ const NlpDatasetSample: FC<NlpDatasetSampleProps> = ({
     });
   const currentText = watch("text");
   const currentType = watch("type");
+  const langauge = watch("language");
   const { apiClient } = useApiClient();
   const { fields: traitEntities, update: updateTraitEntity } = useFieldArray({
     control,
@@ -164,6 +165,16 @@ const NlpDatasetSample: FC<NlpDatasetSampleProps> = ({
     reset(defaultValues);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(defaultValues)]);
+
+  const hasEmptyCurrentType = !currentType;
+  const hasEmptyCurrentText = !currentText;
+  const hasEmptyLanguage = !langauge;
+  const hasEmptyTraitEntitesValue = traitEntities.some((e) => !e.value);
+  const shouldDisableValidateButton =
+    hasEmptyCurrentType ||
+    hasEmptyCurrentText ||
+    hasEmptyTraitEntitesValue ||
+    hasEmptyLanguage;
 
   return (
     <Box className="nlp-train" sx={{ position: "relative", p: 2 }}>
@@ -441,14 +452,7 @@ const NlpDatasetSample: FC<NlpDatasetSampleProps> = ({
             variant="contained"
             startIcon={<Check />}
             onClick={handleSubmit(onSubmitForm)}
-            disabled={
-              !(
-                currentText !== "" &&
-                currentType !== NlpSampleType.inbox &&
-                traitEntities.every((e) => e.value !== "") &&
-                keywordEntities.every((e) => e.value !== "")
-              )
-            }
+            disabled={shouldDisableValidateButton}
             type="submit"
           >
             {t("button.validate")}

--- a/frontend/src/components/nlp/index.tsx
+++ b/frontend/src/components/nlp/index.tsx
@@ -62,7 +62,7 @@ export const Nlp = ({
   };
   const { t } = useTranslate();
   const { toast } = useToast();
-  const { mutate: createSample } = useCreate<
+  const { mutate: createSample, isLoading } = useCreate<
     EntityType.NLP_SAMPLE,
     INlpDatasetSampleAttributes,
     INlpSample,
@@ -91,7 +91,10 @@ export const Nlp = ({
         <Grid container flexDirection="row">
           <Grid item xs={7}>
             <Paper>
-              <NlpDatasetSample submitForm={onSubmitForm} />
+              <NlpDatasetSample
+                submitForm={onSubmitForm}
+                isMutationLoading={isLoading}
+              />
             </Paper>
           </Grid>
           <Grid item xs={5} pl={2}>


### PR DESCRIPTION
# Motivation

This pr fixes edit nlu sample by disabling the `validate` button when the required fields are not selected.
and added a feature that in the settings where we specify `automate inference` defaulted to `true` when its `on` when user sends a message it automatically get the text & run the `helper` `predict` function & assign the necessary metadata to that specific same & change the type from `inbox` to `train` 

fixes #786

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated inference now processes incoming messages when enabled, helping to streamline chatbot interactions.
  - A new “Automate Inference” setting is available in both English and French to customize inference behavior.
  - Enhanced real-time feedback during sample updates and creation for a smoother user experience.
  
- **Chores**
  - Routine maintenance updates applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->