### PR TITLE
fix: synchronized sent messages cross account tabs

### DIFF
--- a/api/src/chat/services/chat.service.ts
+++ b/api/src/chat/services/chat.service.ts
@@ -47,7 +47,12 @@ export class ChatService {
     private readonly attachmentService: AttachmentService,
   ) {}
 
-  broadcastSendedMessages(event: EventWrapper<any, any>) {
+  /**
+   * Synchronize sent messages cross opened websocket connections of the same account
+   *
+   * @param event - The received event
+   */
+  private broadcastSentMessages(event: EventWrapper<any, any>) {
     this.websocketGateway.broadcast(
       event.getSender(),
       event.getEventType(),
@@ -276,7 +281,7 @@ export class ChatService {
         // Already existing user profile
         // Exec lastvisit hook
         this.eventEmitter.emit('hook:user:lastvisit', subscriber);
-        this.broadcastSendedMessages(event);
+        this.broadcastSentMessages(event);
       }
 
       this.websocketGateway.broadcastSubscriberUpdate(subscriber);

--- a/api/src/chat/services/chat.service.ts
+++ b/api/src/chat/services/chat.service.ts
@@ -47,6 +47,14 @@ export class ChatService {
     private readonly attachmentService: AttachmentService,
   ) {}
 
+  broadcastSendedMessages(event: EventWrapper<any, any>) {
+    this.websocketGateway.broadcast(
+      event.getSender(),
+      event.getEventType(),
+      event._adapter.raw,
+    );
+  }
+
   /**
    * Ends a given conversation (sets active to false)
    *
@@ -268,6 +276,7 @@ export class ChatService {
         // Already existing user profile
         // Exec lastvisit hook
         this.eventEmitter.emit('hook:user:lastvisit', subscriber);
+        this.broadcastSendedMessages(event);
       }
 
       this.websocketGateway.broadcastSubscriberUpdate(subscriber);


### PR DESCRIPTION
# Motivation
The main goal of this PR is to synchronize sent messages cross opened websocket connections of the same account.

Fixes #810

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
