### PR TITLE
feat: add handlebars template for text

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -35,6 +35,7 @@
         "dotenv": "^16.3.1",
         "ejs": "^3.1.9",
         "express-session": "^1.17.3",
+        "handlebars": "^4.7.8",
         "module-alias": "^2.2.3",
         "mongoose": "^8.0.0",
         "mongoose-lean-defaults": "^2.2.1",
@@ -11461,7 +11462,6 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "devOptional": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -11482,7 +11482,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15296,8 +15295,7 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "devOptional": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/nest-commander": {
       "version": "3.15.0",
@@ -19313,7 +19311,6 @@
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -20048,8 +20045,7 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "devOptional": true
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -70,6 +70,7 @@
     "dotenv": "^16.3.1",
     "ejs": "^3.1.9",
     "express-session": "^1.17.3",
+    "handlebars": "^4.7.8",
     "module-alias": "^2.2.3",
     "mongoose": "^8.0.0",
     "mongoose-lean-defaults": "^2.2.1",

--- a/api/src/chat/schemas/types/context.ts
+++ b/api/src/chat/schemas/types/context.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -27,4 +27,9 @@ export interface Context {
   user: Subscriber;
   skip: Record<string, number>;
   attempt: number;
+}
+
+export interface TemplateContext {
+  context: Context;
+  contact: Settings['contact'];
 }

--- a/frontend/src/components/visual-editor/form/inputs/ReplacementTokens.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/ReplacementTokens.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -65,7 +65,7 @@ function ReplacementTokens() {
           {(contextVars || []).map((v, index) => (
             <ListItem key={index}>
               <ListItemText
-                primary={`{context.vars.${v.name}}`}
+                primary={`{{context.vars.${v.name}}}`}
                 secondary={`${v.label}`}
               />
             </ListItem>
@@ -76,7 +76,7 @@ function ReplacementTokens() {
           {userInfos.map((v, index) => (
             <ListItem key={index}>
               <ListItemText
-                primary={`{context.user.${v.name}}`}
+                primary={`{{context.user.${v.name}}}`}
                 secondary={`${v.label}`}
               />
             </ListItem>
@@ -87,7 +87,7 @@ function ReplacementTokens() {
           {userLocation.map((v, index) => (
             <ListItem key={index}>
               <ListItemText
-                primary={`{context.user_location.${v.name}}`}
+                primary={`{{context.user_location.${v.name}}}`}
                 secondary={`${v.label}`}
               />
             </ListItem>
@@ -100,7 +100,7 @@ function ReplacementTokens() {
           {(contactInfos || []).map((v, index) => (
             <ListItem key={index}>
               <ListItemText
-                primary={`{contact.${v.label}}`}
+                primary={`{{contact.${v.label}}}`}
                 secondary={t(`label.${v.label}`, {
                   ns: "contact",
                 })}


### PR DESCRIPTION
# Motivation

This PR introduces Handlebars template rendering for block messages within Hexabot. The goal is to allow dynamic token replacements in messages, so that context-dependent values can be injected and displayed at runtime. By integrating Handlebars, we gain a more flexible way to insert user-specific or environment-specific variables into our messages.

Fixes #https://github.com/Hexastack/Hexabot/issues/819
Fixes https://github.com/Hexastack/Hexabot/issues/817

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
