### PR TITLE
feat: support the display samples count per value

### DIFF
--- a/api/src/nlp/controllers/nlp-value.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.spec.ts
@@ -18,6 +18,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpValueCreateDto } from '../dto/nlp-value.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';

--- a/api/src/nlp/controllers/nlp-value.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.spec.ts
@@ -10,18 +10,14 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { getUpdateOneError } from '@/utils/test/errors/messages';
-import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import {
   installNlpValueFixtures,
   nlpValueFixtures,
 } from '@/utils/test/fixtures/nlpvalue';
-import { getPageQuery } from '@/utils/test/pagination';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
-import { TFixtures } from '@/utils/test/types';
-import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpValueCreateDto } from '../dto/nlp-value.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
@@ -29,11 +25,7 @@ import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.rep
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
 import { NlpEntityModel } from '../schemas/nlp-entity.schema';
 import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import {
-  NlpValue,
-  NlpValueFull,
-  NlpValueModel,
-} from '../schemas/nlp-value.schema';
+import { NlpValue, NlpValueModel } from '../schemas/nlp-value.schema';
 import { NlpEntityService } from '../services/nlp-entity.service';
 import { NlpValueService } from '../services/nlp-value.service';
 
@@ -79,63 +71,6 @@ describe('NlpValueController', () => {
   afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
-
-  describe('findPage', () => {
-    it('should find nlp Values, and foreach nlp value populate the corresponding entity', async () => {
-      const pageQuery = getPageQuery<NlpValue>({
-        sort: ['value', 'desc'],
-      });
-      const result = await nlpValueController.findPage(
-        pageQuery,
-        ['entity'],
-        {},
-      );
-
-      const nlpValueFixturesWithEntities = nlpValueFixtures.reduce(
-        (acc, curr) => {
-          acc.push({
-            ...curr,
-            entity: nlpEntityFixtures[
-              parseInt(curr.entity!)
-            ] as NlpValueFull['entity'],
-            builtin: curr.builtin!,
-            expressions: curr.expressions!,
-            metadata: curr.metadata!,
-          });
-          return acc;
-        },
-        [] as TFixtures<NlpValueFull>[],
-      );
-      expect(result).toEqualPayload(nlpValueFixturesWithEntities);
-    });
-
-    it('should find nlp Values', async () => {
-      const pageQuery = getPageQuery<NlpValue>({
-        sort: ['value', 'desc'],
-      });
-      const result = await nlpValueController.findPage(
-        pageQuery,
-        ['invalidCriteria'],
-        {},
-      );
-      const nlpEntities = await nlpEntityService.findAll();
-      const nlpValueFixturesWithEntities = nlpValueFixtures.reduce(
-        (acc, curr) => {
-          const ValueWithEntities = {
-            ...curr,
-            entity: curr.entity ? nlpEntities[parseInt(curr.entity!)].id : null,
-            expressions: curr.expressions!,
-            metadata: curr.metadata!,
-            builtin: curr.builtin!,
-          };
-          acc.push(ValueWithEntities);
-          return acc;
-        },
-        [] as TFixtures<NlpValueCreateDto>[],
-      );
-      expect(result).toEqualPayload(nlpValueFixturesWithEntities);
-    });
-  });
 
   describe('count', () => {
     it('should count the nlp Values', async () => {

--- a/api/src/nlp/controllers/nlp-value.controller.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.ts
@@ -132,12 +132,12 @@ export class NlpValueController extends BaseController<
     @Query(
       new SearchFilterPipe<NlpValue>({ allowedFields: ['entity', 'value'] }),
     )
-    filters?: TFilterQuery<NlpValue>,
+    filters: TFilterQuery<NlpValue>,
   ) {
     return await this.nlpValueService.findAndPopulateNlpValuesWithCount(
+      pageQuery,
       populate,
       filters,
-      pageQuery,
     );
   }
 

--- a/api/src/nlp/controllers/nlp-value.controller.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.ts
@@ -125,24 +125,8 @@ export class NlpValueController extends BaseController<
     return doc;
   }
 
-  @Get('')
-  async findAndPopulateWithCount(
-    @Query(PageQueryPipe) pageQuery: PageQueryDto<NlpValue>,
-    @Query(PopulatePipe) populate: string[],
-    @Query(
-      new SearchFilterPipe<NlpValue>({ allowedFields: ['entity', 'value'] }),
-    )
-    filters: TFilterQuery<NlpValue>,
-  ) {
-    return await this.nlpValueService.findAndPopulateWithCount(
-      pageQuery,
-      populate,
-      filters,
-    );
-  }
-
   /**
-   * Retrieves a paginated list of NLP values.
+   * Retrieves a paginated list of NLP values with NLP Samples count.
    *
    * Supports filtering, pagination, and optional population of related entities.
    *
@@ -150,10 +134,10 @@ export class NlpValueController extends BaseController<
    * @param populate - An array of related entities to populate.
    * @param filters - Filters to apply when retrieving the NLP values.
    *
-   * @returns A promise resolving to a paginated list of NLP values.
+   * @returns A promise resolving to a paginated list of NLP values with NLP Samples count.
    */
-  // @Get('') disabled
-  async findPage(
+  @Get()
+  async findWithCount(
     @Query(PageQueryPipe) pageQuery: PageQueryDto<NlpValue>,
     @Query(PopulatePipe) populate: string[],
     @Query(
@@ -164,8 +148,8 @@ export class NlpValueController extends BaseController<
     filters: TFilterQuery<NlpValue>,
   ) {
     return this.canPopulate(populate)
-      ? await this.nlpValueService.findAndPopulate(filters, pageQuery)
-      : await this.nlpValueService.find(filters, pageQuery);
+      ? await this.nlpValueService.findAndPopulateWithCount(pageQuery, filters)
+      : await this.nlpValueService.findWithCount(pageQuery, filters);
   }
 
   /**

--- a/api/src/nlp/controllers/nlp-value.controller.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.ts
@@ -126,7 +126,7 @@ export class NlpValueController extends BaseController<
   }
 
   @Get('')
-  async findAndPopulateNlpValuesWithCount(
+  async findAndPopulateWithCount(
     @Query(PageQueryPipe) pageQuery: PageQueryDto<NlpValue>,
     @Query(PopulatePipe) populate: string[],
     @Query(
@@ -134,7 +134,7 @@ export class NlpValueController extends BaseController<
     )
     filters: TFilterQuery<NlpValue>,
   ) {
-    return await this.nlpValueService.findAndPopulateNlpValuesWithCount(
+    return await this.nlpValueService.findAndPopulateWithCount(
       pageQuery,
       populate,
       filters,

--- a/api/src/nlp/controllers/nlp-value.controller.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.ts
@@ -30,6 +30,7 @@ import { PageQueryPipe } from '@/utils/pagination/pagination-query.pipe';
 import { PopulatePipe } from '@/utils/pipes/populate.pipe';
 import { SearchFilterPipe } from '@/utils/pipes/search-filter.pipe';
 import { TFilterQuery } from '@/utils/types/filter.types';
+import { Format } from '@/utils/types/format.types';
 
 import { NlpValueCreateDto, NlpValueUpdateDto } from '../dto/nlp-value.dto';
 import {
@@ -147,9 +148,11 @@ export class NlpValueController extends BaseController<
     )
     filters: TFilterQuery<NlpValue>,
   ) {
-    return this.canPopulate(populate)
-      ? await this.nlpValueService.findAndPopulateWithCount(pageQuery, filters)
-      : await this.nlpValueService.findWithCount(pageQuery, filters);
+    return await this.nlpValueService.findWithCount(
+      this.canPopulate(populate) ? Format.FULL : Format.STUB,
+      pageQuery,
+      filters,
+    );
   }
 
   /**

--- a/api/src/nlp/controllers/nlp-value.controller.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.ts
@@ -125,6 +125,22 @@ export class NlpValueController extends BaseController<
     return doc;
   }
 
+  @Get('')
+  async findAndPopulateNlpValuesWithCount(
+    @Query(PageQueryPipe) pageQuery: PageQueryDto<NlpValue>,
+    @Query(PopulatePipe) populate: string[],
+    @Query(
+      new SearchFilterPipe<NlpValue>({ allowedFields: ['entity', 'value'] }),
+    )
+    filters?: TFilterQuery<NlpValue>,
+  ) {
+    return await this.nlpValueService.findAndPopulateNlpValuesWithCount(
+      populate,
+      filters,
+      pageQuery,
+    );
+  }
+
   /**
    * Retrieves a paginated list of NLP values.
    *
@@ -136,7 +152,7 @@ export class NlpValueController extends BaseController<
    *
    * @returns A promise resolving to a paginated list of NLP values.
    */
-  @Get()
+  // @Get('') disabled
   async findPage(
     @Query(PageQueryPipe) pageQuery: PageQueryDto<NlpValue>,
     @Query(PopulatePipe) populate: string[],

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -108,13 +108,13 @@ export class NlpValueRepository extends BaseRepository<
     }
   }
 
-  async findAndPopulateNlpValuesWithCount(
+  async findAndPopulateWithCount(
     { limit = 10, skip = 0, sort = ['createdAt', -1] }: PageQueryDto<NlpValue>,
     populate: string[],
     { $and = [], ...rest }: TFilterQuery<NlpValue>,
   ) {
     return this.model
-      .aggregate<NlpValue>([
+      .aggregate([
         {
           // support filters
           $match: {

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -159,6 +159,14 @@ export class NlpValueRepository extends BaseRepository<
           },
         },
         {
+          $lookup: {
+            from: 'nlpentities',
+            localField: 'entity',
+            foreignField: '_id',
+            as: 'entities',
+          },
+        },
+        {
           $group: {
             _id: '$_id',
             value: { $first: '$value' },

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -9,14 +9,20 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { plainToClass } from 'class-transformer';
-import { Document, Model, PipelineStage, Query, Types } from 'mongoose';
+import mongoose, {
+  Document,
+  Model,
+  PipelineStage,
+  Query,
+  Types,
+} from 'mongoose';
 
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { NlpValueDto } from '../dto/nlp-value.dto';
-import { NlpEntity } from '../schemas/nlp-entity.schema';
+import { NlpEntity, NlpEntityModel } from '../schemas/nlp-entity.schema';
 import {
   NLP_VALUE_POPULATE,
   NlpValue,
@@ -28,7 +34,6 @@ import {
   TNlpValueCountFormat,
 } from '../schemas/nlp-value.schema';
 
-import { NlpEntityRepository } from './nlp-entity.repository';
 import { NlpSampleEntityRepository } from './nlp-sample-entity.repository';
 
 @Injectable()
@@ -41,8 +46,6 @@ export class NlpValueRepository extends BaseRepository<
   constructor(
     @InjectModel(NlpValue.name) readonly model: Model<NlpValue>,
     private readonly nlpSampleEntityRepository: NlpSampleEntityRepository,
-    @Inject(forwardRef(() => NlpEntityRepository))
-    private readonly nlpEntityRepository: NlpEntityRepository,
   ) {
     super(model, NlpValue, NLP_VALUE_POPULATE, NlpValueFull);
   }
@@ -216,7 +219,9 @@ export class NlpValueRepository extends BaseRepository<
           ...rest,
           entity: plainToClass(
             NlpEntity,
-            await this.nlpEntityRepository.findOne(entity),
+            await mongoose
+              .model(NlpEntityModel.name, NlpEntityModel.schema)
+              .findById(entity),
             {
               excludePrefixes: ['_'],
             },

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -9,7 +9,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { plainToClass } from 'class-transformer';
-import { Document, Model, PipelineStage, Query, Types } from 'mongoose';
+import {
+  Document,
+  Model,
+  PipelineStage,
+  Query,
+  SortOrder,
+  Types,
+} from 'mongoose';
 
 import { BaseRepository, DeleteResult } from '@/utils/generics/base-repository';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
@@ -217,18 +224,8 @@ export class NlpValueRepository extends BaseRepository<
         : []),
       {
         $sort: {
-          [sort[0]]:
-            typeof sort[1] === 'number'
-              ? sort[1]
-              : sort[1].toString().toLowerCase() === 'desc'
-                ? -1
-                : 1,
-          _id:
-            typeof sort[1] === 'number'
-              ? sort[1]
-              : sort[1].toString().toLowerCase() === 'desc'
-                ? -1
-                : 1,
+          [sort[0]]: this.getSortDirection(sort[1]),
+          _id: this.getSortDirection(sort[1]),
         },
       },
     ];
@@ -288,5 +285,13 @@ export class NlpValueRepository extends BaseRepository<
       this.logger.error(`Error in findWithCount: ${error.message}`, error);
       throw error;
     }
+  }
+
+  private getSortDirection(sortOrder: SortOrder) {
+    return typeof sortOrder === 'number'
+      ? sortOrder
+      : sortOrder.toString().toLowerCase() === 'desc'
+        ? -1
+        : 1;
   }
 }

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -221,7 +221,8 @@ export class NlpValueRepository extends BaseRepository<
             NlpEntity,
             await mongoose
               .model(NlpEntityModel.name, NlpEntityModel.schema)
-              .findById(entity),
+              .findById(entity)
+              .lean(),
             {
               excludePrefixes: ['_'],
             },

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -123,10 +123,10 @@ export class NlpValueRepository extends BaseRepository<
   /**
    * Performs an aggregation to retrieve NLP values with their sample counts.
    *
+   * @param format - The format can be full or stub
    * @param pageQuery - The pagination parameters
    * @param filterQuery - The filter criteria
-   * @param populatePipelineStages - Optional additional pipeline stages for populating related data
-   * @returns Aggregated results with sample counts
+   * @returns Aggregated Nlp Value results with sample counts
    */
   private async aggregateWithCount<F extends Format>(
     format: F,

--- a/api/src/nlp/schemas/nlp-value.schema.ts
+++ b/api/src/nlp/schemas/nlp-value.schema.ts
@@ -106,6 +106,18 @@ export class NlpValueFull extends NlpValueStub {
   entity: NlpEntity;
 }
 
+export class NlpValueWithCount extends NlpValue {
+  nlpSamplesCount: number;
+}
+
+export class NlpValueFullWithCount extends NlpValueFull {
+  nlpSamplesCount: number;
+}
+
+export class NlpValueFullWithCountDto {
+  nlpSamplesCount: number;
+}
+
 export type NlpValueDocument = THydratedDocument<NlpValue>;
 
 export const NlpValueModel: ModelDefinition = LifecycleHookManager.attach({
@@ -121,3 +133,7 @@ export type NlpValuePopulate = keyof TFilterPopulateFields<
 >;
 
 export const NLP_VALUE_POPULATE: NlpValuePopulate[] = ['entity'];
+
+export type TNlpValueCountFormat<T> = T extends 'stub'
+  ? NlpValueWithCount
+  : NlpValueFullWithCount;

--- a/api/src/nlp/schemas/nlp-value.schema.ts
+++ b/api/src/nlp/schemas/nlp-value.schema.ts
@@ -16,6 +16,7 @@ import {
   TFilterPopulateFields,
   THydratedDocument,
 } from '@/utils/types/filter.types';
+import { TStubOrFull } from '@/utils/types/format.types';
 
 import { NlpEntity, NlpEntityFull } from './nlp-entity.schema';
 import { NlpValueMap } from './types';
@@ -114,10 +115,6 @@ export class NlpValueFullWithCount extends NlpValueFull {
   nlpSamplesCount: number;
 }
 
-export class NlpValueFullWithCountDto {
-  nlpSamplesCount: number;
-}
-
 export type NlpValueDocument = THydratedDocument<NlpValue>;
 
 export const NlpValueModel: ModelDefinition = LifecycleHookManager.attach({
@@ -134,6 +131,8 @@ export type NlpValuePopulate = keyof TFilterPopulateFields<
 
 export const NLP_VALUE_POPULATE: NlpValuePopulate[] = ['entity'];
 
-export type TNlpValueCountFormat<T> = T extends 'stub'
-  ? NlpValueWithCount
-  : NlpValueFullWithCount;
+export type TNlpValueCount<T> = TStubOrFull<
+  T,
+  NlpValueWithCount,
+  NlpValueFullWithCount
+>;

--- a/api/src/nlp/services/nlp-value.service.ts
+++ b/api/src/nlp/services/nlp-value.service.ts
@@ -19,7 +19,9 @@ import { NlpEntity } from '../schemas/nlp-entity.schema';
 import {
   NlpValue,
   NlpValueFull,
+  NlpValueFullWithCount,
   NlpValuePopulate,
+  NlpValueWithCount,
 } from '../schemas/nlp-value.schema';
 import { NlpSampleEntityValue } from '../schemas/types';
 
@@ -221,15 +223,17 @@ export class NlpValueService extends BaseService<
     return Promise.all(promises);
   }
 
+  async findWithCount(
+    pageQuery: PageQueryDto<NlpValue>,
+    filters: TFilterQuery<NlpValue>,
+  ): Promise<NlpValueWithCount[]> {
+    return await this.repository.findWithCount(pageQuery, filters);
+  }
+
   async findAndPopulateWithCount(
     pageQuery: PageQueryDto<NlpValue>,
-    populate: string[],
     filters: TFilterQuery<NlpValue>,
-  ) {
-    return await this.repository.findAndPopulateWithCount(
-      pageQuery,
-      populate,
-      filters,
-    );
+  ): Promise<NlpValueFullWithCount[]> {
+    return await this.repository.findAndPopulateWithCount(pageQuery, filters);
   }
 }

--- a/api/src/nlp/services/nlp-value.service.ts
+++ b/api/src/nlp/services/nlp-value.service.ts
@@ -221,12 +221,12 @@ export class NlpValueService extends BaseService<
     return Promise.all(promises);
   }
 
-  async findAndPopulateNlpValuesWithCount(
+  async findAndPopulateWithCount(
     pageQuery: PageQueryDto<NlpValue>,
     populate: string[],
     filters: TFilterQuery<NlpValue>,
   ) {
-    return await this.repository.findAndPopulateNlpValuesWithCount(
+    return await this.repository.findAndPopulateWithCount(
       pageQuery,
       populate,
       filters,

--- a/api/src/nlp/services/nlp-value.service.ts
+++ b/api/src/nlp/services/nlp-value.service.ts
@@ -12,6 +12,7 @@ import { DeleteResult } from '@/utils/generics/base-repository';
 import { BaseService } from '@/utils/generics/base-service';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { TFilterQuery } from '@/utils/types/filter.types';
+import { Format } from '@/utils/types/format.types';
 
 import { NlpValueCreateDto, NlpValueDto } from '../dto/nlp-value.dto';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
@@ -19,9 +20,8 @@ import { NlpEntity } from '../schemas/nlp-entity.schema';
 import {
   NlpValue,
   NlpValueFull,
-  NlpValueFullWithCount,
   NlpValuePopulate,
-  NlpValueWithCount,
+  TNlpValueCount,
 } from '../schemas/nlp-value.schema';
 import { NlpSampleEntityValue } from '../schemas/types';
 
@@ -223,17 +223,11 @@ export class NlpValueService extends BaseService<
     return Promise.all(promises);
   }
 
-  async findWithCount(
+  async findWithCount<F extends Format>(
+    format: F,
     pageQuery: PageQueryDto<NlpValue>,
     filters: TFilterQuery<NlpValue>,
-  ): Promise<NlpValueWithCount[]> {
-    return await this.repository.findWithCount(pageQuery, filters);
-  }
-
-  async findAndPopulateWithCount(
-    pageQuery: PageQueryDto<NlpValue>,
-    filters: TFilterQuery<NlpValue>,
-  ): Promise<NlpValueFullWithCount[]> {
-    return await this.repository.findAndPopulateWithCount(pageQuery, filters);
+  ): Promise<TNlpValueCount<F>[]> {
+    return await this.repository.findWithCount(format, pageQuery, filters);
   }
 }

--- a/api/src/nlp/services/nlp-value.service.ts
+++ b/api/src/nlp/services/nlp-value.service.ts
@@ -14,7 +14,6 @@ import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { NlpValueCreateDto, NlpValueDto } from '../dto/nlp-value.dto';
-import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
 import { NlpEntity } from '../schemas/nlp-entity.schema';
 import {
@@ -37,7 +36,6 @@ export class NlpValueService extends BaseService<
     readonly repository: NlpValueRepository,
     @Inject(forwardRef(() => NlpEntityService))
     private readonly nlpEntityService: NlpEntityService,
-    private readonly nlpSampleEntityRepository: NlpSampleEntityRepository,
   ) {
     super(repository);
   }
@@ -224,14 +222,14 @@ export class NlpValueService extends BaseService<
   }
 
   async findAndPopulateNlpValuesWithCount(
+    pageQuery: PageQueryDto<NlpValue>,
     populate: string[],
-    filters?: TFilterQuery<NlpValue>,
-    pageQuery?: PageQueryDto<NlpValue>,
+    filters: TFilterQuery<NlpValue>,
   ) {
     return await this.repository.findAndPopulateNlpValuesWithCount(
+      pageQuery,
       populate,
       filters,
-      pageQuery,
     );
   }
 }

--- a/api/src/utils/types/format.types.ts
+++ b/api/src/utils/types/format.types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+export enum Format {
+  NONE = 0,
+  STUB = 1,
+  BASIC = 2,
+  FULL = 3,
+}
+
+export type TStubOrFull<TF, TStub, TFull> = TF extends Format.STUB
+  ? TStub
+  : TFull;

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -334,6 +334,7 @@
     "nlp": "NLU",
     "nlp_entity": "Entity",
     "nlp_entity_value": "Value",
+    "nlp_samples_count": "Nlp Samples count",
     "value": "Value",
     "synonyms": "Synonyms",
     "lookups": "Lookups",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -334,7 +334,7 @@
     "nlp": "NLU",
     "nlp_entity": "Entity",
     "nlp_entity_value": "Value",
-    "nlp_samples_count": "Nlp Samples count",
+    "nlp_samples_count": "Samples count",
     "value": "Value",
     "synonyms": "Synonyms",
     "lookups": "Lookups",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -334,6 +334,7 @@
     "nlp": "NLU",
     "nlp_entity": "Entité NLU",
     "nlp_entity_value": "Valeur NLU",
+    "nlp_samples_count": "Nombre des échantillons",
     "value": "Valeur",
     "lookups": "Stratégies",
     "lookup_strategies": "Stratégie de recherche",

--- a/frontend/src/components/nlp/components/NlpValue.tsx
+++ b/frontend/src/components/nlp/components/NlpValue.tsx
@@ -58,7 +58,7 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
     $or: ["doc", "value"],
   });
   const { dataGridProps } = useFind(
-    { entity: EntityType.NLP_VALUE },
+    { entity: EntityType.NLP_VALUE, format: Format.FULL },
     {
       params: searchPayload,
     },

--- a/frontend/src/components/nlp/components/NlpValue.tsx
+++ b/frontend/src/components/nlp/components/NlpValue.tsx
@@ -137,8 +137,8 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
       renderCell: ({ row }) => (
         <Chip
           sx={{ alignContent: "center" }}
-          id={(row.nlpSamplesCount || `nlpSamplesCount_${row.id}`).toString()}
-          label={row.nlpSamplesCount?.toString()}
+          id={row.id}
+          label={row.nlpSamplesCount || "N/A"}
           variant="inbox"
         />
       ),

--- a/frontend/src/components/nlp/components/NlpValue.tsx
+++ b/frontend/src/components/nlp/components/NlpValue.tsx
@@ -55,7 +55,7 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
   const canHaveSynonyms = nlpEntity?.lookups?.[0] === NlpLookups.keywords;
   const { onSearch, searchPayload } = useSearch<INlpValue>({
     $eq: [{ entity: entityId }],
-    $or: ["doc", "value"]
+    $or: ["doc", "value"],
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.NLP_VALUE },
@@ -103,7 +103,7 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
     ],
     t("label.operations"),
   );
-  const synonymsColumn =  {
+  const synonymsColumn = {
     flex: 3,
     field: "synonyms",
     headerName: t("label.synonyms"),
@@ -124,6 +124,21 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
       sortable: true,
       disableColumnMenu: true,
       renderHeader,
+    },
+    {
+      flex: 3,
+      field: "nlpSamplesCount",
+      headerName: t("label.nlp_samples_count"),
+      sortable: true,
+      disableColumnMenu: true,
+      renderHeader,
+      renderCell: ({ row }) => (
+        <Chip
+          id={(row.nlpSamplesCount || `nlpSamplesCount_${row.id}`).toString()}
+          label={row.nlpSamplesCount?.toString()}
+          variant="inbox"
+        />
+      ),
     },
     {
       flex: 3,

--- a/frontend/src/components/nlp/components/NlpValue.tsx
+++ b/frontend/src/components/nlp/components/NlpValue.tsx
@@ -126,14 +126,17 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
       renderHeader,
     },
     {
-      flex: 3,
+      flex: 2,
       field: "nlpSamplesCount",
+      align: "center",
       headerName: t("label.nlp_samples_count"),
       sortable: true,
       disableColumnMenu: true,
+      headerAlign: "center",
       renderHeader,
       renderCell: ({ row }) => (
         <Chip
+          sx={{ alignContent: "center" }}
           id={(row.nlpSamplesCount || `nlpSamplesCount_${row.id}`).toString()}
           label={row.nlpSamplesCount?.toString()}
           variant="inbox"

--- a/frontend/src/components/nlp/components/NlpValue.tsx
+++ b/frontend/src/components/nlp/components/NlpValue.tsx
@@ -138,7 +138,7 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
         <Chip
           sx={{ alignContent: "center" }}
           id={row.id}
-          label={row.nlpSamplesCount || "N/A"}
+          label={row.nlpSamplesCount}
           variant="inbox"
         />
       ),

--- a/frontend/src/types/nlp-value.types.ts
+++ b/frontend/src/types/nlp-value.types.ts
@@ -19,6 +19,7 @@ export interface INlpValueAttributes {
   expressions?: string[];
   metadata?: Record<string, any>;
   builtin?: boolean;
+  nlpSamplesCount?: number;
 }
 
 export interface INlpValueStub extends IBaseSchema, INlpValueAttributes {}


### PR DESCRIPTION
# Motivation
We currently do not have an easy way to display the number of samples associated with each NLU Value. To address this, we should introduce a new schema, NlpValueFullWithCount, which includes a virtual attribute that aggregates and returns the sample count per value (via a Mongoose aggregation).

# Screenshot
![image](https://github.com/user-attachments/assets/b68d9189-cb68-4316-bde5-5fd90b8c8884)

Fixes #839

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced NLP value listings now show the count of associated samples.
  - Pagination now returns sample count details for improved data insight.
  - Updated localization adds sample count labels in both English and French.
- **Bug Fixes**
  - Removed outdated test cases from the NLP value controller test suite.
- **Documentation**
  - Updated method documentation to reflect changes in functionality and parameters.
- **Chores**
  - Cleaned up unused imports in the NLP value controller test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->