### PR TITLE
fix: move canPopulate method to the base-repository

### DIFF
--- a/api/src/utils/generics/base-controller.ts
+++ b/api/src/utils/generics/base-controller.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -32,12 +32,7 @@ export abstract class BaseController<
    * @return - True if all populate fields are allowed, otherwise false.
    */
   protected canPopulate(populate: string[]): boolean {
-    return populate.some((p) =>
-      this.service
-        .getRepository()
-        .getPopulate()
-        .includes(p as P),
-    );
+    return this.service.canPopulate(populate);
   }
 
   /**

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -89,8 +89,8 @@ export abstract class BaseRepository<
     this.registerLifeCycleHooks();
   }
 
-  getPopulate(): P[] {
-    return this.populate;
+  canPopulate(populate: string[]): boolean {
+    return populate.some((p) => this.populate.includes(p as P));
   }
 
   getEventName(suffix: EHook) {

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -34,6 +34,10 @@ export abstract class BaseService<
     return this.repository;
   }
 
+  canPopulate(populate: string[]): boolean {
+    return this.repository.canPopulate(populate);
+  }
+
   async findOne(
     criteria: string | TFilterQuery<T>,
     options?: ClassTransformOptions,


### PR DESCRIPTION
# Motivation
The main motivation is to move canPopulate method to the base-repository and to make the method available from the service level.

Fixes #845

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
