### PR TITLE
feat: add unit tests global provider config

### DIFF
--- a/api/src/analytics/controllers/bot-stats.controller.spec.ts
+++ b/api/src/analytics/controllers/bot-stats.controller.spec.ts
@@ -1,16 +1,13 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
-import { LoggerService } from '@/logger/logger.service';
 import {
   botstatsFixtures,
   installBotStatsFixtures,
@@ -19,6 +16,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { BotStatsRepository } from '../repositories/bot-stats.repository';
 import { BotStatsModel, BotStatsType } from '../schemas/bot-stats.schema';
@@ -30,25 +28,18 @@ describe('BotStatsController', () => {
   let botStatsController: BotStatsController;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [BotStatsController],
       imports: [
         rootMongooseTestModule(installBotStatsFixtures),
         MongooseModule.forFeature([BotStatsModel]),
       ],
-      providers: [
-        LoggerService,
-        BotStatsService,
-        BotStatsRepository,
-        EventEmitter2,
-      ],
-    }).compile();
-    botStatsController = module.get<BotStatsController>(BotStatsController);
+      providers: [BotStatsService, BotStatsRepository],
+    });
+    [botStatsController] = await getMocks([BotStatsController]);
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/analytics/repositories/bot-stats.repository.spec.ts
+++ b/api/src/analytics/repositories/bot-stats.repository.spec.ts
@@ -1,17 +1,14 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken, MongooseModule } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
-import { LoggerService } from '@/logger/logger.service';
 import {
   botstatsFixtures,
   installBotStatsFixtures,
@@ -20,6 +17,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
   BotStats,
@@ -34,20 +32,20 @@ describe('BotStatsRepository', () => {
   let botStatsModel: Model<BotStats>;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installBotStatsFixtures),
         MongooseModule.forFeature([BotStatsModel]),
       ],
-      providers: [LoggerService, BotStatsRepository, EventEmitter2],
-    }).compile();
-    botStatsRepository = module.get<BotStatsRepository>(BotStatsRepository);
-    botStatsModel = module.get<Model<BotStats>>(getModelToken('BotStats'));
+      providers: [BotStatsRepository],
+    });
+    [botStatsRepository, botStatsModel] = await getMocks([
+      BotStatsRepository,
+      getModelToken(BotStats.name),
+    ]);
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/analytics/services/bot-stats.service.spec.ts
+++ b/api/src/analytics/services/bot-stats.service.spec.ts
@@ -1,16 +1,13 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
-import { LoggerService } from '@/logger/logger.service';
 import {
   botstatsFixtures,
   installBotStatsFixtures,
@@ -19,6 +16,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { BotStatsRepository } from '../repositories/bot-stats.repository';
 import { BotStatsModel, BotStatsType } from '../schemas/bot-stats.schema';
@@ -29,24 +27,17 @@ describe('BotStatsService', () => {
   let botStatsService: BotStatsService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installBotStatsFixtures),
         MongooseModule.forFeature([BotStatsModel]),
       ],
-      providers: [
-        LoggerService,
-        BotStatsService,
-        BotStatsRepository,
-        EventEmitter2,
-      ],
-    }).compile();
-    botStatsService = module.get<BotStatsService>(BotStatsService);
+      providers: [BotStatsService, BotStatsRepository],
+    });
+    [botStatsService] = await getMocks([BotStatsService]);
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/attachment/guards/attachment-ability.guard.spec.ts
+++ b/api/src/attachment/guards/attachment-ability.guard.spec.ts
@@ -7,13 +7,13 @@
  */
 
 import { BadRequestException, ExecutionContext } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { Model } from '@/user/schemas/model.schema';
 import { Permission } from '@/user/schemas/permission.schema';
 import { ModelService } from '@/user/services/model.service';
 import { PermissionService } from '@/user/services/permission.service';
 import { Action } from '@/user/types/action.type';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { attachment } from '../mocks/attachment.mock';
 import { Attachment } from '../schemas/attachment.schema';
@@ -29,7 +29,7 @@ describe('AttachmentGuard', () => {
   let attachmentService: AttachmentService;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       providers: [
         AttachmentGuard,
         {
@@ -45,12 +45,15 @@ describe('AttachmentGuard', () => {
           useValue: { findOne: jest.fn() },
         },
       ],
-    }).compile();
+    });
 
-    guard = module.get<AttachmentGuard>(AttachmentGuard);
-    permissionService = module.get<PermissionService>(PermissionService);
-    modelService = module.get<ModelService>(ModelService);
-    attachmentService = module.get<AttachmentService>(AttachmentService);
+    [guard, permissionService, modelService, attachmentService] =
+      await getMocks([
+        AttachmentGuard,
+        PermissionService,
+        ModelService,
+        AttachmentService,
+      ]);
   });
 
   describe('canActivate', () => {

--- a/api/src/chat/controllers/block.controller.spec.ts
+++ b/api/src/chat/controllers/block.controller.spec.ts
@@ -8,9 +8,7 @@
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { NotFoundException } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
@@ -22,7 +20,6 @@ import { LanguageRepository } from '@/i18n/repositories/language.repository';
 import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
 import { LanguageService } from '@/i18n/services/language.service';
-import { LoggerService } from '@/logger/logger.service';
 import { PluginService } from '@/plugins/plugins.service';
 import { SettingService } from '@/setting/services/setting.service';
 import { InvitationRepository } from '@/user/repositories/invitation.repository';
@@ -46,6 +43,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { BlockCreateDto, BlockUpdateDto } from '../dto/block.dto';
 import { BlockRepository } from '../repositories/block.repository';
@@ -79,7 +77,7 @@ describe('BlockController', () => {
   ];
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [BlockController],
       imports: [
         rootMongooseTestModule(installBlockFixtures),
@@ -117,7 +115,6 @@ describe('BlockController', () => {
         PermissionService,
         LanguageService,
         PluginService,
-        LoggerService,
         {
           provide: I18nService,
           useValue: {
@@ -133,7 +130,6 @@ describe('BlockController', () => {
             getSettings: jest.fn(() => ({})),
           },
         },
-        EventEmitter2,
         {
           provide: CACHE_MANAGER,
           useValue: {
@@ -143,10 +139,12 @@ describe('BlockController', () => {
           },
         },
       ],
-    }).compile();
-    blockController = module.get<BlockController>(BlockController);
-    blockService = module.get<BlockService>(BlockService);
-    categoryService = module.get<CategoryService>(CategoryService);
+    });
+    [blockController, blockService, categoryService] = await getMocks([
+      BlockController,
+      BlockService,
+      CategoryService,
+    ]);
     category = (await categoryService.findOne({ label: 'default' }))!;
     block = (await blockService.findOne({ name: 'first' }))!;
     blockToDelete = (await blockService.findOne({ name: 'buttons' }))!;

--- a/api/src/chat/controllers/context-var.controller.spec.ts
+++ b/api/src/chat/controllers/context-var.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,11 +7,8 @@
  */
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
-import { LoggerService } from '@/logger/logger.service';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import {
   contextVarFixtures,
@@ -23,6 +20,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
   ContextVarCreateDto,
@@ -41,22 +39,18 @@ describe('ContextVarController', () => {
   let contextVarToDelete: ContextVar;
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [ContextVarController],
       imports: [
         rootMongooseTestModule(installContextVarFixtures),
         MongooseModule.forFeature([ContextVarModel]),
       ],
-      providers: [
-        LoggerService,
-        ContextVarService,
-        ContextVarRepository,
-        EventEmitter2,
-      ],
-    }).compile();
-    contextVarController =
-      module.get<ContextVarController>(ContextVarController);
-    contextVarService = module.get<ContextVarService>(ContextVarService);
+      providers: [ContextVarService, ContextVarRepository],
+    });
+    [contextVarController, contextVarService] = await getMocks([
+      ContextVarController,
+      ContextVarService,
+    ]);
     contextVar = (await contextVarService.findOne({
       label: 'test context var 1',
     }))!;

--- a/api/src/chat/controllers/label.controller.spec.ts
+++ b/api/src/chat/controllers/label.controller.spec.ts
@@ -7,14 +7,11 @@
  */
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LoggerService } from '@/logger/logger.service';
 import { InvitationRepository } from '@/user/repositories/invitation.repository';
 import { RoleRepository } from '@/user/repositories/role.repository';
 import { UserRepository } from '@/user/repositories/user.repository';
@@ -35,6 +32,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelCreateDto, LabelUpdateDto } from '../dto/label.dto';
 import { LabelRepository } from '../repositories/label.repository';
@@ -55,7 +53,7 @@ describe('LabelController', () => {
   let subscriberService: SubscriberService;
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [LabelController],
       imports: [
         rootMongooseTestModule(installSubscriberFixtures),
@@ -70,7 +68,6 @@ describe('LabelController', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         LabelController,
         LabelService,
         LabelRepository,
@@ -81,14 +78,15 @@ describe('LabelController', () => {
         InvitationRepository,
         SubscriberService,
         SubscriberRepository,
-        EventEmitter2,
         AttachmentService,
         AttachmentRepository,
       ],
-    }).compile();
-    labelService = module.get<LabelService>(LabelService);
-    subscriberService = module.get<SubscriberService>(SubscriberService);
-    labelController = module.get<LabelController>(LabelController);
+    });
+    [labelService, subscriberService, labelController] = await getMocks([
+      LabelService,
+      SubscriberService,
+      LabelController,
+    ]);
     label = (await labelService.findOne({ name: 'TEST_TITLE_1' })) as Label;
     labelToDelete = (await labelService.findOne({
       name: 'TEST_TITLE_2',

--- a/api/src/chat/controllers/subscriber.controller.spec.ts
+++ b/api/src/chat/controllers/subscriber.controller.spec.ts
@@ -1,19 +1,16 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LoggerService } from '@/logger/logger.service';
 import { InvitationRepository } from '@/user/repositories/invitation.repository';
 import { RoleRepository } from '@/user/repositories/role.repository';
 import { UserRepository } from '@/user/repositories/user.repository';
@@ -32,6 +29,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 import { SocketEventDispatcherService } from '@/websocket/services/socket-event-dispatcher.service';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
@@ -56,7 +54,7 @@ describe('SubscriberController', () => {
   let allUsers: User[];
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [SubscriberController],
       imports: [
         rootMongooseTestModule(installSubscriberFixtures),
@@ -71,7 +69,6 @@ describe('SubscriberController', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         SubscriberRepository,
         SubscriberService,
         LabelService,
@@ -83,17 +80,17 @@ describe('SubscriberController', () => {
         RoleService,
         RoleRepository,
         InvitationRepository,
-        EventEmitter2,
         AttachmentService,
         AttachmentRepository,
       ],
-    }).compile();
-    subscriberService = module.get<SubscriberService>(SubscriberService);
-    labelService = module.get<LabelService>(LabelService);
-    userService = module.get<UserService>(UserService);
-
-    subscriberController =
-      module.get<SubscriberController>(SubscriberController);
+    });
+    [subscriberService, labelService, userService, subscriberController] =
+      await getMocks([
+        SubscriberService,
+        LabelService,
+        UserService,
+        SubscriberController,
+      ]);
     subscriber = (await subscriberService.findOne({
       first_name: 'Jhon',
     }))!;

--- a/api/src/chat/repositories/block.repository.spec.ts
+++ b/api/src/chat/repositories/block.repository.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 import { Model } from 'mongoose';
 
 import {
@@ -19,6 +17,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Block, BlockModel } from '../schemas/block.schema';
 import { Category, CategoryModel } from '../schemas/category.schema';
@@ -39,16 +38,18 @@ describe('BlockRepository', () => {
   let blockValidIds: string[];
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installBlockFixtures),
         MongooseModule.forFeature([BlockModel, CategoryModel, LabelModel]),
       ],
-      providers: [BlockRepository, CategoryRepository, EventEmitter2],
-    }).compile();
-    blockRepository = module.get<BlockRepository>(BlockRepository);
-    categoryRepository = module.get<CategoryRepository>(CategoryRepository);
-    blockModel = module.get<Model<Block>>(getModelToken('Block'));
+      providers: [BlockRepository, CategoryRepository],
+    });
+    [blockRepository, categoryRepository, blockModel] = await getMocks([
+      BlockRepository,
+      CategoryRepository,
+      getModelToken(Block.name),
+    ]);
     validIds = ['64abc1234def567890fedcba', '64abc1234def567890fedcbc'];
     validCategory = '64def5678abc123490fedcba';
 

--- a/api/src/chat/repositories/label.repository.spec.ts
+++ b/api/src/chat/repositories/label.repository.spec.ts
@@ -6,12 +6,9 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 import { Model } from 'mongoose';
 
-import { LoggerService } from '@/logger/logger.service';
 import { labelFixtures } from '@/utils/test/fixtures/label';
 import { installSubscriberFixtures } from '@/utils/test/fixtures/subscriber';
 import { getPageQuery } from '@/utils/test/pagination';
@@ -20,6 +17,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Label, LabelFull, LabelModel } from '../schemas/label.schema';
 import { Subscriber, SubscriberModel } from '../schemas/subscriber.schema';
@@ -34,22 +32,18 @@ describe('LabelRepository', () => {
   let users: Subscriber[];
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installSubscriberFixtures),
         MongooseModule.forFeature([LabelModel, SubscriberModel]),
       ],
-      providers: [
-        LabelRepository,
-        SubscriberRepository,
-        EventEmitter2,
-        LoggerService,
-      ],
-    }).compile();
-    labelRepository = module.get<LabelRepository>(LabelRepository);
-    subscriberRepository =
-      module.get<SubscriberRepository>(SubscriberRepository);
-    labelModel = module.get<Model<Label>>(getModelToken('Label'));
+      providers: [LabelRepository, SubscriberRepository],
+    });
+    [labelRepository, subscriberRepository, labelModel] = await getMocks([
+      LabelRepository,
+      SubscriberRepository,
+      getModelToken(Label.name),
+    ]);
     users = await subscriberRepository.findAll();
   });
 

--- a/api/src/chat/repositories/message.repository.spec.ts
+++ b/api/src/chat/repositories/message.repository.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 import { Model } from 'mongoose';
 
 import { UserRepository } from '@/user/repositories/user.repository';
@@ -22,6 +20,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Message, MessageModel } from '../schemas/message.schema';
 import { SubscriberModel } from '../schemas/subscriber.schema';
@@ -37,23 +36,20 @@ describe('MessageRepository', () => {
   let messageModel: Model<Message>;
 
   beforeAll(async () => {
-    const testModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installMessageFixtures),
         MongooseModule.forFeature([MessageModel, SubscriberModel, UserModel]),
       ],
-      providers: [
+      providers: [MessageRepository, SubscriberRepository, UserRepository],
+    });
+    [messageRepository, userRepository, subscriberRepository, messageModel] =
+      await getMocks([
         MessageRepository,
-        SubscriberRepository,
         UserRepository,
-        EventEmitter2,
-      ],
-    }).compile();
-    messageRepository = testModule.get<MessageRepository>(MessageRepository);
-    userRepository = testModule.get<UserRepository>(UserRepository);
-    subscriberRepository =
-      testModule.get<SubscriberRepository>(SubscriberRepository);
-    messageModel = testModule.get<Model<Message>>(getModelToken('Message'));
+        SubscriberRepository,
+        getModelToken(Message.name),
+      ]);
   });
 
   afterEach(jest.clearAllMocks);

--- a/api/src/chat/services/bot.service.spec.ts
+++ b/api/src/chat/services/bot.service.spec.ts
@@ -10,7 +10,6 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { JwtModule } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
@@ -34,7 +33,6 @@ import { LanguageRepository } from '@/i18n/repositories/language.repository';
 import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
 import { LanguageService } from '@/i18n/services/language.service';
-import { LoggerService } from '@/logger/logger.service';
 import { PluginService } from '@/plugins/plugins.service';
 import { SettingService } from '@/setting/services/setting.service';
 import { installBlockFixtures } from '@/utils/test/fixtures/block';
@@ -44,6 +42,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 import { SocketEventDispatcherService } from '@/websocket/services/socket-event-dispatcher.service';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
@@ -81,7 +80,7 @@ describe('BlockService', () => {
   let eventEmitter: EventEmitter2;
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(async () => {
           await installSubscriberFixtures();
@@ -105,7 +104,6 @@ describe('BlockService', () => {
         JwtModule,
       ],
       providers: [
-        EventEmitter2,
         BlockRepository,
         CategoryRepository,
         WebsocketGateway,
@@ -141,7 +139,6 @@ describe('BlockService', () => {
           provide: PluginService,
           useValue: {},
         },
-        LoggerService,
         {
           provide: I18nService,
           useValue: {
@@ -168,12 +165,15 @@ describe('BlockService', () => {
           },
         },
       ],
-    }).compile();
-    subscriberService = module.get<SubscriberService>(SubscriberService);
-    botService = module.get<BotService>(BotService);
-    blockService = module.get<BlockService>(BlockService);
-    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
-    handler = module.get<WebChannelHandler>(WebChannelHandler);
+    });
+    [subscriberService, botService, blockService, eventEmitter, handler] =
+      await getMocks([
+        SubscriberService,
+        BotService,
+        BlockService,
+        EventEmitter2,
+        WebChannelHandler,
+      ]);
   });
 
   afterEach(jest.clearAllMocks);

--- a/api/src/chat/services/label.service.spec.ts
+++ b/api/src/chat/services/label.service.spec.ts
@@ -6,14 +6,11 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LoggerService } from '@/logger/logger.service';
 import {
   installLabelFixtures,
   labelFixtures,
@@ -24,6 +21,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelRepository } from '../repositories/label.repository';
 import { Label, LabelFull, LabelModel } from '../schemas/label.schema';
@@ -42,7 +40,7 @@ describe('LabelService', () => {
   let labelsWithUsers: LabelFull[];
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installLabelFixtures),
         MongooseModule.forFeature([
@@ -52,20 +50,19 @@ describe('LabelService', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         LabelService,
         LabelRepository,
         SubscriberService,
         AttachmentService,
         AttachmentRepository,
         SubscriberRepository,
-        EventEmitter2,
       ],
-    }).compile();
-    labelService = module.get<LabelService>(LabelService);
-    labelRepository = module.get<LabelRepository>(LabelRepository);
-    subscriberRepository =
-      module.get<SubscriberRepository>(SubscriberRepository);
+    });
+    [labelService, labelRepository, subscriberRepository] = await getMocks([
+      LabelService,
+      LabelRepository,
+      SubscriberRepository,
+    ]);
     allSubscribers = await subscriberRepository.findAll();
     allLabels = await labelRepository.findAll();
     labelsWithUsers = allLabels.map((label) => ({

--- a/api/src/chat/services/message.service.spec.ts
+++ b/api/src/chat/services/message.service.spec.ts
@@ -1,19 +1,16 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LoggerService } from '@/logger/logger.service';
 import { InvitationRepository } from '@/user/repositories/invitation.repository';
 import { RoleRepository } from '@/user/repositories/role.repository';
 import { UserRepository } from '@/user/repositories/user.repository';
@@ -33,6 +30,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MessageRepository } from '../repositories/message.repository';
 import { Message, MessageModel } from '../schemas/message.schema';
@@ -57,7 +55,7 @@ describe('MessageService', () => {
   let user: User;
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installMessageFixtures),
         MongooseModule.forFeature([
@@ -71,7 +69,6 @@ describe('MessageService', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         AttachmentService,
         AttachmentRepository,
         UserService,
@@ -83,14 +80,15 @@ describe('MessageService', () => {
         SubscriberRepository,
         MessageService,
         MessageRepository,
-        EventEmitter2,
       ],
-    }).compile();
-    messageService = module.get<MessageService>(MessageService);
-    messageRepository = module.get<MessageRepository>(MessageRepository);
-    subscriberRepository =
-      module.get<SubscriberRepository>(SubscriberRepository);
-    userRepository = module.get<UserRepository>(UserRepository);
+    });
+    [messageService, messageRepository, subscriberRepository, userRepository] =
+      await getMocks([
+        MessageService,
+        MessageRepository,
+        SubscriberRepository,
+        UserRepository,
+      ]);
     allSubscribers = await subscriberRepository.findAll();
     allUsers = await userRepository.findAll();
     allMessages = await messageRepository.findAll();

--- a/api/src/chat/services/subscriber.service.spec.ts
+++ b/api/src/chat/services/subscriber.service.spec.ts
@@ -1,19 +1,16 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LoggerService } from '@/logger/logger.service';
 import { InvitationRepository } from '@/user/repositories/invitation.repository';
 import { RoleRepository } from '@/user/repositories/role.repository';
 import { UserRepository } from '@/user/repositories/user.repository';
@@ -30,6 +27,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelRepository } from '../repositories/label.repository';
 import { SubscriberRepository } from '../repositories/subscriber.repository';
@@ -49,7 +47,7 @@ describe('SubscriberService', () => {
   let allUsers: User[];
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installSubscriberFixtures),
         MongooseModule.forFeature([
@@ -72,17 +70,17 @@ describe('SubscriberService', () => {
         RoleService,
         RoleRepository,
         InvitationRepository,
-        LoggerService,
-        EventEmitter2,
         AttachmentService,
         AttachmentRepository,
       ],
-    }).compile();
-    labelRepository = module.get<LabelRepository>(LabelRepository);
-    userRepository = module.get<UserRepository>(UserRepository);
-    subscriberService = module.get<SubscriberService>(SubscriberService);
-    subscriberRepository =
-      module.get<SubscriberRepository>(SubscriberRepository);
+    });
+    [labelRepository, userRepository, subscriberService, subscriberRepository] =
+      await getMocks([
+        LabelRepository,
+        UserRepository,
+        SubscriberService,
+        SubscriberRepository,
+      ]);
     allSubscribers = await subscriberRepository.findAll();
     allLabels = await labelRepository.findAll();
     allUsers = await userRepository.findAll();

--- a/api/src/cms/controllers/content-type.controller.spec.ts
+++ b/api/src/cms/controllers/content-type.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,15 +7,12 @@
  */
 
 import { NotFoundException } from '@nestjs/common/exceptions';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
 import { BlockService } from '@/chat/services/block.service';
-import { LoggerService } from '@/logger/logger.service';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import { installContentFixtures } from '@/utils/test/fixtures/content';
@@ -25,6 +22,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeCreateDto } from '../dto/contentType.dto';
 import { ContentTypeRepository } from '../repositories/content-type.repository';
@@ -44,7 +42,7 @@ describe('ContentTypeController', () => {
   let blockService: BlockService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [ContentTypeController],
       imports: [
         rootMongooseTestModule(installContentFixtures),
@@ -61,8 +59,6 @@ describe('ContentTypeController', () => {
         ContentTypeService,
         ContentService,
         AttachmentService,
-        LoggerService,
-        EventEmitter2,
         {
           provide: BlockService,
           useValue: {
@@ -70,13 +66,14 @@ describe('ContentTypeController', () => {
           },
         },
       ],
-    }).compile();
-    blockService = module.get<BlockService>(BlockService);
-    contentTypeController = module.get<ContentTypeController>(
-      ContentTypeController,
-    );
-    contentTypeService = module.get<ContentTypeService>(ContentTypeService);
-    contentService = module.get<ContentService>(ContentService);
+    });
+    [blockService, contentTypeController, contentTypeService, contentService] =
+      await getMocks([
+        BlockService,
+        ContentTypeController,
+        ContentTypeService,
+        ContentService,
+      ]);
     contentType = await contentTypeService.findOne({ name: 'Product' })!;
   });
 

--- a/api/src/cms/controllers/content.controller.spec.ts
+++ b/api/src/cms/controllers/content.controller.spec.ts
@@ -7,11 +7,8 @@
  */
 
 import { NotFoundException } from '@nestjs/common/exceptions';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
-import { LoggerService } from '@/logger/logger.service';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
@@ -25,6 +22,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentCreateDto } from '../dto/content.dto';
 import { ContentTypeRepository } from '../repositories/content-type.repository';
@@ -46,24 +44,24 @@ describe('ContentController', () => {
   let pageQuery: PageQueryDto<Content>;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [ContentController],
       imports: [
         rootMongooseTestModule(installContentFixtures),
         MongooseModule.forFeature([ContentTypeModel, ContentModel]),
       ],
       providers: [
-        LoggerService,
         ContentTypeService,
         ContentService,
         ContentRepository,
         ContentTypeRepository,
-        EventEmitter2,
       ],
-    }).compile();
-    contentController = module.get<ContentController>(ContentController);
-    contentService = module.get<ContentService>(ContentService);
-    contentTypeService = module.get<ContentTypeService>(ContentTypeService);
+    });
+    [contentController, contentService, contentTypeService] = await getMocks([
+      ContentController,
+      ContentService,
+      ContentTypeService,
+    ]);
     contentType = await contentTypeService.findOne({ name: 'Product' });
     content = await contentService.findOne({
       title: 'Jean',

--- a/api/src/cms/controllers/menu.controller.spec.ts
+++ b/api/src/cms/controllers/menu.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,11 +7,8 @@
  */
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
-import { LoggerService } from '@/logger/logger.service';
 import {
   installMenuFixtures,
   offerMenuFixture,
@@ -22,6 +19,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuRepository } from '../repositories/menu.repository';
 import { MenuModel } from '../schemas/menu.schema';
@@ -35,7 +33,7 @@ describe('MenuController', () => {
   let menuController: MenuController;
   let menuService: MenuService;
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installMenuFixtures),
         MongooseModule.forFeature([MenuModel]),
@@ -43,7 +41,6 @@ describe('MenuController', () => {
       providers: [
         MenuRepository,
         MenuService,
-        EventEmitter2,
         {
           provide: CACHE_MANAGER,
           useValue: {
@@ -52,12 +49,13 @@ describe('MenuController', () => {
             set: jest.fn(),
           },
         },
-        LoggerService,
       ],
       controllers: [MenuController],
-    }).compile();
-    menuController = module.get<MenuController>(MenuController);
-    menuService = module.get<MenuService>(MenuService);
+    });
+    [menuController, menuService] = await getMocks([
+      MenuController,
+      MenuService,
+    ]);
   });
 
   afterAll(closeInMongodConnection);

--- a/api/src/cms/repositories/content-type.repository.spec.ts
+++ b/api/src/cms/repositories/content-type.repository.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 import { Model } from 'mongoose';
 
 import { BlockRepository } from '@/chat/repositories/block.repository';
@@ -18,11 +16,11 @@ import {
   ContentType,
   ContentTypeModel,
 } from '@/cms/schemas/content-type.schema';
-import { LoggerService } from '@/logger/logger.service';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Content, ContentModel } from '../schemas/content.schema';
 
@@ -37,13 +35,12 @@ describe('ContentTypeRepository', () => {
   let blockService: BlockService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installContentFixtures),
         MongooseModule.forFeature([ContentTypeModel, ContentModel, BlockModel]),
       ],
       providers: [
-        LoggerService,
         ContentRepository,
         ContentTypeRepository,
         BlockService,
@@ -54,18 +51,15 @@ describe('ContentTypeRepository', () => {
             findOne: jest.fn(),
           },
         },
-        EventEmitter2,
       ],
-    }).compile();
-    blockService = module.get<BlockService>(BlockService);
-    contentTypeRepository = module.get<ContentTypeRepository>(
-      ContentTypeRepository,
-    );
-    contentTypeModel = module.get<Model<ContentType>>(
-      getModelToken('ContentType'),
-    );
-
-    contentModel = module.get<Model<Content>>(getModelToken('Content'));
+    });
+    [blockService, contentTypeRepository, contentTypeModel, contentModel] =
+      await getMocks([
+        BlockService,
+        ContentTypeRepository,
+        getModelToken(ContentType.name),
+        getModelToken(Content.name),
+      ]);
   });
 
   afterAll(closeInMongodConnection);

--- a/api/src/cms/repositories/content.repository.spec.ts
+++ b/api/src/cms/repositories/content.repository.spec.ts
@@ -1,27 +1,25 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 import { Model } from 'mongoose';
 
 import {
   ContentType,
   ContentTypeModel,
 } from '@/cms/schemas/content-type.schema';
-import { LoggerService } from '@/logger/logger.service';
 import { contentTypeFixtures } from '@/utils/test/fixtures/contenttype';
 import { getPageQuery } from '@/utils/test/pagination';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Content, ContentModel } from '../schemas/content.schema';
 
@@ -37,18 +35,18 @@ describe('ContentRepository', () => {
   let contentTypeModel: Model<ContentType>;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installContentFixtures),
         MongooseModule.forFeature([ContentTypeModel, ContentModel]),
       ],
-      providers: [LoggerService, ContentRepository, EventEmitter2],
-    }).compile();
-    contentRepository = module.get<ContentRepository>(ContentRepository);
-    contentModel = module.get<Model<Content>>(getModelToken('Content'));
-    contentTypeModel = module.get<Model<ContentType>>(
-      getModelToken('ContentType'),
-    );
+      providers: [ContentRepository],
+    });
+    [contentRepository, contentModel, contentTypeModel] = await getMocks([
+      ContentRepository,
+      getModelToken(Content.name),
+      getModelToken(ContentType.name),
+    ]);
   });
 
   afterAll(closeInMongodConnection);

--- a/api/src/cms/repositories/menu.reporsitory.spec.ts
+++ b/api/src/cms/repositories/menu.reporsitory.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import {
   installMenuFixtures,
@@ -18,6 +16,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuModel } from '../schemas/menu.schema';
 import { MenuType } from '../schemas/types/menu';
@@ -27,18 +26,17 @@ import { MenuRepository } from './menu.repository';
 describe('MenuRepository', () => {
   let menuRepository: MenuRepository;
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installMenuFixtures),
         MongooseModule.forFeature([MenuModel]),
       ],
-      providers: [MenuRepository, EventEmitter2],
-    }).compile();
-    menuRepository = module.get<MenuRepository>(MenuRepository);
+      providers: [MenuRepository],
+    });
+    [menuRepository] = await getMocks([MenuRepository]);
   });
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/cms/services/content-type.service.spec.ts
+++ b/api/src/cms/services/content-type.service.spec.ts
@@ -1,25 +1,23 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
 import { BlockService } from '@/chat/services/block.service';
-import { LoggerService } from '@/logger/logger.service';
 import { installContentFixtures } from '@/utils/test/fixtures/content';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeRepository } from '../repositories/content-type.repository';
 import { ContentRepository } from '../repositories/content.repository';
@@ -36,7 +34,7 @@ describe('ContentTypeService', () => {
   let blockService: BlockService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installContentFixtures),
         MongooseModule.forFeature([
@@ -52,8 +50,6 @@ describe('ContentTypeService', () => {
         ContentTypeService,
         ContentService,
         AttachmentService,
-        LoggerService,
-        EventEmitter2,
         {
           provide: BlockService,
           useValue: {
@@ -61,18 +57,17 @@ describe('ContentTypeService', () => {
           },
         },
       ],
-    }).compile();
-    blockService = module.get<BlockService>(BlockService);
-    contentTypeService = module.get<ContentTypeService>(ContentTypeService);
-    contentService = module.get<ContentService>(ContentService);
-    contentTypeRepository = module.get<ContentTypeRepository>(
-      ContentTypeRepository,
-    );
+    });
+    [blockService, contentTypeService, contentService, contentTypeRepository] =
+      await getMocks([
+        BlockService,
+        ContentTypeService,
+        ContentService,
+        ContentTypeRepository,
+      ]);
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/cms/services/content.service.spec.ts
+++ b/api/src/cms/services/content.service.spec.ts
@@ -6,13 +6,10 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { OutgoingMessageFormat } from '@/chat/schemas/types/message';
 import { ContentOptions } from '@/chat/schemas/types/options';
-import { LoggerService } from '@/logger/logger.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import {
   contentFixtures,
@@ -23,6 +20,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeRepository } from '../repositories/content-type.repository';
 import { ContentRepository } from '../repositories/content.repository';
@@ -38,7 +36,7 @@ describe('ContentService', () => {
   let contentRepository: ContentRepository;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installContentFixtures),
         MongooseModule.forFeature([ContentTypeModel, ContentModel]),
@@ -48,18 +46,16 @@ describe('ContentService', () => {
         ContentRepository,
         ContentTypeService,
         ContentService,
-        LoggerService,
-        EventEmitter2,
       ],
-    }).compile();
-    contentService = module.get<ContentService>(ContentService);
-    contentTypeService = module.get<ContentTypeService>(ContentTypeService);
-    contentRepository = module.get<ContentRepository>(ContentRepository);
+    });
+    [contentService, contentTypeService, contentRepository] = await getMocks([
+      ContentService,
+      ContentTypeService,
+      ContentRepository,
+    ]);
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/cms/services/menu.service.spec.ts
+++ b/api/src/cms/services/menu.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,11 +8,8 @@
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { NotFoundException } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
-import { LoggerService } from '@/logger/logger.service';
 import {
   installMenuFixtures,
   rootMenuFixtures,
@@ -21,6 +18,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuRepository } from '../repositories/menu.repository';
 import { MenuModel } from '../schemas/menu.schema';
@@ -33,7 +31,7 @@ describe('MenuService', () => {
   let menuService: MenuService;
   let menuRepository: MenuRepository;
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installMenuFixtures),
         MongooseModule.forFeature([MenuModel]),
@@ -41,7 +39,6 @@ describe('MenuService', () => {
       providers: [
         MenuRepository,
         MenuService,
-        EventEmitter2,
         {
           provide: CACHE_MANAGER,
           useValue: {
@@ -50,15 +47,15 @@ describe('MenuService', () => {
             set: jest.fn(),
           },
         },
-        LoggerService,
       ],
-    }).compile();
-    menuService = module.get<MenuService>(MenuService);
-    menuRepository = module.get<MenuRepository>(MenuRepository);
+    });
+    [menuService, menuRepository] = await getMocks([
+      MenuService,
+      MenuRepository,
+    ]);
   });
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
   describe('create', () => {

--- a/api/src/extensions/channels/web/__test__/wrapper.spec.ts
+++ b/api/src/extensions/channels/web/__test__/wrapper.spec.ts
@@ -7,10 +7,8 @@
  */
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { JwtModule } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import {
@@ -33,7 +31,6 @@ import { MenuRepository } from '@/cms/repositories/menu.repository';
 import { MenuModel } from '@/cms/schemas/menu.schema';
 import { MenuService } from '@/cms/services/menu.service';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LoggerService } from '@/logger/logger.service';
 import { NlpService } from '@/nlp/services/nlp.service';
 import { SettingService } from '@/setting/services/setting.service';
 import { installSubscriberFixtures } from '@/utils/test/fixtures/subscriber';
@@ -41,6 +38,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 import { SocketEventDispatcherService } from '@/websocket/services/socket-event-dispatcher.service';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
@@ -54,11 +52,9 @@ describe(`Web event wrapper`, () => {
   let handler: WebChannelHandler;
   const webSettings = {};
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
-        rootMongooseTestModule(async () => {
-          await installSubscriberFixtures();
-        }),
+        rootMongooseTestModule(installSubscriberFixtures),
         MongooseModule.forFeature([
           SubscriberModel,
           AttachmentModel,
@@ -97,8 +93,6 @@ describe(`Web event wrapper`, () => {
         MenuService,
         MenuRepository,
         WebChannelHandler,
-        EventEmitter2,
-        LoggerService,
         {
           provide: I18nService,
           useValue: {
@@ -114,8 +108,8 @@ describe(`Web event wrapper`, () => {
           },
         },
       ],
-    }).compile();
-    handler = module.get<WebChannelHandler>(WebChannelHandler);
+    });
+    [handler] = await getMocks([WebChannelHandler]);
   });
 
   afterAll(async () => {

--- a/api/src/i18n/controllers/language.controller.spec.ts
+++ b/api/src/i18n/controllers/language.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,12 +8,9 @@
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { BadRequestException } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LoggerService } from '@/logger/logger.service';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import {
@@ -25,6 +22,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LanguageUpdateDto } from '../dto/language.dto';
 import { LanguageRepository } from '../repositories/language.repository';
@@ -39,7 +37,7 @@ describe('LanguageController', () => {
   let language: Language;
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installLanguageFixtures),
         MongooseModule.forFeature([LanguageModel]),
@@ -48,7 +46,6 @@ describe('LanguageController', () => {
         LanguageController,
         LanguageService,
         LanguageRepository,
-        LoggerService,
         {
           provide: I18nService,
           useValue: {
@@ -64,12 +61,12 @@ describe('LanguageController', () => {
             set: jest.fn(),
           },
         },
-        LoggerService,
-        EventEmitter2,
       ],
-    }).compile();
-    languageService = module.get<LanguageService>(LanguageService);
-    languageController = module.get<LanguageController>(LanguageController);
+    });
+    [languageService, languageController] = await getMocks([
+      LanguageService,
+      LanguageController,
+    ]);
     language = (await languageService.findOne({ code: 'en' })) as Language;
   });
 

--- a/api/src/i18n/controllers/translation.controller.spec.ts
+++ b/api/src/i18n/controllers/translation.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,9 +7,7 @@
  */
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
@@ -32,7 +30,6 @@ import { MenuModel } from '@/cms/schemas/menu.schema';
 import { ContentService } from '@/cms/services/content.service';
 import { MenuService } from '@/cms/services/menu.service';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LoggerService } from '@/logger/logger.service';
 import { NlpService } from '@/nlp/services/nlp.service';
 import { PluginService } from '@/plugins/plugins.service';
 import { SettingService } from '@/setting/services/setting.service';
@@ -47,6 +44,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { TranslationUpdateDto } from '../dto/translation.dto';
 import { LanguageRepository } from '../repositories/language.repository';
@@ -64,7 +62,7 @@ describe('TranslationController', () => {
   let translation: Translation;
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [MessageController],
       imports: [
         rootMongooseTestModule(installTranslationFixtures),
@@ -115,8 +113,6 @@ describe('TranslationController', () => {
           provide: PluginService,
           useValue: {},
         },
-        EventEmitter2,
-        LoggerService,
         {
           provide: I18nService,
           useValue: {
@@ -132,15 +128,14 @@ describe('TranslationController', () => {
             set: jest.fn(),
           },
         },
-        LoggerService,
         LanguageService,
         LanguageRepository,
       ],
-    }).compile();
-    translationService = module.get<TranslationService>(TranslationService);
-    translationController = module.get<TranslationController>(
+    });
+    [translationService, translationController] = await getMocks([
+      TranslationService,
       TranslationController,
-    );
+    ]);
     translation = (await translationService.findOne({
       str: 'Welcome',
     })) as Translation;

--- a/api/src/i18n/services/translation.service.spec.ts
+++ b/api/src/i18n/services/translation.service.spec.ts
@@ -6,15 +6,13 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
-import { Test, TestingModule } from '@nestjs/testing';
-
 import { I18nService } from '@/i18n/services/i18n.service';
 import { BasePlugin } from '@/plugins/base-plugin.service';
 import { PluginService } from '@/plugins/plugins.service';
 import { PluginBlockTemplate } from '@/plugins/types';
 import { SettingType } from '@/setting/schemas/types';
 import { SettingService } from '@/setting/services/setting.service';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Block } from '../../chat/schemas/block.schema';
 import { BlockOptions } from '../../chat/schemas/types/options';
@@ -24,11 +22,11 @@ import { TranslationService } from '../services/translation.service';
 
 describe('TranslationService', () => {
   let service: TranslationService;
-  let i18nService: I18nService;
+  let i18nService: I18nService<unknown>;
   let pluginService: PluginService;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       providers: [
         TranslationService,
         {
@@ -106,13 +104,13 @@ describe('TranslationService', () => {
             refreshDynamicTranslations: jest.fn(),
           },
         },
-        EventEmitter2,
       ],
-    }).compile();
-
-    service = module.get<TranslationService>(TranslationService);
-    i18nService = module.get<I18nService>(I18nService);
-    pluginService = module.get<PluginService>(PluginService);
+    });
+    [service, i18nService, pluginService] = await getMocks([
+      TranslationService,
+      I18nService,
+      PluginService,
+    ]);
   });
 
   it('should call refreshDynamicTranslations with translations from findAll', async () => {

--- a/api/src/nlp/controllers/nlp-sample.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-sample.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,16 +8,13 @@
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { HelperService } from '@/helper/helper.service';
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
 import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
 import { LanguageService } from '@/i18n/services/language.service';
-import { LoggerService } from '@/logger/logger.service';
 import { SettingRepository } from '@/setting/repositories/setting.repository';
 import { SettingModel } from '@/setting/schemas/setting.schema';
 import { SettingSeeder } from '@/setting/seeds/setting.seed';
@@ -32,6 +29,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { TFixtures } from '@/utils/test/types';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpSampleDto } from '../dto/nlp-sample.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
@@ -65,7 +63,7 @@ describe('NlpSampleController', () => {
   let languages: Language[];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [NlpSampleController],
       imports: [
         rootMongooseTestModule(async () => {
@@ -82,7 +80,6 @@ describe('NlpSampleController', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         NlpSampleRepository,
         NlpSampleEntityRepository,
         NlpEntityService,
@@ -93,7 +90,6 @@ describe('NlpSampleController', () => {
         NlpSampleEntityService,
         LanguageRepository,
         LanguageService,
-        EventEmitter2,
         HelperService,
         SettingRepository,
         SettingService,
@@ -113,26 +109,32 @@ describe('NlpSampleController', () => {
           },
         },
       ],
-    }).compile();
-    nlpSampleController = module.get<NlpSampleController>(NlpSampleController);
-    nlpSampleEntityService = module.get<NlpSampleEntityService>(
+    });
+    [
+      nlpSampleController,
+      nlpSampleEntityService,
+      nlpSampleService,
+      nlpEntityService,
+      nlpValueService,
+      languageService,
+    ] = await getMocks([
+      NlpSampleController,
       NlpSampleEntityService,
-    );
-    nlpSampleService = module.get<NlpSampleService>(NlpSampleService);
-    nlpEntityService = module.get<NlpEntityService>(NlpEntityService);
-    nlpValueService = module.get<NlpValueService>(NlpValueService);
+      NlpSampleService,
+      NlpEntityService,
+      NlpValueService,
+      LanguageService,
+    ]);
     byeJhonSampleId =
       (
         await nlpSampleService.findOne({
           text: 'Bye Jhon',
         })
       )?.id || null;
-    languageService = module.get<LanguageService>(LanguageService);
     languages = await languageService.findAll();
   });
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/nlp/controllers/nlp-value.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,11 +7,8 @@
  */
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
-import { LoggerService } from '@/logger/logger.service';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import {
@@ -24,6 +21,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { TFixtures } from '@/utils/test/types';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpValueCreateDto } from '../dto/nlp-value.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
@@ -50,7 +48,7 @@ describe('NlpValueController', () => {
   let negativeValue: NlpValue | null;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [NlpValueController],
       imports: [
         rootMongooseTestModule(installNlpValueFixtures),
@@ -61,25 +59,24 @@ describe('NlpValueController', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         NlpValueRepository,
         NlpValueService,
         NlpSampleEntityRepository,
         NlpEntityService,
         NlpEntityRepository,
-        EventEmitter2,
       ],
-    }).compile();
-    nlpValueController = module.get<NlpValueController>(NlpValueController);
-    nlpValueService = module.get<NlpValueService>(NlpValueService);
-    nlpEntityService = module.get<NlpEntityService>(NlpEntityService);
+    });
+    [nlpValueController, nlpValueService, nlpEntityService] = await getMocks([
+      NlpValueController,
+      NlpValueService,
+      NlpEntityService,
+    ]);
     jhonNlpValue = await nlpValueService.findOne({ value: 'jhon' });
     positiveValue = await nlpValueService.findOne({ value: 'positive' });
     negativeValue = await nlpValueService.findOne({ value: 'negative' });
   });
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/nlp/repositories/nlp-entity.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-entity.repository.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import { installNlpValueFixtures } from '@/utils/test/fixtures/nlpvalue';
@@ -17,6 +15,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpEntity, NlpEntityModel } from '../schemas/nlp-entity.schema';
 import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
@@ -32,7 +31,7 @@ describe('NlpEntityRepository', () => {
   let firstNameNlpEntity: NlpEntity | null;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installNlpValueFixtures),
         MongooseModule.forFeature([
@@ -45,19 +44,18 @@ describe('NlpEntityRepository', () => {
         NlpEntityRepository,
         NlpValueRepository,
         NlpSampleEntityRepository,
-        EventEmitter2,
       ],
-    }).compile();
-    nlpEntityRepository = module.get<NlpEntityRepository>(NlpEntityRepository);
-    nlpValueRepository = module.get<NlpValueRepository>(NlpValueRepository);
+    });
+    [nlpEntityRepository, nlpValueRepository] = await getMocks([
+      NlpEntityRepository,
+      NlpValueRepository,
+    ]);
     firstNameNlpEntity = await nlpEntityRepository.findOne({
       name: 'first_name',
     });
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/nlp/repositories/nlp-sample-entity.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-sample-entity.repository.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
 import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
@@ -24,6 +22,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { TFixtures } from '@/utils/test/types';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpEntity, NlpEntityModel } from '../schemas/nlp-entity.schema';
 import {
@@ -47,7 +46,7 @@ describe('NlpSampleEntityRepository', () => {
   let languages: Language[];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installNlpSampleEntityFixtures),
         MongooseModule.forFeature([
@@ -63,22 +62,20 @@ describe('NlpSampleEntityRepository', () => {
         NlpEntityRepository,
         NlpValueRepository,
         LanguageRepository,
-        EventEmitter2,
       ],
-    }).compile();
-    nlpSampleEntityRepository = module.get<NlpSampleEntityRepository>(
-      NlpSampleEntityRepository,
-    );
-    nlpEntityRepository = module.get<NlpEntityRepository>(NlpEntityRepository);
-    languageRepository = module.get<LanguageRepository>(LanguageRepository);
+    });
+    [nlpSampleEntityRepository, nlpEntityRepository, languageRepository] =
+      await getMocks([
+        NlpSampleEntityRepository,
+        NlpEntityRepository,
+        LanguageRepository,
+      ]);
     nlpSampleEntities = await nlpSampleEntityRepository.findAll();
     nlpEntities = await nlpEntityRepository.findAll();
     languages = await languageRepository.findAll();
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/nlp/repositories/nlp-sample.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-sample.repository.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
 import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
@@ -20,6 +18,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { TFixtures } from '@/utils/test/types';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
   NlpSampleEntity,
@@ -43,7 +42,7 @@ describe('NlpSampleRepository', () => {
   let languages: Language[];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installNlpSampleEntityFixtures),
         MongooseModule.forFeature([
@@ -56,14 +55,14 @@ describe('NlpSampleRepository', () => {
         NlpSampleRepository,
         NlpSampleEntityRepository,
         LanguageRepository,
-        EventEmitter2,
       ],
-    }).compile();
-    nlpSampleRepository = module.get<NlpSampleRepository>(NlpSampleRepository);
-    nlpSampleEntityRepository = module.get<NlpSampleEntityRepository>(
-      NlpSampleEntityRepository,
-    );
-    languageRepository = module.get<LanguageRepository>(LanguageRepository);
+    });
+    [nlpSampleRepository, nlpSampleEntityRepository, languageRepository] =
+      await getMocks([
+        NlpSampleRepository,
+        NlpSampleEntityRepository,
+        LanguageRepository,
+      ]);
     noNlpSample = await nlpSampleRepository.findOne({ text: 'No' });
     nlpSampleEntity = await nlpSampleEntityRepository.findOne({
       sample: noNlpSample!.id,
@@ -71,9 +70,7 @@ describe('NlpSampleRepository', () => {
     languages = await languageRepository.findAll();
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/nlp/repositories/nlp-value.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import { installNlpSampleEntityFixtures } from '@/utils/test/fixtures/nlpsampleentity';
@@ -19,6 +17,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { TFixtures } from '@/utils/test/types';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpEntityModel } from '../schemas/nlp-entity.schema';
 import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
@@ -37,7 +36,7 @@ describe('NlpValueRepository', () => {
   let nlpValues: NlpValue[];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installNlpSampleEntityFixtures),
         MongooseModule.forFeature([
@@ -46,18 +45,17 @@ describe('NlpValueRepository', () => {
           NlpEntityModel,
         ]),
       ],
-      providers: [NlpValueRepository, NlpSampleEntityRepository, EventEmitter2],
-    }).compile();
-    nlpValueRepository = module.get<NlpValueRepository>(NlpValueRepository);
-    nlpSampleEntityRepository = module.get<NlpSampleEntityRepository>(
+      providers: [NlpValueRepository, NlpSampleEntityRepository],
+    });
+    [nlpValueRepository, nlpSampleEntityRepository] = await getMocks([
+      NlpValueRepository,
       NlpSampleEntityRepository,
-    );
+    ]);
+
     nlpValues = await nlpValueRepository.findAll();
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/nlp/services/nlp-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-entity.service.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import { installNlpValueFixtures } from '@/utils/test/fixtures/nlpvalue';
@@ -17,6 +15,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
@@ -34,7 +33,7 @@ describe('nlpEntityService', () => {
   let nlpValueRepository: NlpValueRepository;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installNlpValueFixtures),
         MongooseModule.forFeature([
@@ -49,17 +48,17 @@ describe('nlpEntityService', () => {
         NlpValueService,
         NlpValueRepository,
         NlpSampleEntityRepository,
-        EventEmitter2,
       ],
-    }).compile();
-    nlpEntityService = module.get<NlpEntityService>(NlpEntityService);
-    nlpEntityRepository = module.get<NlpEntityRepository>(NlpEntityRepository);
-    nlpValueRepository = module.get<NlpValueRepository>(NlpValueRepository);
+    });
+    [nlpEntityService, nlpEntityRepository, nlpValueRepository] =
+      await getMocks([
+        NlpEntityService,
+        NlpEntityRepository,
+        NlpValueRepository,
+      ]);
   });
 
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/nlp/services/nlp-sample-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample-entity.service.spec.ts
@@ -6,9 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
 import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
@@ -24,6 +22,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { TFixtures } from '@/utils/test/types';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpSampleEntityCreateDto } from '../dto/nlp-sample-entity.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
@@ -58,7 +57,7 @@ describe('NlpSampleEntityService', () => {
   let nlpValueService: NlpValueService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installNlpSampleEntityFixtures),
         MongooseModule.forFeature([
@@ -77,22 +76,25 @@ describe('NlpSampleEntityService', () => {
         NlpSampleEntityService,
         NlpEntityService,
         NlpValueService,
-        EventEmitter2,
       ],
-    }).compile();
-    nlpSampleEntityService = module.get<NlpSampleEntityService>(
+    });
+    [
+      nlpSampleEntityService,
+      nlpSampleEntityRepository,
+      nlpEntityRepository,
+      languageRepository,
+      nlpSampleEntityService,
+      nlpEntityService,
+      nlpValueService,
+    ] = await getMocks([
       NlpSampleEntityService,
-    );
-    nlpSampleEntityRepository = module.get<NlpSampleEntityRepository>(
       NlpSampleEntityRepository,
-    );
-    nlpEntityRepository = module.get<NlpEntityRepository>(NlpEntityRepository);
-    languageRepository = module.get<LanguageRepository>(LanguageRepository);
-    nlpSampleEntityService = module.get<NlpSampleEntityService>(
+      NlpEntityRepository,
+      LanguageRepository,
       NlpSampleEntityService,
-    );
-    nlpEntityService = module.get<NlpEntityService>(NlpEntityService);
-    nlpValueService = module.get<NlpValueService>(NlpValueService);
+      NlpEntityService,
+      NlpValueService,
+    ]);
     nlpSampleEntities = await nlpSampleEntityRepository.findAll();
     nlpEntities = await nlpEntityRepository.findAll();
     languages = await languageRepository.findAll();

--- a/api/src/nlp/services/nlp-value.service.spec.ts
+++ b/api/src/nlp/services/nlp-value.service.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { BaseSchema } from '@/utils/generics/base-schema';
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
@@ -21,6 +19,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
@@ -44,7 +43,7 @@ describe('NlpValueService', () => {
   let nlpValues: NlpValue[];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installNlpValueFixtures),
         MongooseModule.forFeature([
@@ -59,13 +58,19 @@ describe('NlpValueService', () => {
         NlpEntityRepository,
         NlpValueService,
         NlpEntityService,
-        EventEmitter2,
       ],
-    }).compile();
-    nlpValueService = module.get<NlpValueService>(NlpValueService);
-    nlpEntityService = module.get<NlpEntityService>(NlpEntityService);
-    nlpValueRepository = module.get<NlpValueRepository>(NlpValueRepository);
-    nlpEntityRepository = module.get<NlpEntityRepository>(NlpEntityRepository);
+    });
+    [
+      nlpValueService,
+      nlpEntityService,
+      nlpValueRepository,
+      nlpEntityRepository,
+    ] = await getMocks([
+      NlpValueService,
+      NlpEntityService,
+      NlpValueRepository,
+      NlpEntityRepository,
+    ]);
     nlpValues = await nlpValueRepository.findAll();
   });
 

--- a/api/src/plugins/plugins.service.spec.ts
+++ b/api/src/plugins/plugins.service.spec.ts
@@ -1,15 +1,14 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { Test } from '@nestjs/testing';
-
 import { LoggerModule } from '@/logger/logger.module';
 import { DummyPlugin } from '@/utils/test/dummy/dummy.plugin';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { BaseBlockPlugin } from './base-block-plugin';
 import { PluginService } from './plugins.service';
@@ -17,17 +16,21 @@ import { PluginType } from './types';
 
 describe('PluginsService', () => {
   let pluginsService: PluginService;
+  let dummyPlugin: DummyPlugin;
+
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       providers: [PluginService, DummyPlugin],
       imports: [LoggerModule],
-    }).compile();
-    pluginsService = module.get<PluginService>(PluginService);
-    await module.get<DummyPlugin>(DummyPlugin).onModuleInit();
+    });
+    [pluginsService, dummyPlugin] = await getMocks([
+      PluginService,
+      DummyPlugin,
+    ]);
+    await dummyPlugin.onModuleInit();
   });
-  afterAll(async () => {
-    jest.clearAllMocks();
-  });
+
+  afterAll(jest.clearAllMocks);
   describe('getAll', () => {
     it('should return an array of instances of base plugin', () => {
       const result = pluginsService.getAllByType(PluginType.block);

--- a/api/src/setting/controllers/setting.controller.spec.ts
+++ b/api/src/setting/controllers/setting.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,12 +7,9 @@
  */
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LoggerService } from '@/logger/logger.service';
 import {
   installSettingFixtures,
   settingFixtures,
@@ -21,6 +18,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SettingRepository } from '../repositories/setting.repository';
 import { Setting, SettingModel } from '../schemas/setting.schema';
@@ -34,7 +32,7 @@ describe('SettingController', () => {
   let settingService: SettingService;
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [SettingController],
       imports: [
         rootMongooseTestModule(installSettingFixtures),
@@ -44,8 +42,6 @@ describe('SettingController', () => {
         SettingService,
         SettingRepository,
         SettingSeeder,
-        LoggerService,
-        EventEmitter2,
         {
           provide: I18nService,
           useValue: {
@@ -61,10 +57,11 @@ describe('SettingController', () => {
           },
         },
       ],
-    }).compile();
-
-    settingController = module.get<SettingController>(SettingController);
-    settingService = module.get<SettingService>(SettingService);
+    });
+    [settingController, settingService] = await getMocks([
+      SettingController,
+      SettingService,
+    ]);
   });
 
   afterAll(closeInMongodConnection);

--- a/api/src/setting/repositories/setting.repository.spec.ts
+++ b/api/src/setting/repositories/setting.repository.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,7 +8,6 @@
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { getModelToken, MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 import { Model } from 'mongoose';
 
 import { installSettingFixtures } from '@/utils/test/fixtures/setting';
@@ -16,6 +15,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Setting, SettingModel } from '../schemas/setting.schema';
 import { SettingType } from '../schemas/types';
@@ -28,22 +28,21 @@ describe('SettingRepository', () => {
   let eventEmitter: EventEmitter2;
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installSettingFixtures),
         MongooseModule.forFeature([SettingModel]),
       ],
-      providers: [SettingRepository, EventEmitter2],
-    }).compile();
-
-    settingRepository = module.get<SettingRepository>(SettingRepository);
-    settingModel = module.get<Model<Setting>>(getModelToken(Setting.name));
-    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+      providers: [SettingRepository],
+    });
+    [settingRepository, settingModel, eventEmitter] = await getMocks([
+      SettingRepository,
+      getModelToken(Setting.name),
+      EventEmitter2,
+    ]);
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  afterEach(jest.clearAllMocks);
 
   afterAll(closeInMongodConnection);
 

--- a/api/src/setting/services/setting.service.spec.ts
+++ b/api/src/setting/services/setting.service.spec.ts
@@ -7,12 +7,9 @@
  */
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test } from '@nestjs/testing';
 
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LoggerService } from '@/logger/logger.service';
 import {
   installSettingFixtures,
   settingFixtures,
@@ -21,6 +18,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SettingRepository } from '../repositories/setting.repository';
 import { Setting, SettingModel } from '../schemas/setting.schema';
@@ -40,7 +38,7 @@ describe('SettingService', () => {
   };
 
   beforeAll(async () => {
-    const module = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installSettingFixtures),
         MongooseModule.forFeature([SettingModel]),
@@ -49,7 +47,6 @@ describe('SettingService', () => {
         SettingService,
         SettingRepository,
         SettingSeeder,
-        EventEmitter2,
         {
           provide: I18nService,
           useValue: {
@@ -64,12 +61,12 @@ describe('SettingService', () => {
             set: jest.fn(),
           },
         },
-        LoggerService,
       ],
-    }).compile();
-
-    settingService = module.get<SettingService>(SettingService);
-    settingRepository = module.get<SettingRepository>(SettingRepository);
+    });
+    [settingService, settingRepository] = await getMocks([
+      SettingService,
+      SettingRepository,
+    ]);
   });
 
   afterAll(closeInMongodConnection);

--- a/api/src/user/controllers/model.controller.spec.ts
+++ b/api/src/user/controllers/model.controller.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,14 +7,11 @@
  */
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LoggerService } from '@/logger/logger.service';
 import {
   installModelFixtures,
   modelFixtures,
@@ -23,6 +20,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { InvitationRepository } from '../repositories/invitation.repository';
 import { ModelRepository } from '../repositories/model.repository';
@@ -47,7 +45,7 @@ describe('ModelController', () => {
   let permissionService: PermissionService;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       controllers: [ModelController],
       imports: [
         rootMongooseTestModule(installModelFixtures),
@@ -61,7 +59,6 @@ describe('ModelController', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         PermissionService,
         AttachmentService,
         AttachmentRepository,
@@ -73,7 +70,6 @@ describe('ModelController', () => {
         RoleRepository,
         InvitationRepository,
         PermissionRepository,
-        EventEmitter2,
         {
           provide: CACHE_MANAGER,
           useValue: {
@@ -83,10 +79,12 @@ describe('ModelController', () => {
           },
         },
       ],
-    }).compile();
-    modelController = module.get<ModelController>(ModelController);
-    modelService = module.get<ModelService>(ModelService);
-    permissionService = module.get<PermissionService>(PermissionService);
+    });
+    [modelController, modelService, permissionService] = await getMocks([
+      ModelController,
+      ModelService,
+      PermissionService,
+    ]);
   });
 
   afterAll(closeInMongodConnection);

--- a/api/src/user/repositories/invitation.repository.spec.ts
+++ b/api/src/user/repositories/invitation.repository.spec.ts
@@ -1,17 +1,14 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 import { Model } from 'mongoose';
 
-import { LoggerService } from '@/logger/logger.service';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import {
   installInvitationFixtures,
@@ -22,6 +19,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
   Invitation,
@@ -40,7 +38,7 @@ describe('InvitationRepository', () => {
   let invitationRepository: InvitationRepository;
   let invitationModel: Model<Invitation>;
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installInvitationFixtures),
         MongooseModule.forFeature([
@@ -49,24 +47,16 @@ describe('InvitationRepository', () => {
           InvitationModel,
         ]),
       ],
-      providers: [
-        RoleRepository,
-        InvitationRepository,
-        PermissionRepository,
-        LoggerService,
-        EventEmitter2,
-      ],
-    }).compile();
-    roleRepository = module.get<RoleRepository>(RoleRepository);
-    invitationRepository =
-      module.get<InvitationRepository>(InvitationRepository);
-    invitationModel = module.get<Model<Invitation>>(
-      getModelToken('Invitation'),
-    );
+      providers: [RoleRepository, InvitationRepository, PermissionRepository],
+    });
+    [roleRepository, invitationRepository, invitationModel] = await getMocks([
+      RoleRepository,
+      InvitationRepository,
+      getModelToken(Invitation.name),
+    ]);
   });
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/user/repositories/model.repository.spec.ts
+++ b/api/src/user/repositories/model.repository.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 import { Model } from 'mongoose';
 
 import { modelFixtures } from '@/utils/test/fixtures/model';
@@ -17,6 +15,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelRepository } from '../repositories/model.repository';
 import { PermissionRepository } from '../repositories/permission.repository';
@@ -33,17 +32,18 @@ describe('ModelRepository', () => {
   let permissions: Permission[];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installPermissionFixtures),
         MongooseModule.forFeature([ModelModel, PermissionModel]),
       ],
-      providers: [ModelRepository, PermissionRepository, EventEmitter2],
-    }).compile();
-    permissionRepository =
-      module.get<PermissionRepository>(PermissionRepository);
-    modelRepository = module.get<ModelRepository>(ModelRepository);
-    modelModel = module.get<Model<ModelType>>(getModelToken('Model'));
+      providers: [ModelRepository, PermissionRepository],
+    });
+    [permissionRepository, modelRepository, modelModel] = await getMocks([
+      PermissionRepository,
+      ModelRepository,
+      getModelToken(Model.name),
+    ]);
     model = await modelRepository.findOne({ name: 'ContentType' });
     permissions = await permissionRepository.find({ model: model!.id });
   });

--- a/api/src/user/services/auth.service.spec.ts
+++ b/api/src/user/services/auth.service.spec.ts
@@ -1,25 +1,23 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { JwtService } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LoggerService } from '@/logger/logger.service';
 import { installUserFixtures } from '@/utils/test/fixtures/user';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { InvitationRepository } from '../repositories/invitation.repository';
 import { RoleRepository } from '../repositories/role.repository';
@@ -38,7 +36,7 @@ describe('AuthService', () => {
   let userRepository: UserRepository;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installUserFixtures),
         MongooseModule.forFeature([
@@ -50,7 +48,6 @@ describe('AuthService', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         AuthService,
         UserService,
         UserRepository,
@@ -58,13 +55,14 @@ describe('AuthService', () => {
         RoleRepository,
         InvitationRepository,
         JwtService,
-        EventEmitter2,
         AttachmentService,
         AttachmentRepository,
       ],
-    }).compile();
-    authService = module.get<AuthService>(AuthService);
-    userRepository = module.get<UserRepository>(UserRepository);
+    });
+    [authService, userRepository] = await getMocks([
+      AuthService,
+      UserRepository,
+    ]);
     jest.spyOn(userRepository, 'findOne');
   });
 

--- a/api/src/user/services/invitation.service.spec.ts
+++ b/api/src/user/services/invitation.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,10 +8,8 @@
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Logger } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { SentMessageInfo } from 'nodemailer';
 
@@ -19,7 +17,6 @@ import { LanguageRepository } from '@/i18n/repositories/language.repository';
 import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
 import { LanguageService } from '@/i18n/services/language.service';
-import { LoggerService } from '@/logger/logger.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import {
   installInvitationFixtures,
@@ -30,6 +27,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { InvitationCreateDto } from '../dto/invitation.dto';
 import { InvitationRepository } from '../repositories/invitation.repository';
@@ -52,7 +50,7 @@ describe('InvitationService', () => {
   const IGNORED_FIELDS = ['iat', 'exp', 'token', ...IGNORED_TEST_FIELDS];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(async () => {
           await installLanguageFixtures();
@@ -67,7 +65,6 @@ describe('InvitationService', () => {
         JwtModule,
       ],
       providers: [
-        LoggerService,
         PermissionService,
         RoleService,
         RoleRepository,
@@ -76,7 +73,6 @@ describe('InvitationService', () => {
         InvitationService,
         LanguageRepository,
         LanguageService,
-        JwtService,
         Logger,
         {
           provide: I18nService,
@@ -94,7 +90,6 @@ describe('InvitationService', () => {
             ),
           },
         },
-        EventEmitter2,
         {
           provide: CACHE_MANAGER,
           useValue: {
@@ -104,17 +99,23 @@ describe('InvitationService', () => {
           },
         },
       ],
-    }).compile();
-    roleRepository = module.get<RoleRepository>(RoleRepository);
-    invitationService = module.get<InvitationService>(InvitationService);
-    invitationRepository =
-      module.get<InvitationRepository>(InvitationRepository);
-    jwtService = module.get<JwtService>(JwtService);
-    mailerService = module.get<MailerService>(MailerService);
+    });
+    [
+      roleRepository,
+      invitationService,
+      invitationRepository,
+      jwtService,
+      mailerService,
+    ] = await getMocks([
+      RoleRepository,
+      InvitationService,
+      InvitationRepository,
+      JwtService,
+      MailerService,
+    ]);
   });
-  afterAll(async () => {
-    await closeInMongodConnection();
-  });
+
+  afterAll(closeInMongodConnection);
 
   afterEach(jest.clearAllMocks);
 

--- a/api/src/user/services/model.service.spec.ts
+++ b/api/src/user/services/model.service.spec.ts
@@ -1,14 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { modelFixtures } from '@/utils/test/fixtures/model';
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
@@ -16,6 +14,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelRepository } from '../repositories/model.repository';
 import { PermissionRepository } from '../repositories/permission.repository';
@@ -32,22 +31,18 @@ describe('ModelService', () => {
   let permissions: Permission[];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installPermissionFixtures),
         MongooseModule.forFeature([ModelModel, PermissionModel]),
       ],
-      providers: [
-        ModelService,
-        ModelRepository,
-        PermissionRepository,
-        EventEmitter2,
-      ],
-    }).compile();
-    modelService = module.get<ModelService>(ModelService);
-    permissionRepository =
-      module.get<PermissionRepository>(PermissionRepository);
-    modelRepository = module.get<ModelRepository>(ModelRepository);
+      providers: [ModelService, ModelRepository, PermissionRepository],
+    });
+    [modelService, permissionRepository, modelRepository] = await getMocks([
+      ModelService,
+      PermissionRepository,
+      ModelRepository,
+    ]);
     model = await modelRepository.findOne({ name: 'ContentType' });
     permissions = await permissionRepository.find({ model: model!.id });
   });

--- a/api/src/user/services/user.service.spec.ts
+++ b/api/src/user/services/user.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,14 +7,11 @@
  */
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
 import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LoggerService } from '@/logger/logger.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
 import { userFixtures } from '@/utils/test/fixtures/user';
@@ -23,6 +20,7 @@ import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { InvitationRepository } from '../repositories/invitation.repository';
 import { PermissionRepository } from '../repositories/permission.repository';
@@ -56,7 +54,7 @@ describe('UserService', () => {
   ];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [
         rootMongooseTestModule(installPermissionFixtures),
         MongooseModule.forFeature([
@@ -68,7 +66,6 @@ describe('UserService', () => {
         ]),
       ],
       providers: [
-        LoggerService,
         UserService,
         AttachmentService,
         AttachmentRepository,
@@ -78,7 +75,6 @@ describe('UserService', () => {
         RoleRepository,
         InvitationRepository,
         PermissionRepository,
-        EventEmitter2,
         {
           provide: CACHE_MANAGER,
           useValue: {
@@ -88,10 +84,12 @@ describe('UserService', () => {
           },
         },
       ],
-    }).compile();
-    userService = module.get<UserService>(UserService);
-    roleRepository = module.get<RoleRepository>(RoleRepository);
-    userRepository = module.get<UserRepository>(UserRepository);
+    });
+    [userService, roleRepository, userRepository] = await getMocks([
+      UserService,
+      RoleRepository,
+      UserRepository,
+    ]);
     user = await userRepository.findOne({ username: 'admin' });
     allRoles = await roleRepository.findAll();
   });

--- a/api/src/utils/generics/base-repository.spec.ts
+++ b/api/src/utils/generics/base-repository.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,7 +7,6 @@
  */
 
 import { getModelToken } from '@nestjs/mongoose';
-import { Test, TestingModule } from '@nestjs/testing';
 import { Model, Types } from 'mongoose';
 
 import { DummyRepository } from '@/utils/test/dummy/repositories/dummy.repository';
@@ -15,6 +14,7 @@ import { closeInMongodConnection } from '@/utils/test/test';
 
 import { DummyModule } from '../test/dummy/dummy.module';
 import { Dummy } from '../test/dummy/schemas/dummy.schema';
+import { buildTestingMocks } from '../test/utils';
 
 describe('BaseRepository', () => {
   let dummyModel: Model<Dummy>;
@@ -22,11 +22,13 @@ describe('BaseRepository', () => {
   let createdId: string;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [DummyModule],
-    }).compile();
-    dummyModel = module.get<Model<Dummy>>(getModelToken(Dummy.name));
-    dummyRepository = module.get<DummyRepository>(DummyRepository);
+    });
+    [dummyRepository, dummyModel] = await getMocks([
+      DummyRepository,
+      getModelToken(Dummy.name),
+    ]);
   });
   afterEach(jest.clearAllMocks);
   afterAll(closeInMongodConnection);

--- a/api/src/utils/generics/base-service.spec.ts
+++ b/api/src/utils/generics/base-service.spec.ts
@@ -6,13 +6,12 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { Test, TestingModule } from '@nestjs/testing';
-
 import { DummyService } from '@/utils/test/dummy/services/dummy.service';
 import { closeInMongodConnection } from '@/utils/test/test';
 
 import { DummyModule } from '../test/dummy/dummy.module';
 import { DummyRepository } from '../test/dummy/repositories/dummy.repository';
+import { buildTestingMocks } from '../test/utils';
 
 describe('BaseService', () => {
   let dummyRepository: DummyRepository;
@@ -30,11 +29,13 @@ describe('BaseService', () => {
   };
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const { getMocks } = await buildTestingMocks({
       imports: [DummyModule],
-    }).compile();
-    dummyRepository = module.get<DummyRepository>(DummyRepository);
-    dummyService = module.get<DummyService>(DummyService);
+    });
+    [dummyRepository, dummyService] = await getMocks([
+      DummyRepository,
+      DummyService,
+    ]);
   });
   afterEach(jest.clearAllMocks);
   afterAll(closeInMongodConnection);

--- a/api/src/utils/test/utils.ts
+++ b/api/src/utils/test/utils.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { ModuleMetadata } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { LoggerService } from '@/logger/logger.service';
+
+type TTypeOrToken = [
+  new (...args: any[]) => any,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  ...(new (...args: any[]) => any[]),
+];
+const findInstances = async <T extends TTypeOrToken>(
+  type: keyof TestingModule,
+  module: TestingModule,
+  typesOrTokens: T,
+): Promise<{ [K in keyof T]: InstanceType<T[K]> }> =>
+  Promise.all(
+    typesOrTokens.map((typeOrToken) =>
+      module[type.toString()]<InstanceType<typeof typeOrToken>>(typeOrToken),
+    ),
+  );
+
+const extractInstances =
+  (type: keyof TestingModule, module: TestingModule) =>
+  async <T extends TTypeOrToken>(types: T) =>
+    await findInstances(type, module, types);
+
+export const buildTestingMocks = async ({
+  providers,
+  ...rest
+}: ModuleMetadata) => {
+  const module = await Test.createTestingModule({
+    ...rest,
+    ...(providers && {
+      providers: [LoggerService, EventEmitter2, ...providers],
+    }),
+  }).compile();
+
+  return {
+    module,
+    getMocks: extractInstances('get', module),
+    resolveMocks: extractInstances('resolve', module),
+  };
+};

--- a/api/src/websocket/websocket.gateway.spec.ts
+++ b/api/src/websocket/websocket.gateway.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -8,14 +8,13 @@
 
 import { INestApplication } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { Test } from '@nestjs/testing';
 import { Socket, io } from 'socket.io-client';
 
-import { LoggerService } from '@/logger/logger.service';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SocketEventDispatcherService } from './services/socket-event-dispatcher.service';
 import { WebsocketGateway } from './websocket.gateway';
@@ -27,10 +26,9 @@ describe('WebsocketGateway', () => {
 
   beforeAll(async () => {
     // Instantiate the app
-    const testingModule = await Test.createTestingModule({
+    const { module } = await buildTestingMocks({
       providers: [
         WebsocketGateway,
-        LoggerService,
         EventEmitter2,
         SocketEventDispatcherService,
       ],
@@ -41,8 +39,8 @@ describe('WebsocketGateway', () => {
           return Promise.resolve();
         }),
       ],
-    }).compile();
-    app = testingModule.createNestApplication();
+    });
+    app = module.createNestApplication();
     // Get the gateway instance from the app instance
     gateway = app.get<WebsocketGateway>(WebsocketGateway);
     // Create a new client that will interact with the gateway

--- a/api/test/app.e2e-spec.ts
+++ b/api/test/app.e2e-spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,8 +7,9 @@
  */
 
 import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
+
+import { buildTestingMocks } from '@/utils/test/utils';
 
 import { HexabotModule } from './../src/app.module';
 
@@ -16,11 +17,11 @@ describe('AppController (e2e)', () => {
   let app: INestApplication;
 
   beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
+    const { module } = await buildTestingMocks({
       imports: [HexabotModule],
-    }).compile();
+    });
 
-    app = moduleFixture.createNestApplication();
+    app = module.createNestApplication();
     await app.init();
   });
 


### PR DESCRIPTION
# Motivation
The main motivation is to make loggerService and eventEmitter2 as global providers.

Fixes #847

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes