### PR TITLE
fix: nlp-sample pagination

### DIFF
--- a/api/src/nlp/controllers/nlp-sample.controller.ts
+++ b/api/src/nlp/controllers/nlp-sample.controller.ts
@@ -181,7 +181,11 @@ export class NlpSampleController extends BaseController<
    */
   @Get('count')
   async filterCount(
-    @Query(new SearchFilterPipe<NlpSample>({ allowedFields: ['text', 'type'] }))
+    @Query(
+      new SearchFilterPipe<NlpSample>({
+        allowedFields: ['text', 'type', 'language'],
+      }),
+    )
     filters?: TFilterQuery<NlpSample>,
   ) {
     return await this.count(filters);


### PR DESCRIPTION
# Motivation

This PR fixes the issue where nlp-same pagination doesn't work due to missing value allowedFields in `SearchFilterPipe`

Fixes [#420](https://github.com/Hexastack/Hexabot/issues/420)

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code