### PR TITLE
fix: plugin setting [DO_NOT_MERGE_MIGHT_BREAK_HEXABOT_PROJECTS]

### DIFF
--- a/api/src/plugins/types.ts
+++ b/api/src/plugins/types.ts
@@ -11,6 +11,7 @@ import { BlockCreateDto } from '@/chat/dto/block.dto';
 import { Block } from '@/chat/schemas/block.schema';
 import { Conversation } from '@/chat/schemas/conversation.schema';
 import { SettingCreateDto } from '@/setting/dto/setting.dto';
+import { SettingType } from '@/setting/schemas/types';
 
 export type PluginName = `${string}-plugin`;
 
@@ -23,7 +24,21 @@ export interface CustomBlocks {}
 
 type BlockAttrs = Partial<BlockCreateDto> & { name: string };
 
-export type PluginSetting = Omit<SettingCreateDto, 'weight'>;
+type EnforceTranslatable<T extends SettingType> = T extends
+  | 'text'
+  | 'multiple_text'
+  ? { translatable: boolean }
+  : { translatable: boolean };
+
+export type SettingCreateDtoStrict<
+  T extends SettingType,
+  S extends SettingCreateDto,
+> = S & EnforceTranslatable<T>;
+
+export type PluginSetting = Omit<
+  SettingCreateDtoStrict<SettingType, SettingCreateDto>,
+  'weight'
+>;
 
 export type PluginBlockTemplate = Omit<
   BlockAttrs,


### PR DESCRIPTION
# Motivation

This PR help us to enforce that the developer sets translatable field in the plugin/channel settings whenever the type of the setting is `text` or `multiple_text`
fixes #863

(code can improve when we plan to merge this PR)

Fixes # (issue)

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
