### PR TITLE
fix: custom plugins displayed unsorted

### DIFF
--- a/frontend/src/components/visual-editor/CustomBlocks.tsx
+++ b/frontend/src/components/visual-editor/CustomBlocks.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -7,6 +7,7 @@
  */
 
 import { Grid } from "@mui/material";
+import { useMemo } from "react";
 
 import PluginIcon from "@/app-components/svg/toolbar/PluginIcon";
 import { useFind } from "@/hooks/crud/useFind";
@@ -17,18 +18,22 @@ import { Block, StyledTitle } from "./Aside";
 
 export const CustomBlocks = () => {
   const { t } = useTranslate();
-  const { data: customBlocks } = useFind(
+  const { data: customBlocks = [] } = useFind(
     { entity: EntityType.CUSTOM_BLOCK },
     { hasCount: false },
   );
+  const memoizedCustomBlock = useMemo(
+    () => customBlocks.sort((a, b) => a.id.localeCompare(b.id)),
+    [customBlocks],
+  );
 
-  return customBlocks?.length ? (
+  return memoizedCustomBlock.length ? (
     <>
       <Grid mb="2">
         <StyledTitle>{t("title.custom_blocks")}</StyledTitle>
       </Grid>
       <Grid container>
-        {customBlocks?.map((customBlock) => (
+        {memoizedCustomBlock.map((customBlock) => (
           <Block
             key={customBlock.id}
             title={t(`title.${customBlock.namespace}`, {

--- a/frontend/src/components/visual-editor/CustomBlocks.tsx
+++ b/frontend/src/components/visual-editor/CustomBlocks.tsx
@@ -22,18 +22,18 @@ export const CustomBlocks = () => {
     { entity: EntityType.CUSTOM_BLOCK },
     { hasCount: false },
   );
-  const memoizedCustomBlock = useMemo(
+  const memoizedCustomBlocks = useMemo(
     () => customBlocks.sort((a, b) => a.id.localeCompare(b.id)),
     [customBlocks],
   );
 
-  return memoizedCustomBlock.length ? (
+  return memoizedCustomBlocks.length ? (
     <>
       <Grid mb="2">
         <StyledTitle>{t("title.custom_blocks")}</StyledTitle>
       </Grid>
       <Grid container>
-        {memoizedCustomBlock.map((customBlock) => (
+        {memoizedCustomBlocks.map((customBlock) => (
           <Block
             key={customBlock.id}
             title={t(`title.${customBlock.namespace}`, {


### PR DESCRIPTION
# Motivation

This PR ensures sorting (based on name) custom plugins before rendering them to ensure display order consistency 

Fixes #867

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code