### PR TITLE
fix: end conversation when a block have no matching outcomes

### DIFF
--- a/api/src/chat/services/bot.service.ts
+++ b/api/src/chat/services/bot.service.ts
@@ -200,6 +200,7 @@ export class BotService {
                 'Block outcome did not match any of the next blocks',
                 convo,
               );
+              this.eventEmitter.emit('hook:conversation:end', convo, false);
             }
           } else {
             // Conversation continues : Go forward to next blocks


### PR DESCRIPTION
# Motivation

addresses an issue in the Hexabot project where the bot would hang if a conversation block had no matching outcomes. The proposed change ensures that the conversation ends gracefully in such scenarios, preventing the bot from becoming unresponsive.

Fixes #878

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
