### PR TITLE
fix: remove unused parameter when emitting hook-conversation-end event

### DIFF
--- a/api/src/chat/services/bot.service.ts
+++ b/api/src/chat/services/bot.service.ts
@@ -165,7 +165,7 @@ export class BotService {
           return await this.triggerBlock(event, convo, attachedBlock, fallback);
         } catch (err) {
           this.logger.error('Unable to retrieve attached block', err);
-          this.eventEmitter.emit('hook:conversation:end', convo, true);
+          this.eventEmitter.emit('hook:conversation:end', convo);
         }
       } else if (
         Array.isArray(block.nextBlocks) &&
@@ -200,7 +200,7 @@ export class BotService {
                 'Block outcome did not match any of the next blocks',
                 convo,
               );
-              this.eventEmitter.emit('hook:conversation:end', convo, false);
+              this.eventEmitter.emit('hook:conversation:end', convo);
             }
           } else {
             // Conversation continues : Go forward to next blocks
@@ -218,11 +218,11 @@ export class BotService {
       } else {
         // We need to end the conversation in this case
         this.logger.debug('No attached/next blocks to execute ...');
-        this.eventEmitter.emit('hook:conversation:end', convo, false);
+        this.eventEmitter.emit('hook:conversation:end', convo);
       }
     } catch (err) {
       this.logger.error('Unable to process/send message.', err);
-      this.eventEmitter.emit('hook:conversation:end', convo, true);
+      this.eventEmitter.emit('hook:conversation:end', convo);
     }
   }
 
@@ -309,19 +309,19 @@ export class BotService {
           await this.triggerBlock(event, updatedConversation, next, fallback);
         } catch (err) {
           this.logger.error('Unable to store context data!', err);
-          return this.eventEmitter.emit('hook:conversation:end', convo, true);
+          return this.eventEmitter.emit('hook:conversation:end', convo);
         }
         return true;
       } else {
         // Conversation is still active, but there's no matching block to call next
         // We'll end the conversation but this message is probably lost in time and space.
         this.logger.debug('No matching block found to call next ', convo.id);
-        this.eventEmitter.emit('hook:conversation:end', convo, false);
+        this.eventEmitter.emit('hook:conversation:end', convo);
         return false;
       }
     } catch (err) {
       this.logger.error('Unable to populate the next blocks!', err);
-      this.eventEmitter.emit('hook:conversation:end', convo, true);
+      this.eventEmitter.emit('hook:conversation:end', convo);
       throw err;
     }
   }
@@ -405,7 +405,7 @@ export class BotService {
         return this.triggerBlock(event, updatedConversation, block, false);
       } catch (err) {
         this.logger.error('Unable to store context data!', err);
-        this.eventEmitter.emit('hook:conversation:end', convo, true);
+        this.eventEmitter.emit('hook:conversation:end', convo);
       }
     } catch (err) {
       this.logger.error('Unable to start a new conversation with ', err);


### PR DESCRIPTION
# Motivation

addresses the removal of an unused parameter in the hook-conversation-end event emission. This change simplifies the event emission process and enhances code clarity.

Fixes #881

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
