### PR TITLE
fix: editText, addText warning attribute not recognized by html

### DIFF
--- a/frontend/src/app-components/dialogs/GenericFormDialog.tsx
+++ b/frontend/src/app-components/dialogs/GenericFormDialog.tsx
@@ -24,11 +24,13 @@ export const GenericFormDialog = <T,>({
   Form,
   rowKey,
   payload: data,
+  editText,
+  addText,
   ...rest
 }: GenericFormDialogProps<T>) => {
   const { t } = useTranslate();
   const hasRow = rowKey ? data?.[rowKey] : data;
-  const translationKey = hasRow ? rest.editText : rest.addText;
+  const translationKey = hasRow ? editText : addText;
 
   return (
     <Form


### PR DESCRIPTION
# Motivation

This pr fixes the warning in the console for addText , editText attribute.

Fixes #886

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the dialog configuration by introducing dedicated options to customize text for editing and adding operations, offering clearer and more intuitive dialog displays for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->