### PR TITLE
feat: handle backward curve drawing

### DIFF
--- a/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
+++ b/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
@@ -21,6 +21,9 @@ const PROXIMITY_THRESHOLD = 500;
 const MIN_DISTANCE = 0.1;
 const MAX_DISTANCE = 2000;
 const CONTROL_POINT_PADDING = 10;
+const BACKWARD_LINK_THRESHOLD = 12; // pixels
+const MIN_SCALE_FACTOR = 1.5;
+const MAX_SCALE_FACTOR = 2.0;
 
 interface Point {
   x: number;
@@ -68,7 +71,7 @@ const logFactor = (
 ): number => {
   const scale = Math.log(distance + minDistance) / Math.log(maxDistance + minDistance);
 
-  return 1.5 + scale * 0.5; // Scaled to range between 1.5 and 2
+  return MIN_SCALE_FACTOR + scale * (MAX_SCALE_FACTOR - MIN_SCALE_FACTOR); // Scaled to range between 1.5 and 2
 };
 /**
  * Calculates the horizontal (X-axis) overlap in pixels between two node boundaries.
@@ -309,11 +312,10 @@ export class AdvancedLinkFactory extends DefaultLinkFactory {
     selected: boolean,
     path: string,
   ) {  
-
+    const backwardLinkThreshold = BACKWARD_LINK_THRESHOLD;
     const sourcePort = model.getSourcePort();
     const targetPort = model.getTargetPort();
-    const isSelfLoop =
-    sourcePort.getNode() === targetPort.getNode();
+    const isSelfLoop = sourcePort.getNode() === targetPort.getNode();
     const sourcePortPosition = sourcePort.getPosition();
     const targetPortPosition = targetPort.getPosition();
     const startPoint: Point = {
@@ -325,7 +327,7 @@ export class AdvancedLinkFactory extends DefaultLinkFactory {
       y: targetPortPosition.y + 20,
     };
     // Check if it's a backward link (moving left)
-    const isBackward = startPoint.x - endPoint.x > 12;
+    const isBackward = startPoint.x - endPoint.x > backwardLinkThreshold;
 
     if (isSelfLoop) {
       // Adjust start Point to match the exact source port's centre

--- a/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
+++ b/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
@@ -32,7 +32,6 @@ interface Boundaries {
   right: number,
   top: number,
   bottom: number,
-
 }
 
 interface Dimensions {
@@ -109,7 +108,7 @@ const calculateOverlapRatio = (
   targetDimension: number
 ): number => {
   const maxRange = Math.max(sourceDimension, targetDimension);
-  
+
   return overlapAmount / maxRange;
 };
 /**

--- a/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
+++ b/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
@@ -309,13 +309,13 @@ export class AdvancedLinkFactory extends DefaultLinkFactory {
       const adjustedStartPoint: Point = getPortCenterPoint(sourcePort);
       // Handle self-loop (curved) links
       const targetPortHeight = targetPort.height;
-      const targetNdeHeight =
+      const targetNodeHeight =
         (targetPort.getPosition().y -
         targetPort.getNode().getPosition().y) *
           2 +
         targetPortHeight;
 
-      path = createCurvedPath(adjustedStartPoint, endPoint, targetNdeHeight);
+      path = createCurvedPath(adjustedStartPoint, endPoint, targetNodeHeight);
     } else if (isBackward) {
       // Handle backward (leftward) link with refined function
       path = createBackwardCurvedPath(sourcePort, targetPort);

--- a/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
+++ b/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
@@ -11,6 +11,7 @@ import styled from "@emotion/styled";
 import {
   DefaultLinkFactory,
   DefaultLinkWidget,
+  PortModel
 } from "@projectstorm/react-diagrams";
 
 import { AdvancedLinkModel } from "./AdvancedLinkModel";
@@ -27,6 +28,112 @@ const createCurvedPath = (start: Point, end: Point, nodeHeight: number) => {
   const controlPoint2Y = end.y - nodeHeight;
 
   return `M ${start.x},${start.y} C ${controlPoint1X},${controlPoint1Y} ${controlPoint2X},${controlPoint2Y} ${end.x},${end.y}`;
+};
+const createBackwardCurvedPath = (
+  sourcePort: PortModel,
+  targetPort: PortModel,
+) => {
+  const sourceNode = sourcePort.getNode();
+  const targetNode = targetPort.getNode();
+  // **NEW:** Get port dimensions for better alignment
+  const sourcePortSize = { width: sourcePort.width || 10, height: sourcePort.height || 10 };
+  const targetPortSize = { width: targetPort.width || 10, height: targetPort.height || 10 };
+  // Get node dimensions
+  const sourceNodeWidth = sourceNode.width;
+  const targetNodeWidth = targetNode.width;
+  const sourceNodeHeight = sourceNode.height;
+  const targetNodeHeight = targetNode.height;
+  // Get node boundaries
+  const sourceNodeBounds = {
+    left: sourceNode.getPosition().x,
+    right: sourceNode.getPosition().x + sourceNodeWidth,
+    top: sourceNode.getPosition().y,
+    bottom: sourceNode.getPosition().y + sourceNodeHeight,
+  };
+  const targetNodeBounds = {
+    left: targetNode.getPosition().x,
+    right: targetNode.getPosition().x + targetNodeWidth,
+    top: targetNode.getPosition().y,
+    bottom: targetNode.getPosition().y +targetNodeHeight,
+  };
+  // **NEW:** Adjust `start` and `end` to match the exact center of ports
+  const adjustedStart: Point = {
+    x: sourcePort.getPosition().x + sourcePortSize.width / 2,
+    y: sourcePort.getPosition().y + sourcePortSize.height / 2,
+  };
+  const adjustedEnd: Point = {
+    x: targetPort.getPosition().x + targetPortSize.width / 2,
+    y: targetPort.getPosition().y + targetPortSize.height / 2,
+  };
+  // Calculate the distance between nodes
+  const nodeDistance = Math.sqrt(
+    Math.pow(adjustedEnd.x - adjustedStart.x, 2) + Math.pow(adjustedEnd.y - adjustedStart.y, 2)
+  );
+  // Logarithmic scaling function that adjusts between 1.5 and 2 based on distance
+  const logFactor = (distance) => {
+    const minDistance = 0.1; // A small value to prevent division by zero or too small values
+    const maxDistance = 2000; // A maximum value for nodeDistance where the function plateaus
+    // Logarithmic scale function to map distance to a factor between 1.5 and 2
+    const scale = Math.log(distance + minDistance) / Math.log(maxDistance + minDistance);
+
+    // Scale result to range between 1.5 and 2
+    return 1.5 + scale * (2 - 1.5);
+  };
+  // Use node dimensions and distance to calculate dynamic offsets
+  const horizontalOffset = Math.max(sourceNodeWidth, targetNodeWidth);
+  const verticalOffset = Math.max(sourceNodeHeight, targetNodeHeight);
+
+  // Dynamic factor, adjusting horizontal and vertical offsets based on the distance
+  let adjustedHorizontalOffset = horizontalOffset*  logFactor(nodeDistance);
+
+  ;
+  let adjustedVerticalOffset = verticalOffset * logFactor(nodeDistance);
+
+  // Horizontal overlap ratio (0 = no overlap, 1 = fully overlapping horizontally)
+  const xOverlapAmount = Math.max(
+    0,
+    Math.min(sourceNodeBounds.right, targetNodeBounds.right) -
+    Math.max(sourceNodeBounds.left, targetNodeBounds.left)
+  );
+  const maxXRange = Math.max(sourceNodeWidth, targetNodeWidth);
+  const xOverlapRatio = xOverlapAmount / maxXRange;
+  // Vertical overlap ratio (0 = no overlap, 1 = fully overlapping vertically)
+  const yOverlapAmount = Math.max(
+    0,
+    Math.min(sourceNodeBounds.bottom, targetNodeBounds.bottom) -
+    Math.max(sourceNodeBounds.top, targetNodeBounds.top)
+  );
+  const maxYRange = Math.max(sourceNodeHeight, targetNodeHeight);
+  const yOverlapRatio = yOverlapAmount / maxYRange;
+  // Determine vertical direction for Y alignment
+  const verticalDirection = adjustedEnd.y >= adjustedStart.y ? 1 : -1;
+
+  // If Node Distance is small, multiply offsets by overlap ratios
+  // to avoid abrupt curve steepness
+  if (nodeDistance < 500) {
+    adjustedHorizontalOffset *= xOverlapRatio; 
+    adjustedVerticalOffset *= yOverlapRatio;  
+  }
+  // Compute control points with dynamic offset
+  let controlPoint1X = adjustedStart.x + adjustedHorizontalOffset;
+  let controlPoint1Y = adjustedStart.y + verticalDirection * adjustedVerticalOffset;
+
+  let controlPoint2X = adjustedEnd.x - adjustedHorizontalOffset;
+  let controlPoint2Y = adjustedEnd.y - verticalDirection * adjustedVerticalOffset;
+
+  controlPoint1X = Math.max(controlPoint1X, sourceNodeBounds.right + 10);
+  controlPoint2X = Math.min(controlPoint2X, targetNodeBounds.left - 10);
+
+  controlPoint1Y = verticalDirection > 0
+    ? Math.max(controlPoint1Y, sourceNodeBounds.bottom + 10)
+    : Math.min(controlPoint1Y, sourceNodeBounds.top - 10);
+
+  controlPoint2Y = verticalDirection > 0
+    ? Math.min(controlPoint2Y, targetNodeBounds.top - 10)
+    : Math.max(controlPoint2Y, targetNodeBounds.bottom + 10);
+
+  // Return the cubic Bezier curve
+  return `M ${adjustedStart.x},${adjustedStart.y} C ${controlPoint1X},${controlPoint1Y} ${controlPoint2X},${controlPoint2Y} ${adjustedEnd.x},${adjustedEnd.y}`;
 };
 
 namespace S {
@@ -68,37 +175,53 @@ export class AdvancedLinkFactory extends DefaultLinkFactory {
     model: AdvancedLinkModel,
     selected: boolean,
     path: string,
-  ) {
+  ) {  
+
+    const sourcePort = model.getSourcePort();
+    const targetPort = model.getTargetPort();
     const isSelfLoop =
-      model.getSourcePort().getNode() === model.getTargetPort().getNode();
+    sourcePort.getNode() === targetPort.getNode();
+    const sourcePortPosition = sourcePort.getPosition();
+    const targetPortPosition = targetPort.getPosition();
+    const startPoint: Point = {
+      x: sourcePortPosition.x + 20,
+      y: sourcePortPosition.y + 20,
+    };
+    const endPoint: Point = {
+      x: targetPortPosition.x + 20,
+      y: targetPortPosition.y + 20,
+    };
+    // Check if it's a backward link (moving left)
+    const isBackward = startPoint.x - endPoint.x > 12;
 
     if (isSelfLoop) {
-      // Adjust the path to create a curve
-      const sourcePortPosition = model.getSourcePort().getPosition();
-      const targetPortPosition = model.getTargetPort().getPosition();
-      const startPoint: Point = {
-        x: sourcePortPosition.x + 20,
-        y: sourcePortPosition.y + 20,
+      const sourcePortSize = { width:sourcePort.width || 10, height:sourcePort.height || 10 };
+      // Adjust start Point to match the exact source port's centre
+      const adjustedStartPoint: Point = {
+        x: sourcePortPosition.x + sourcePortSize.width / 2,
+        y: sourcePortPosition.y + sourcePortSize.height / 2,
       };
-      const endPoint: Point = {
-        x: targetPortPosition.x + 20,
-        y: targetPortPosition.y + 20,
-      };
-      const targetPortHeight = model.getTargetPort().height;
+      // Handle self-loop (curved) links
+      const targetPortHeight =targetPort.height;
       const targetNdeHeight =
-        (model.getTargetPort().getPosition().y -
-          model.getTargetPort().getNode().getPosition().y) *
+        (targetPort.getPosition().y -
+        targetPort.getNode().getPosition().y) *
           2 +
         targetPortHeight;
 
-      path = createCurvedPath(startPoint, endPoint, targetNdeHeight);
-    }
-
-    return (
+      path = createCurvedPath(adjustedStartPoint, endPoint, targetNdeHeight);
+    } else if (isBackward) {
+      // Handle backward (leftward) link with refined function
+      path = createBackwardCurvedPath(sourcePort, targetPort);
+    } 
+    
+return (
       <S.Path
         selected={selected}
         stroke={
-          selected ? model.getOptions().selectedColor : model.getOptions().color
+          selected
+            ? model.getOptions().selectedColor
+            : model.getOptions().color
         }
         strokeWidth={model.getOptions().width}
         d={path}

--- a/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
+++ b/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
@@ -133,6 +133,31 @@ const calculateNodeBoundaries = (node: NodeModel): Boundaries => {
   };
 };
 /**
+ * Calculates the width and height of a node based on the position of one of its ports.
+ * 
+ * This approach avoids relying on the node's width and height properties,
+ * which may not be accurate or available at render time due to asynchronous rendering behavior.
+ * 
+ * Instead, it uses the relative position of the port to infer the size of the node.
+ * Assumes that the port's position reflects the visual layout and placement on the node.
+ *
+ * @param port - A PortModel instance attached to the node
+ * @returns An object containing the inferred width and height of the node
+ */
+const calculateNodeDimension = (port: PortModel): Dimensions => {
+  // Get the top-left position of the node
+  const nodePos = port.getNode().getPosition();
+  // Get the top-left position of the port
+  const portPos = port.getPosition();
+  // Width is the horizontal distance from the node's left to the port's right edge
+  const width = (portPos.x - nodePos.x) + port.width;
+  // Height is estimated by doubling the vertical offset from the node to the port
+  // (port is vertically centered), then adding the port's height
+  const height = Math.abs(portPos.y - nodePos.y) * 2 + port.height;
+
+  return { width, height };
+};
+/**
  * Calculates a single control point for a cubic Bézier curve.
  * Adjusts based on direction, dynamic offset, and node boundaries.
  */
@@ -187,10 +212,8 @@ const createBackwardCurvedPath = (
   const sourceNode = sourcePort.getNode();
   const targetNode = targetPort.getNode();
   // Get node dimensions
-  const sourceNodeWidth = sourceNode.width;
-  const targetNodeWidth = targetNode.width;
-  const sourceNodeHeight = sourceNode.height;
-  const targetNodeHeight = targetNode.height;
+  const { width: sourceNodeWidth, height: sourceNodeHeight } = calculateNodeDimension(sourcePort);
+  const { width: targetNodeWidth, height: targetNodeHeight } = calculateNodeDimension(targetPort);
   // Get node boundaries
   const sourceNodeBounds: Boundaries = calculateNodeBoundaries(sourceNode);
   const targetNodeBounds: Boundaries = calculateNodeBoundaries(targetNode);

--- a/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
+++ b/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
@@ -33,6 +33,9 @@ const createBackwardCurvedPath = (
   sourcePort: PortModel,
   targetPort: PortModel,
 ) => {
+  // Set a threshold for node proximity, below which dynamic adjustments to offsets are applied
+  // This helps in reducing abrupt curve steepness when nodes are close to each other
+  const proximityThreshold = 500;
   const sourceNode = sourcePort.getNode();
   const targetNode = targetPort.getNode();
   // **NEW:** Get port dimensions for better alignment
@@ -110,7 +113,7 @@ const createBackwardCurvedPath = (
 
   // If Node Distance is small, multiply offsets by overlap ratios
   // to avoid abrupt curve steepness
-  if (nodeDistance < 500) {
+  if (nodeDistance < proximityThreshold) {
     adjustedHorizontalOffset *= xOverlapRatio; 
     adjustedVerticalOffset *= yOverlapRatio;  
   }

--- a/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
+++ b/frontend/src/components/visual-editor/v2/AdvancedLink/AdvancedLinkFactory.tsx
@@ -57,7 +57,7 @@ const createBackwardCurvedPath = (
     left: targetNode.getPosition().x,
     right: targetNode.getPosition().x + targetNodeWidth,
     top: targetNode.getPosition().y,
-    bottom: targetNode.getPosition().y +targetNodeHeight,
+    bottom: targetNode.getPosition().y + targetNodeHeight,
   };
   // **NEW:** Adjust `start` and `end` to match the exact center of ports
   const adjustedStart: Point = {
@@ -73,7 +73,7 @@ const createBackwardCurvedPath = (
     Math.pow(adjustedEnd.x - adjustedStart.x, 2) + Math.pow(adjustedEnd.y - adjustedStart.y, 2)
   );
   // Logarithmic scaling function that adjusts between 1.5 and 2 based on distance
-  const logFactor = (distance) => {
+  const logFactor = (distance: number) => {
     const minDistance = 0.1; // A small value to prevent division by zero or too small values
     const maxDistance = 2000; // A maximum value for nodeDistance where the function plateaus
     // Logarithmic scale function to map distance to a factor between 1.5 and 2
@@ -87,9 +87,7 @@ const createBackwardCurvedPath = (
   const verticalOffset = Math.max(sourceNodeHeight, targetNodeHeight);
 
   // Dynamic factor, adjusting horizontal and vertical offsets based on the distance
-  let adjustedHorizontalOffset = horizontalOffset*  logFactor(nodeDistance);
-
-  ;
+  let adjustedHorizontalOffset = horizontalOffset * logFactor(nodeDistance);
   let adjustedVerticalOffset = verticalOffset * logFactor(nodeDistance);
 
   // Horizontal overlap ratio (0 = no overlap, 1 = fully overlapping horizontally)
@@ -114,8 +112,8 @@ const createBackwardCurvedPath = (
   // If Node Distance is small, multiply offsets by overlap ratios
   // to avoid abrupt curve steepness
   if (nodeDistance < proximityThreshold) {
-    adjustedHorizontalOffset *= xOverlapRatio; 
-    adjustedVerticalOffset *= yOverlapRatio;  
+    adjustedHorizontalOffset *= xOverlapRatio;
+    adjustedVerticalOffset *= yOverlapRatio;
   }
   // Compute control points with dynamic offset
   let controlPoint1X = adjustedStart.x + adjustedHorizontalOffset;
@@ -205,7 +203,7 @@ export class AdvancedLinkFactory extends DefaultLinkFactory {
         y: sourcePortPosition.y + sourcePortSize.height / 2,
       };
       // Handle self-loop (curved) links
-      const targetPortHeight =targetPort.height;
+      const targetPortHeight = targetPort.height;
       const targetNdeHeight =
         (targetPort.getPosition().y -
         targetPort.getNode().getPosition().y) *


### PR DESCRIPTION
# Motivation

The following PR introduces improvements to the path calculation for connections between ports, specifically for backward curved paths using cubic Bezier curves. The path is dynamically adjusted based on both the distance between nodes and their visual overlap, resulting in smoother, more intuitive connections in the diagram.

![Screenshot from 2025-04-04 12-33-35](https://github.com/user-attachments/assets/2c73ae35-f297-499c-9188-a19f1ea5bd14)

Fixes # (issue)

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced visual rendering of backward connections with dynamically calculated, smoother curved paths.
	- Introduced new helper functions for improved calculations related to port dimensions, distances, overlaps, and control points.
- **Refactor**
	- Revised self-loop detection and link segment alignment for improved visual consistency in connection displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->