### PR TITLE
fix: empty file when no dataset is selected

### DIFF
--- a/frontend/src/components/nlp/components/NlpSample.tsx
+++ b/frontend/src/components/nlp/components/NlpSample.tsx
@@ -392,6 +392,7 @@ export default function NlpSample() {
                   `nlpsample/export${type ? `?type=${type}` : ""}`,
                 )}
                 startIcon={<DownloadIcon />}
+                disabled={dataGridProps?.rows?.length === 0}
               >
                 {t("button.export")}
               </Button>


### PR DESCRIPTION
# Motivation

This PR introduces a minor UX improvement by disabling the "Export" button when there are no NLP samples to export. This prevents users from downloading an empty file when the dataset is empty or filters no results.

Fixes #775

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The export button now automatically disables when there is no data available, ensuring a more responsive and intuitive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->