### PR TITLE
fix: importing csv file ignores fields and status always true

### DIFF
--- a/api/src/cms/services/content.service.ts
+++ b/api/src/cms/services/content.service.ts
@@ -145,7 +145,7 @@ export class ContentService extends BaseService<
         ...acc,
         {
           title: String(title),
-          status: Boolean(status),
+          status: status.trim().toLowerCase() === 'true',
           entity: targetContentType,
           dynamicFields: Object.keys(rest)
             .filter((key) =>


### PR DESCRIPTION
# Motivation
Previously, the status field in CSV imports was parsed using Boolean(status), which incorrectly converted string values like "false" to true, since any non-empty string is truthy in JavaScript..

Fixes #797

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the evaluation of content statuses during CSV imports for improved data consistency. End-users uploading CSV-based content will experience more predictable behavior as status values are now determined more precisely. This fix minimizes inconsistencies in status indications and ensures that CSV uploads are processed reliably, contributing to a more robust content management experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->