### PR TITLE
fix(frontend): align BlockFormProvider method prop and the useForm typing

### DIFF
--- a/frontend/src/components/visual-editor/form/BlockFormProvider.tsx
+++ b/frontend/src/components/visual-editor/form/BlockFormProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -9,7 +9,7 @@
 import { createContext, ReactNode, useContext } from "react";
 import { FormProvider, UseFormReturn } from "react-hook-form";
 
-import { IBlockAttributes, IBlock } from "@/types/block.types";
+import { IBlock, IBlockAttributes } from "@/types/block.types";
 
 // Create a custom context for the block value
 const BlockContext = createContext<IBlock | undefined>(undefined);
@@ -23,7 +23,7 @@ function BlockFormProvider({
   methods,
   block,
 }: {
-  methods: UseFormReturn<IBlockAttributes, any, undefined>;
+  methods: UseFormReturn<IBlockAttributes>;
   block: IBlock | undefined;
   children: ReactNode;
 }) {


### PR DESCRIPTION
# Motivation
The main motivation is to align the typing of the BlockFormProvider method prop with the useForm hook typing.

Fixes #903

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated legal information to align with the current year.
  
- **Refactor**
  - Streamlined internal definitions to enhance clarity and maintainability.

These behind-the-scenes improvements ensure a cleaner, more up-to-date foundation for future enhancements while maintaining stable functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->