### PR TITLE
Fix: Make translatable plugin settings

### DIFF
--- a/api/src/i18n/services/translation.service.ts
+++ b/api/src/i18n/services/translation.service.ts
@@ -73,7 +73,9 @@ export class TranslationService extends BaseService<Translation> {
         );
 
         for (const [key, value] of Object.entries(block.message.args)) {
-          switch (settingTypeMap.get(key)) {
+          const settingType = settingTypeMap.get(key);
+
+          switch (settingType) {
             case SettingType.multiple_text:
               strings = strings.concat(value);
               break;


### PR DESCRIPTION
# Motivation
The main motivation is to make plugin settings having SettingType.text,SettingType.textarea,SettingType.multiple_text types translatable. 

Fixes #863

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the internal translation handling to ensure default settings are applied consistently and only relevant, translatable content is processed when rendering block messages, leading to a more streamlined and reliable translation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->