### PR TITLE
fix: add exception when useBlock is outside the block provider

### DIFF
--- a/frontend/src/components/visual-editor/form/BlockFormProvider.tsx
+++ b/frontend/src/components/visual-editor/form/BlockFormProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -9,13 +9,21 @@
 import { createContext, ReactNode, useContext } from "react";
 import { FormProvider, UseFormReturn } from "react-hook-form";
 
-import { IBlockAttributes, IBlock } from "@/types/block.types";
+import { IBlock, IBlockAttributes } from "@/types/block.types";
 
 // Create a custom context for the block value
 const BlockContext = createContext<IBlock | undefined>(undefined);
 
 // Custom hook to use block context
-export const useBlock = () => useContext(BlockContext);
+export const useBlock = () => {
+  const context = useContext(BlockContext);
+
+  if (!context) {
+    throw new Error("useBlock must be used within an BlockContext");
+  }
+
+  return context;
+};
 
 // This component wraps FormProvider and adds block to its context
 function BlockFormProvider({


### PR DESCRIPTION
# Motivation
The main motivation is to handle the case when the useBlock hook is used outside the Block Provider

Fixes #911

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the reliability of block functionality in the Visual Editor by ensuring that essential context is properly utilized. The update adds robust error handling that minimizes potential runtime disruptions, resulting in a smoother and more stable editing experience. These enhancements overall support an optimal, error-free editing environment for our users.
- **Chores**
  - Updated the copyright notice to reflect the current year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->