### PR TITLE
fix(api): resolve getAllowsOrigins bug

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -50,11 +50,11 @@ async function bootstrap() {
 
   const settingService = app.get<SettingService>(SettingService);
   app.enableCors({
-    origin: (origin, callback) => {
-      settingService
+    origin: async (origin, callback) => {
+      await settingService
         .getAllowedOrigins()
         .then((allowedOrigins) => {
-          if (!origin || allowedOrigins.has(origin)) {
+          if (!origin || allowedOrigins.includes(origin)) {
             callback(null, true);
           } else {
             callback(new Error('Not allowed by CORS'));

--- a/api/src/setting/services/setting.service.spec.ts
+++ b/api/src/setting/services/setting.service.spec.ts
@@ -161,14 +161,12 @@ describe('SettingService', () => {
       expect(settingService.find).toHaveBeenCalledWith({
         label: 'allowed_domains',
       });
-      expect(result).toEqual(
-        new Set([
-          '*',
-          'https://example.com',
-          'https://test.com',
-          'https://another.com',
-        ]),
-      );
+      expect(result).toEqual([
+        '*',
+        'https://example.com',
+        'https://test.com',
+        'https://another.com',
+      ]);
     });
 
     it('should return the config allowed cors only if no settings are found', async () => {
@@ -179,7 +177,7 @@ describe('SettingService', () => {
       expect(settingService.find).toHaveBeenCalledWith({
         label: 'allowed_domains',
       });
-      expect(result).toEqual(new Set(['*']));
+      expect(result).toEqual(['*']);
     });
 
     it('should handle settings with empty values', async () => {

--- a/api/src/setting/services/setting.service.spec.ts
+++ b/api/src/setting/services/setting.service.spec.ts
@@ -195,7 +195,7 @@ describe('SettingService', () => {
       expect(settingService.find).toHaveBeenCalledWith({
         label: 'allowed_domains',
       });
-      expect(result).toEqual(new Set(['*', 'https://example.com']));
+      expect(result).toEqual(['*', 'https://example.com']);
     });
   });
 });

--- a/api/src/setting/services/setting.service.ts
+++ b/api/src/setting/services/setting.service.ts
@@ -135,7 +135,7 @@ export class SettingService extends BaseService<Setting> {
    * @returns A promise that resolves to a set of allowed origins
    */
   @Cacheable(ALLOWED_ORIGINS_CACHE_KEY)
-  async getAllowedOrigins() {
+  async getAllowedOrigins(): Promise<string[]> {
     const settings = (await this.find({
       label: 'allowed_domains',
     })) as TextSetting[];
@@ -150,7 +150,7 @@ export class SettingService extends BaseService<Setting> {
       ...allowedDomains,
     ]);
 
-    return uniqueOrigins;
+    return Array.from(uniqueOrigins);
   }
 
   /**

--- a/api/src/websocket/utils/gateway-options.ts
+++ b/api/src/websocket/utils/gateway-options.ts
@@ -54,15 +54,15 @@ export const buildWebSocketGatewayOptions = (): Partial<ServerOptions> => {
     ...(config.sockets.cookie && { cookie: config.sockets.cookie }),
     ...(config.sockets.onlyAllowOrigins && {
       cors: {
-        origin: (origin, cb) => {
+        origin: async (origin, cb) => {
           // Retrieve the allowed origins from the settings
           const app = AppInstance.getApp();
           const settingService = app.get<SettingService>(SettingService);
 
-          settingService
+          await settingService
             .getAllowedOrigins()
             .then((allowedOrigins) => {
-              if (origin && allowedOrigins.has(origin)) {
+              if (origin && allowedOrigins.includes(origin)) {
                 cb(null, true);
               } else {
                 // eslint-disable-next-line no-console


### PR DESCRIPTION
# Motivation
The main motivation is to fix an issue that cause a bug with the getAllowsOrigins logic

Fixes #816

# Screenshot of the fix
![image](https://github.com/user-attachments/assets/64989df6-a3b7-4b30-93a0-29a41f57bed4)

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved how allowed origins are validated for both standard and WebSocket connections by ensuring that origin checks wait for asynchronous retrieval of allowed origins. This enhancement results in more consistent and secure behavior.
- **Tests**
	- Updated test cases to align with the improved origin handling, reinforcing overall stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->