### PR TITLE
fix(api): optimize preUpdateMany

### DIFF
--- a/api/src/chat/repositories/block.repository.spec.ts
+++ b/api/src/chat/repositories/block.repository.spec.ts
@@ -54,6 +54,7 @@ describe('BlockRepository', () => {
     validCategory = '64def5678abc123490fedcba';
 
     category = (await categoryRepository.findOne({ label: 'default' }))!;
+
     hasPreviousBlocks = (await blockRepository.findOne({
       name: 'hasPreviousBlocks',
     }))!;
@@ -171,42 +172,38 @@ describe('BlockRepository', () => {
 
   describe('prepareBlocksInCategoryUpdateScope', () => {
     it('should update blocks within the scope based on category and ids', async () => {
-      jest.spyOn(blockRepository, 'findOne').mockResolvedValue({
-        id: blockValidIds[0],
-        category: 'oldCategory',
-        nextBlocks: [blockValidIds[1]],
-        attachedBlock: blockValidIds[1],
-      } as Block);
-
-      const mockUpdateOne = jest.spyOn(blockRepository, 'updateOne');
+      jest.spyOn(blockRepository, 'find').mockResolvedValue([
+        {
+          id: blockValidIds[0],
+          category: category.id,
+          nextBlocks: [blockValidIds[1]],
+          attachedBlock: blockValidIds[2],
+        },
+      ] as Block[]);
+      jest.spyOn(blockRepository, 'updateOne');
 
       await blockRepository.prepareBlocksInCategoryUpdateScope(
         validCategory,
         blockValidIds,
       );
 
-      expect(mockUpdateOne).toHaveBeenCalledWith(blockValidIds[0], {
+      expect(blockRepository.updateOne).toHaveBeenCalledWith(blockValidIds[0], {
         nextBlocks: [blockValidIds[1]],
-        attachedBlock: blockValidIds[1],
+        attachedBlock: blockValidIds[2],
       });
     });
 
     it('should not update blocks if the category already matches', async () => {
-      jest.spyOn(blockRepository, 'findOne').mockResolvedValue({
-        id: validIds[0],
-        category: validCategory,
-        nextBlocks: [],
-        attachedBlock: null,
-      } as unknown as Block);
-
-      const mockUpdateOne = jest.spyOn(blockRepository, 'updateOne');
+      jest.spyOn(blockRepository, 'find').mockResolvedValue([]);
+      jest.spyOn(blockRepository, 'updateOne');
 
       await blockRepository.prepareBlocksInCategoryUpdateScope(
-        validCategory,
-        validIds,
+        category.id,
+        blockValidIds,
       );
 
-      expect(mockUpdateOne).not.toHaveBeenCalled();
+      expect(blockRepository.find).toHaveBeenCalled();
+      expect(blockRepository.updateOne).not.toHaveBeenCalled();
     });
   });
 

--- a/api/src/chat/repositories/block.repository.spec.ts
+++ b/api/src/chat/repositories/block.repository.spec.ts
@@ -54,7 +54,6 @@ describe('BlockRepository', () => {
     validCategory = '64def5678abc123490fedcba';
 
     category = (await categoryRepository.findOne({ label: 'default' }))!;
-
     hasPreviousBlocks = (await blockRepository.findOne({
       name: 'hasPreviousBlocks',
     }))!;

--- a/api/src/chat/repositories/block.repository.ts
+++ b/api/src/chat/repositories/block.repository.ts
@@ -172,22 +172,24 @@ export class BlockRepository extends BaseRepository<
     category: string,
     ids: string[],
   ): Promise<void> {
-    for (const id of ids) {
-      const oldState = await this.findOne(id);
-      if (oldState && oldState.category !== category) {
-        const updatedNextBlocks = oldState.nextBlocks?.filter((nextBlock) =>
-          ids.includes(nextBlock),
-        );
+    const blocks = await this.find({
+      _id: { $in: ids },
+      category: { $ne: category },
+    });
 
-        const updatedAttachedBlock = ids.includes(oldState.attachedBlock || '')
-          ? oldState.attachedBlock
-          : null;
+    for (const { id, nextBlocks, attachedBlock } of blocks) {
+      const updatedNextBlocks = nextBlocks.filter((nextBlock) =>
+        ids.includes(nextBlock),
+      );
 
-        await this.updateOne(id, {
-          nextBlocks: updatedNextBlocks,
-          attachedBlock: updatedAttachedBlock,
-        });
-      }
+      const updatedAttachedBlock = ids.includes(attachedBlock || '')
+        ? attachedBlock
+        : null;
+
+      await this.updateOne(id, {
+        nextBlocks: updatedNextBlocks,
+        attachedBlock: updatedAttachedBlock,
+      });
     }
   }
 


### PR DESCRIPTION
# Motivation
The main motivation is to optimize preUpdateMany logic.

Fixes #536

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the update process by consolidating multiple queries into a single efficient operation, reducing redundant processing and enhancing overall performance.

- **Tests**
  - Updated test scenarios to align with the improved bulk update mechanism, ensuring consistent and reliable behavior across different cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->