### PR TITLE
feat: add loading spinner for document upload

### DIFF
--- a/frontend/src/app-components/attachment/AttachmentUploader.tsx
+++ b/frontend/src/app-components/attachment/AttachmentUploader.tsx
@@ -8,7 +8,15 @@
 
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import FolderCopyIcon from "@mui/icons-material/FolderCopy";
-import { Box, Button, Divider, Grid, styled, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  Grid,
+  styled,
+  Typography,
+} from "@mui/material";
 import { ChangeEvent, DragEvent, FC, useState } from "react";
 
 import { useUpload } from "@/hooks/crud/useUpload";
@@ -84,17 +92,20 @@ const AttachmentUploader: FC<FileUploadProps> = ({
   const dialogs = useDialogs();
   const [isDragOver, setIsDragOver] = useState<boolean>(false);
   const { toast } = useToast();
-  const { mutate: uploadAttachment } = useUpload(EntityType.ATTACHMENT, {
-    onError: () => {
-      toast.error(t("message.upload_failed"));
+  const { mutate: uploadAttachment, isLoading } = useUpload(
+    EntityType.ATTACHMENT,
+    {
+      onError: () => {
+        toast.error(t("message.upload_failed"));
+      },
+      onSuccess: (data) => {
+        toast.success(t("message.success_save"));
+        setAttachment(data);
+        onChange && onChange(data);
+        onUploadComplete && onUploadComplete();
+      },
     },
-    onSuccess: (data) => {
-      toast.success(t("message.success_save"));
-      setAttachment(data);
-      onChange && onChange(data);
-      onUploadComplete && onUploadComplete();
-    },
-  });
+  );
   const stopDefaults = (e: DragEvent) => {
     e.stopPropagation();
     e.preventDefault();
@@ -167,7 +178,9 @@ const AttachmentUploader: FC<FileUploadProps> = ({
               alignItems="center"
               sx={{ padding: "20px" }}
             >
-              {attachment ? (
+              {isLoading ? (
+                <CircularProgress />
+              ) : attachment ? (
                 <AttachmentThumbnail
                   id={attachment.id}
                   format="full"

--- a/frontend/src/app-components/attachment/AttachmentUploader.tsx
+++ b/frontend/src/app-components/attachment/AttachmentUploader.tsx
@@ -101,8 +101,8 @@ const AttachmentUploader: FC<FileUploadProps> = ({
       onSuccess: (data) => {
         toast.success(t("message.success_save"));
         setAttachment(data);
-        onChange && onChange(data);
-        onUploadComplete && onUploadComplete();
+        onChange?.(data);
+        onUploadComplete?.();
       },
     },
   );


### PR DESCRIPTION
# Motivation
The main motivation is to add a spinner when downloading a document.

Fixes #153

# Demonstration screen recording
<video src="https://github.com/user-attachments/assets/3f124a5b-f30c-4271-b5b0-da36e6a28e30"></video>

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the attachment upload experience with a visual loading indicator during uploads.
	- Streamlined success notifications to provide immediate, clear feedback once an upload completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->