### PR TITLE
feat: add contextVar regex validation

### DIFF
--- a/api/src/chat/controllers/context-var.controller.spec.ts
+++ b/api/src/chat/controllers/context-var.controller.spec.ts
@@ -103,6 +103,7 @@ describe('ContextVarController', () => {
         label: 'contextVarLabel2',
         name: 'test_add',
         permanent: false,
+        pattern: '/.+/',
       };
       const result = await contextVarController.create(contextVarCreateDto);
 

--- a/api/src/chat/dto/context-var.dto.ts
+++ b/api/src/chat/dto/context-var.dto.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { DtoConfig } from '@/utils/types/dto.types';
@@ -26,6 +26,14 @@ export class ContextVarCreateDto {
   @IsOptional()
   @IsBoolean()
   permanent?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Context var pattern',
+    type: String,
+  })
+  @IsOptional()
+  @IsString()
+  pattern?: string;
 }
 
 export class ContextVarUpdateDto extends PartialType(ContextVarCreateDto) {}

--- a/api/src/chat/schemas/context-var.schema.ts
+++ b/api/src/chat/schemas/context-var.schema.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -10,7 +10,10 @@ import { ModelDefinition, Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 
 import { BaseSchema } from '@/utils/generics/base-schema';
 import { LifecycleHookManager } from '@/utils/generics/lifecycle-hook-manager';
+import { buildZodSchemaValidator } from '@/utils/helpers/zod-validation';
 import { THydratedDocument } from '@/utils/types/filter.types';
+
+import { stringRegexPatternSchema } from './types/pattern';
 
 @Schema({ timestamps: true })
 export class ContextVar extends BaseSchema {
@@ -39,6 +42,13 @@ export class ContextVar extends BaseSchema {
     default: false,
   })
   permanent: boolean;
+
+  @Prop({
+    type: String,
+    validate: buildZodSchemaValidator(stringRegexPatternSchema),
+    default: '/.+/',
+  })
+  pattern?: string;
 }
 
 export const ContextVarModel: ModelDefinition = LifecycleHookManager.attach({

--- a/api/src/chat/services/context-var.service.ts
+++ b/api/src/chat/services/context-var.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -34,7 +34,7 @@ export class ContextVarService extends BaseService<
    */
   async getContextVarsByBlock(
     block: Block | BlockFull,
-  ): Promise<Record<string, ContextVar>> {
+  ): Promise<Record<string, ContextVar | undefined>> {
     const vars = await this.find({
       name: { $in: block.capture_vars.map(({ context_var }) => context_var) },
     });

--- a/api/src/chat/services/context-var.service.ts
+++ b/api/src/chat/services/context-var.service.ts
@@ -30,7 +30,7 @@ export class ContextVarService extends BaseService<
    * Retrieves a mapping of context variable names to their corresponding `ContextVar` objects for a given block.
    *
    * @param {Block | BlockFull} block - The block containing the capture variables to retrieve context variables for.
-   * @returns {Promise<Record<string, ContextVar | undefined>>} A promise that resolves to a record mapping context variable names to `ContextVar` objects.
+   * @returns {Promise<Record<string, ContextVar | undefined>>} A promise that resolves to a record mapping context variable names to `ContextVar` objects or undefined if not found.
    */
   async getContextVarsByBlock(
     block: Block | BlockFull,

--- a/api/src/chat/services/context-var.service.ts
+++ b/api/src/chat/services/context-var.service.ts
@@ -30,7 +30,7 @@ export class ContextVarService extends BaseService<
    * Retrieves a mapping of context variable names to their corresponding `ContextVar` objects for a given block.
    *
    * @param {Block | BlockFull} block - The block containing the capture variables to retrieve context variables for.
-   * @returns {Promise<Record<string, ContextVar>>} A promise that resolves to a record mapping context variable names to `ContextVar` objects.
+   * @returns {Promise<Record<string, ContextVar | undefined>>} A promise that resolves to a record mapping context variable names to `ContextVar` objects.
    */
   async getContextVarsByBlock(
     block: Block | BlockFull,

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -116,9 +116,17 @@ export class ConversationService extends BaseService<
 
         const context_var = contextVars[capture.context_var];
         const { permanent, pattern = '' } = context_var || {};
-        const isValidContextValue = new RegExp(pattern.slice(1, -1)).test(
-          `${contextValue}`,
-        );
+        const isValidContextValue = (() => {
+          try {
+            return new RegExp(pattern.slice(1, -1)).test(`${contextValue}`);
+          } catch (error) {
+            this.logger.error(
+              `Invalid regex pattern for ContextVar[${capture.context_var}]: ${pattern}`,
+            );
+            return false;
+          }
+        })();
+
         if (isValidContextValue) {
           if (profile.context?.vars && permanent) {
             this.logger.debug(

--- a/api/src/utils/test/fixtures/contextvar.ts
+++ b/api/src/utils/test/fixtures/contextvar.ts
@@ -18,6 +18,7 @@ type TContentVarFixtures = FixturesTypeBuilder<ContextVar, ContextVarCreateDto>;
 
 export const contentVarDefaultValues: TContentVarFixtures['defaultValues'] = {
   permanent: false,
+  pattern: '/.+/',
 };
 
 const contextVars: TContentVarFixtures['values'][] = [

--- a/frontend/src/components/context-vars/ContextVarForm.tsx
+++ b/frontend/src/components/context-vars/ContextVarForm.tsx
@@ -12,6 +12,7 @@ import { Controller, useForm } from "react-hook-form";
 
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import { Input } from "@/app-components/inputs/Input";
+import { RegexInput } from "@/app-components/inputs/RegexInput";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { useToast } from "@/hooks/useToast";
@@ -20,6 +21,8 @@ import { EntityType } from "@/services/types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
 import { IContextVar, IContextVarAttributes } from "@/types/context-var.types";
 import { slugify } from "@/utils/string";
+
+import { isRegex } from "../visual-editor/form/inputs/triggers/PatternInput";
 
 export const ContextVarForm: FC<ComponentFormProps<IContextVar>> = ({
   data,
@@ -59,6 +62,7 @@ export const ContextVarForm: FC<ComponentFormProps<IContextVar>> = ({
       name: data?.name || "",
       label: data?.label || "",
       permanent: data?.permanent || false,
+      pattern: data?.pattern || "",
     },
   });
   const validationRules = {
@@ -86,6 +90,7 @@ export const ContextVarForm: FC<ComponentFormProps<IContextVar>> = ({
         name: data.name,
         label: data.label,
         permanent: data.permanent,
+        pattern: data.pattern,
       });
     } else {
       reset();
@@ -134,6 +139,48 @@ export const ContextVarForm: FC<ComponentFormProps<IContextVar>> = ({
               )}
             />
             <FormHelperText>{t("help.permanent")}</FormHelperText>
+          </ContentItem>
+          <ContentItem>
+            <Controller
+              name="pattern"
+              control={control}
+              render={({ field: { value, ...rest } }) => (
+                <RegexInput
+                  {...rest}
+                  {...register("pattern", {
+                    validate: (pattern) => {
+                      try {
+                        if (pattern) {
+                          const parsedPattern = new RegExp(
+                            pattern.slice(1, -1),
+                          );
+
+                          if (pattern.slice(1, -1) === "") {
+                            return true;
+                          }
+
+                          if (String(parsedPattern) !== pattern) {
+                            throw t("message.regex_is_invalid");
+                          }
+
+                          return true;
+                        }
+
+                        return false;
+                      } catch (_e) {
+                        return t("message.regex_is_invalid");
+                      }
+                    },
+                    setValueAs: (v) => (isRegex(v) ? v : `/${v}/`),
+                  })}
+                  error={!!errors.pattern}
+                  value={value?.slice(1, -1) || ""}
+                  label={t("label.regex")}
+                  onChange={rest.onChange}
+                  helperText={errors.pattern ? errors.pattern.message : null}
+                />
+              )}
+            />
           </ContentItem>
         </ContentContainer>
       </form>

--- a/frontend/src/components/context-vars/ContextVarForm.tsx
+++ b/frontend/src/components/context-vars/ContextVarForm.tsx
@@ -151,17 +151,7 @@ export const ContextVarForm: FC<ComponentFormProps<IContextVar>> = ({
                     validate: (pattern) => {
                       try {
                         if (pattern) {
-                          const parsedPattern = new RegExp(
-                            pattern.slice(1, -1),
-                          );
-
-                          if (pattern.slice(1, -1) === "") {
-                            return true;
-                          }
-
-                          if (String(parsedPattern) !== pattern) {
-                            throw t("message.regex_is_invalid");
-                          }
+                          new RegExp(pattern.slice(1, -1));
 
                           return true;
                         }

--- a/frontend/src/components/context-vars/index.tsx
+++ b/frontend/src/components/context-vars/index.tsx
@@ -9,7 +9,7 @@
 import { faAsterisk } from "@fortawesome/free-solid-svg-icons";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { Button, Grid, Paper, Switch } from "@mui/material";
+import { Button, Chip, Grid, Paper, Switch } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useState } from "react";
 
@@ -109,6 +109,15 @@ export const ContextVars = () => {
       disableColumnMenu: true,
       renderHeader,
       headerAlign: "left",
+    },
+    {
+      flex: 1,
+      field: "pattern",
+      headerName: t("label.regex"),
+      disableColumnMenu: true,
+      renderHeader,
+      headerAlign: "left",
+      renderCell: ({ row }) => <Chip label={row?.pattern} variant="role" />,
     },
     {
       maxWidth: 120,

--- a/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/triggers/PatternInput.tsx
@@ -26,7 +26,7 @@ import {
 import { OutcomeInput } from "./OutcomeInput";
 import { PostbackInput } from "./PostbackInput";
 
-const isRegex = (str: Pattern) => {
+export const isRegex = (str: Pattern) => {
   return typeof str === "string" && str.startsWith("/") && str.endsWith("/");
 };
 const getType = (pattern: Pattern): PatternType => {

--- a/frontend/src/types/context-var.types.ts
+++ b/frontend/src/types/context-var.types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -14,6 +14,7 @@ export interface IContextVarAttributes {
   name: string;
   label: string;
   permanent: boolean;
+  pattern?: string;
 }
 
 export interface IContextVarStub


### PR DESCRIPTION
# Motivation:
The main motivation is to add an extra regex validation before updating contextVars (permanent, and not permanent).
This added feature will give us the possibility to use multiple contextVars in the same block without value interference. 

(NB: this update suppose that the regex for all the contextVars used in the same block are unique) 

Fixes #917

# Screenshots:
![image](https://github.com/user-attachments/assets/704956d4-fe2f-46cf-b12a-0ff1c5d63221)
![image](https://github.com/user-attachments/assets/43029613-1092-4fdc-9178-88e6024186d0)


# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced regex pattern support for context variable configurations. Users can now specify a custom regex pattern when creating or updating context variables.
  - Expanded the context variable form with a dedicated input field that validates the regex format.
  - Enhanced the display in context variable listings with a new column showing the configured regex pattern.

- **Refactor**
  - Improved validation logic ensures that only context variable values matching the defined patterns are accepted.
  - Updated method signatures to accommodate potential undefined values in context variable retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->