### PR TITLE
fix: backward compatibility content type fields type

### DIFF
--- a/api/src/cms/dto/contentType.dto.ts
+++ b/api/src/cms/dto/contentType.dto.ts
@@ -40,7 +40,7 @@ export class ContentField {
     message:
       "type must be one of the following values: 'text', 'url', 'textarea', 'checkbox', 'file', 'html'",
   })
-  type: `${FieldType}`;
+  type: `${FieldType}` | FieldType;
 }
 
 export class ContentTypeCreateDto {

--- a/api/src/cms/dto/contentType.dto.ts
+++ b/api/src/cms/dto/contentType.dto.ts
@@ -40,7 +40,7 @@ export class ContentField {
     message:
       "type must be one of the following values: 'text', 'url', 'textarea', 'checkbox', 'file', 'html'",
   })
-  type: FieldType | `${FieldType}`;
+  type: `${FieldType}`;
 }
 
 export class ContentTypeCreateDto {

--- a/api/src/cms/dto/contentType.dto.ts
+++ b/api/src/cms/dto/contentType.dto.ts
@@ -40,7 +40,7 @@ export class ContentField {
     message:
       "type must be one of the following values: 'text', 'url', 'textarea', 'checkbox', 'file', 'html'",
   })
-  type: FieldType | string;
+  type: FieldType | `${FieldType}`;
 }
 
 export class ContentTypeCreateDto {

--- a/api/src/cms/dto/contentType.dto.ts
+++ b/api/src/cms/dto/contentType.dto.ts
@@ -40,7 +40,7 @@ export class ContentField {
     message:
       "type must be one of the following values: 'text', 'url', 'textarea', 'checkbox', 'file', 'html'",
   })
-  type: FieldType;
+  type: FieldType | string;
 }
 
 export class ContentTypeCreateDto {


### PR DESCRIPTION
# Motivation

This pull request addresses a backward compatibility issue related to the content_type fields. Previously, changes to the data type of these fields have caused inconsistencies or errors when interacting with projects using older version of the hexabot. 

Fixes #795
Related PR #890

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved type flexibility for content field types, allowing for broader input compatibility while maintaining validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->