### PR TITLE
Filter out wildcard origins from allowed domains

### DIFF
--- a/api/src/extensions/channels/web/base-web-channel.ts
+++ b/api/src/extensions/channels/web/base-web-channel.ts
@@ -337,6 +337,7 @@ export default abstract class BaseWebChannelHandler<
     // Get the allowed origins
     const origins: string[] = settings.allowed_domains.split(',');
     const foundOrigin = origins
+      .filter((origin) => origin.trim() !== '*') // Skip "*"
       .map((origin) => {
         try {
           return new URL(origin.trim()).origin;


### PR DESCRIPTION
Filtered out "*" before attempting to normalize the origins with new URL(). This prevents the unnecessary error log while keeping the core logic intact.

**How to test:** 

- Add "*" to your allowed domains settings in the admin console channel or web channel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved CORS origin validation to prevent wildcard entries ("*") from being incorrectly treated as literal origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->