### PR TITLE
fix: undefined subscriber

### DIFF
--- a/api/src/chat/services/chat.service.ts
+++ b/api/src/chat/services/chat.service.ts
@@ -278,7 +278,6 @@ export class ChatService {
       let subscriber = await this.subscriberService.findOne({
         foreign_id: foreignId,
       });
-
       if (!subscriber) {
         const subscriberData = await handler.getSubscriberData(event);
         subscriberData.channel = event.getChannelData();
@@ -287,12 +286,12 @@ export class ChatService {
         if (!subscriber) {
           throw new Error('Unable to create a new subscriber');
         }
-      } else {
-        // Already existing user profile
-        // Exec lastvisit hook
-        this.eventEmitter.emit('hook:user:lastvisit', subscriber);
-        this.broadcastSentMessages(event);
       }
+      event.setSender(subscriber);
+      // Already existing user profile
+      // Exec lastvisit hook
+      this.eventEmitter.emit('hook:user:lastvisit', subscriber);
+      this.broadcastSentMessages(event);
 
       this.websocketGateway.broadcastSubscriberUpdate(subscriber);
 


### PR DESCRIPTION
# Motivation

This PR fixes the issue where subscriber is set to undefined.


# How to test
1. Clone messenger channel code into `api/src/extensions/channels`
2. Setup Facebook page & setup the `messenger-channel` configuration
3. Setup Ngrok to expose API
4. Add Block in the Visual Editor and trigger it through chatting with Facebook Page. 

Fixes #947

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved message handling logic for more consistent event processing. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->