### PR TITLE
fix: prioritize exact outcome matches over any in block matching

### DIFF
--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -357,15 +357,27 @@ export class BlockService extends BaseService<
       this.filterBlocksByChannel(blocks, event.getHandler().getName()),
       event.getSender(),
     );
-    return filteredBlocks.find((b) => {
-      return b.patterns
-        .filter(
-          (p) => typeof p === 'object' && 'type' in p && p.type === 'outcome',
-        )
-        .some((p: PayloadPattern) =>
-          ['any', envelope.message.outcome].includes(p.value),
-        );
-    });
+
+    return (
+      filteredBlocks.find((b) =>
+        b.patterns.some(
+          (p) =>
+            typeof p === 'object' &&
+            'type' in p &&
+            p.type === 'outcome' &&
+            p.value === envelope.message.outcome,
+        ),
+      ) ||
+      filteredBlocks.find((b) =>
+        b.patterns.some(
+          (p) =>
+            typeof p === 'object' &&
+            'type' in p &&
+            p.type === 'outcome' &&
+            p.value === 'any',
+        ),
+      )
+    );
   }
 
   /**


### PR DESCRIPTION
# Motivation

This PR updates the matchOutcome function to ensure exact outcome matches are prioritized over generic 'any' outcome blocks during system message processin

Fixes #866 

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
