### PR TITLE
fix: llm nlu confidence

### DIFF
--- a/api/src/extensions/helpers/llm-nlu/index.helper.ts
+++ b/api/src/extensions/helpers/llm-nlu/index.helper.ts
@@ -146,7 +146,7 @@ export default class LlmNluHelper
       {
         entity: 'language',
         value: language || defaultLanguage.code,
-        confidence: 100,
+        confidence: 1,
       },
     ];
     for await (const { name, doc, prompt, values } of this

--- a/api/src/extensions/helpers/llm-nlu/index.helper.ts
+++ b/api/src/extensions/helpers/llm-nlu/index.helper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -168,7 +168,7 @@ export default class LlmNluHelper
       traits.push({
         entity: name,
         value,
-        confidence: 100,
+        confidence: 1,
       });
     }
 

--- a/api/src/helper/types.ts
+++ b/api/src/helper/types.ts
@@ -6,6 +6,8 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
+import { z } from 'zod';
+
 import { SettingCreateDto } from '@/setting/dto/setting.dto';
 import { HyphenToUnderscore } from '@/utils/types/extension';
 
@@ -15,13 +17,15 @@ import BaseNlpHelper from './lib/base-nlp-helper';
 import BaseStorageHelper from './lib/base-storage-helper';
 
 export namespace NLU {
-  export interface ParseEntity {
-    entity: string; // Entity name
-    value: string; // Value name
-    confidence: number;
-    start?: number;
-    end?: number;
-  }
+  const ParseEntitySchema = z.object({
+    entity: z.string(),
+    value: z.string(),
+    confidence: z.number().min(0).max(1),
+    start: z.number().optional(),
+    end: z.number().optional(),
+  });
+
+  export type ParseEntity = z.infer<typeof ParseEntitySchema>;
 
   export interface ParseEntities {
     entities: ParseEntity[];

--- a/api/src/helper/types.ts
+++ b/api/src/helper/types.ts
@@ -6,8 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { z } from 'zod';
-
 import { SettingCreateDto } from '@/setting/dto/setting.dto';
 import { HyphenToUnderscore } from '@/utils/types/extension';
 
@@ -17,15 +15,13 @@ import BaseNlpHelper from './lib/base-nlp-helper';
 import BaseStorageHelper from './lib/base-storage-helper';
 
 export namespace NLU {
-  const ParseEntitySchema = z.object({
-    entity: z.string(),
-    value: z.string(),
-    confidence: z.number().min(0).max(1),
-    start: z.number().optional(),
-    end: z.number().optional(),
-  });
-
-  export type ParseEntity = z.infer<typeof ParseEntitySchema>;
+  export interface ParseEntity {
+    entity: string; // Entity name
+    value: string; // Value name
+    confidence: number;
+    start?: number;
+    end?: number;
+  }
 
   export interface ParseEntities {
     entities: ParseEntity[];


### PR DESCRIPTION
# Motivation

This PR includes validation on the confidence attribute of the ParseEntity type to ensure it is a decimal value between 0 and 1 and update the LLM NLU Helper to return 1 instead of 100 for confidence values.

Fixes #702 

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted confidence values for detected traits to use a normalized scale (0–1) instead of a fixed value.

- **Refactor**
  - Updated the internal structure for trait entity validation to enable runtime validation and maintain consistent type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->