### PR TITLE
Fix/llm nlu helper settings not properly loaded

### DIFF
--- a/api/src/extensions/helpers/llm-nlu/index.helper.ts
+++ b/api/src/extensions/helpers/llm-nlu/index.helper.ts
@@ -165,7 +165,12 @@ export default class LlmNluHelper
   }
 
   async predict(text: string): Promise<NLU.ParseEntities> {
-    const settings = await this.getSettings();
+    const settings: LlmNluHelperSettings | undefined =
+      await this.loadSettings();
+    if (!settings) {
+      this.logger.error('Failed to load settings for Llm Nlu inference');
+      return { entities: [] };
+    }
     const helper = await this.helperService.getDefaultLlmHelper();
     const defaultLanguage = await this.languageService.getDefaultLanguage();
     // Detect language

--- a/api/src/extensions/helpers/llm-nlu/index.helper.ts
+++ b/api/src/extensions/helpers/llm-nlu/index.helper.ts
@@ -60,14 +60,18 @@ export default class LlmNluHelper
           await this.getSettings();
 
         if (settings) {
+          this.logger.log(`Llm Nlu Helper Settings successfully loaded`);
           return settings;
         }
 
         this.logger.warn(
-          `Settings not available yet, retrying... (${retryCount + 1}/${maxRetries})`,
+          `Llm Nlu Helper Settings not available yet, retrying... (${retryCount + 1}/${maxRetries})`,
         );
       } catch (error) {
-        this.logger.error('Error while loading settings:', error);
+        this.logger.error(
+          'Error while loading Llm Nlu Helper Settings:',
+          error,
+        );
         return undefined;
       }
 

--- a/api/src/extensions/helpers/llm-nlu/types.ts
+++ b/api/src/extensions/helpers/llm-nlu/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+export type LlmNluHelperSettings = {
+  model: string;
+  language_classifier_prompt_template: string;
+  trait_classifier_prompt_template: string;
+};


### PR DESCRIPTION
# Motivation
The following PR addresses the issue:  **LLM-NLU Helper: Language Entity Value Incorrectly Returns User Input.**
The root cause was that **settings were not reliably loaded at application startup**, causing the language classifier to work with an incomplete or missing prompt template. This sometimes resulted in the **LLM incorrectly returning the user input as the language.**

## Changes Introduced
- Added a `loadSettings` method with retry logic to wait for settings availability at startup.
- Improved error handling and logging when settings fail to load after retries.

Fixes # ([929](https://github.com/Hexastack/Hexabot/issues/929))

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved reliability when loading AI language model settings by introducing automatic retries with configurable limits and delays.
- **Other Changes**
	- Updated copyright year to 2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->