### PR TITLE
fix: broadcast event

### DIFF
--- a/api/src/chat/services/chat.service.ts
+++ b/api/src/chat/services/chat.service.ts
@@ -288,10 +288,8 @@ export class ChatService {
         }
       }
       event.setSender(subscriber);
-      // Already existing user profile
       // Exec lastvisit hook
       this.eventEmitter.emit('hook:user:lastvisit', subscriber);
-      this.broadcastSentMessages(event);
 
       this.websocketGateway.broadcastSubscriberUpdate(subscriber);
 

--- a/api/src/extensions/channels/web/base-web-channel.ts
+++ b/api/src/extensions/channels/web/base-web-channel.ts
@@ -788,6 +788,7 @@ export default abstract class BaseWebChannelHandler<
 
       const type = event.getEventType();
       if (type) {
+        this.broadcast(profile, type, event._adapter.raw);
         this.eventEmitter.emit(`hook:chatbot:${type}`, event);
       } else {
         this.logger.error('Webhook received unknown event ', event);

--- a/api/src/extensions/channels/web/settings.ts
+++ b/api/src/extensions/channels/web/settings.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -17,7 +17,7 @@ export default [
   {
     group: WEB_CHANNEL_NAMESPACE,
     label: 'allowed_domains',
-    value: 'http://localhost:8080,http://localhost:4000',
+    value: 'http://localhost:8080,http://localhost:4000,http://localhost:5173',
     type: SettingType.text,
   },
   {


### PR DESCRIPTION
# Motivation

This pr ensures the removal of duplicate logic that exist in method `broadcastSentMessages` in chatService & `broadcast` method in `gateway` service & changes where we broadcast the message in base-web-channel instead of `@OnEvent('hook:chatbot:message')`

Fixes #959

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event broadcasting to ensure subscribers receive updates more reliably across websocket and polling clients.

- **Chores**
  - Updated copyright year.
  - Expanded the list of allowed domains for web channel access to include `http://localhost:5173`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->