### PR TITLE
Handle context update conflicts

### DIFF
--- a/api/src/chat/services/bot.service.ts
+++ b/api/src/chat/services/bot.service.ts
@@ -205,6 +205,14 @@ export class BotService {
                     block.attachedBlock,
                 );
               }
+
+              await this.conversationService.storeContextData(
+                convo,
+                nextBlock,
+                event,
+                false,
+              );
+
               return await this.triggerBlock(event, convo, nextBlock, fallback);
             } else {
               this.logger.warn(

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -175,9 +175,15 @@ export class ConversationService extends BaseService<
       const criteria =
         typeof convo.sender === 'object' ? convo.sender.id : convo.sender;
 
-      await this.subscriberService.updateOne(criteria, {
-        context: profile.context,
-      });
+      await this.subscriberService.updateOne(
+        criteria,
+        {
+          context: profile.context,
+        },
+        {
+          flatten: true,
+        },
+      );
 
       return updatedConversation;
     } catch (err) {

--- a/api/src/chat/services/conversation.service.ts
+++ b/api/src/chat/services/conversation.service.ts
@@ -181,7 +181,7 @@ export class ConversationService extends BaseService<
           context: profile.context,
         },
         {
-          flatten: true,
+          shouldFlatten: true,
         },
       );
 

--- a/api/src/utils/generics/base-repository.spec.ts
+++ b/api/src/utils/generics/base-repository.spec.ts
@@ -148,7 +148,7 @@ describe('BaseRepository', () => {
       });
     });
 
-    it('should updated and flatten by id and return one dummy data', async () => {
+    it('should update and flatten by id and return one dummy data', async () => {
       jest.spyOn(dummyModel, 'findOneAndUpdate');
       const result = await dummyRepository.updateOne(
         createdId,

--- a/api/src/utils/generics/base-repository.spec.ts
+++ b/api/src/utils/generics/base-repository.spec.ts
@@ -12,9 +12,17 @@ import { Model, Types } from 'mongoose';
 import { DummyRepository } from '@/utils/test/dummy/repositories/dummy.repository';
 import { closeInMongodConnection } from '@/utils/test/test';
 
+import { flatten } from '../helpers/flatten';
 import { DummyModule } from '../test/dummy/dummy.module';
 import { Dummy } from '../test/dummy/schemas/dummy.schema';
 import { buildTestingMocks } from '../test/utils';
+
+import { BaseSchema } from './base-schema';
+
+const FLATTEN_PAYLOAD = {
+  dummy: 'updated dummy text',
+  dynamicField: { field1: 'value1', field2: 'value2' },
+} as const satisfies Omit<Dummy, keyof BaseSchema>;
 
 describe('BaseRepository', () => {
   let dummyModel: Model<Dummy>;
@@ -137,6 +145,32 @@ describe('BaseRepository', () => {
       );
       expect(result).toEqualPayload({
         dummy: 'updated dummy text 2',
+      });
+    });
+
+    it('should updated and flatten by id and return one dummy data', async () => {
+      jest.spyOn(dummyModel, 'findOneAndUpdate');
+      const result = await dummyRepository.updateOne(
+        createdId,
+        FLATTEN_PAYLOAD,
+        {
+          new: true,
+          shouldFlatten: true,
+        },
+      );
+
+      expect(dummyModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: createdId },
+        {
+          $set: flatten(FLATTEN_PAYLOAD),
+        },
+        {
+          new: true,
+        },
+      );
+      expect(result).toEqualPayload({
+        dummy: 'updated dummy text',
+        dynamicField: { field1: 'value1', field2: 'value2' },
       });
     });
 

--- a/api/src/utils/generics/base-repository.ts
+++ b/api/src/utils/generics/base-repository.ts
@@ -99,7 +99,7 @@ export abstract class BaseRepository<
     this.registerLifeCycleHooks();
   }
 
-  private flatten(obj: object, prefix: string = '', result = {}) {
+  private flatten(obj: object, prefix: string = '', result: object = {}) {
     for (const [key, value] of Object.entries(obj)) {
       const path = prefix ? `${prefix}.${key}` : key;
 

--- a/api/src/utils/generics/base-service.ts
+++ b/api/src/utils/generics/base-service.ts
@@ -9,10 +9,14 @@
 import { ConflictException, Inject } from '@nestjs/common';
 import { ClassTransformOptions } from 'class-transformer';
 import { MongoError } from 'mongodb';
-import { ProjectionType, QueryOptions } from 'mongoose';
+import { ProjectionType } from 'mongoose';
 
 import { LoggerService } from '@/logger/logger.service';
-import { TFilterQuery } from '@/utils/types/filter.types';
+import {
+  TFilterQuery,
+  TFlattenOption,
+  TQueryOptions,
+} from '@/utils/types/filter.types';
 
 import { PageQueryDto, QuerySortDto } from '../pagination/pagination-query.dto';
 import { DtoAction, DtoConfig, DtoInfer } from '../types/dto.types';
@@ -188,13 +192,17 @@ export abstract class BaseService<
   async updateOne(
     criteria: string | TFilterQuery<T>,
     dto: DtoInfer<DtoAction.Update, Dto, Partial<U>>,
-    options?: QueryOptions<Partial<U>> | null,
+    options?: TQueryOptions<Partial<U>>,
   ): Promise<T> {
     return await this.repository.updateOne(criteria, dto, options);
   }
 
-  async updateMany(filter: TFilterQuery<T>, dto: Partial<U>) {
-    return await this.repository.updateMany(filter, dto);
+  async updateMany(
+    filter: TFilterQuery<T>,
+    dto: Partial<U>,
+    options?: TFlattenOption,
+  ) {
+    return await this.repository.updateMany(filter, dto, options);
   }
 
   async deleteOne(criteria: string | TFilterQuery<T>) {

--- a/api/src/utils/helpers/flatten.spec.ts
+++ b/api/src/utils/helpers/flatten.spec.ts
@@ -76,6 +76,25 @@ describe('flatten', () => {
     });
   });
 
+  it('should handle arrays as values without recursing into them', () => {
+    const object = {
+      items: [1, 2, 3],
+      nested: {
+        moreItems: [4, 5, 6],
+        deepNested: {
+          evenMoreItems: [7, 8, 9],
+        },
+      },
+    };
+    const result = flatten(object);
+
+    expect(result).toStrictEqual({
+      items: [1, 2, 3],
+      'nested.moreItems': [4, 5, 6],
+      'nested.deepNested.evenMoreItems': [7, 8, 9],
+    });
+  });
+
   it('should support an object without nested object', () => {
     const object = {
       name: 'name',

--- a/api/src/utils/helpers/flatten.spec.ts
+++ b/api/src/utils/helpers/flatten.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { flatten } from './flatten';
+
+describe('flatten', () => {
+  it('should support a nested object with one nested level', () => {
+    const object = {
+      name: 'name',
+      context: { nestedField: 'value' },
+    };
+    const result = flatten(object);
+
+    expect(result).toStrictEqual({
+      name: 'name',
+      'context.nestedField': 'value',
+    });
+  });
+
+  it('should support a nested object with multiple nested levels', () => {
+    const object = {
+      name: 'name',
+      context: {
+        nestedField: 'value',
+        country: {
+          isoCode: 'usa',
+          phonePrefix: '+1',
+          countryName: 'United States',
+        },
+      },
+    };
+    const result = flatten(object);
+
+    expect(result).toStrictEqual({
+      name: 'name',
+      'context.nestedField': 'value',
+      'context.country.isoCode': 'usa',
+      'context.country.phonePrefix': '+1',
+      'context.country.countryName': 'United States',
+    });
+  });
+
+  it('should support custom prefix', () => {
+    const object = {
+      isoCode: 'tun',
+      phonePrefix: '+216',
+      countryName: 'Tunisia',
+    };
+    const result = flatten(object, 'context.country');
+
+    expect(result).toStrictEqual({
+      'context.country.isoCode': 'tun',
+      'context.country.phonePrefix': '+216',
+      'context.country.countryName': 'Tunisia',
+    });
+  });
+
+  it('should support custom static initial value', () => {
+    const object = {
+      context: {
+        country: { isoCode: 'fra', phonePrefix: '+33', countryName: 'France' },
+      },
+    };
+    const result = flatten(object, undefined, { language: 'fr' });
+
+    expect(result).toStrictEqual({
+      language: 'fr',
+      'context.country.isoCode': 'fra',
+      'context.country.phonePrefix': '+33',
+      'context.country.countryName': 'France',
+    });
+  });
+
+  it('should support an object without nested object', () => {
+    const object = {
+      name: 'name',
+    };
+    const result = flatten(object);
+
+    expect(result).toStrictEqual({
+      name: 'name',
+    });
+  });
+
+  it('should support an empty object', () => {
+    const result = flatten({});
+
+    expect(result).toStrictEqual({});
+  });
+});

--- a/api/src/utils/helpers/flatten.spec.ts
+++ b/api/src/utils/helpers/flatten.spec.ts
@@ -111,4 +111,8 @@ describe('flatten', () => {
 
     expect(result).toStrictEqual({});
   });
+
+  it('should throw an error if data is an array', () => {
+    expect(() => flatten([])).toThrow('Data should be an object!');
+  });
 });

--- a/api/src/utils/helpers/flatten.spec.ts
+++ b/api/src/utils/helpers/flatten.spec.ts
@@ -45,6 +45,23 @@ describe('flatten', () => {
     });
   });
 
+  it('should support object with flattened keys', () => {
+    const object = {
+      'user.name': {
+        id: 'Alice',
+      },
+      nested: {
+        'country.name': 'France',
+      },
+    };
+    const result = flatten(object);
+
+    expect(result).toStrictEqual({
+      'nested.country.name': 'France',
+      'user.name.id': 'Alice',
+    });
+  });
+
   it('should support custom prefix', () => {
     const object = {
       isoCode: 'tun',

--- a/api/src/utils/helpers/flatten.ts
+++ b/api/src/utils/helpers/flatten.ts
@@ -17,7 +17,7 @@ export const flatten = (
   data: object,
   prefix: string | undefined = undefined,
   result: object = {},
-) => {
+): object => {
   for (const [key, value] of Object.entries(data)) {
     const path = prefix ? `${prefix}.${key}` : key;
 

--- a/api/src/utils/helpers/flatten.ts
+++ b/api/src/utils/helpers/flatten.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+/**
+ * Flattens a nested object into a single-level object with dot-separated keys.
+ * @param data - The data object to flatten
+ * @param prefix - The optional base key to prefix to the current object's keys
+ * @param result - The optional accumulator for the flattened object  data
+ * @returns A new object with flattened keys
+ */
+export const flatten = (
+  data: object,
+  prefix: string | undefined = undefined,
+  result: object = {},
+) => {
+  for (const [key, value] of Object.entries(data)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      flatten(value, path, result);
+    } else {
+      result[path] = value;
+    }
+  }
+
+  return result;
+};

--- a/api/src/utils/helpers/flatten.ts
+++ b/api/src/utils/helpers/flatten.ts
@@ -18,6 +18,10 @@ export const flatten = (
   prefix: string | undefined = undefined,
   result: object = {},
 ): object => {
+  if (Array.isArray(data)) {
+    throw new Error('Data should be an object!');
+  }
+
   for (const [key, value] of Object.entries(data)) {
     const path = prefix ? `${prefix}.${key}` : key;
 

--- a/api/src/utils/helpers/flatten.ts
+++ b/api/src/utils/helpers/flatten.ts
@@ -12,6 +12,7 @@
  * @param prefix - The optional base key to prefix to the current object's keys
  * @param result - The optional accumulator for the flattened object  data
  * @returns A new object with flattened keys
+ * @throws Error if the data is an array
  */
 export const flatten = (
   data: object,

--- a/api/src/utils/test/dummy/schemas/dummy.schema.ts
+++ b/api/src/utils/test/dummy/schemas/dummy.schema.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -19,6 +19,11 @@ export class Dummy extends BaseSchema {
     required: true,
   })
   dummy: string;
+
+  @Prop({
+    type: Object,
+  })
+  dynamicField?: Record<string, any> | undefined;
 }
 
 export type DummyDocument = THydratedDocument<Dummy>;

--- a/api/src/utils/types/filter.types.ts
+++ b/api/src/utils/types/filter.types.ts
@@ -1,12 +1,17 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { HydratedDocument, QuerySelector, RootQuerySelector } from 'mongoose';
+import {
+  HydratedDocument,
+  QueryOptions,
+  QuerySelector,
+  RootQuerySelector,
+} from 'mongoose';
 
 export type TFilterKeysOfType<T, U> = {
   [K in keyof T]: T[K] extends U ? K : never;
@@ -137,3 +142,7 @@ export type TFilterQuery<T, S = TReplaceId<T>> = (
   WithoutGenericAny<RootQuerySelector<S>>;
 
 export type THydratedDocument<T> = TOmitId<HydratedDocument<T>>;
+
+export type TFlattenOption = { flatten?: boolean };
+
+export type TQueryOptions<D> = (QueryOptions<D> & TFlattenOption) | null;

--- a/api/src/utils/types/filter.types.ts
+++ b/api/src/utils/types/filter.types.ts
@@ -143,6 +143,6 @@ export type TFilterQuery<T, S = TReplaceId<T>> = (
 
 export type THydratedDocument<T> = TOmitId<HydratedDocument<T>>;
 
-export type TFlattenOption = { flatten?: boolean };
+export type TFlattenOption = { shouldFlatten?: boolean };
 
 export type TQueryOptions<D> = (QueryOptions<D> & TFlattenOption) | null;


### PR DESCRIPTION
Reverts Hexastack/Hexabot#969

Concurrent update conflicts occur when two operations modify the same document (or nested subdocument) at the same time, potentially overwriting each other’s changes. In MongoDB, individual write operations are atomic at the document level (no partial writes), but multiple separate updates on the same document can interleave if not coordinated. Here’s how to prevent unintended overwrites:

## Use Targeted $set for Nested Fields

By default, doing a direct update of a subdocument in MongoDB (e.g., updating an object field by providing a new object) replaces the entire subdocument rather than merging fields. This can cause earlier changes to that subdocument to be lost. Solution: use $set with dot notation to update only the specific field path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conversation flow handling to ensure context data is properly stored before moving to the next step when processing system messages.
- **New Features**
  - Added support for conditional flattening of update data in single and bulk update operations, enhancing data update flexibility.
- **Tests**
  - Introduced comprehensive tests for the new object flattening utility to ensure correct behavior across various scenarios.
- **New Utilities**
  - Added a utility function to flatten nested objects into dot-separated key-value pairs for streamlined data processing.
- **Enhancements**
  - Extended schema support to include dynamic fields allowing flexible key-value storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->