### PR TITLE
fix: add warn message to not found resource

### DIFF
--- a/api/src/channel/lib/Handler.ts
+++ b/api/src/channel/lib/Handler.ts
@@ -311,6 +311,7 @@ export default abstract class ChannelHandler<
     const [name, _suffix] = this.getName().split('-');
     if ('id' in attachment) {
       if (!attachment || !attachment.id) {
+        this.logger.warn('Unable to build public URL: Empty attachment ID');
         return buildURL(config.apiBaseUrl, `/webhook/${name}/not-found`);
       }
 
@@ -330,6 +331,10 @@ export default abstract class ChannelHandler<
       // In case the url is external
       return attachment.url;
     } else {
+      this.logger.warn(
+        'Unable to resolve the attachment public URL.',
+        attachment,
+      );
       return buildURL(config.apiBaseUrl, `/webhook/${name}/not-found`);
     }
   }

--- a/api/src/channel/lib/Handler.ts
+++ b/api/src/channel/lib/Handler.ts
@@ -309,7 +309,7 @@ export default abstract class ChannelHandler<
    */
   public async getPublicUrl(attachment: AttachmentRef | Attachment) {
     const [name, _suffix] = this.getName().split('-');
-    if ('id' in attachment) {
+    if (attachment && 'id' in attachment) {
       if (!attachment || !attachment.id) {
         this.logger.warn('Unable to build public URL: Empty attachment ID');
         return buildURL(config.apiBaseUrl, `/webhook/${name}/not-found`);

--- a/api/src/channel/webhook.controller.ts
+++ b/api/src/channel/webhook.controller.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -92,6 +92,6 @@ export class WebhookController {
   @Roles('public')
   @Get(':channel/not-found')
   async handleNotFound(@Res() res: Response) {
-    return res.status(404).send({ error: 'Not found!' });
+    return res.status(404).send({ error: 'Resource not found!' });
   }
 }


### PR DESCRIPTION
# Motivation

Add warn log message to the "not found" resource when accessing a public URL.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for missing resources to provide clearer feedback when a resource is not found.

- **Chores**
  - Updated copyright year in documentation.
  - Enhanced internal logging for better tracking of attachment URL issues (no user-facing changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->