### PR TITLE
feat: undo message attachment reference removal

### DIFF
--- a/api/src/chat/chat.module.ts
+++ b/api/src/chat/chat.module.ts
@@ -11,9 +11,6 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { AttachmentModule } from '@/attachment/attachment.module';
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import { ChannelModule } from '@/channel/channel.module';
 import { CmsModule } from '@/cms/cms.module';
 import { UserModule } from '@/user/user.module';
@@ -61,7 +58,6 @@ import { SubscriberService } from './services/subscriber.service';
       SubscriberModel,
       ConversationModel,
       SubscriberModel,
-      AttachmentModel,
     ]),
     forwardRef(() => ChannelModule),
     CmsModule,
@@ -96,8 +92,6 @@ import { SubscriberService } from './services/subscriber.service';
     ConversationService,
     ChatService,
     BotService,
-    AttachmentService,
-    AttachmentRepository,
   ],
   exports: [
     SubscriberService,

--- a/api/src/chat/services/message.service.ts
+++ b/api/src/chat/services/message.service.ts
@@ -11,14 +11,8 @@ import {
   InternalServerErrorException,
   Optional,
 } from '@nestjs/common';
-import { OnEvent } from '@nestjs/event-emitter';
-import { Document, Query } from 'mongoose';
 
-import { Attachment } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { DeleteResult } from '@/utils/generics/base-repository';
 import { BaseService } from '@/utils/generics/base-service';
-import { TFilterQuery } from '@/utils/types/filter.types';
 import {
   SocketGet,
   SocketPost,
@@ -45,7 +39,6 @@ export class MessageService extends BaseService<
 
   constructor(
     private readonly messageRepository: MessageRepository,
-    private attachmentService: AttachmentService,
     @Optional() gateway?: WebsocketGateway,
   ) {
     super(messageRepository);
@@ -133,41 +126,5 @@ export class MessageService extends BaseService<
     );
 
     return lastMessages.reverse();
-  }
-
-  @OnEvent('hook:attachment:preDelete')
-  async handleDeleteImage(
-    _query: Query<
-      DeleteResult,
-      Document<Attachment, any, any>,
-      unknown,
-      Attachment,
-      'deleteOne' | 'deleteMany'
-    >,
-    criteria: TFilterQuery<Attachment>,
-  ) {
-    try {
-      this.logger.log(
-        'deleting attachment messages containing deleted images',
-        criteria,
-      );
-      const foundAttachments = await this.attachmentService.find(criteria);
-
-      for (const attachment of foundAttachments) {
-        await this.updateMany(
-          {
-            'message.attachment.payload.id': attachment.id,
-          },
-          {
-            ['message.attachment.payload.id' as any]: null,
-          },
-        );
-      }
-    } catch (error) {
-      this.logger.error(
-        'Unable to cleanup old messages with attachment ids',
-        error,
-      );
-    }
   }
 }


### PR DESCRIPTION
# Motivation

Undo the removal of attachment reference since this could be heavy on a DB with a large amount of messages.

The issue stems from the fact that we didn't remove the delete attachment feature from UI everywhere (https://github.com/Hexastack/Hexabot/pull/585). So we shouldn't allow for attachments to be delete at the first place.

Another PR will follow this one...

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed all attachment-related functionality from chat features, including event handling and service dependencies. This results in a clearer separation between chat and attachment management within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->