### PR TITLE
refactor: subscriber avatar store

### DIFF
--- a/api/src/chat/services/bot.service.spec.ts
+++ b/api/src/chat/services/bot.service.spec.ts
@@ -85,7 +85,7 @@ import { ConversationService } from './conversation.service';
 import { MessageService } from './message.service';
 import { SubscriberService } from './subscriber.service';
 
-describe('BlockService', () => {
+describe('BotService', () => {
   let blockService: BlockService;
   let subscriberService: SubscriberService;
   let botService: BotService;

--- a/api/src/chat/services/subscriber.service.spec.ts
+++ b/api/src/chat/services/subscriber.service.spec.ts
@@ -178,11 +178,11 @@ describe('SubscriberService', () => {
 
       const fakeAttachment = { id: '9'.repeat(24) } as Attachment;
       jest.spyOn(attachmentService, 'store').mockResolvedValue(fakeAttachment);
-      const updateOneSpy = jest
-        .spyOn(subscriberService, 'updateOne')
-        .mockResolvedValue(allSubscribers[0]);
 
-      await subscriberService.storeAvatar(subscriber.id, avatarPayload);
+      const result = await subscriberService.storeAvatar(
+        subscriber.id,
+        avatarPayload,
+      );
 
       expect(attachmentService.store).toHaveBeenCalledTimes(1);
       expect(attachmentService.store).toHaveBeenCalledWith(
@@ -198,9 +198,7 @@ describe('SubscriberService', () => {
         }),
       );
 
-      expect(updateOneSpy).toHaveBeenCalledWith(subscriber.id, {
-        avatar: fakeAttachment.id,
-      });
+      expect(result.avatar).toBe(fakeAttachment.id);
     });
 
     it('should propagate an error from AttachmentService and leave the subscriber unchanged', async () => {

--- a/api/src/chat/services/subscriber.service.spec.ts
+++ b/api/src/chat/services/subscriber.service.spec.ts
@@ -7,10 +7,20 @@
  */
 
 import { MongooseModule } from '@nestjs/mongoose';
+import mime from 'mime';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
+import {
+  Attachment,
+  AttachmentModel,
+} from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
+import {
+  AttachmentAccess,
+  AttachmentCreatedByRef,
+  AttachmentFile,
+  AttachmentResourceRef,
+} from '@/attachment/types';
 import { InvitationRepository } from '@/user/repositories/invitation.repository';
 import { RoleRepository } from '@/user/repositories/role.repository';
 import { UserRepository } from '@/user/repositories/user.repository';
@@ -37,11 +47,14 @@ import { Subscriber, SubscriberModel } from '../schemas/subscriber.schema';
 import { LabelService } from './label.service';
 import { SubscriberService } from './subscriber.service';
 
+jest.mock('uuid', () => ({ v4: jest.fn(() => 'test-uuid') }));
+
 describe('SubscriberService', () => {
   let subscriberRepository: SubscriberRepository;
   let labelRepository: LabelRepository;
   let userRepository: UserRepository;
   let subscriberService: SubscriberService;
+  let attachmentService: AttachmentService;
   let allSubscribers: Subscriber[];
   let allLabels: Label[];
   let allUsers: User[];
@@ -74,13 +87,19 @@ describe('SubscriberService', () => {
         AttachmentRepository,
       ],
     });
-    [labelRepository, userRepository, subscriberService, subscriberRepository] =
-      await getMocks([
-        LabelRepository,
-        UserRepository,
-        SubscriberService,
-        SubscriberRepository,
-      ]);
+    [
+      labelRepository,
+      userRepository,
+      subscriberService,
+      subscriberRepository,
+      attachmentService,
+    ] = await getMocks([
+      LabelRepository,
+      UserRepository,
+      SubscriberService,
+      SubscriberRepository,
+      AttachmentService,
+    ]);
     allSubscribers = await subscriberRepository.findAll();
     allLabels = await labelRepository.findAll();
     allUsers = await userRepository.findAll();
@@ -144,6 +163,88 @@ describe('SubscriberService', () => {
           .filter((label) => subscriber.labels.includes(label.id))
           .map((label) => label.id),
       });
+    });
+  });
+
+  describe('storeAvatar', () => {
+    it('should persist the avatar and patch the subscriber', async () => {
+      const subscriber = { ...allSubscribers[0], avatar: null };
+      const avatarPayload: AttachmentFile = {
+        file: Buffer.from('fake-png'),
+        type: 'image/png',
+        size: 8_192,
+      };
+      jest.spyOn(mime, 'extension').mockReturnValue('png');
+
+      const fakeAttachment = { id: '9'.repeat(24) } as Attachment;
+      jest.spyOn(attachmentService, 'store').mockResolvedValue(fakeAttachment);
+      const updateOneSpy = jest
+        .spyOn(subscriberService, 'updateOne')
+        .mockResolvedValue(allSubscribers[0]);
+
+      await subscriberService.storeAvatar(subscriber.id, avatarPayload);
+
+      expect(attachmentService.store).toHaveBeenCalledTimes(1);
+      expect(attachmentService.store).toHaveBeenCalledWith(
+        avatarPayload.file,
+        expect.objectContaining({
+          name: 'avatar-test-uuid.png',
+          type: 'image/png',
+          size: 8_192,
+          resourceRef: AttachmentResourceRef.SubscriberAvatar,
+          access: AttachmentAccess.Private,
+          createdByRef: AttachmentCreatedByRef.Subscriber,
+          createdBy: subscriber.id,
+        }),
+      );
+
+      expect(updateOneSpy).toHaveBeenCalledWith(subscriber.id, {
+        avatar: fakeAttachment.id,
+      });
+    });
+
+    it('should propagate an error from AttachmentService and leave the subscriber unchanged', async () => {
+      const subscriber = allSubscribers[0];
+      const avatarPayload: AttachmentFile = {
+        file: Buffer.from('fake-jpg'),
+        type: 'image/jpeg',
+        size: 5_048,
+      };
+      jest.spyOn(mime, 'extension').mockReturnValue('jpg');
+
+      const failure = new Error('disk full');
+      jest.spyOn(attachmentService, 'store').mockRejectedValue(failure);
+      const updateOneSpy = jest
+        .spyOn(subscriberService, 'updateOne')
+        .mockResolvedValue(allSubscribers[0]);
+
+      await expect(
+        subscriberService.storeAvatar(subscriber.id, avatarPayload),
+      ).rejects.toThrow(failure);
+
+      expect(updateOneSpy).not.toHaveBeenCalled();
+    });
+
+    it('should generate the filename with the proper extension', async () => {
+      const subscriber = { ...allSubscribers[0], avatar: null };
+      const avatarPayload: AttachmentFile = {
+        file: Buffer.from('fake-png'),
+        type: 'image/png',
+        size: 1_024,
+      };
+      jest.spyOn(mime, 'extension').mockReturnValue('png');
+
+      jest
+        .spyOn(attachmentService, 'store')
+        .mockResolvedValue({ id: '9'.repeat(24) } as any);
+      jest
+        .spyOn(subscriberService, 'updateOne')
+        .mockResolvedValue(allSubscribers[0]);
+
+      await subscriberService.storeAvatar(subscriber.id, avatarPayload);
+
+      const { name } = (attachmentService.store as jest.Mock).mock.calls[0][1]; // second arg in the first call
+      expect(name).toBe('avatar-test-uuid.png');
     });
   });
 });

--- a/api/src/chat/services/subscriber.service.ts
+++ b/api/src/chat/services/subscriber.service.ts
@@ -156,7 +156,10 @@ export class SubscriberService extends BaseService<
    *
    * @returns Resolves once the subscriber avatar is stored
    */
-  async storeAvatar(subscriberId: string, avatar: AttachmentFile) {
+  async storeAvatar(
+    subscriberId: string,
+    avatar: AttachmentFile,
+  ): Promise<Subscriber> {
     const { file, type, size } = avatar;
     const extension = mime.extension(type);
 
@@ -170,7 +173,7 @@ export class SubscriberService extends BaseService<
       createdBy: subscriberId,
     });
 
-    await this.updateOne(subscriberId, {
+    return await this.updateOne(subscriberId, {
       avatar: attachment.id,
     });
   }

--- a/api/src/user/user.module.ts
+++ b/api/src/user/user.module.ts
@@ -12,7 +12,6 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { PassportModule } from '@nestjs/passport';
 
 import { AttachmentModule } from '@/attachment/attachment.module';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 
 import { LocalAuthController } from './controllers/auth.controller';
 import { ModelController } from './controllers/model.controller';
@@ -53,7 +52,6 @@ import { ValidateAccountService } from './services/validate-account.service';
       InvitationModel,
       RoleModel,
       PermissionModel,
-      AttachmentModel,
     ]),
     PassportModule.register({
       session: true,


### PR DESCRIPTION
# Motivation

Refactor subscriber avatar storage method and add unit tests.

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to store and update subscriber avatars, allowing users to associate an image with their profile.

- **Bug Fixes**
	- Corrected a test suite name to accurately reflect the service being tested.

- **Chores**
	- Simplified avatar storage logic for chatbot messages, streamlining how avatars are handled internally.
	- Removed unused imports and references to attachment models and services to improve code maintainability.

- **Tests**
	- Expanded test coverage for subscriber avatar storage, including success, error handling, and filename generation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->