### PR TITLE
fix: disalow attachment delete

### DIFF
--- a/api/src/attachment/controllers/attachment.controller.spec.ts
+++ b/api/src/attachment/controllers/attachment.controller.spec.ts
@@ -9,7 +9,10 @@
 import fs from 'fs';
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { BadRequestException } from '@nestjs/common/exceptions';
+import {
+  BadRequestException,
+  MethodNotAllowedException,
+} from '@nestjs/common/exceptions';
 import { NotFoundException } from '@nestjs/common/exceptions/not-found.exception';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Request } from 'express';
@@ -215,29 +218,10 @@ describe('AttachmentController', () => {
   });
 
   describe('deleteOne', () => {
-    it('should delete an attachment by id', async () => {
-      jest.spyOn(attachmentService, 'deleteOne');
-      const result = await attachmentController.deleteOne(
-        attachmentToDelete.id,
-      );
-
-      expect(attachmentService.deleteOne).toHaveBeenCalledWith(
-        attachmentToDelete.id,
-      );
-      expect(result).toEqual({
-        acknowledged: true,
-        deletedCount: 1,
-      });
-    });
-
-    it('should throw a NotFoundException when attempting to delete an attachment by id', async () => {
+    it('should throw a MethodNotAllowedException when attempting to delete an attachment by id', async () => {
       await expect(
         attachmentController.deleteOne(attachmentToDelete.id),
-      ).rejects.toThrow(
-        new NotFoundException(
-          `Attachment with ID ${attachmentToDelete.id} not found`,
-        ),
-      );
+      ).rejects.toThrow(MethodNotAllowedException);
     });
   });
 });

--- a/frontend/src/app-components/attachment/AttachmentThumbnail.tsx
+++ b/frontend/src/app-components/attachment/AttachmentThumbnail.tsx
@@ -1,13 +1,12 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
-import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
+import ClearIcon from "@mui/icons-material/Clear";
 import FileOpenIcon from "@mui/icons-material/FileOpen";
 import MusicNoteIcon from "@mui/icons-material/MusicNote";
 import VideoCameraBackOutlinedIcon from "@mui/icons-material/VideoCameraBackOutlined";
@@ -21,18 +20,11 @@ import {
 } from "@mui/material";
 import { FC } from "react";
 
-import { useDelete } from "@/hooks/crud/useDelete";
 import { useGet } from "@/hooks/crud/useGet";
-import { useDialogs } from "@/hooks/useDialogs";
 import useFormattedFileSize from "@/hooks/useFormattedFileSize";
-import { useHasPermission } from "@/hooks/useHasPermission";
-import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { IAttachment } from "@/types/attachment.types";
-import { PermissionAction } from "@/types/permission.types";
-
-import { ConfirmDialogBody } from "../dialogs";
 
 const AttachmentPreview = ({
   attachment,
@@ -79,22 +71,10 @@ const AttachmentThumbnail: FC<AttachmentThumbnailProps> = ({
   onChange,
 }) => {
   const formatSize = useFormattedFileSize();
-  const hasPermission = useHasPermission();
   const { data: attachment } = useGet(id, {
     entity: EntityType.ATTACHMENT,
   });
-  const { toast } = useToast();
   const { t } = useTranslate();
-  const dialogs = useDialogs();
-  const { mutate: deleteAttachment } = useDelete(EntityType.ATTACHMENT, {
-    onError: () => {
-      toast.error(t("message.internal_server_error"));
-    },
-    onSuccess: () => {
-      toast.success(t("message.success_save"));
-      onChange && onChange(null);
-    },
-  });
 
   if (!attachment) {
     return t("message.attachment_not_found") + id;
@@ -117,45 +97,22 @@ const AttachmentThumbnail: FC<AttachmentThumbnailProps> = ({
             </Typography>
           </CardContent>
 
-          {format === "full" &&
-          hasPermission(EntityType.ATTACHMENT, PermissionAction.DELETE) &&
-          onChange ? (
-            <>
-              <CardActions sx={{ justifyContent: "center", flex: "1 1 50%" }}>
-                <Button
-                  color="primary"
-                  variant="contained"
-                  startIcon={<CancelOutlinedIcon />}
-                  onClick={(e) => {
-                    onChange && onChange(null);
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  size="small"
-                >
-                  {t("button.unselect")}
-                </Button>
-                <Button
-                  color="secondary"
-                  variant="contained"
-                  startIcon={<DeleteOutlineOutlinedIcon />}
-                  onClick={async (e) => {
-                    const isConfirmed = await dialogs.confirm(
-                      ConfirmDialogBody,
-                    );
-
-                    if (isConfirmed) {
-                      deleteAttachment(attachment.id);
-                    }
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  size="small"
-                >
-                  {t("button.remove")}
-                </Button>
-              </CardActions>
-            </>
+          {format === "full" && onChange ? (
+            <CardActions sx={{ justifyContent: "center", flex: "1 1 50%" }}>
+              <Button
+                color="inherit"
+                variant="contained"
+                startIcon={<ClearIcon />}
+                onClick={async (e) => {
+                  onChange && onChange(null);
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                size="small"
+              >
+                {t("button.delete")}
+              </Button>
+            </CardActions>
           ) : null}
         </>
       ) : null}

--- a/frontend/src/app-components/attachment/AttachmentThumbnail.tsx
+++ b/frontend/src/app-components/attachment/AttachmentThumbnail.tsx
@@ -103,8 +103,8 @@ const AttachmentThumbnail: FC<AttachmentThumbnailProps> = ({
                 color="inherit"
                 variant="contained"
                 startIcon={<ClearIcon />}
-                onClick={async (e) => {
-                  onChange && onChange(null);
+                onClick={(e) => {
+                  onChange?.(null);
                   e.preventDefault();
                   e.stopPropagation();
                 }}


### PR DESCRIPTION
# Motivation

This PR modifies the DELETE /attachments/:id endpoint to disallow direct deletion of attachments. Instead of deleting the record, the controller now throws a MethodNotAllowedException and logs a warning.

Attachments in Hexabot may be referenced in multiple places, including:
- Blocks
- Messages
- Content elements

Allowing deletion directly via this endpoint could lead to data inconsistencies, such as broken references or missing media, especially in conversational flows or the visual editor.

Fixes #586

Related PRs : 
- https://github.com/Hexastack/Hexabot/pull/998
- https://github.com/Hexastack/Hexabot/pull/585

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Deletion of attachments is now explicitly disallowed to prevent data inconsistencies. Attempts to delete an attachment will result in a "Method Not Allowed" error.
  - The "delete" button in the attachment UI now only removes the attachment locally without affecting backend data or requiring confirmation dialogs.

- **User Interface**
  - The attachment thumbnail UI has been simplified: the "delete" button now only updates the local view and no longer interacts with the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->