### PR TITLE
fix(frontend): update dialogs types

### DIFF
--- a/frontend/src/components/languages/index.tsx
+++ b/frontend/src/components/languages/index.tsx
@@ -205,7 +205,9 @@ export const Languages = () => {
                 startIcon={<AddIcon />}
                 variant="contained"
                 sx={{ float: "right" }}
-                onClick={() => dialogs.open(LanguageFormDialog, null)}
+                onClick={() =>
+                  dialogs.open(LanguageFormDialog, { defaultValues: null })
+                }
               >
                 {t("button.add")}
               </Button>

--- a/frontend/src/components/visual-editor/v2/Diagrams.tsx
+++ b/frontend/src/components/visual-editor/v2/Diagrams.tsx
@@ -678,7 +678,7 @@ const Diagrams = () => {
                 minWidth: "42px",
               }}
               onClick={(e) => {
-                dialogs.open(CategoryFormDialog, null);
+                dialogs.open(CategoryFormDialog, { defaultValues: null });
                 e.preventDefault();
               }}
             >

--- a/frontend/src/types/common/dialogs.types.ts
+++ b/frontend/src/types/common/dialogs.types.ts
@@ -184,4 +184,4 @@ export type ExtractFormProps<T extends (arg: { data: any }) => unknown> =
 
 export type ComponentFormDialogProps<
   T extends (arg: { data: any }) => unknown,
-> = FormButtonsProps & DialogProps<ExtractFormProps<T> | null, boolean>;
+> = FormButtonsProps & DialogProps<ExtractFormProps<T>, boolean>;


### PR DESCRIPTION
# Motivation
The main motivations are :
- Enhance dialog types to avoid passing null when we open a dialog component
- Fix LanguageFormDialog props
- Fix CategoryFormDialog props

Fixes #1007

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved dialog opening behavior by explicitly passing default values options when adding categories and languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->