### PR TITLE
fix: block deletion for built Nlp Entities

### DIFF
--- a/api/src/nlp/controllers/nlp-entity.controller.ts
+++ b/api/src/nlp/controllers/nlp-entity.controller.ts
@@ -222,6 +222,21 @@ export class NlpEntityController extends BaseController<
     if (!ids?.length) {
       throw new BadRequestException('No IDs provided for deletion.');
     }
+
+    const { count: builtinCount } = await this.filterCount({
+      _id: { $in: ids },
+      builtin: true,
+    });
+
+    if (builtinCount) {
+      this.logger.warn(
+        `Unable to delete NLP entities with provided IDs: ${ids}`,
+      );
+      throw new NotFoundException(
+        'Cannot delete builtin NLP entities because at least one is built-in',
+      );
+    }
+
     const deleteResult = await this.nlpEntityService.deleteMany({
       _id: { $in: ids },
     });

--- a/api/src/nlp/controllers/nlp-entity.controller.ts
+++ b/api/src/nlp/controllers/nlp-entity.controller.ts
@@ -223,17 +223,17 @@ export class NlpEntityController extends BaseController<
       throw new BadRequestException('No IDs provided for deletion.');
     }
 
-    const { count: builtinCount } = await this.filterCount({
+    const { count: builtinNlpEntitiesCount } = await this.filterCount({
       _id: { $in: ids },
       builtin: true,
     });
 
-    if (builtinCount) {
+    if (builtinNlpEntitiesCount > 0) {
       this.logger.warn(
         `Unable to delete NLP entities with provided IDs: ${ids}`,
       );
-      throw new NotFoundException(
-        'Cannot delete builtin NLP entities because at least one is built-in',
+      throw new MethodNotAllowedException(
+        'Deletion failed: Selection includes built-in NLP entities that are protected',
       );
     }
 

--- a/frontend/src/components/nlp/components/NlpEntity.tsx
+++ b/frontend/src/components/nlp/components/NlpEntity.tsx
@@ -267,6 +267,7 @@ const NlpEntity = () => {
         <DataGrid
           columns={nlpEntityColumns}
           {...nlpEntityGrid}
+          isRowSelectable={({ row }) => !row.builtin}
           checkboxSelection
           onRowSelectionModelChange={handleSelectionChange}
         />


### PR DESCRIPTION
# Motivation
The motivation of this PR are : 
- (Frontend) Add protection to avoid the selection of builtin NlpEntities
- (API) Update the bulk delete controller to avoid deleting NlpEntities including at least a builtin NlpEntity

Fixes #829


# Screen recording demo
[ui NlpEntity delete.webm](https://github.com/user-attachments/assets/895ff0a1-362f-4a86-80ed-ffbbc583760a)


[api NlpEntity delete.webm.webm](https://github.com/user-attachments/assets/1a39492a-14a2-423c-9a32-97327971058f)

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
