### PR TITLE
fix(frontend): update incorrect translation keys

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -123,7 +123,7 @@
     "video_error": "Video not found",
     "missing_fields_error": "Please make sure that all required fields are filled",
     "weight_required_error": "Weight is required or invalid",
-    "weight_positive_number_error": "Weight must be a strictly positive number" 
+    "weight_positive_number_error": "Weight must be a strictly positive number"
   },
   "menu": {
     "terms": "Terms of Use",
@@ -490,7 +490,9 @@
     "original_text": "Original Text",
     "inputs": "Inputs",
     "outputs": "Outputs",
-    "any": "- Any -"
+    "any": "- Any -",
+    "full_name": "First and last name",
+    "password": "Password"
   },
   "placeholder": {
     "your_username": "Your username",
@@ -498,7 +500,6 @@
     "your_password": "Your password",
     "username": "Username",
     "email": "E-mail address",
-    "full_name": "First and last name",
     "password": "Password",
     "password2": "Confirm your password",
     "timezone": "Timezone",
@@ -527,7 +528,9 @@
     "end_date": "End Date",
     "nlp_value": "Value",
     "type_message_here": "Type message here ....",
-    "mark_as_default": "By Default"
+    "mark_as_default": "By Default",
+    "pattern": "Pattern",
+    "full_name": "First and last name"
   },
   "button": {
     "login": "Sign In",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -491,7 +491,9 @@
     "original_text": "Texte par défaut",
     "inputs": "Ports d'entrée",
     "outputs": "Ports de sortie",
-    "any": "- Toutes -"
+    "any": "- Toutes -",
+    "full_name": "Nom et Prénom",
+    "password": "Mot de passe"
   },
   "placeholder": {
     "your_username": "Votre nom d'utilisateur",
@@ -499,7 +501,6 @@
     "your_password": "Votre mot de passe",
     "username": "Nom d'utilisateur",
     "email": "Adresse e-mail",
-    "full_name": "Nom et Prénom",
     "password": "Mot de passe",
     "password2": "Confirmez votre mot de passe",
     "timezone": "Fuseau horaire",
@@ -528,7 +529,9 @@
     "end_date": "Date de fin",
     "nlp_value": "Valeur",
     "type_message_here": "Ecrivez quelque chose ici ....",
-    "mark_as_default": "Par Défaut"
+    "mark_as_default": "Par Défaut",
+    "pattern": "Motif",
+    "full_name": "Nom et Prénom"
   },
   "button": {
     "login": "Se connecter",

--- a/frontend/src/app-components/auth/Login.tsx
+++ b/frontend/src/app-components/auth/Login.tsx
@@ -110,7 +110,7 @@ export const Login = () => {
             />
 
             <PasswordInput
-              label={t("placeholder.password")}
+              label={t("label.password")}
               error={!!errors.password}
               required
               InputProps={{

--- a/frontend/src/app-components/auth/Register.tsx
+++ b/frontend/src/app-components/auth/Register.tsx
@@ -206,7 +206,7 @@ export const Register = () => {
             </ContentItem>
             <ContentItem>
               <PasswordInput
-                label={t("placeholder.password")}
+                label={t("label.password")}
                 error={!!errors.password}
                 required
                 {...register("password", validationRules.password)}

--- a/frontend/src/app-components/auth/Register.tsx
+++ b/frontend/src/app-components/auth/Register.tsx
@@ -206,7 +206,7 @@ export const Register = () => {
             </ContentItem>
             <ContentItem>
               <PasswordInput
-                label={t("label.auth_pass")}
+                label={t("placeholder.password")}
                 error={!!errors.password}
                 required
                 {...register("password", validationRules.password)}

--- a/frontend/src/app-components/auth/ResetPassword.tsx
+++ b/frontend/src/app-components/auth/ResetPassword.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -69,7 +69,7 @@ export const ResetPassword = () => {
             </Typography>
             <PasswordInput
               autoFocus
-              label={t("placeholder.password")}
+              label={t("label.password")}
               error={!!errors.password}
               required
               InputProps={{

--- a/frontend/src/components/nlp/components/NlpValueForm.tsx
+++ b/frontend/src/components/nlp/components/NlpValueForm.tsx
@@ -157,7 +157,7 @@ export const NlpValueForm: FC<ComponentFormProps<INlpValue, INlpEntity>> = ({
                   helperText={errors.metadata?.pattern?.message}
                   error={!!errors.metadata?.pattern}
                   label={t("label.regex")}
-                  placeholder={t("label.pattern")}
+                  placeholder={t("placeholder.pattern")}
                   flags={["i"]}
                 />
               </ContentItem>

--- a/frontend/src/components/nlp/components/NlpValueForm.tsx
+++ b/frontend/src/components/nlp/components/NlpValueForm.tsx
@@ -157,7 +157,7 @@ export const NlpValueForm: FC<ComponentFormProps<INlpValue, INlpEntity>> = ({
                   helperText={errors.metadata?.pattern?.message}
                   error={!!errors.metadata?.pattern}
                   label={t("label.regex")}
-                  placeholder={t("placeholder.pattern")}
+                  placeholder={t("label.pattern")}
                   flags={["i"]}
                 />
               </ContentItem>

--- a/frontend/src/components/profile/profile.tsx
+++ b/frontend/src/components/profile/profile.tsx
@@ -177,7 +177,7 @@ export const ProfileForm: FC<ProfileFormProps> = ({ user }) => {
             </ContentItem>
             <ContentItem>
               <PasswordInput
-                label={t("placeholder.password")}
+                label={t("label.password")}
                 {...register("password", validationRules.password)}
                 required
                 error={!!errors.password}

--- a/frontend/src/components/settings/SettingInput.tsx
+++ b/frontend/src/components/settings/SettingInput.tsx
@@ -118,8 +118,8 @@ const SettingInput: React.FC<RenderSettingInputProps> = ({
             entity={EntityType.BLOCK}
             format={Format.BASIC}
             labelKey="name"
-            label={t("label.fallback_block")}
-            helperText={t("help.fallback_block")}
+            label={t("help.fallback_message")}
+            helperText={t("help.fallback_message")}
             multiple={false}
             onChange={(_e, selected, ..._) => onChange(selected?.id || "")}
             {...rest}

--- a/frontend/src/components/settings/SettingInput.tsx
+++ b/frontend/src/components/settings/SettingInput.tsx
@@ -118,7 +118,7 @@ const SettingInput: React.FC<RenderSettingInputProps> = ({
             entity={EntityType.BLOCK}
             format={Format.BASIC}
             labelKey="name"
-            label={t("help.fallback_message")}
+            label={t("label.fallback_message")}
             helperText={t("help.fallback_message")}
             multiple={false}
             onChange={(_e, selected, ..._) => onChange(selected?.id || "")}

--- a/frontend/src/components/users/EditUserForm.tsx
+++ b/frontend/src/components/users/EditUserForm.tsx
@@ -76,7 +76,7 @@ export const EditUserForm: FC<ComponentFormProps<IUser, IRole[]>> = ({
           <ContentItem>
             <Input
               disabled
-              label={t("placeholder.full_name")}
+              label={t("label.full_name")}
               value={user ? getFullName(user) : undefined}
               InputProps={{
                 readOnly: true,

--- a/frontend/src/components/users/EditUserForm.tsx
+++ b/frontend/src/components/users/EditUserForm.tsx
@@ -76,7 +76,7 @@ export const EditUserForm: FC<ComponentFormProps<IUser, IRole[]>> = ({
           <ContentItem>
             <Input
               disabled
-              label={t("label.auth_user")}
+              label={t("placeholder.full_name")}
               value={user ? getFullName(user) : undefined}
               InputProps={{
                 readOnly: true,


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to make UI translation keys typed.

Fixes #1024

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated various labels in forms to improve consistency, including changing password and full name field labels across authentication, profile, and user settings screens.
  - Adjusted translation keys for certain settings and helper texts for improved clarity.

- **Documentation**
  - Updated English and French translation files with new and reorganized keys for labels and placeholders, enhancing language support and consistency.
  - Fixed minor formatting issues in translation files.

- **Chores**
  - Updated copyright year in the Reset Password screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->