### PR TITLE
fix(frontend): rename display_mode field

### DIFF
--- a/frontend/src/components/visual-editor/form/ListMessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/ListMessageForm.tsx
@@ -47,7 +47,7 @@ const ListMessageForm = () => {
     formState: { errors },
   } = useFormContext();
   const contentTypeId = watch("options.content.entity");
-  const displayMode = watch("options.content.display_mode");
+  const displayMode = watch("options.content.display");
   const { data: contentType } = useGet(contentTypeId, {
     entity: EntityType.CONTENT_TYPE,
   });
@@ -61,10 +61,9 @@ const ListMessageForm = () => {
           <FormControl>
             <FormLabel>{t("label.display_mode")}</FormLabel>
             <Controller
-              rules={{ required: true }}
               control={control}
-              defaultValue={content?.display || "list"}
-              name="options.content.display_mode"
+              defaultValue={content?.display || OutgoingMessageFormat.list}
+              name="options.content.display"
               render={({ field }) => (
                 <RadioGroup row {...field}>
                   {[
@@ -75,10 +74,7 @@ const ListMessageForm = () => {
                       key={display}
                       value={display}
                       control={
-                        <Radio
-                          defaultChecked={display === content?.display}
-                          {...register("options.content.display")}
-                        />
+                        <Radio defaultChecked={display === content?.display} />
                       }
                       label={t(`label.${display}`)}
                     />


### PR DESCRIPTION
# Motivation
The main motivation is to remove an extra field named "display_mode".

Fixes #1037

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the display mode selection in the List Message form for a more streamlined user experience. The form now uses a unified field for display mode and improved default selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->