### PR TITLE
Apply persist search on all pages

### DIFF
--- a/frontend/src/components/categories/index.tsx
+++ b/frontend/src/components/categories/index.tsx
@@ -43,8 +43,9 @@ export const Categories = () => {
   const { toast } = useToast();
   const dialogs = useDialogs();
   const hasPermission = useHasPermission();
-  const { onSearch, searchPayload } = useSearch<ICategory>({
+  const { ref, onSearch, searchPayload } = useSearch<ICategory>({
     $iLike: ["label"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.CATEGORY },
@@ -142,7 +143,7 @@ export const Categories = () => {
             width="max-content"
           >
             <Grid item>
-              <FilterTextfield onChange={onSearch} />
+              <FilterTextfield inputRef={ref} onChange={onSearch} />
             </Grid>
             {hasPermission(EntityType.CATEGORY, PermissionAction.CREATE) ? (
               <Grid item>

--- a/frontend/src/components/content-types/index.tsx
+++ b/frontend/src/components/content-types/index.tsx
@@ -40,8 +40,9 @@ export const ContentTypes = () => {
   const router = useRouter();
   const dialogs = useDialogs();
   // data fetching
-  const { onSearch, searchPayload } = useSearch<IContentType>({
+  const { ref, onSearch, searchPayload } = useSearch<IContentType>({
     $iLike: ["name"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.CONTENT_TYPE },
@@ -99,7 +100,7 @@ export const ContentTypes = () => {
           width="max-content"
         >
           <Grid item>
-            <FilterTextfield onChange={onSearch} />
+            <FilterTextfield inputRef={ref} onChange={onSearch} />
           </Grid>
           {hasPermission(EntityType.CONTENT_TYPE, PermissionAction.CREATE) ? (
             <Grid item>

--- a/frontend/src/components/contents/index.tsx
+++ b/frontend/src/components/contents/index.tsx
@@ -57,9 +57,10 @@ export const Contents = () => {
   const queryClient = useQueryClient();
   const dialogs = useDialogs();
   // data fetching
-  const { onSearch, searchPayload } = useSearch<IContent>({
+  const { ref, onSearch, searchPayload } = useSearch<IContent>({
     $eq: [{ entity: String(query.id) }],
     $iLike: ["title"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const hasPermission = useHasPermission();
   const { dataGridProps } = useFind(
@@ -157,7 +158,7 @@ export const Contents = () => {
         >
           <Grid justifyContent="flex-end" gap={1} container alignItems="center">
             <Grid item>
-              <FilterTextfield onChange={onSearch} />
+              <FilterTextfield inputRef={ref} onChange={onSearch} />
             </Grid>
             {hasPermission(EntityType.CONTENT, PermissionAction.CREATE) ? (
               <ButtonGroup sx={{ marginLeft: "auto" }}>

--- a/frontend/src/components/context-vars/index.tsx
+++ b/frontend/src/components/context-vars/index.tsx
@@ -43,8 +43,9 @@ export const ContextVars = () => {
   const { toast } = useToast();
   const dialogs = useDialogs();
   const hasPermission = useHasPermission();
-  const { onSearch, searchPayload } = useSearch<IContextVar>({
+  const { ref, onSearch, searchPayload } = useSearch<IContextVar>({
     $iLike: ["label"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.CONTEXT_VAR },
@@ -176,7 +177,7 @@ export const ContextVars = () => {
           width="max-content"
         >
           <Grid item>
-            <FilterTextfield onChange={onSearch} />
+            <FilterTextfield inputRef={ref} onChange={onSearch} />
           </Grid>
           {hasPermission(EntityType.CONTEXT_VAR, PermissionAction.CREATE) ? (
             <Grid item>

--- a/frontend/src/components/inbox/index.tsx
+++ b/frontend/src/components/inbox/index.tsx
@@ -6,12 +6,13 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MainContainer, Search, Sidebar } from "@chatscope/chat-ui-kit-react";
+import { MainContainer, Sidebar } from "@chatscope/chat-ui-kit-react";
 import "@chatscope/chat-ui-kit-styles/dist/default/styles.min.css";
 import { Grid, MenuItem } from "@mui/material";
 import { useState } from "react";
 
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
+import { FilterTextfield } from "@/app-components/inputs/FilterTextfield";
 import { Input } from "@/app-components/inputs/Input";
 import { useSearch } from "@/hooks/useSearch";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -26,8 +27,9 @@ import { AssignedTo } from "./types";
 
 export const Inbox = () => {
   const { t } = useTranslate();
-  const { onSearch, searchPayload, searchText } = useSearch<ISubscriber>({
+  const { ref, onSearch, searchPayload } = useSearch<ISubscriber>({
     $or: ["first_name", "last_name"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const [channels, setChannels] = useState<string[]>([]);
   const [assignment, setAssignment] = useState<AssignedTo>(AssignedTo.ALL);
@@ -46,12 +48,10 @@ export const Inbox = () => {
         <Grid item width="100%" height="100%" overflow="hidden">
           <MainContainer style={{ height: "100%" }}>
             <Sidebar position="left">
-              <Grid paddingX={1} paddingTop={1}>
-                <Search
-                  value={searchText}
-                  onClearClick={() => onSearch("")}
-                  className="changeColor"
-                  onChange={(v) => onSearch(v)}
+              <Grid paddingX={1} pt={2} pb={1} mx={1}>
+                <FilterTextfield
+                  inputRef={ref}
+                  onChange={onSearch}
                   placeholder="Search..."
                 />
               </Grid>

--- a/frontend/src/components/labels/index.tsx
+++ b/frontend/src/components/labels/index.tsx
@@ -42,8 +42,9 @@ export const Labels = () => {
   const { toast } = useToast();
   const dialogs = useDialogs();
   const hasPermission = useHasPermission();
-  const { onSearch, searchPayload } = useSearch<ILabel>({
+  const { ref, onSearch, searchPayload } = useSearch<ILabel>({
     $or: ["name", "title"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.LABEL, format: Format.FULL },
@@ -173,7 +174,7 @@ export const Labels = () => {
           width="max-content"
         >
           <Grid item>
-            <FilterTextfield onChange={onSearch} />
+            <FilterTextfield inputRef={ref} onChange={onSearch} />
           </Grid>
           {hasPermission(EntityType.LABEL, PermissionAction.CREATE) ? (
             <Grid item>

--- a/frontend/src/components/languages/index.tsx
+++ b/frontend/src/components/languages/index.tsx
@@ -43,8 +43,9 @@ export const Languages = () => {
   const dialogs = useDialogs();
   const queryClient = useQueryClient();
   const hasPermission = useHasPermission();
-  const { onSearch, searchPayload } = useSearch<ILanguage>({
+  const { ref, onSearch, searchPayload } = useSearch<ILanguage>({
     $or: ["title", "code"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps, refetch } = useFind(
     { entity: EntityType.LANGUAGE },
@@ -197,7 +198,7 @@ export const Languages = () => {
           width="max-content"
         >
           <Grid item>
-            <FilterTextfield onChange={onSearch} />
+            <FilterTextfield inputRef={ref} onChange={onSearch} />
           </Grid>
           {hasPermission(EntityType.LANGUAGE, PermissionAction.CREATE) ? (
             <Grid item>

--- a/frontend/src/components/media-library/index.tsx
+++ b/frontend/src/components/media-library/index.tsx
@@ -37,8 +37,9 @@ type MediaLibraryProps = {
 export const MediaLibrary = ({ onSelect, accept }: MediaLibraryProps) => {
   const { t } = useTranslate();
   const formatFileSize = useFormattedFileSize();
-  const { onSearch, searchPayload } = useSearch<IAttachment>({
+  const { ref, onSearch, searchPayload } = useSearch<IAttachment>({
     $iLike: ["name"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.ATTACHMENT },
@@ -151,7 +152,7 @@ export const MediaLibrary = ({ onSelect, accept }: MediaLibraryProps) => {
           width="max-content"
         >
           <Grid item>
-            <FilterTextfield onChange={onSearch} />
+            <FilterTextfield inputRef={ref} onChange={onSearch} />
           </Grid>
         </Grid>
       </PageHeader>

--- a/frontend/src/components/nlp/components/NlpEntity.tsx
+++ b/frontend/src/components/nlp/components/NlpEntity.tsx
@@ -80,8 +80,9 @@ const NlpEntity = () => {
     },
   });
   const [selectedNlpEntities, setSelectedNlpEntities] = useState<string[]>([]);
-  const { onSearch, searchPayload } = useSearch<INlpEntity>({
+  const { ref, onSearch, searchPayload } = useSearch<INlpEntity>({
     $or: ["name", "doc"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps: nlpEntityGrid } = useFind(
     {
@@ -224,7 +225,7 @@ const NlpEntity = () => {
         flexShrink={0}
       >
         <Grid item>
-          <FilterTextfield onChange={onSearch} />
+          <FilterTextfield inputRef={ref} onChange={onSearch} />
         </Grid>
 
         {hasPermission(EntityType.NLP_ENTITY, PermissionAction.CREATE) ? (

--- a/frontend/src/components/nlp/components/NlpSample.tsx
+++ b/frontend/src/components/nlp/components/NlpSample.tsx
@@ -86,12 +86,13 @@ export default function NlpSample() {
     EntityType.NLP_SAMPLE_ENTITY,
   );
   const getLanguageFromCache = useGetFromCache(EntityType.LANGUAGE);
-  const { onSearch, searchPayload } = useSearch<INlpSample>({
+  const { ref, onSearch, searchPayload } = useSearch<INlpSample>({
     $eq: [
       ...(type !== "all" ? [{ type }] : []),
       ...(language ? [{ language }] : []),
     ],
     $iLike: ["text"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { mutate: deleteNlpSample } = useDelete(EntityType.NLP_SAMPLE, {
     onError: () => {
@@ -316,6 +317,7 @@ export default function NlpSample() {
           direction="row"
         >
           <FilterTextfield
+            inputRef={ref}
             onChange={onSearch}
             fullWidth={false}
             sx={{ minWidth: "256px" }}

--- a/frontend/src/components/nlp/components/NlpValue.tsx
+++ b/frontend/src/components/nlp/components/NlpValue.tsx
@@ -51,9 +51,10 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
     entity: EntityType.NLP_ENTITY,
     format: Format.FULL,
   });
-  const { onSearch, searchPayload } = useSearch<INlpValue>({
+  const { ref, onSearch, searchPayload } = useSearch<INlpValue>({
     $eq: [{ entity: entityId }],
     $or: ["doc", "value"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.NLP_VALUE, format: Format.FULL },
@@ -228,7 +229,7 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
                 sx={{ width: "max-content", gap: 1 }}
               >
                 <Grid item>
-                  <FilterTextfield onChange={onSearch} />
+                  <FilterTextfield inputRef={ref} onChange={onSearch} />
                 </Grid>
                 <ButtonGroup sx={{ marginLeft: "auto" }}>
                   {hasPermission(

--- a/frontend/src/components/roles/index.tsx
+++ b/frontend/src/components/roles/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -40,8 +40,9 @@ export const Roles = () => {
   const { toast } = useToast();
   const dialogs = useDialogs();
   const hasPermission = useHasPermission();
-  const { onSearch, searchPayload } = useSearch<IRole>({
+  const { ref, onSearch, searchPayload } = useSearch<IRole>({
     $iLike: ["name"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.ROLE },
@@ -140,7 +141,7 @@ export const Roles = () => {
           width="max-content"
         >
           <Grid item>
-            <FilterTextfield onChange={onSearch} />
+            <FilterTextfield inputRef={ref} onChange={onSearch} />
           </Grid>
           {hasPermission(EntityType.ROLE, PermissionAction.CREATE) ? (
             <Grid item>

--- a/frontend/src/components/subscribers/index.tsx
+++ b/frontend/src/components/subscribers/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -43,9 +43,10 @@ export const Subscribers = () => {
     { hasCount: false },
   );
   const [labelFilter, setLabelFilter] = useState<string>("");
-  const { onSearch, searchPayload } = useSearch<ISubscriber>({
+  const { ref, onSearch, searchPayload } = useSearch<ISubscriber>({
     $eq: labelFilter ? [{ labels: [labelFilter] }] : [],
     $or: ["first_name", "last_name"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps } = useFind(
     { entity: EntityType.SUBSCRIBER, format: Format.FULL },
@@ -172,7 +173,7 @@ export const Subscribers = () => {
           flexWrap="nowrap"
           width="50%"
         >
-          <FilterTextfield onChange={onSearch} fullWidth={true} />
+          <FilterTextfield inputRef={ref} onChange={onSearch} />
           <Input
             select
             label={t("label.labels")}

--- a/frontend/src/components/translations/index.tsx
+++ b/frontend/src/components/translations/index.tsx
@@ -44,8 +44,9 @@ export const Translations = () => {
       hasCount: false,
     },
   );
-  const { onSearch, searchPayload } = useSearch<ITranslation>({
+  const { ref, onSearch, searchPayload } = useSearch<ITranslation>({
     $iLike: ["str"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { dataGridProps, refetch: refreshTranslations } = useFind(
     { entity: EntityType.TRANSLATION },
@@ -152,7 +153,7 @@ export const Translations = () => {
           width="max-content"
         >
           <Grid item>
-            <FilterTextfield onChange={onSearch} />
+            <FilterTextfield inputRef={ref} onChange={onSearch} />
           </Grid>
           <Grid item>
             <Button

--- a/frontend/src/components/users/index.tsx
+++ b/frontend/src/components/users/index.tsx
@@ -53,8 +53,9 @@ export const Users = () => {
     },
   });
   const hasPermission = useHasPermission();
-  const { onSearch, searchPayload } = useSearch<IUser>({
+  const { ref, onSearch, searchPayload } = useSearch<IUser>({
     $or: ["first_name", "last_name", "email"],
+    queryParam: { key: "search", defaultValue: "" },
   });
   const { data: roles } = useFind(
     {
@@ -198,7 +199,7 @@ export const Users = () => {
           width="max-content"
         >
           <Grid item>
-            <FilterTextfield onChange={onSearch} />
+            <FilterTextfield inputRef={ref} onChange={onSearch} />
           </Grid>
           {!ssoEnabled &&
           hasPermission(EntityType.USER, PermissionAction.CREATE) ? (

--- a/frontend/src/hooks/useQueryParam.ts
+++ b/frontend/src/hooks/useQueryParam.ts
@@ -51,8 +51,8 @@ export const useQueryParam = () => {
     [updateUrl],
   );
   const getQueryParam = useCallback(
-    <T extends keyof QueryParams>(key: T): T | undefined => {
-      return queryParams[key] as T;
+    <T extends keyof QueryParams>(key: T): QueryParams[T] | undefined => {
+      return queryParams[key] as QueryParams[T];
     },
     [queryParams],
   );

--- a/frontend/src/hooks/useQueryParam.ts
+++ b/frontend/src/hooks/useQueryParam.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { useRouter } from "next/router";
+import { useCallback, useMemo } from "react";
+
+export type QueryParams = Record<string, string | string[] | undefined>;
+export type QueryParamCallback<T> = (value: T) => void;
+
+export const useQueryParam = () => {
+  const router = useRouter();
+  const { query } = router;
+  const queryParams: QueryParams = useMemo(() => ({ ...query }), [query]);
+  const updateUrl = useCallback(
+    async <T>(newParams: QueryParams, defaultValue?: T) => {
+      const updatedQuery: QueryParams = { ...query };
+
+      Object.entries(newParams).forEach(([key, value]) => {
+        if (value === defaultValue) {
+          delete updatedQuery[key];
+        } else {
+          updatedQuery[key] = value;
+        }
+      });
+
+      await router.replace(
+        {
+          query: updatedQuery,
+        },
+        undefined,
+        { shallow: true },
+      );
+    },
+    [query, router],
+  );
+  const setQueryParam = useCallback(
+    async <T>(key: string, value: T, defaultValue?: T) => {
+      return await updateUrl({ [key]: value } as QueryParams, defaultValue);
+    },
+    [updateUrl],
+  );
+  const removeQueryParam = useCallback(
+    async (key: string) => {
+      await updateUrl({ [key]: undefined });
+    },
+    [updateUrl],
+  );
+  const getQueryParam = useCallback(
+    <T extends keyof QueryParams>(key: T): T | undefined => {
+      return queryParams[key] as T;
+    },
+    [queryParams],
+  );
+  const clearQueryParams = useCallback(async () => {
+    await router.push(
+      {
+        query: {},
+      },
+      undefined,
+      { shallow: true },
+    );
+  }, [router]);
+
+  return {
+    queryParams,
+    setQueryParam,
+    getQueryParam,
+    removeQueryParam,
+    clearQueryParams,
+  };
+};

--- a/frontend/src/hooks/useQueryParam.ts
+++ b/frontend/src/hooks/useQueryParam.ts
@@ -28,7 +28,7 @@ export const useQueryParam = () => {
         }
       });
 
-      await router.replace(
+      await router.push(
         {
           query: updatedQuery,
         },

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -68,21 +68,22 @@ export const useSearch = <T>({
   );
 
   useEffect(() => {
+    if (queryParamValue) {
+      setSearchText(queryParamValue.toString() || "");
+    } else {
+      if (searchText && ref.current) {
+        ref.current.value = "";
+      }
+      setSearchText("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryParamValue]);
+
+  useEffect(() => {
     if (searchText && ref.current) {
       ref.current.value = searchText;
     }
   }, [searchText]);
-
-  useEffect(() => {
-    if (
-      queryParamKey &&
-      queryParamValue !== searchText &&
-      queryParamValue !== undefined
-    ) {
-      setSearchText(queryParamValue.toString() || "");
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queryParamValue, queryParamKey]);
 
   const onSearch = debounce(
     async (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | string) => {

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -12,6 +12,7 @@ import { ChangeEvent, useEffect, useRef, useState } from "react";
 import {
   TBuildInitialParamProps,
   TBuildParamProps,
+  TFilterStringFields,
   TParamItem,
 } from "@/types/search.types";
 
@@ -23,13 +24,11 @@ const buildOrParams = <T>({ params, searchText }: TBuildParamProps<T>) => ({
   })),
 });
 const buildILikeParams = <T>({ params, searchText }: TBuildParamProps<T>) =>
-  params?.reduce(
-    (acc, field) => ({
-      ...acc,
-      [field]: { contains: searchText },
-    }),
-    {},
-  );
+  params?.reduce((acc, field) => {
+    acc[field] = { contains: searchText };
+
+    return acc;
+  }, {} as Record<TFilterStringFields<T>, unknown>);
 const buildEqInitialParams = <T>({
   initialParams,
 }: TBuildInitialParamProps<T>) =>
@@ -75,11 +74,15 @@ export const useSearch = <T>({
   }, [searchText]);
 
   useEffect(() => {
-    if (queryParamKey && queryParamValue !== searchText) {
-      setSearchText(queryParamValue || "");
+    if (
+      queryParamKey &&
+      queryParamValue !== searchText &&
+      queryParamValue !== undefined
+    ) {
+      setSearchText(queryParamValue.toString() || "");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queryParamValue]);
+  }, [queryParamValue, queryParamKey]);
 
   const onSearch = debounce(
     async (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | string) => {

--- a/frontend/src/types/search.types.ts
+++ b/frontend/src/types/search.types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -12,9 +12,10 @@ export type TFilterStringFields<T> = {
 
 export type TParamItem<T> = {
   $eq?: { [key in keyof T]?: T[key] }[];
-  $iLike?: TFilterStringFields<T>[];
   $neq?: { [key in keyof T]?: T[key] }[];
+  $iLike?: TFilterStringFields<T>[];
   $or?: TFilterStringFields<T>[];
+  queryParam?: { key: string; defaultValue?: string };
 };
 
 export type TBuildParamProps<T> = {


### PR DESCRIPTION
# Motivation
The main motivation is to restrict persisting query search parameters only for some components

Fixes #874

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
