### PR TITLE
fix(frontend): add limit validation based on block list type

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -103,6 +103,7 @@
     "message_is_required": "Message is required",
     "context_var_is_required": "You need to add a context variable",
     "invalid_list_limit": "List limit must be >=2 and <= 4",
+    "invalid_carousel_limit": "List limit must be >=1 and <= 10",
     "no_content_type": "No content type available, please create one first",
     "invalid_max_fallback_attempt_limit": "Max fallback attempt limit must have positive value",
     "regex_is_invalid": "Regex is invalid",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -103,6 +103,7 @@
     "message_is_required": "Le message est requis",
     "context_var_is_required": "Vous devez ajouter une variable contextuelle",
     "invalid_list_limit": "La limite doit être >=2 et <= 4",
+    "invalid_carousel_limit": "La limite doit être >=1 et <= 10",
     "no_content_type": "Il n'y a aucun type de contenu pour le moment, veuillez en ajouter un.",
     "invalid_max_fallback_attempt_limit": "La limite des tentatives de secours doit être un nombre positif.",
     "regex_is_invalid": "Le regex est invalide",

--- a/frontend/src/components/visual-editor/form/ListMessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/ListMessageForm.tsx
@@ -120,9 +120,19 @@ const ListMessageForm = () => {
             }}
             {...register("options.content.limit", {
               validate: {
-                min: (value) =>
-                  (value && value >= 2 && value <= 4) ||
-                  t("message.invalid_list_limit"),
+                min: (value) => {
+                  if (
+                    displayMode === OutgoingMessageFormat.list &&
+                    (value < 2 || value > 4)
+                  ) {
+                    return t("message.invalid_list_limit");
+                  } else if (
+                    displayMode === OutgoingMessageFormat.carousel &&
+                    (value < 1 || value > 10)
+                  ) {
+                    return t("message.invalid_carousel_limit");
+                  }
+                },
               },
               valueAsNumber: true,
             })}

--- a/frontend/src/components/visual-editor/form/ListMessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/ListMessageForm.tsx
@@ -113,14 +113,14 @@ const ListMessageForm = () => {
             label={t("label.content_limit")}
             type="number"
             inputProps={{
-              maxLength: 25,
-              step: "1",
-              min: 2,
-              max: 4,
+              maxLength: 2,
+              step: 1,
+              min: displayMode === OutgoingMessageFormat.list ? 2 : 1,
+              max: displayMode === OutgoingMessageFormat.list ? 4 : 10,
             }}
             {...register("options.content.limit", {
               validate: {
-                min: (value) => {
+                limitRange: (value) => {
                   if (
                     displayMode === OutgoingMessageFormat.list &&
                     (value < 2 || value > 4)


### PR DESCRIPTION
# Motivation
The main motivation is to add UI validation to the limit field in the blockForm for the block list based on the selected type list or carousel.

Fixes #1058

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new validation messages for carousel list limits in English and French.
- **Bug Fixes**
  - Enhanced input validation for list and carousel display modes with dynamic limit ranges and localized error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->