### PR TITLE
Update autolinker and tslib versions in chat widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@mui/x-data-grid": "^7.3.2",
         "@projectstorm/react-canvas-core": "^7.0.3",
         "@projectstorm/react-diagrams": "^7.0.4",
+        "autolinker": "^4.1.5",
         "axios": "^1.7.7",
         "eazychart-css": "^0.2.1-alpha.0",
         "eazychart-react": "^0.8.0-alpha.0",
@@ -3592,12 +3593,15 @@
       "license": "MIT"
     },
     "node_modules/autolinker": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-4.0.0.tgz",
-      "integrity": "sha512-fl5Kh6BmEEZx+IWBfEirnRUU5+cOiV0OK7PEt0RBKvJMJ8GaRseIOeDU3FKf4j3CE5HVefcjHmhYPOcaVt0bZw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-4.1.5.tgz",
+      "integrity": "sha512-vEfYZPmvVOIuE567XBVCsx8SBgOYtjB2+S1iAaJ+HgH+DNjAcrHem2hmAeC9yaNGWayicv4yR+9UaJlkF3pvtw==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "pnpm": ">=10.10.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -9642,9 +9646,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -10307,7 +10311,7 @@
       "version": "2.2.8",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "autolinker": "^4.0.0",
+        "autolinker": "^4.1.5",
         "dayjs": "^1.11.12",
         "emoji-js": "^3.8.0",
         "normalize.css": "^8.0.1",

--- a/widget/package.json
+++ b/widget/package.json
@@ -20,7 +20,7 @@
     "*.{ts,tsx}": "eslint --fix -c \".eslintrc-staged.json\""
   },
   "dependencies": {
-    "autolinker": "^4.0.0",
+    "autolinker": "^4.1.5",
     "dayjs": "^1.11.12",
     "emoji-js": "^3.8.0",
     "normalize.css": "^8.0.1",
@@ -47,7 +47,7 @@
     "vite-plugin-dts": "^4.0.2"
   },
   "optionalDependencies": {
-    "@rollup/rollup-darwin-arm64": "^4.24.0",
-    "@esbuild/darwin-arm64": "^0.24.0"
+    "@esbuild/darwin-arm64": "^0.24.0",
+    "@rollup/rollup-darwin-arm64": "^4.24.0"
   }
 }


### PR DESCRIPTION
Upgrade autolinker to version 4.1.5 and tslib to version 2.8.1 in chat widget package.json and the frontend app package-lock.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated a dependency to a newer version for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->