### PR TITLE
fix(frontend): fix category redirection to the visual editor

### DIFF
--- a/frontend/src/components/categories/CategoryForm.tsx
+++ b/frontend/src/components/categories/CategoryForm.tsx
@@ -34,10 +34,12 @@ export const CategoryForm: FC<ComponentFormProps<ICategory>> = ({
       rest.onError?.();
       toast.error(error || t("message.internal_server_error"));
     },
-    onSuccess: (category: ICategory) => {
+    onSuccess: ({ id }: ICategory) => {
       rest.onSuccess?.();
       toast.success(t("message.success_save"));
-      router.push(`/${RouterType.VISUAL_EDITOR}/flows/${category.id}`);
+      if (router.pathname.startsWith(`/${RouterType.VISUAL_EDITOR}`)) {
+        router.push(`/${RouterType.VISUAL_EDITOR}/flows/${id}`);
+      }
     },
   };
   const { mutate: createCategory } = useCreate(EntityType.CATEGORY, options);


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to resolve the extra redirection from the category page to the visual editor after creation a new category. 

Fixes #1073

# Type of change:

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation behavior after saving a category, ensuring users are only redirected to the visual editor flows page when already within the visual editor section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->