### PR TITLE
fix(frontend): resolve useInfiniteLiveSubscribers hook or operator bug

### DIFF
--- a/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
+++ b/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -29,14 +29,15 @@ export const useInfiniteLiveSubscribers = (props: {
   const queryClient = useQueryClient();
   const params = {
     where: {
-      ...(props.channels.length > 0
-        ? {
-            or: props.channels.map((channel) => ({
-              "channel.name": channel,
-            })),
-          }
-        : {}),
       ...props.searchPayload.where,
+      ...(props.channels.length > 0 && {
+        or: [
+          ...props.searchPayload.where.or,
+          ...props.channels.map((channel) => ({
+            "channel.name": channel,
+          })),
+        ],
+      }),
       ...(props.assignedTo === AssignedTo.ME
         ? { assignedTo: user?.id }
         : props.assignedTo === AssignedTo.OTHERS

--- a/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
+++ b/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
@@ -32,7 +32,7 @@ export const useInfiniteLiveSubscribers = (props: {
       ...props.searchPayload.where,
       ...(props.channels.length > 0 && {
         or: [
-          ...props.searchPayload.where.or,
+          ...(props.searchPayload.where.or || []),
           ...props.channels.map((channel) => ({
             "channel.name": channel,
           })),


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to update the **useInfiniteLiveSubscribers** hook to be able to support multiple or operators from **channels** filter or/and **search** or filters.
This fix will make available the feature of searching by text and by channels filters simultaneously .

Fixes #1056

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtering logic to ensure search results include both existing search conditions and selected channel filters.

- **Chores**
  - Updated copyright year in file header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->