### PR TITLE
fix(frontend): make quickReplies response message required

### DIFF
--- a/frontend/src/components/visual-editor/form/QuickRepliesMessageForm.tsx
+++ b/frontend/src/components/visual-editor/form/QuickRepliesMessageForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -46,7 +46,9 @@ const QuickRepliesMessageForm = () => {
               minRows={3}
               helperText={errors?.message?.["text"]?.message}
               error={!!errors?.message?.["text"]}
-              {...register("message.text")}
+              {...register("message.text", {
+                required: t("message.message_is_required"),
+              })}
             />
           </ContentItem>
         </>


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to make the block Quick Replies response message required.

Fixes #1023

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added required field validation to the message text input, ensuring users are notified with a localized error message if left empty.

- **Chores**
  - Updated copyright year to 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->