### PR TITLE
fix(api): add textarea & secret missed types to the settings type

### DIFF
--- a/api/src/setting/schemas/types.ts
+++ b/api/src/setting/schemas/types.ts
@@ -129,6 +129,8 @@ export type SettingByType<T extends SettingType> = T extends SettingType.text
 
 export type AnySetting =
   | TextSetting
+  | TextareaSetting
+  | SecretSetting
   | MultiTextSetting
   | CheckboxSetting
   | SelectSetting

--- a/api/src/setting/schemas/types.ts
+++ b/api/src/setting/schemas/types.ts
@@ -29,17 +29,6 @@ export enum FieldType {
   html = 'html',
 }
 
-/**
- * The following interfaces are declared, and currently not used
- * TextSetting
- * MultiTextSetting
- * CheckboxSetting
- * SelectSetting
- * NumberSetting
- * AttachmentSetting
- * MultipleAttachmentSetting
- * AnySetting
- **/
 export interface TextSetting extends Setting {
   type: SettingType.text;
   value: string;


### PR DESCRIPTION
# Motivation
The main motivations of this PR are : 
- [x] To add the missed **textarea** and **secret** typeq to the setting type
- [x] To Remove unused comment

Fixes #1078

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for additional setting types, ensuring that all relevant settings are properly recognized and handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->