### PR TITLE
fix(frontend): support contentType default name value

### DIFF
--- a/api/src/cms/dto/contentType.dto.ts
+++ b/api/src/cms/dto/contentType.dto.ts
@@ -14,7 +14,6 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
-  Matches,
   Validate,
   ValidateNested,
 } from 'class-validator';
@@ -27,7 +26,6 @@ import { ValidateRequiredFields } from '../validators/validate-required-fields.v
 export class ContentField {
   @IsString()
   @IsNotEmpty()
-  @Matches(/^[a-z][a-z_0-9]*$/)
   name: string;
 
   @IsString()

--- a/frontend/src/components/content-types/ContentTypeForm.tsx
+++ b/frontend/src/components/content-types/ContentTypeForm.tsx
@@ -130,6 +130,8 @@ export const ContentTypeForm: FC<ComponentFormProps<IContentType>> = ({
               gap={2}
             >
               <FieldInput
+                defaultLabel={contentType?.fields?.[index]?.label}
+                defaultName={contentType?.fields?.[index]?.name}
                 setValue={setValue}
                 control={control}
                 remove={remove}

--- a/frontend/src/components/content-types/components/FieldInput.tsx
+++ b/frontend/src/components/content-types/components/FieldInput.tsx
@@ -26,6 +26,8 @@ import { slugify } from "@/utils/string";
 export const FieldInput = ({
   setValue,
   index,
+  defaultLabel,
+  defaultName,
   ...props
 }: {
   index: number;
@@ -33,6 +35,8 @@ export const FieldInput = ({
   remove: UseFieldArrayRemove;
   control: Control<Partial<IContentType>>;
   setValue: UseFormSetValue<Partial<IContentType>>;
+  defaultLabel?: string;
+  defaultName?: string;
 }) => {
   const { t } = useTranslate();
   const label = useWatch({
@@ -41,7 +45,11 @@ export const FieldInput = ({
   });
 
   useEffect(() => {
-    setValue(`fields.${index}.name`, label ? slugify(label) : "");
+    if (defaultLabel && defaultName !== slugify(defaultLabel)) {
+      defaultName && setValue(`fields.${index}.name`, defaultName);
+    } else {
+      setValue(`fields.${index}.name`, label ? slugify(label) : "");
+    }
   }, [label, setValue, index]);
 
   return (


### PR DESCRIPTION
# Motivation
The main motivation of this PR are : 
- [x] Make the API contentType field accepting name camelCase by updating the update DTO
- [x] Make the UI supporting default camelCase values

Fixes #1018

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
