### PR TITLE
fix: rename CSS class for outgoing message content to use CustomContent

### DIFF
--- a/frontend/src/components/inbox/inbox.css
+++ b/frontend/src/components/inbox/inbox.css
@@ -20,7 +20,7 @@ div .cs-message--outgoing .cs-message__content {
   background-color: var(--cs-message-outgoing-color) !important;
 }
 
-div .cs-message--outgoing .cs-message__text-content {
+div .cs-message--outgoing .cs-message__custom-content {
   color: var(--cs-message-outgoing-text-color) !important;
 }
 


### PR DESCRIPTION
# Motivation

rename CSS class for outgoing message content to use CustomContent

Fixes # (issue)

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
