### PR TITLE
feat(inbox): Only update subscriber cache when no filters are active

### DIFF
--- a/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
+++ b/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
@@ -73,8 +73,9 @@ export const useInfiniteLiveSubscribers = (props: {
       if (event.op === "newSubscriber") {
         const { result } = normalizeAndCache(event.profile);
 
+        // Only update the unfiltered (all-subscribers) cache
         queryClient.setQueryData(
-          [QueryType.infinite, EntityType.SUBSCRIBER, params],
+          [QueryType.infinite, EntityType.SUBSCRIBER, { where: {} }],
           (oldData) => {
             if (oldData) {
               const data = oldData as InfiniteData<string[]>;


### PR DESCRIPTION
This PR modifies the subscriber cache update behavior in the inbox component to prevent unwanted updates when filters are applied. Previously, new subscribers were always added to the cache regardless of active filters, which could interfere with search results and filtered views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subscriber list updates to ensure new subscribers appear correctly in the unfiltered view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->