### PR TITLE
Simplify quick replies removal logic

### DIFF
--- a/frontend/src/components/visual-editor/form/inputs/message/QuickRepliesInput.tsx
+++ b/frontend/src/components/visual-editor/form/inputs/message/QuickRepliesInput.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -48,17 +48,7 @@ const QuickRepliesInput: FC<QuickRepliesInput> = ({
     const updatedQuickReplies = [...quickReplies];
 
     updatedQuickReplies.splice(index, 1);
-    setQuickReplies(
-      updatedQuickReplies.length
-        ? updatedQuickReplies
-        : [
-            createValueWithId({
-              content_type: QuickReplyType.text,
-              title: "",
-              payload: "",
-            }),
-          ],
-    );
+    setQuickReplies(updatedQuickReplies);
   };
   const updateInput = (index: number) => (p: StdQuickReply) => {
     quickReplies[index].value = p;


### PR DESCRIPTION
- Modified the `removeInput` function in `QuickRepliesInput` component to allow removing all quick replies when `minInput` is 0
- Removed the logic that was forcing at least one quick reply to exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quick replies input behavior by allowing all quick replies to be removed, instead of always keeping one default quick reply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->