### PR TITLE
refactor: block fallback options

### DIFF
--- a/api/src/chat/constants/block.ts
+++ b/api/src/chat/constants/block.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { FallbackOptions } from '../schemas/types/options';
+
+export function getDefaultFallbackOptions(): FallbackOptions {
+  return {
+    active: false,
+    max_attempts: 0,
+    message: [],
+  };
+}

--- a/api/src/chat/constants/conversation.ts
+++ b/api/src/chat/constants/conversation.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { Subscriber } from '../schemas/subscriber.schema';
+import { Context } from '../schemas/types/context';
+
+export function getDefaultConversationContext(): Context {
+  return {
+    vars: {}, // Used for capturing vars from user entries
+    user: {
+      first_name: '',
+      last_name: '',
+      // @TODO: Typing is not correct
+    } as Subscriber,
+    user_location: {
+      // Used for capturing geolocation from QR
+      lat: 0.0,
+      lon: 0.0,
+    },
+    skip: {}, // Used for list pagination
+    attempt: 0, // Used to track fallback max attempts
+  };
+}

--- a/api/src/chat/schemas/conversation.schema.ts
+++ b/api/src/chat/schemas/conversation.schema.ts
@@ -17,26 +17,11 @@ import {
   THydratedDocument,
 } from '@/utils/types/filter.types';
 
+import { getDefaultConversationContext } from '../constants/conversation';
+
 import { Block } from './block.schema';
 import { Subscriber } from './subscriber.schema';
 import { Context } from './types/context';
-
-export function getDefaultConversationContext(): Context {
-  return {
-    vars: {}, // Used for capturing vars from user entries
-    user: {
-      first_name: '',
-      last_name: '',
-    } as Subscriber,
-    user_location: {
-      // Used for capturing geolocation from QR
-      lat: 0.0,
-      lon: 0.0,
-    },
-    skip: {}, // Used for list pagination
-    attempt: 0, // Used to track fallback max attempts
-  };
-}
 
 @Schema({ timestamps: true, minimize: false })
 class ConversationStub extends BaseSchema {

--- a/api/src/chat/schemas/types/options.ts
+++ b/api/src/chat/schemas/types/options.ts
@@ -29,16 +29,18 @@ export const contentOptionsSchema = z.object({
 
 export type ContentOptions = z.infer<typeof contentOptionsSchema>;
 
+export const fallbackOptionsSchema = z.object({
+  active: z.boolean(),
+  message: z.array(z.string()),
+  max_attempts: z.number().finite(),
+});
+
+export type FallbackOptions = z.infer<typeof fallbackOptionsSchema>;
+
 export const BlockOptionsSchema = z.object({
   typing: z.number().optional(),
   content: contentOptionsSchema.optional(),
-  fallback: z
-    .object({
-      active: z.boolean(),
-      message: z.array(z.string()),
-      max_attempts: z.number().finite(),
-    })
-    .optional(),
+  fallback: fallbackOptionsSchema.optional(),
   assignTo: z.string().optional(),
   effects: z.array(z.string()).optional(),
 });

--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -784,10 +784,7 @@ export class BlockService extends BaseService<
    * @returns The fallback options for the block, or default options if not specified.
    */
   getFallbackOptions<T extends BlockStub>(block: T): FallbackOptions {
-    const fallbackOptions: FallbackOptions = block.options?.fallback
-      ? block.options.fallback
-      : getDefaultFallbackOptions();
-    return fallbackOptions;
+    return block.options?.fallback ?? getDefaultFallbackOptions();
   }
 
   /**

--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -23,6 +23,7 @@ import { FALLBACK_DEFAULT_NLU_PENALTY_FACTOR } from '@/utils/constants/nlp';
 import { BaseService } from '@/utils/generics/base-service';
 import { getRandomElement } from '@/utils/helpers/safeRandom';
 
+import { getDefaultFallbackOptions } from '../constants/block';
 import { BlockDto } from '../dto/block.dto';
 import { EnvelopeFactory } from '../helpers/envelope-factory';
 import { BlockRepository } from '../repositories/block.repository';
@@ -40,6 +41,7 @@ import {
   StdOutgoingEnvelope,
   StdOutgoingSystemEnvelope,
 } from '../schemas/types/message';
+import { FallbackOptions } from '../schemas/types/options';
 import { NlpPattern, PayloadPattern } from '../schemas/types/pattern';
 import { Payload } from '../schemas/types/quick-reply';
 import { SubscriberContext } from '../schemas/types/subscriberContext';
@@ -773,6 +775,19 @@ export class BlockService extends BaseService<
       }
     }
     throw new Error('Invalid message format.');
+  }
+
+  /**
+   * Retrieves the fallback options for a block.
+   *
+   * @param block - The block to retrieve fallback options from.
+   * @returns The fallback options for the block, or default options if not specified.
+   */
+  getFallbackOptions<T extends BlockStub>(block: T): FallbackOptions {
+    const fallbackOptions: FallbackOptions = block.options?.fallback
+      ? block.options.fallback
+      : getDefaultFallbackOptions();
+    return fallbackOptions;
   }
 
   /**

--- a/api/src/chat/services/bot.service.ts
+++ b/api/src/chat/services/bot.service.ts
@@ -24,7 +24,7 @@ import {
   OutgoingMessageFormat,
   StdOutgoingMessageEnvelope,
 } from '../schemas/types/message';
-import { BlockOptions } from '../schemas/types/options';
+import { BlockOptions, FallbackOptions } from '../schemas/types/options';
 
 import { BlockService } from './block.service';
 import { ConversationService } from './conversation.service';
@@ -285,19 +285,46 @@ export class BotService {
   }
 
   /**
+   * Finds the next block that matches the event criteria within the conversation's next blocks.
+   *
+   * @param convo - The current conversation object containing context and state.
+   * @param event - The incoming event that triggered the conversation flow.
+   *
+   * @returns A promise that resolves with the matched block or undefined if no match is found.
+   */
+  async findNextMatchingBlock(
+    convo: ConversationFull,
+    event: EventWrapper<any, any>,
+  ): Promise<BlockFull | undefined> {
+    const fallbackOptions: FallbackOptions =
+      this.blockService.getFallbackOptions(convo.current);
+    // We will avoid having multiple matches when we are not at the start of a conversation
+    // and only if local fallback is enabled
+    const canHaveMultipleMatches = !fallbackOptions?.active;
+    // Find the next block that matches
+    const nextBlocks = await this.blockService.findAndPopulate({
+      _id: { $in: convo.next.map(({ id }) => id) },
+    });
+    return await this.blockService.match(
+      nextBlocks,
+      event,
+      canHaveMultipleMatches,
+    );
+  }
+
+  /**
    * Determines if a fallback should be attempted based on the event type, fallback options, and conversation context.
    *
-   * @param event - The incoming event that triggered the conversation flow.
-   * @param fallbackOptions - The options for fallback behavior defined in the block.
    * @param convo - The current conversation object containing context and state.
+   * @param event - The incoming event that triggered the conversation flow.
    *
    * @returns A boolean indicating whether a fallback should be attempted.
    */
-  private shouldAttemptLocalFallback(
-    event: EventWrapper<any, any>,
-    fallbackOptions: BlockOptions['fallback'],
+  shouldAttemptLocalFallback(
     convo: ConversationFull,
+    event: EventWrapper<any, any>,
   ): boolean {
+    const fallbackOptions = this.blockService.getFallbackOptions(convo.current);
     return (
       event.getMessageType() === IncomingMessageType.message &&
       !!fallbackOptions?.active &&
@@ -346,10 +373,7 @@ export class BotService {
       // If there is no match in next block then loopback (current fallback)
       // This applies only to text messages + there's a max attempt to be specified
       let fallbackBlock: BlockFull | undefined = undefined;
-      if (
-        !matchedBlock &&
-        this.shouldAttemptLocalFallback(event, fallbackOptions, convo)
-      ) {
+      if (!matchedBlock && this.shouldAttemptLocalFallback(convo, event)) {
         // Trigger block fallback
         // NOTE : current is not populated, this may cause some anomaly
         fallbackBlock = {

--- a/api/src/chat/services/bot.service.ts
+++ b/api/src/chat/services/bot.service.ts
@@ -14,13 +14,10 @@ import EventWrapper from '@/channel/lib/EventWrapper';
 import { LoggerService } from '@/logger/logger.service';
 import { SettingService } from '@/setting/services/setting.service';
 
+import { getDefaultConversationContext } from '../constants/conversation';
 import { MessageCreateDto } from '../dto/message.dto';
 import { BlockFull } from '../schemas/block.schema';
-import {
-  Conversation,
-  ConversationFull,
-  getDefaultConversationContext,
-} from '../schemas/conversation.schema';
+import { Conversation, ConversationFull } from '../schemas/conversation.schema';
 import { Context } from '../schemas/types/context';
 import {
   IncomingMessageType,


### PR DESCRIPTION
# Motivation

Performing a refactoring on the fallback option usage.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced default configuration for fallback options in chat blocks.
	- Added a method to retrieve fallback options for chat blocks, using defaults when not specified.
	- Provided a default conversation context for new conversations.

- **Refactor**
	- Centralized the definition of fallback options and conversation context for improved consistency and reusability.
	- Updated the schema for fallback options to use a standalone, reusable structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->