### PR TITLE
feat(api): add automatic DI into unit tests

### DIFF
--- a/api/src/analytics/controllers/bot-stats.controller.spec.ts
+++ b/api/src/analytics/controllers/bot-stats.controller.spec.ts
@@ -6,8 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import {
   botstatsFixtures,
   installBotStatsFixtures,
@@ -18,9 +16,7 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { BotStatsRepository } from '../repositories/bot-stats.repository';
-import { BotStatsModel, BotStatsType } from '../schemas/bot-stats.schema';
-import { BotStatsService } from '../services/bot-stats.service';
+import { BotStatsType } from '../schemas/bot-stats.schema';
 
 import { BotStatsController } from './bot-stats.controller';
 
@@ -29,12 +25,9 @@ describe('BotStatsController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [BotStatsController],
-      imports: [
-        rootMongooseTestModule(installBotStatsFixtures),
-        MongooseModule.forFeature([BotStatsModel]),
-      ],
-      providers: [BotStatsService, BotStatsRepository],
+      imports: [rootMongooseTestModule(installBotStatsFixtures)],
     });
     [botStatsController] = await getMocks([BotStatsController]);
   });

--- a/api/src/analytics/repositories/bot-stats.repository.spec.ts
+++ b/api/src/analytics/repositories/bot-stats.repository.spec.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { getModelToken, MongooseModule } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import {
@@ -19,11 +19,7 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import {
-  BotStats,
-  BotStatsModel,
-  BotStatsType,
-} from '../schemas/bot-stats.schema';
+import { BotStats, BotStatsType } from '../schemas/bot-stats.schema';
 
 import { BotStatsRepository } from './bot-stats.repository';
 
@@ -33,10 +29,8 @@ describe('BotStatsRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installBotStatsFixtures),
-        MongooseModule.forFeature([BotStatsModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installBotStatsFixtures)],
       providers: [BotStatsRepository],
     });
     [botStatsRepository, botStatsModel] = await getMocks([

--- a/api/src/analytics/services/bot-stats.service.spec.ts
+++ b/api/src/analytics/services/bot-stats.service.spec.ts
@@ -6,8 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import {
   botstatsFixtures,
   installBotStatsFixtures,
@@ -18,8 +16,7 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { BotStatsRepository } from '../repositories/bot-stats.repository';
-import { BotStatsModel, BotStatsType } from '../schemas/bot-stats.schema';
+import { BotStatsType } from '../schemas/bot-stats.schema';
 
 import { BotStatsService } from './bot-stats.service';
 
@@ -28,11 +25,9 @@ describe('BotStatsService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installBotStatsFixtures),
-        MongooseModule.forFeature([BotStatsModel]),
-      ],
-      providers: [BotStatsService, BotStatsRepository],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installBotStatsFixtures)],
+      providers: [BotStatsService],
     });
     [botStatsService] = await getMocks([BotStatsService]);
   });

--- a/api/src/attachment/controllers/attachment.controller.spec.ts
+++ b/api/src/attachment/controllers/attachment.controller.spec.ts
@@ -8,26 +8,17 @@
 
 import fs from 'fs';
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import {
   BadRequestException,
   MethodNotAllowedException,
 } from '@nestjs/common/exceptions';
 import { NotFoundException } from '@nestjs/common/exceptions/not-found.exception';
-import { MongooseModule } from '@nestjs/mongoose';
 import { Request } from 'express';
 
 import LocalStorageHelper from '@/extensions/helpers/local-storage/index.helper';
 import { HelperService } from '@/helper/helper.service';
 import { LoggerService } from '@/logger/logger.service';
-import { SettingRepository } from '@/setting/repositories/setting.repository';
-import { SettingModel } from '@/setting/schemas/setting.schema';
-import { SettingSeeder } from '@/setting/seeds/setting.seed';
 import { SettingService } from '@/setting/services/setting.service';
-import { ModelRepository } from '@/user/repositories/model.repository';
-import { PermissionRepository } from '@/user/repositories/permission.repository';
-import { ModelModel } from '@/user/schemas/model.schema';
-import { PermissionModel } from '@/user/schemas/permission.schema';
 import { ModelService } from '@/user/services/model.service';
 import { PermissionService } from '@/user/services/permission.service';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
@@ -44,8 +35,7 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { attachment, attachmentFile } from '../mocks/attachment.mock';
-import { AttachmentRepository } from '../repositories/attachment.repository';
-import { Attachment, AttachmentModel } from '../schemas/attachment.schema';
+import { Attachment } from '../schemas/attachment.schema';
 import { AttachmentService } from '../services/attachment.service';
 import {
   AttachmentAccess,
@@ -64,39 +54,15 @@ describe('AttachmentController', () => {
 
   beforeAll(async () => {
     const { getMocks, resolveMocks } = await buildTestingMocks({
+      autoInjectFrom: ['all'],
       controllers: [AttachmentController],
       imports: [
         rootMongooseTestModule(async () => {
           await installSettingFixtures();
           await installAttachmentFixtures();
         }),
-        MongooseModule.forFeature([
-          AttachmentModel,
-          PermissionModel,
-          ModelModel,
-          SettingModel,
-        ]),
       ],
-      providers: [
-        AttachmentService,
-        AttachmentRepository,
-        PermissionService,
-        PermissionRepository,
-        SettingRepository,
-        ModelService,
-        ModelRepository,
-        SettingSeeder,
-        SettingService,
-        HelperService,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      providers: [PermissionService, ModelService],
     });
     [attachmentController, attachmentService, helperService, settingService] =
       await getMocks([

--- a/api/src/attachment/controllers/attachment.controller.spec.ts
+++ b/api/src/attachment/controllers/attachment.controller.spec.ts
@@ -54,7 +54,7 @@ describe('AttachmentController', () => {
 
   beforeAll(async () => {
     const { getMocks, resolveMocks } = await buildTestingMocks({
-      autoInjectFrom: ['all'],
+      autoInjectFrom: ['controllers', 'providers'],
       controllers: [AttachmentController],
       imports: [
         rootMongooseTestModule(async () => {

--- a/api/src/chat/controllers/block.controller.spec.ts
+++ b/api/src/chat/controllers/block.controller.spec.ts
@@ -6,34 +6,9 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ContentRepository } from '@/cms/repositories/content.repository';
-import { ContentModel } from '@/cms/schemas/content.schema';
-import { ContentService } from '@/cms/services/content.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LanguageService } from '@/i18n/services/language.service';
-import { NlpService } from '@/nlp/services/nlp.service';
-import { PluginService } from '@/plugins/plugins.service';
-import { SettingService } from '@/setting/services/setting.service';
-import { InvitationRepository } from '@/user/repositories/invitation.repository';
-import { PermissionRepository } from '@/user/repositories/permission.repository';
-import { RoleRepository } from '@/user/repositories/role.repository';
-import { UserRepository } from '@/user/repositories/user.repository';
-import { InvitationModel } from '@/user/schemas/invitation.schema';
-import { PermissionModel } from '@/user/schemas/permission.schema';
-import { RoleModel } from '@/user/schemas/role.schema';
-import { UserModel } from '@/user/schemas/user.schema';
-import { PermissionService } from '@/user/services/permission.service';
-import { RoleService } from '@/user/services/role.service';
-import { UserService } from '@/user/services/user.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import {
@@ -47,17 +22,12 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { BlockCreateDto, BlockUpdateDto } from '../dto/block.dto';
-import { BlockRepository } from '../repositories/block.repository';
-import { CategoryRepository } from '../repositories/category.repository';
-import { LabelRepository } from '../repositories/label.repository';
-import { Block, BlockModel } from '../schemas/block.schema';
-import { LabelModel } from '../schemas/label.schema';
+import { Block } from '../schemas/block.schema';
 import { PayloadType } from '../schemas/types/button';
 import { BlockService } from '../services/block.service';
 import { CategoryService } from '../services/category.service';
-import { LabelService } from '../services/label.service';
 
-import { Category, CategoryModel } from './../schemas/category.schema';
+import { Category } from './../schemas/category.schema';
 import { BlockController } from './block.controller';
 
 describe('BlockController', () => {
@@ -80,69 +50,15 @@ describe('BlockController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [BlockController],
-      imports: [
-        rootMongooseTestModule(installBlockFixtures),
-        MongooseModule.forFeature([
-          BlockModel,
-          LabelModel,
-          CategoryModel,
-          ContentModel,
-          InvitationModel,
-          AttachmentModel,
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          LanguageModel,
-        ]),
-      ],
+      imports: [rootMongooseTestModule(installBlockFixtures)],
       providers: [
-        BlockRepository,
-        LabelRepository,
-        CategoryRepository,
-        ContentRepository,
-        AttachmentRepository,
-        UserRepository,
-        RoleRepository,
-        PermissionRepository,
-        InvitationRepository,
-        LanguageRepository,
-        BlockService,
-        LabelService,
-        CategoryService,
-        ContentService,
-        AttachmentService,
-        UserService,
-        RoleService,
-        PermissionService,
-        LanguageService,
-        PluginService,
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
           },
-        },
-        {
-          provide: SettingService,
-          useValue: {
-            getConfig: jest.fn(() => ({
-              chatbot: { lang: { default: 'fr' } },
-            })),
-            getSettings: jest.fn(() => ({})),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-        {
-          provide: NlpService,
-          useValue: {},
         },
       ],
     });

--- a/api/src/chat/controllers/category.contoller.spec.ts
+++ b/api/src/chat/controllers/category.contoller.spec.ts
@@ -7,17 +7,8 @@
  */
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ContentRepository } from '@/cms/repositories/content.repository';
-import { ContentModel } from '@/cms/schemas/content.schema';
-import { ContentService } from '@/cms/services/content.service';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { PluginService } from '@/plugins/plugins.service';
-import { SettingService } from '@/setting/services/setting.service';
 import {
   categoryFixtures,
   installCategoryFixtures,
@@ -31,14 +22,9 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { CategoryCreateDto, CategoryUpdateDto } from '../dto/category.dto';
-import { BlockRepository } from '../repositories/block.repository';
-import { CategoryRepository } from '../repositories/category.repository';
-import { BlockModel } from '../schemas/block.schema';
-import { LabelModel } from '../schemas/label.schema';
-import { BlockService } from '../services/block.service';
 import { CategoryService } from '../services/category.service';
 
-import { Category, CategoryModel } from './../schemas/category.schema';
+import { Category } from './../schemas/category.schema';
 import { CategoryController } from './category.controller';
 
 describe('CategoryController', () => {
@@ -49,49 +35,14 @@ describe('CategoryController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [CategoryController],
-      imports: [
-        rootMongooseTestModule(installCategoryFixtures),
-        MongooseModule.forFeature([
-          BlockModel,
-          LabelModel,
-          CategoryModel,
-          ContentModel,
-          AttachmentModel,
-        ]),
-      ],
+      imports: [rootMongooseTestModule(installCategoryFixtures)],
       providers: [
-        BlockRepository,
-        CategoryRepository,
-        ContentRepository,
-        AttachmentRepository,
-        BlockService,
-        CategoryService,
-        ContentService,
-        AttachmentService,
-        {
-          provide: PluginService,
-          useValue: {},
-        },
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: SettingService,
-          useValue: {
-            getConfig: jest.fn(() => ({
-              chatbot: { lang: { default: 'fr' } },
-            })),
-            getSettings: jest.fn(() => ({})),
-          },
-        },
-        {
-          provide: BlockService,
-          useValue: {
-            findOne: jest.fn(),
           },
         },
       ],

--- a/api/src/chat/controllers/context-var.controller.spec.ts
+++ b/api/src/chat/controllers/context-var.controller.spec.ts
@@ -7,8 +7,8 @@
  */
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
+import { I18nService } from '@/i18n/services/i18n.service';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import {
   contextVarFixtures,
@@ -26,8 +26,7 @@ import {
   ContextVarCreateDto,
   ContextVarUpdateDto,
 } from '../dto/context-var.dto';
-import { ContextVarRepository } from '../repositories/context-var.repository';
-import { ContextVar, ContextVarModel } from '../schemas/context-var.schema';
+import { ContextVar } from '../schemas/context-var.schema';
 import { ContextVarService } from '../services/context-var.service';
 
 import { ContextVarController } from './context-var.controller';
@@ -40,12 +39,17 @@ describe('ContextVarController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [ContextVarController],
-      imports: [
-        rootMongooseTestModule(installContextVarFixtures),
-        MongooseModule.forFeature([ContextVarModel]),
+      imports: [rootMongooseTestModule(installContextVarFixtures)],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: {
+            t: jest.fn().mockImplementation((t) => t),
+          },
+        },
       ],
-      providers: [ContextVarService, ContextVarRepository],
     });
     [contextVarController, contextVarService] = await getMocks([
       ContextVarController,

--- a/api/src/chat/controllers/label.controller.spec.ts
+++ b/api/src/chat/controllers/label.controller.spec.ts
@@ -7,20 +7,7 @@
  */
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { InvitationRepository } from '@/user/repositories/invitation.repository';
-import { RoleRepository } from '@/user/repositories/role.repository';
-import { UserRepository } from '@/user/repositories/user.repository';
-import { InvitationModel } from '@/user/schemas/invitation.schema';
-import { PermissionModel } from '@/user/schemas/permission.schema';
-import { RoleModel } from '@/user/schemas/role.schema';
-import { UserModel } from '@/user/schemas/user.schema';
-import { RoleService } from '@/user/services/role.service';
-import { UserService } from '@/user/services/user.service';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
@@ -35,10 +22,7 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelCreateDto, LabelUpdateDto } from '../dto/label.dto';
-import { LabelRepository } from '../repositories/label.repository';
-import { SubscriberRepository } from '../repositories/subscriber.repository';
-import { Label, LabelModel } from '../schemas/label.schema';
-import { SubscriberModel } from '../schemas/subscriber.schema';
+import { Label } from '../schemas/label.schema';
 import { LabelService } from '../services/label.service';
 import { SubscriberService } from '../services/subscriber.service';
 
@@ -54,33 +38,10 @@ describe('LabelController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['all'],
       controllers: [LabelController],
-      imports: [
-        rootMongooseTestModule(installSubscriberFixtures),
-        MongooseModule.forFeature([
-          LabelModel,
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          SubscriberModel,
-          InvitationModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        LabelController,
-        LabelService,
-        LabelRepository,
-        UserService,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        SubscriberService,
-        SubscriberRepository,
-        AttachmentService,
-        AttachmentRepository,
-      ],
+      imports: [rootMongooseTestModule(installSubscriberFixtures)],
+      providers: [SubscriberService],
     });
     [labelService, subscriberService, labelController] = await getMocks([
       LabelService,

--- a/api/src/chat/controllers/label.controller.spec.ts
+++ b/api/src/chat/controllers/label.controller.spec.ts
@@ -38,7 +38,7 @@ describe('LabelController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      autoInjectFrom: ['all'],
+      autoInjectFrom: ['controllers', 'providers'],
       controllers: [LabelController],
       imports: [rootMongooseTestModule(installSubscriberFixtures)],
       providers: [SubscriberService],

--- a/api/src/chat/controllers/message.controller.spec.ts
+++ b/api/src/chat/controllers/message.controller.spec.ts
@@ -41,7 +41,7 @@ describe('MessageController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      autoInjectFrom: ['all'],
+      autoInjectFrom: ['controllers', 'providers'],
       controllers: [MessageController],
       imports: [rootMongooseTestModule(installMessageFixtures)],
       providers: [UserService],

--- a/api/src/chat/controllers/message.controller.spec.ts
+++ b/api/src/chat/controllers/message.controller.spec.ts
@@ -6,27 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ChannelService } from '@/channel/channel.service';
-import { MenuRepository } from '@/cms/repositories/menu.repository';
-import { MenuModel } from '@/cms/schemas/menu.schema';
-import { MenuService } from '@/cms/services/menu.service';
-import { I18nService } from '@/i18n/services/i18n.service';
-import { NlpService } from '@/nlp/services/nlp.service';
-import { SettingService } from '@/setting/services/setting.service';
-import { InvitationRepository } from '@/user/repositories/invitation.repository';
-import { RoleRepository } from '@/user/repositories/role.repository';
-import { UserRepository } from '@/user/repositories/user.repository';
-import { InvitationModel } from '@/user/schemas/invitation.schema';
-import { PermissionModel } from '@/user/schemas/permission.schema';
-import { RoleModel } from '@/user/schemas/role.schema';
-import { User, UserModel } from '@/user/schemas/user.schema';
-import { RoleService } from '@/user/services/role.service';
+import { User } from '@/user/schemas/user.schema';
 import { UserService } from '@/user/services/user.service';
 import {
   installMessageFixtures,
@@ -39,10 +19,8 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { MessageRepository } from '../repositories/message.repository';
-import { SubscriberRepository } from '../repositories/subscriber.repository';
-import { Message, MessageModel } from '../schemas/message.schema';
-import { Subscriber, SubscriberModel } from '../schemas/subscriber.schema';
+import { Message } from '../schemas/message.schema';
+import { Subscriber } from '../schemas/subscriber.schema';
 import { MessageService } from '../services/message.service';
 import { SubscriberService } from '../services/subscriber.service';
 
@@ -63,66 +41,10 @@ describe('MessageController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['all'],
       controllers: [MessageController],
-      imports: [
-        rootMongooseTestModule(installMessageFixtures),
-        MongooseModule.forFeature([
-          SubscriberModel,
-          MessageModel,
-          UserModel,
-          RoleModel,
-          InvitationModel,
-          PermissionModel,
-          AttachmentModel,
-          MenuModel,
-        ]),
-      ],
-      providers: [
-        MessageController,
-        MessageRepository,
-        MessageService,
-        SubscriberService,
-        UserService,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        SubscriberRepository,
-        ChannelService,
-        AttachmentService,
-        AttachmentRepository,
-        MenuService,
-        MenuRepository,
-        {
-          provide: I18nService,
-          useValue: {
-            t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: NlpService,
-          useValue: {
-            getNLP: jest.fn(() => undefined),
-          },
-        },
-        {
-          provide: SettingService,
-          useValue: {
-            getConfig: jest.fn(() => ({
-              chatbot: { lang: { default: 'fr' } },
-            })),
-            getSettings: jest.fn(() => ({})),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      imports: [rootMongooseTestModule(installMessageFixtures)],
+      providers: [UserService],
     });
     [messageService, userService, subscriberService, messageController] =
       await getMocks([

--- a/api/src/chat/controllers/subscriber.controller.spec.ts
+++ b/api/src/chat/controllers/subscriber.controller.spec.ts
@@ -39,7 +39,7 @@ describe('SubscriberController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      autoInjectFrom: ['all'],
+      autoInjectFrom: ['controllers', 'providers'],
       controllers: [SubscriberController],
       imports: [rootMongooseTestModule(installSubscriberFixtures)],
       providers: [LabelService, UserService],

--- a/api/src/chat/controllers/subscriber.controller.spec.ts
+++ b/api/src/chat/controllers/subscriber.controller.spec.ts
@@ -6,19 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { InvitationRepository } from '@/user/repositories/invitation.repository';
-import { RoleRepository } from '@/user/repositories/role.repository';
-import { UserRepository } from '@/user/repositories/user.repository';
-import { InvitationModel } from '@/user/schemas/invitation.schema';
-import { PermissionModel } from '@/user/schemas/permission.schema';
-import { RoleModel } from '@/user/schemas/role.schema';
-import { User, UserModel } from '@/user/schemas/user.schema';
-import { RoleService } from '@/user/services/role.service';
+import { User } from '@/user/schemas/user.schema';
 import {
   installSubscriberFixtures,
   subscriberFixtures,
@@ -30,13 +18,9 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
-import { SocketEventDispatcherService } from '@/websocket/services/socket-event-dispatcher.service';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
-import { LabelRepository } from '../repositories/label.repository';
-import { SubscriberRepository } from '../repositories/subscriber.repository';
-import { Label, LabelModel } from '../schemas/label.schema';
-import { Subscriber, SubscriberModel } from '../schemas/subscriber.schema';
+import { Label } from '../schemas/label.schema';
+import { Subscriber } from '../schemas/subscriber.schema';
 import { SubscriberService } from '../services/subscriber.service';
 
 import { UserService } from './../../user/services/user.service';
@@ -55,34 +39,10 @@ describe('SubscriberController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['all'],
       controllers: [SubscriberController],
-      imports: [
-        rootMongooseTestModule(installSubscriberFixtures),
-        MongooseModule.forFeature([
-          SubscriberModel,
-          LabelModel,
-          UserModel,
-          RoleModel,
-          InvitationModel,
-          PermissionModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        SubscriberRepository,
-        SubscriberService,
-        LabelService,
-        LabelRepository,
-        UserService,
-        WebsocketGateway,
-        SocketEventDispatcherService,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        AttachmentService,
-        AttachmentRepository,
-      ],
+      imports: [rootMongooseTestModule(installSubscriberFixtures)],
+      providers: [LabelService, UserService],
     });
     [subscriberService, labelService, userService, subscriberController] =
       await getMocks([

--- a/api/src/chat/repositories/block.repository.spec.ts
+++ b/api/src/chat/repositories/block.repository.spec.ts
@@ -6,9 +6,10 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
+import { I18nService } from '@/i18n/services/i18n.service';
 import {
   blockFixtures,
   installBlockFixtures,
@@ -19,9 +20,8 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { Block, BlockModel } from '../schemas/block.schema';
-import { Category, CategoryModel } from '../schemas/category.schema';
-import { LabelModel } from '../schemas/label.schema';
+import { Block } from '../schemas/block.schema';
+import { Category } from '../schemas/category.schema';
 
 import { BlockRepository } from './block.repository';
 import { CategoryRepository } from './category.repository';
@@ -39,11 +39,19 @@ describe('BlockRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installBlockFixtures),
-        MongooseModule.forFeature([BlockModel, CategoryModel, LabelModel]),
+      models: ['LabelModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installBlockFixtures)],
+      providers: [
+        BlockRepository,
+        CategoryRepository,
+        {
+          provide: I18nService,
+          useValue: {
+            t: jest.fn().mockImplementation((t) => t),
+          },
+        },
       ],
-      providers: [BlockRepository, CategoryRepository],
     });
     [blockRepository, categoryRepository, blockModel] = await getMocks([
       BlockRepository,

--- a/api/src/chat/repositories/label.repository.spec.ts
+++ b/api/src/chat/repositories/label.repository.spec.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { labelFixtures } from '@/utils/test/fixtures/label';
@@ -19,8 +19,8 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { Label, LabelFull, LabelModel } from '../schemas/label.schema';
-import { Subscriber, SubscriberModel } from '../schemas/subscriber.schema';
+import { Label, LabelFull } from '../schemas/label.schema';
+import { Subscriber } from '../schemas/subscriber.schema';
 
 import { LabelRepository } from './label.repository';
 import { SubscriberRepository } from './subscriber.repository';
@@ -33,10 +33,8 @@ describe('LabelRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installSubscriberFixtures),
-        MongooseModule.forFeature([LabelModel, SubscriberModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installSubscriberFixtures)],
       providers: [LabelRepository, SubscriberRepository],
     });
     [labelRepository, subscriberRepository, labelModel] = await getMocks([

--- a/api/src/chat/repositories/message.repository.spec.ts
+++ b/api/src/chat/repositories/message.repository.spec.ts
@@ -6,11 +6,10 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { UserRepository } from '@/user/repositories/user.repository';
-import { UserModel } from '@/user/schemas/user.schema';
 import {
   installMessageFixtures,
   messageFixtures,
@@ -22,8 +21,7 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { Message, MessageModel } from '../schemas/message.schema';
-import { SubscriberModel } from '../schemas/subscriber.schema';
+import { Message } from '../schemas/message.schema';
 import { AnyMessage } from '../schemas/types/message';
 
 import { MessageRepository } from './message.repository';
@@ -37,10 +35,8 @@ describe('MessageRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installMessageFixtures),
-        MongooseModule.forFeature([MessageModel, SubscriberModel, UserModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installMessageFixtures)],
       providers: [MessageRepository, SubscriberRepository, UserRepository],
     });
     [messageRepository, userRepository, subscriberRepository, messageModel] =

--- a/api/src/chat/repositories/subscriber.repository.spec.ts
+++ b/api/src/chat/repositories/subscriber.repository.spec.ts
@@ -6,17 +6,13 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import {
-  Attachment,
-  AttachmentModel,
-} from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
+import { Attachment } from '@/attachment/schemas/attachment.schema';
 import { UserRepository } from '@/user/repositories/user.repository';
-import { User, UserModel } from '@/user/schemas/user.schema';
+import { User } from '@/user/schemas/user.schema';
 import {
   installSubscriberFixtures,
   subscriberFixtures,
@@ -29,12 +25,8 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { Label, LabelModel } from '../schemas/label.schema';
-import {
-  Subscriber,
-  SubscriberFull,
-  SubscriberModel,
-} from '../schemas/subscriber.schema';
+import { Label } from '../schemas/label.schema';
+import { Subscriber, SubscriberFull } from '../schemas/subscriber.schema';
 
 import { LabelRepository } from './label.repository';
 import { SubscriberRepository } from './subscriber.repository';
@@ -53,20 +45,12 @@ describe('SubscriberRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installSubscriberFixtures),
-        MongooseModule.forFeature([
-          SubscriberModel,
-          LabelModel,
-          UserModel,
-          AttachmentModel,
-        ]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installSubscriberFixtures)],
       providers: [
         SubscriberRepository,
         LabelRepository,
         UserRepository,
-        AttachmentService,
         AttachmentRepository,
       ],
     });

--- a/api/src/chat/services/block.service.spec.ts
+++ b/api/src/chat/services/block.service.spec.ts
@@ -6,47 +6,19 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import {
   subscriberWithLabels,
   subscriberWithoutLabels,
 } from '@/channel/lib/__test__/subscriber.mock';
 import { ButtonType, PayloadType } from '@/chat/schemas/types/button';
-import { ContentTypeRepository } from '@/cms/repositories/content-type.repository';
-import { ContentRepository } from '@/cms/repositories/content.repository';
-import { ContentTypeModel } from '@/cms/schemas/content-type.schema';
-import { Content, ContentModel } from '@/cms/schemas/content.schema';
+import { Content } from '@/cms/schemas/content.schema';
 import { ContentTypeService } from '@/cms/services/content-type.service';
 import { ContentService } from '@/cms/services/content.service';
 import WebChannelHandler from '@/extensions/channels/web/index.channel';
 import { WEB_CHANNEL_NAME } from '@/extensions/channels/web/settings';
 import { Web } from '@/extensions/channels/web/types';
 import WebEventWrapper from '@/extensions/channels/web/wrapper';
-import { HelperService } from '@/helper/helper.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LanguageService } from '@/i18n/services/language.service';
-import { NlpEntityRepository } from '@/nlp/repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '@/nlp/repositories/nlp-sample-entity.repository';
-import { NlpSampleRepository } from '@/nlp/repositories/nlp-sample.repository';
-import { NlpValueRepository } from '@/nlp/repositories/nlp-value.repository';
-import { NlpEntityModel } from '@/nlp/schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '@/nlp/schemas/nlp-sample-entity.schema';
-import { NlpSampleModel } from '@/nlp/schemas/nlp-sample.schema';
-import { NlpValueModel } from '@/nlp/schemas/nlp-value.schema';
-import { NlpEntityService } from '@/nlp/services/nlp-entity.service';
-import { NlpSampleEntityService } from '@/nlp/services/nlp-sample-entity.service';
-import { NlpSampleService } from '@/nlp/services/nlp-sample.service';
-import { NlpValueService } from '@/nlp/services/nlp-value.service';
-import { NlpService } from '@/nlp/services/nlp.service';
-import { PluginService } from '@/plugins/plugins.service';
-import { SettingService } from '@/setting/services/setting.service';
 import { FALLBACK_DEFAULT_NLU_PENALTY_FACTOR } from '@/utils/constants/nlp';
 import {
   blockFixtures,
@@ -83,9 +55,8 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { BlockRepository } from '../repositories/block.repository';
-import { Block, BlockFull, BlockModel } from '../schemas/block.schema';
-import { Category, CategoryModel } from '../schemas/category.schema';
-import { LabelModel } from '../schemas/label.schema';
+import { Block, BlockFull } from '../schemas/block.schema';
+import { Category } from '../schemas/category.schema';
 import { Subscriber } from '../schemas/subscriber.schema';
 import { FileType } from '../schemas/types/attachment';
 import { Context } from '../schemas/types/context';
@@ -97,7 +68,6 @@ import { QuickReplyType } from '../schemas/types/quick-reply';
 
 import { CategoryRepository } from './../repositories/category.repository';
 import { BlockService } from './block.service';
-import { CategoryService } from './category.service';
 
 function makeMockBlock(overrides: Partial<Block>): Block {
   return {
@@ -135,79 +105,25 @@ describe('BlockService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      models: ['LabelModel'],
+      autoInjectFrom: ['providers'],
       imports: [
         rootMongooseTestModule(async () => {
           await installContentFixtures();
           await installBlockFixtures();
           await installNlpValueFixtures();
         }),
-        MongooseModule.forFeature([
-          BlockModel,
-          CategoryModel,
-          ContentTypeModel,
-          ContentModel,
-          AttachmentModel,
-          LabelModel,
-          LanguageModel,
-          NlpEntityModel,
-          NlpSampleEntityModel,
-          NlpValueModel,
-          NlpSampleModel,
-        ]),
       ],
       providers: [
-        BlockRepository,
-        CategoryRepository,
-        ContentTypeRepository,
-        ContentRepository,
-        AttachmentRepository,
-        LanguageRepository,
         BlockService,
-        CategoryService,
         ContentTypeService,
-        ContentService,
-        AttachmentService,
-        LanguageService,
-        NlpEntityRepository,
-        NlpValueRepository,
-        NlpSampleRepository,
-        NlpSampleEntityRepository,
-        NlpEntityService,
-        NlpValueService,
-        NlpSampleService,
-        NlpSampleEntityService,
-        NlpService,
-        HelperService,
-        {
-          provide: PluginService,
-          useValue: {},
-        },
+        CategoryRepository,
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => {
               return t === 'Welcome' ? 'Bienvenue' : t;
             }),
-          },
-        },
-        {
-          provide: SettingService,
-          useValue: {
-            getConfig: jest.fn(() => ({
-              chatbot: { lang: { default: 'fr' } },
-            })),
-            getSettings: jest.fn(() => ({
-              contact: { company_name: 'Your company name' },
-              chatbot_settings: { default_nlu_penalty_factor: 0.95 },
-            })),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/chat/services/bot.service.spec.ts
+++ b/api/src/chat/services/bot.service.spec.ts
@@ -6,48 +6,14 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { JwtModule } from '@nestjs/jwt';
-import { MongooseModule } from '@nestjs/mongoose';
+import { JwtService } from '@nestjs/jwt';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ChannelService } from '@/channel/channel.service';
-import { ContentTypeRepository } from '@/cms/repositories/content-type.repository';
-import { ContentRepository } from '@/cms/repositories/content.repository';
-import { MenuRepository } from '@/cms/repositories/menu.repository';
-import { ContentTypeModel } from '@/cms/schemas/content-type.schema';
-import { ContentModel } from '@/cms/schemas/content.schema';
-import { MenuModel } from '@/cms/schemas/menu.schema';
-import { ContentTypeService } from '@/cms/services/content-type.service';
-import { ContentService } from '@/cms/services/content.service';
-import { MenuService } from '@/cms/services/menu.service';
 import { webEventText } from '@/extensions/channels/web/__test__/events.mock';
 import WebChannelHandler from '@/extensions/channels/web/index.channel';
 import { WEB_CHANNEL_NAME } from '@/extensions/channels/web/settings';
 import WebEventWrapper from '@/extensions/channels/web/wrapper';
-import { HelperService } from '@/helper/helper.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LanguageService } from '@/i18n/services/language.service';
-import { NlpEntityRepository } from '@/nlp/repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '@/nlp/repositories/nlp-sample-entity.repository';
-import { NlpSampleRepository } from '@/nlp/repositories/nlp-sample.repository';
-import { NlpValueRepository } from '@/nlp/repositories/nlp-value.repository';
-import { NlpEntityModel } from '@/nlp/schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '@/nlp/schemas/nlp-sample-entity.schema';
-import { NlpSampleModel } from '@/nlp/schemas/nlp-sample.schema';
-import { NlpValueModel } from '@/nlp/schemas/nlp-value.schema';
-import { NlpEntityService } from '@/nlp/services/nlp-entity.service';
-import { NlpSampleEntityService } from '@/nlp/services/nlp-sample-entity.service';
-import { NlpSampleService } from '@/nlp/services/nlp-sample.service';
-import { NlpValueService } from '@/nlp/services/nlp-value.service';
-import { NlpService } from '@/nlp/services/nlp.service';
-import { PluginService } from '@/plugins/plugins.service';
-import { SettingService } from '@/setting/services/setting.service';
 import { installBlockFixtures } from '@/utils/test/fixtures/block';
 import { installContentFixtures } from '@/utils/test/fixtures/content';
 import { installSubscriberFixtures } from '@/utils/test/fixtures/subscriber';
@@ -63,33 +29,13 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
-import { SocketEventDispatcherService } from '@/websocket/services/socket-event-dispatcher.service';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
-import { BlockRepository } from '../repositories/block.repository';
-import { ContextVarRepository } from '../repositories/context-var.repository';
-import { ConversationRepository } from '../repositories/conversation.repository';
-import { MessageRepository } from '../repositories/message.repository';
-import { SubscriberRepository } from '../repositories/subscriber.repository';
-import { BlockFull, BlockModel } from '../schemas/block.schema';
-import { CategoryModel } from '../schemas/category.schema';
-import { ContextVarModel } from '../schemas/context-var.schema';
-import {
-  Conversation,
-  ConversationFull,
-  ConversationModel,
-} from '../schemas/conversation.schema';
-import { LabelModel } from '../schemas/label.schema';
-import { MessageModel } from '../schemas/message.schema';
-import { SubscriberModel } from '../schemas/subscriber.schema';
+import { BlockFull } from '../schemas/block.schema';
+import { Conversation, ConversationFull } from '../schemas/conversation.schema';
 
-import { CategoryRepository } from './../repositories/category.repository';
 import { BlockService } from './block.service';
 import { BotService } from './bot.service';
-import { CategoryService } from './category.service';
-import { ContextVarService } from './context-var.service';
 import { ConversationService } from './conversation.service';
-import { MessageService } from './message.service';
 import { SubscriberService } from './subscriber.service';
 
 describe('BotService', () => {
@@ -102,100 +48,23 @@ describe('BotService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      models: ['LabelModel', 'CategoryModel'],
+      autoInjectFrom: ['providers'],
       imports: [
         rootMongooseTestModule(async () => {
           await installSubscriberFixtures();
           await installContentFixtures();
           await installBlockFixtures();
         }),
-        MongooseModule.forFeature([
-          BlockModel,
-          CategoryModel,
-          ContentTypeModel,
-          ContentModel,
-          AttachmentModel,
-          LabelModel,
-          ConversationModel,
-          SubscriberModel,
-          MessageModel,
-          MenuModel,
-          ContextVarModel,
-          LanguageModel,
-          NlpEntityModel,
-          NlpSampleEntityModel,
-          NlpValueModel,
-          NlpSampleModel,
-        ]),
-        JwtModule,
       ],
       providers: [
-        BlockRepository,
-        CategoryRepository,
-        WebsocketGateway,
-        SocketEventDispatcherService,
-        ConversationRepository,
-        ContentTypeRepository,
-        ContentRepository,
-        AttachmentRepository,
-        SubscriberRepository,
-        MessageRepository,
-        MenuRepository,
-        LanguageRepository,
-        ContextVarRepository,
-        NlpEntityRepository,
-        NlpSampleEntityRepository,
-        NlpValueRepository,
-        NlpSampleRepository,
-        BlockService,
-        CategoryService,
-        ContentTypeService,
-        ContentService,
-        AttachmentService,
-        SubscriberService,
-        ConversationService,
+        JwtService,
         BotService,
-        ChannelService,
-        MessageService,
-        MenuService,
         WebChannelHandler,
-        ContextVarService,
-        LanguageService,
-        NlpEntityService,
-        NlpValueService,
-        NlpSampleService,
-        NlpSampleEntityService,
-        NlpService,
-        {
-          provide: HelperService,
-          useValue: {},
-        },
-        {
-          provide: PluginService,
-          useValue: {},
-        },
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: SettingService,
-          useValue: {
-            getConfig: jest.fn(() => ({
-              chatbot: { lang: { default: 'fr' } },
-            })),
-            getSettings: jest.fn(() => ({
-              contact: { company_name: 'Your company name' },
-            })),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/chat/services/conversation.service.spec.ts
+++ b/api/src/chat/services/conversation.service.spec.ts
@@ -6,12 +6,8 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import EventWrapper from '@/channel/lib/EventWrapper';
+import { I18nService } from '@/i18n/services/i18n.service';
 import { installContextVarFixtures } from '@/utils/test/fixtures/contextvar';
 import { installConversationTypeFixtures } from '@/utils/test/fixtures/conversation';
 import {
@@ -21,16 +17,9 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { VIEW_MORE_PAYLOAD } from '../helpers/constants';
-import { ContextVarRepository } from '../repositories/context-var.repository';
-import { ConversationRepository } from '../repositories/conversation.repository';
-import { SubscriberRepository } from '../repositories/subscriber.repository';
 import { Block } from '../schemas/block.schema';
-import { ContextVarModel } from '../schemas/context-var.schema';
-import { ConversationModel } from '../schemas/conversation.schema';
-import { SubscriberModel } from '../schemas/subscriber.schema';
 import { OutgoingMessageFormat } from '../schemas/types/message';
 
-import { ContextVarService } from './context-var.service';
 import { ConversationService } from './conversation.service';
 import { SubscriberService } from './subscriber.service';
 
@@ -45,30 +34,21 @@ describe('ConversationService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['providers'],
       imports: [
         rootMongooseTestModule(async () => {
           await installContextVarFixtures();
           await installConversationTypeFixtures();
         }),
-        MongooseModule.forFeature([
-          // LabelModel,
-          SubscriberModel,
-          ConversationModel,
-          AttachmentModel,
-          ContextVarModel,
-        ]),
       ],
       providers: [
-        // LabelService,
-        // LabelRepository,
-        AttachmentService,
-        SubscriberService,
         ConversationService,
-        ContextVarService,
-        AttachmentRepository,
-        SubscriberRepository,
-        ConversationRepository,
-        ContextVarRepository,
+        {
+          provide: I18nService,
+          useValue: {
+            t: jest.fn().mockImplementation((t) => t),
+          },
+        },
       ],
     });
     [conversationService, subscriberService] = await getMocks([

--- a/api/src/chat/services/label.service.spec.ts
+++ b/api/src/chat/services/label.service.spec.ts
@@ -6,11 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import {
   installLabelFixtures,
   labelFixtures,
@@ -24,12 +19,11 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelRepository } from '../repositories/label.repository';
-import { Label, LabelFull, LabelModel } from '../schemas/label.schema';
-import { Subscriber, SubscriberModel } from '../schemas/subscriber.schema';
+import { Label, LabelFull } from '../schemas/label.schema';
+import { Subscriber } from '../schemas/subscriber.schema';
 
 import { SubscriberRepository } from './../repositories/subscriber.repository';
 import { LabelService } from './label.service';
-import { SubscriberService } from './subscriber.service';
 
 describe('LabelService', () => {
   let labelRepository: LabelRepository;
@@ -41,22 +35,9 @@ describe('LabelService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installLabelFixtures),
-        MongooseModule.forFeature([
-          LabelModel,
-          SubscriberModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        LabelService,
-        LabelRepository,
-        SubscriberService,
-        AttachmentService,
-        AttachmentRepository,
-        SubscriberRepository,
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installLabelFixtures)],
+      providers: [LabelService, SubscriberRepository],
     });
     [labelService, labelRepository, subscriberRepository] = await getMocks([
       LabelService,

--- a/api/src/chat/services/message.service.spec.ts
+++ b/api/src/chat/services/message.service.spec.ts
@@ -6,20 +6,8 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { InvitationRepository } from '@/user/repositories/invitation.repository';
-import { RoleRepository } from '@/user/repositories/role.repository';
 import { UserRepository } from '@/user/repositories/user.repository';
-import { InvitationModel } from '@/user/schemas/invitation.schema';
-import { PermissionModel } from '@/user/schemas/permission.schema';
-import { RoleModel } from '@/user/schemas/role.schema';
-import { User, UserModel } from '@/user/schemas/user.schema';
-import { RoleService } from '@/user/services/role.service';
-import { UserService } from '@/user/services/user.service';
+import { User } from '@/user/schemas/user.schema';
 import {
   installMessageFixtures,
   messageFixtures,
@@ -36,12 +24,11 @@ import { Room } from '@/websocket/types';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import { MessageRepository } from '../repositories/message.repository';
-import { Message, MessageModel } from '../schemas/message.schema';
-import { Subscriber, SubscriberModel } from '../schemas/subscriber.schema';
+import { Message } from '../schemas/message.schema';
+import { Subscriber } from '../schemas/subscriber.schema';
 
 import { SubscriberRepository } from './../repositories/subscriber.repository';
 import { MessageService } from './message.service';
-import { SubscriberService } from './subscriber.service';
 
 describe('MessageService', () => {
   let messageRepository: MessageRepository;
@@ -66,31 +53,9 @@ describe('MessageService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installMessageFixtures),
-        MongooseModule.forFeature([
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          InvitationModel,
-          SubscriberModel,
-          MessageModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        AttachmentService,
-        AttachmentRepository,
-        UserService,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        SubscriberService,
-        SubscriberRepository,
-        MessageService,
-        MessageRepository,
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installMessageFixtures)],
+      providers: [MessageService, SubscriberRepository, UserRepository],
     });
     [messageService, messageRepository, subscriberRepository, userRepository] =
       await getMocks([

--- a/api/src/chat/services/subscriber.service.spec.ts
+++ b/api/src/chat/services/subscriber.service.spec.ts
@@ -6,14 +6,9 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
 import mime from 'mime';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import {
-  Attachment,
-  AttachmentModel,
-} from '@/attachment/schemas/attachment.schema';
+import { Attachment } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
 import {
   AttachmentAccess,
@@ -21,15 +16,8 @@ import {
   AttachmentFile,
   AttachmentResourceRef,
 } from '@/attachment/types';
-import { InvitationRepository } from '@/user/repositories/invitation.repository';
-import { RoleRepository } from '@/user/repositories/role.repository';
 import { UserRepository } from '@/user/repositories/user.repository';
-import { InvitationModel } from '@/user/schemas/invitation.schema';
-import { PermissionModel } from '@/user/schemas/permission.schema';
-import { RoleModel } from '@/user/schemas/role.schema';
-import { User, UserModel } from '@/user/schemas/user.schema';
-import { RoleService } from '@/user/services/role.service';
-import { UserService } from '@/user/services/user.service';
+import { User } from '@/user/schemas/user.schema';
 import { installSubscriberFixtures } from '@/utils/test/fixtures/subscriber';
 import { getPageQuery } from '@/utils/test/pagination';
 import { sortRowsBy } from '@/utils/test/sort';
@@ -44,10 +32,9 @@ import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import { LabelRepository } from '../repositories/label.repository';
 import { SubscriberRepository } from '../repositories/subscriber.repository';
-import { Label, LabelModel } from '../schemas/label.schema';
-import { Subscriber, SubscriberModel } from '../schemas/subscriber.schema';
+import { Label } from '../schemas/label.schema';
+import { Subscriber } from '../schemas/subscriber.schema';
 
-import { LabelService } from './label.service';
 import { SubscriberService } from './subscriber.service';
 
 jest.mock('uuid', () => ({ v4: jest.fn(() => 'test-uuid') }));
@@ -71,31 +58,9 @@ describe('SubscriberService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installSubscriberFixtures),
-        MongooseModule.forFeature([
-          SubscriberModel,
-          LabelModel,
-          UserModel,
-          RoleModel,
-          InvitationModel,
-          PermissionModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        SubscriberService,
-        SubscriberRepository,
-        LabelService,
-        LabelRepository,
-        UserService,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        AttachmentService,
-        AttachmentRepository,
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installSubscriberFixtures)],
+      providers: [SubscriberService, LabelRepository, UserRepository],
     });
     [
       labelRepository,

--- a/api/src/cms/controllers/content-type.controller.spec.ts
+++ b/api/src/cms/controllers/content-type.controller.spec.ts
@@ -7,12 +7,9 @@
  */
 
 import { NotFoundException } from '@nestjs/common/exceptions';
-import { MongooseModule } from '@nestjs/mongoose';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import { BlockService } from '@/chat/services/block.service';
+import { I18nService } from '@/i18n/services/i18n.service';
 import { FieldType } from '@/setting/schemas/types';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
@@ -26,10 +23,7 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeCreateDto } from '../dto/contentType.dto';
-import { ContentTypeRepository } from '../repositories/content-type.repository';
-import { ContentRepository } from '../repositories/content.repository';
-import { ContentType, ContentTypeModel } from '../schemas/content-type.schema';
-import { ContentModel } from '../schemas/content.schema';
+import { ContentType } from '../schemas/content-type.schema';
 import { ContentTypeService } from '../services/content-type.service';
 import { ContentService } from '../services/content.service';
 
@@ -44,26 +38,14 @@ describe('ContentTypeController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [ContentTypeController],
-      imports: [
-        rootMongooseTestModule(installContentFixtures),
-        MongooseModule.forFeature([
-          ContentTypeModel,
-          ContentModel,
-          AttachmentModel,
-        ]),
-      ],
+      imports: [rootMongooseTestModule(installContentFixtures)],
       providers: [
-        ContentTypeRepository,
-        ContentRepository,
-        AttachmentRepository,
-        ContentTypeService,
-        ContentService,
-        AttachmentService,
         {
-          provide: BlockService,
+          provide: I18nService,
           useValue: {
-            findOne: jest.fn(),
+            t: jest.fn().mockImplementation((t) => t),
           },
         },
       ],

--- a/api/src/cms/controllers/content.controller.spec.ts
+++ b/api/src/cms/controllers/content.controller.spec.ts
@@ -7,8 +7,8 @@
  */
 
 import { NotFoundException } from '@nestjs/common/exceptions';
-import { MongooseModule } from '@nestjs/mongoose';
 
+import { I18nService } from '@/i18n/services/i18n.service';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
@@ -25,10 +25,8 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentCreateDto } from '../dto/content.dto';
-import { ContentTypeRepository } from '../repositories/content-type.repository';
-import { ContentRepository } from '../repositories/content.repository';
-import { ContentType, ContentTypeModel } from '../schemas/content-type.schema';
-import { Content, ContentModel } from '../schemas/content.schema';
+import { ContentType } from '../schemas/content-type.schema';
+import { Content } from '../schemas/content.schema';
 import { ContentTypeService } from '../services/content-type.service';
 import { ContentService } from '../services/content.service';
 
@@ -45,16 +43,16 @@ describe('ContentController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [ContentController],
-      imports: [
-        rootMongooseTestModule(installContentFixtures),
-        MongooseModule.forFeature([ContentTypeModel, ContentModel]),
-      ],
+      imports: [rootMongooseTestModule(installContentFixtures)],
       providers: [
-        ContentTypeService,
-        ContentService,
-        ContentRepository,
-        ContentTypeRepository,
+        {
+          provide: I18nService,
+          useValue: {
+            t: jest.fn().mockImplementation((t) => t),
+          },
+        },
       ],
     });
     [contentController, contentService, contentTypeService] = await getMocks([

--- a/api/src/cms/controllers/menu.controller.spec.ts
+++ b/api/src/cms/controllers/menu.controller.spec.ts
@@ -6,9 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
 import {
   installMenuFixtures,
   offerMenuFixture,
@@ -21,8 +18,6 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { MenuRepository } from '../repositories/menu.repository';
-import { MenuModel } from '../schemas/menu.schema';
 import { MenuType } from '../schemas/types/menu';
 import { MenuService } from '../services/menu.service';
 import { verifyTree } from '../utilities/verifyTree';
@@ -34,22 +29,8 @@ describe('MenuController', () => {
   let menuService: MenuService;
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installMenuFixtures),
-        MongooseModule.forFeature([MenuModel]),
-      ],
-      providers: [
-        MenuRepository,
-        MenuService,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      autoInjectFrom: ['controllers'],
+      imports: [rootMongooseTestModule(installMenuFixtures)],
       controllers: [MenuController],
     });
     [menuController, menuService] = await getMocks([

--- a/api/src/cms/repositories/content-type.repository.spec.ts
+++ b/api/src/cms/repositories/content-type.repository.spec.ts
@@ -6,27 +6,22 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
-import { BlockRepository } from '@/chat/repositories/block.repository';
-import { BlockModel } from '@/chat/schemas/block.schema';
 import { BlockService } from '@/chat/services/block.service';
-import {
-  ContentType,
-  ContentTypeModel,
-} from '@/cms/schemas/content-type.schema';
+import { ContentType } from '@/cms/schemas/content-type.schema';
+import { I18nService } from '@/i18n/services/i18n.service';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { Content, ContentModel } from '../schemas/content.schema';
+import { Content } from '../schemas/content.schema';
 
 import { installContentFixtures } from './../../utils/test/fixtures/content';
 import { ContentTypeRepository } from './content-type.repository';
-import { ContentRepository } from './content.repository';
 
 describe('ContentTypeRepository', () => {
   let contentTypeRepository: ContentTypeRepository;
@@ -36,19 +31,14 @@ describe('ContentTypeRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installContentFixtures),
-        MongooseModule.forFeature([ContentTypeModel, ContentModel, BlockModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installContentFixtures)],
       providers: [
-        ContentRepository,
         ContentTypeRepository,
-        BlockService,
-        BlockRepository,
         {
-          provide: BlockService,
+          provide: I18nService,
           useValue: {
-            findOne: jest.fn(),
+            t: jest.fn().mockImplementation((t) => t),
           },
         },
       ],

--- a/api/src/cms/repositories/content.repository.spec.ts
+++ b/api/src/cms/repositories/content.repository.spec.ts
@@ -6,13 +6,10 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
-import {
-  ContentType,
-  ContentTypeModel,
-} from '@/cms/schemas/content-type.schema';
+import { ContentType } from '@/cms/schemas/content-type.schema';
 import { contentTypeFixtures } from '@/utils/test/fixtures/contenttype';
 import { getPageQuery } from '@/utils/test/pagination';
 import {
@@ -21,7 +18,7 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { Content, ContentModel } from '../schemas/content.schema';
+import { Content } from '../schemas/content.schema';
 
 import {
   contentFixtures,
@@ -36,10 +33,9 @@ describe('ContentRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installContentFixtures),
-        MongooseModule.forFeature([ContentTypeModel, ContentModel]),
-      ],
+      models: ['ContentTypeModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installContentFixtures)],
       providers: [ContentRepository],
     });
     [contentRepository, contentModel, contentTypeModel] = await getMocks([

--- a/api/src/cms/repositories/menu.reporsitory.spec.ts
+++ b/api/src/cms/repositories/menu.reporsitory.spec.ts
@@ -6,8 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import {
   installMenuFixtures,
   rootMenuFixtures,
@@ -18,7 +16,6 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { MenuModel } from '../schemas/menu.schema';
 import { MenuType } from '../schemas/types/menu';
 
 import { MenuRepository } from './menu.repository';
@@ -27,10 +24,8 @@ describe('MenuRepository', () => {
   let menuRepository: MenuRepository;
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installMenuFixtures),
-        MongooseModule.forFeature([MenuModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installMenuFixtures)],
       providers: [MenuRepository],
     });
     [menuRepository] = await getMocks([MenuRepository]);

--- a/api/src/cms/services/content-type.service.spec.ts
+++ b/api/src/cms/services/content-type.service.spec.ts
@@ -6,12 +6,8 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import { BlockService } from '@/chat/services/block.service';
+import { I18nService } from '@/i18n/services/i18n.service';
 import { installContentFixtures } from '@/utils/test/fixtures/content';
 import {
   closeInMongodConnection,
@@ -20,9 +16,6 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeRepository } from '../repositories/content-type.repository';
-import { ContentRepository } from '../repositories/content.repository';
-import { ContentTypeModel } from '../schemas/content-type.schema';
-import { ContentModel } from '../schemas/content.schema';
 
 import { ContentTypeService } from './content-type.service';
 import { ContentService } from './content.service';
@@ -35,25 +28,14 @@ describe('ContentTypeService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installContentFixtures),
-        MongooseModule.forFeature([
-          ContentTypeModel,
-          ContentModel,
-          AttachmentModel,
-        ]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installContentFixtures)],
       providers: [
-        ContentTypeRepository,
-        ContentRepository,
-        AttachmentRepository,
         ContentTypeService,
-        ContentService,
-        AttachmentService,
         {
-          provide: BlockService,
+          provide: I18nService,
           useValue: {
-            findOne: jest.fn(),
+            t: jest.fn().mockImplementation((t) => t),
           },
         },
       ],

--- a/api/src/cms/services/content.service.spec.ts
+++ b/api/src/cms/services/content.service.spec.ts
@@ -6,10 +6,9 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { OutgoingMessageFormat } from '@/chat/schemas/types/message';
 import { ContentOptions } from '@/chat/schemas/types/options';
+import { I18nService } from '@/i18n/services/i18n.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import {
   contentFixtures,
@@ -22,10 +21,8 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { ContentTypeRepository } from '../repositories/content-type.repository';
 import { ContentRepository } from '../repositories/content.repository';
-import { ContentTypeModel } from '../schemas/content-type.schema';
-import { Content, ContentModel } from '../schemas/content.schema';
+import { Content } from '../schemas/content.schema';
 
 import { ContentTypeService } from './content-type.service';
 import { ContentService } from './content.service';
@@ -37,15 +34,16 @@ describe('ContentService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installContentFixtures),
-        MongooseModule.forFeature([ContentTypeModel, ContentModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installContentFixtures)],
       providers: [
-        ContentTypeRepository,
-        ContentRepository,
         ContentTypeService,
-        ContentService,
+        {
+          provide: I18nService,
+          useValue: {
+            t: jest.fn().mockImplementation((t) => t),
+          },
+        },
       ],
     });
     [contentService, contentTypeService, contentRepository] = await getMocks([

--- a/api/src/cms/services/menu.service.spec.ts
+++ b/api/src/cms/services/menu.service.spec.ts
@@ -6,9 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
 import {
   installMenuFixtures,
@@ -21,7 +19,6 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuRepository } from '../repositories/menu.repository';
-import { MenuModel } from '../schemas/menu.schema';
 import { MenuType } from '../schemas/types/menu';
 import { verifyTree } from '../utilities/verifyTree';
 
@@ -32,22 +29,9 @@ describe('MenuService', () => {
   let menuRepository: MenuRepository;
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installMenuFixtures),
-        MongooseModule.forFeature([MenuModel]),
-      ],
-      providers: [
-        MenuRepository,
-        MenuService,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installMenuFixtures)],
+      providers: [MenuService],
     });
     [menuService, menuRepository] = await getMocks([
       MenuService,

--- a/api/src/extension/cleanup.service.spec.ts
+++ b/api/src/extension/cleanup.service.spec.ts
@@ -6,22 +6,10 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ChannelService } from '@/channel/channel.service';
-import { SubscriberRepository } from '@/chat/repositories/subscriber.repository';
-import { SubscriberModel } from '@/chat/schemas/subscriber.schema';
-import { SubscriberService } from '@/chat/services/subscriber.service';
 import LocalStorageHelper from '@/extensions/helpers/local-storage/index.helper';
 import { HelperService } from '@/helper/helper.service';
 import { LoggerService } from '@/logger/logger.service';
-import { SettingRepository } from '@/setting/repositories/setting.repository';
-import { Setting, SettingModel } from '@/setting/schemas/setting.schema';
-import { SettingSeeder } from '@/setting/seeds/setting.seed';
+import { Setting } from '@/setting/schemas/setting.schema';
 import { SettingService } from '@/setting/services/setting.service';
 import { installSettingFixtures } from '@/utils/test/fixtures/setting';
 import {
@@ -41,34 +29,9 @@ describe('CleanupService', () => {
 
   beforeAll(async () => {
     const { getMocks, resolveMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installSettingFixtures),
-        MongooseModule.forFeature([
-          SettingModel,
-          SubscriberModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        CleanupService,
-        HelperService,
-        SettingService,
-        SettingRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-        SettingSeeder,
-        SubscriberService,
-        SubscriberRepository,
-        AttachmentService,
-        AttachmentRepository,
-        ChannelService,
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installSettingFixtures)],
+      providers: [CleanupService],
     });
     [cleanupService, settingService, helperService] = await getMocks([
       CleanupService,

--- a/api/src/extensions/channels/web/__test__/index.spec.ts
+++ b/api/src/extensions/channels/web/__test__/index.spec.ts
@@ -6,15 +6,9 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { JwtModule } from '@nestjs/jwt';
-import { MongooseModule } from '@nestjs/mongoose';
+import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ChannelService } from '@/channel/channel.service';
 import {
   attachmentMessage,
   buttonsMessage,
@@ -22,30 +16,17 @@ import {
   quickRepliesMessage,
   textMessage,
 } from '@/channel/lib/__test__/common.mock';
-import { MessageRepository } from '@/chat/repositories/message.repository';
-import { SubscriberRepository } from '@/chat/repositories/subscriber.repository';
-import { LabelModel } from '@/chat/schemas/label.schema';
-import { MessageModel } from '@/chat/schemas/message.schema';
-import { SubscriberModel } from '@/chat/schemas/subscriber.schema';
 import { OutgoingMessageFormat } from '@/chat/schemas/types/message';
-import { MessageService } from '@/chat/services/message.service';
 import { SubscriberService } from '@/chat/services/subscriber.service';
-import { MenuRepository } from '@/cms/repositories/menu.repository';
-import { MenuModel } from '@/cms/schemas/menu.schema';
-import { MenuService } from '@/cms/services/menu.service';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { SettingService } from '@/setting/services/setting.service';
-import { UserModel } from '@/user/schemas/user.schema';
 import { installMessageFixtures } from '@/utils/test/fixtures/message';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
-import { SocketEventDispatcherService } from '@/websocket/services/socket-event-dispatcher.service';
 import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import WebChannelHandler from '../index.channel';
 
@@ -61,60 +42,23 @@ import {
 describe('WebChannelHandler', () => {
   let subscriberService: SubscriberService;
   let handler: WebChannelHandler;
-  const webSettings = {};
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      models: ['LabelModel', 'UserModel'],
+      autoInjectFrom: ['providers'],
       imports: [
         rootMongooseTestModule(async () => {
           await installMessageFixtures();
         }),
-        MongooseModule.forFeature([
-          SubscriberModel,
-          AttachmentModel,
-          MessageModel,
-          MenuModel,
-          LabelModel,
-          UserModel,
-        ]),
-        JwtModule,
       ],
       providers: [
-        {
-          provide: SettingService,
-          useValue: {
-            getConfig: jest.fn(() => ({
-              chatbot: { lang: { default: 'fr' } },
-            })),
-            getSettings: jest.fn(() => ({
-              web: webSettings,
-            })),
-          },
-        },
-        ChannelService,
-        WebsocketGateway,
-        SocketEventDispatcherService,
-        SubscriberService,
-        SubscriberRepository,
-        AttachmentService,
-        AttachmentRepository,
-        MessageService,
-        MessageRepository,
-        MenuService,
-        MenuRepository,
+        JwtService,
         WebChannelHandler,
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/extensions/channels/web/__test__/wrapper.spec.ts
+++ b/api/src/extensions/channels/web/__test__/wrapper.spec.ts
@@ -6,41 +6,20 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { JwtModule } from '@nestjs/jwt';
-import { MongooseModule } from '@nestjs/mongoose';
+import { JwtService } from '@nestjs/jwt';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import {
-  Attachment,
-  AttachmentModel,
-} from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ChannelService } from '@/channel/channel.service';
-import { MessageRepository } from '@/chat/repositories/message.repository';
-import { SubscriberRepository } from '@/chat/repositories/subscriber.repository';
-import { MessageModel } from '@/chat/schemas/message.schema';
-import { SubscriberModel } from '@/chat/schemas/subscriber.schema';
+import { Attachment } from '@/attachment/schemas/attachment.schema';
 import {
   IncomingMessageType,
   StdEventType,
 } from '@/chat/schemas/types/message';
-import { MessageService } from '@/chat/services/message.service';
-import { SubscriberService } from '@/chat/services/subscriber.service';
-import { MenuRepository } from '@/cms/repositories/menu.repository';
-import { MenuModel } from '@/cms/schemas/menu.schema';
-import { MenuService } from '@/cms/services/menu.service';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { NlpService } from '@/nlp/services/nlp.service';
-import { SettingService } from '@/setting/services/setting.service';
 import { installSubscriberFixtures } from '@/utils/test/fixtures/subscriber';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
-import { SocketEventDispatcherService } from '@/websocket/services/socket-event-dispatcher.service';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import WebChannelHandler from '../index.channel';
 import { WEB_CHANNEL_NAME } from '../settings';
@@ -50,61 +29,17 @@ import { webEvents } from './events.mock';
 
 describe(`Web event wrapper`, () => {
   let handler: WebChannelHandler;
-  const webSettings = {};
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installSubscriberFixtures),
-        MongooseModule.forFeature([
-          SubscriberModel,
-          AttachmentModel,
-          MessageModel,
-          MenuModel,
-        ]),
-        JwtModule,
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installSubscriberFixtures)],
       providers: [
-        {
-          provide: SettingService,
-          useValue: {
-            getConfig: jest.fn(() => ({
-              chatbot: { lang: { default: 'fr' } },
-            })),
-            getSettings: jest.fn(() => ({
-              web: webSettings,
-            })),
-          },
-        },
-        {
-          provide: NlpService,
-          useValue: {
-            getNLP: jest.fn(() => undefined),
-          },
-        },
-        ChannelService,
-        SubscriberService,
-        SubscriberRepository,
-        WebsocketGateway,
-        SocketEventDispatcherService,
-        AttachmentService,
-        AttachmentRepository,
-        MessageService,
-        MessageRepository,
-        MenuService,
-        MenuRepository,
+        JwtService,
         WebChannelHandler,
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/i18n/controllers/language.controller.spec.ts
+++ b/api/src/i18n/controllers/language.controller.spec.ts
@@ -6,11 +6,8 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { BadRequestException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
-import { I18nService } from '@/i18n/services/i18n.service';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import {
@@ -25,8 +22,7 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LanguageUpdateDto } from '../dto/language.dto';
-import { LanguageRepository } from '../repositories/language.repository';
-import { Language, LanguageModel } from '../schemas/language.schema';
+import { Language } from '../schemas/language.schema';
 import { LanguageService } from '../services/language.service';
 
 import { LanguageController } from './language.controller';
@@ -38,30 +34,9 @@ describe('LanguageController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installLanguageFixtures),
-        MongooseModule.forFeature([LanguageModel]),
-      ],
-      providers: [
-        LanguageController,
-        LanguageService,
-        LanguageRepository,
-        {
-          provide: I18nService,
-          useValue: {
-            t: jest.fn().mockImplementation((t) => t),
-            initDynamicLanguages: jest.fn(),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      autoInjectFrom: ['controllers'],
+      imports: [rootMongooseTestModule(installLanguageFixtures)],
+      controllers: [LanguageController],
     });
     [languageService, languageController] = await getMocks([
       LanguageService,

--- a/api/src/i18n/controllers/translation.controller.spec.ts
+++ b/api/src/i18n/controllers/translation.controller.spec.ts
@@ -6,41 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ChannelService } from '@/channel/channel.service';
-import { MessageController } from '@/chat/controllers/message.controller';
-import { BlockRepository } from '@/chat/repositories/block.repository';
-import { MessageRepository } from '@/chat/repositories/message.repository';
-import { SubscriberRepository } from '@/chat/repositories/subscriber.repository';
-import { BlockModel } from '@/chat/schemas/block.schema';
-import { MessageModel } from '@/chat/schemas/message.schema';
-import { SubscriberModel } from '@/chat/schemas/subscriber.schema';
-import { BlockService } from '@/chat/services/block.service';
-import { MessageService } from '@/chat/services/message.service';
-import { SubscriberService } from '@/chat/services/subscriber.service';
-import { ContentRepository } from '@/cms/repositories/content.repository';
-import { MenuRepository } from '@/cms/repositories/menu.repository';
-import { ContentModel } from '@/cms/schemas/content.schema';
-import { MenuModel } from '@/cms/schemas/menu.schema';
-import { ContentService } from '@/cms/services/content.service';
-import { MenuService } from '@/cms/services/menu.service';
-import { I18nService } from '@/i18n/services/i18n.service';
-import { NlpEntityRepository } from '@/nlp/repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '@/nlp/repositories/nlp-sample-entity.repository';
-import { NlpValueRepository } from '@/nlp/repositories/nlp-value.repository';
-import { NlpEntityModel } from '@/nlp/schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '@/nlp/schemas/nlp-sample-entity.schema';
-import { NlpValueModel } from '@/nlp/schemas/nlp-value.schema';
-import { NlpEntityService } from '@/nlp/services/nlp-entity.service';
-import { NlpValueService } from '@/nlp/services/nlp-value.service';
-import { NlpService } from '@/nlp/services/nlp.service';
-import { PluginService } from '@/plugins/plugins.service';
-import { SettingService } from '@/setting/services/setting.service';
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import {
@@ -55,11 +20,8 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { TranslationUpdateDto } from '../dto/translation.dto';
-import { LanguageRepository } from '../repositories/language.repository';
-import { TranslationRepository } from '../repositories/translation.repository';
-import { LanguageModel } from '../schemas/language.schema';
-import { Translation, TranslationModel } from '../schemas/translation.schema';
-import { LanguageService } from '../services/language.service';
+import { Translation } from '../schemas/translation.schema';
+import { I18nService } from '../services/i18n.service';
 import { TranslationService } from '../services/translation.service';
 
 import { TranslationController } from './translation.controller';
@@ -71,59 +33,10 @@ describe('TranslationController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      controllers: [MessageController],
-      imports: [
-        rootMongooseTestModule(installTranslationFixtures),
-        MongooseModule.forFeature([
-          SubscriberModel,
-          TranslationModel,
-          MessageModel,
-          AttachmentModel,
-          MenuModel,
-          BlockModel,
-          ContentModel,
-          LanguageModel,
-          NlpEntityModel,
-          NlpSampleEntityModel,
-          NlpValueModel,
-        ]),
-      ],
+      autoInjectFrom: ['controllers'],
+      controllers: [TranslationController],
+      imports: [rootMongooseTestModule(installTranslationFixtures)],
       providers: [
-        TranslationController,
-        TranslationService,
-        TranslationRepository,
-        MessageService,
-        MessageRepository,
-        SubscriberService,
-        SubscriberRepository,
-        ChannelService,
-        AttachmentService,
-        AttachmentRepository,
-        MenuService,
-        MenuRepository,
-        {
-          provide: NlpService,
-          useValue: {
-            getNLP: jest.fn(() => undefined),
-          },
-        },
-        {
-          provide: SettingService,
-          useValue: {
-            getConfig: jest.fn(() => ({
-              chatbot: { lang: { default: 'fr' } },
-            })),
-            getSettings: jest.fn(() => ({})),
-          },
-        },
-        BlockService,
-        BlockRepository,
-        ContentService,
-        ContentRepository,
-        {
-          provide: PluginService,
-          useValue: {},
-        },
         {
           provide: I18nService,
           useValue: {
@@ -131,21 +44,6 @@ describe('TranslationController', () => {
             refreshDynamicTranslations: jest.fn(),
           },
         },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-        LanguageService,
-        LanguageRepository,
-        NlpEntityRepository,
-        NlpEntityService,
-        NlpValueRepository,
-        NlpValueService,
-        NlpSampleEntityRepository,
       ],
     });
     [translationService, translationController] = await getMocks([

--- a/api/src/migration/migration.service.spec.ts
+++ b/api/src/migration/migration.service.spec.ts
@@ -10,12 +10,10 @@ import fs from 'fs';
 
 import { HttpService } from '@nestjs/axios';
 import { ModuleRef } from '@nestjs/core';
-import { getModelToken, MongooseModule } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import { LoggerService } from '@/logger/logger.service';
-import { MetadataRepository } from '@/setting/repositories/metadata.repository';
-import { Metadata, MetadataModel } from '@/setting/schemas/metadata.schema';
+import { Metadata } from '@/setting/schemas/metadata.schema';
 import { MetadataService } from '@/setting/services/metadata.service';
 import {
   closeInMongodConnection,
@@ -23,7 +21,7 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { Migration, MigrationModel } from './migration.schema';
+import { Migration } from './migration.schema';
 import { MigrationService } from './migration.service';
 import { MigrationAction } from './types';
 
@@ -34,13 +32,9 @@ describe('MigrationService', () => {
 
   beforeAll(async () => {
     const { getMocks, resolveMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(async () => await Promise.resolve()),
-        MongooseModule.forFeature([MetadataModel, MigrationModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(async () => await Promise.resolve())],
       providers: [
-        MetadataRepository,
-        MetadataService,
         MigrationService,
         {
           provide: LoggerService,
@@ -51,10 +45,6 @@ describe('MigrationService', () => {
         },
         {
           provide: HttpService,
-          useValue: {},
-        },
-        {
-          provide: AttachmentService,
           useValue: {},
         },
         {

--- a/api/src/nlp/controllers/nlp-entity.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-entity.controller.spec.ts
@@ -6,14 +6,12 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import {
   BadRequestException,
   ConflictException,
   MethodNotAllowedException,
   NotFoundException,
 } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
@@ -30,16 +28,7 @@ import { TFixtures } from '@/utils/test/types';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpEntityCreateDto, NlpEntityUpdateDto } from '../dto/nlp-entity.dto';
-import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
-import { NlpValueRepository } from '../repositories/nlp-value.repository';
-import {
-  NlpEntity,
-  NlpEntityFull,
-  NlpEntityModel,
-} from '../schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import { NlpValueModel } from '../schemas/nlp-value.schema';
+import { NlpEntity, NlpEntityFull } from '../schemas/nlp-entity.schema';
 import { NlpEntityService } from '../services/nlp-entity.service';
 import { NlpValueService } from '../services/nlp-value.service';
 
@@ -54,28 +43,9 @@ describe('NlpEntityController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [NlpEntityController],
-      imports: [
-        rootMongooseTestModule(installNlpValueFixtures),
-        MongooseModule.forFeature([
-          NlpEntityModel,
-          NlpSampleEntityModel,
-          NlpValueModel,
-        ]),
-      ],
-      providers: [
-        NlpEntityService,
-        NlpEntityRepository,
-        NlpValueService,
-        NlpSampleEntityRepository,
-        NlpValueRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-          },
-        },
-      ],
+      imports: [rootMongooseTestModule(installNlpValueFixtures)],
     });
     [nlpEntityController, nlpValueService, nlpEntityService] = await getMocks([
       NlpEntityController,

--- a/api/src/nlp/controllers/nlp-sample.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-sample.controller.spec.ts
@@ -6,20 +6,11 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
 import { NlpValueMatchPattern } from '@/chat/schemas/types/pattern';
-import { HelperService } from '@/helper/helper.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
-import { I18nService } from '@/i18n/services/i18n.service';
+import { Language } from '@/i18n/schemas/language.schema';
 import { LanguageService } from '@/i18n/services/language.service';
-import { SettingRepository } from '@/setting/repositories/setting.repository';
-import { SettingModel } from '@/setting/schemas/setting.schema';
-import { SettingSeeder } from '@/setting/seeds/setting.seed';
-import { SettingService } from '@/setting/services/setting.service';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import { installAttachmentFixtures } from '@/utils/test/fixtures/attachment';
 import { nlpSampleFixtures } from '@/utils/test/fixtures/nlpsample';
@@ -33,18 +24,7 @@ import { TFixtures } from '@/utils/test/types';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpSampleDto } from '../dto/nlp-sample.dto';
-import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
-import { NlpSampleRepository } from '../repositories/nlp-sample.repository';
-import { NlpValueRepository } from '../repositories/nlp-value.repository';
-import { NlpEntityModel } from '../schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import {
-  NlpSample,
-  NlpSampleFull,
-  NlpSampleModel,
-} from '../schemas/nlp-sample.schema';
-import { NlpValueModel } from '../schemas/nlp-value.schema';
+import { NlpSample, NlpSampleFull } from '../schemas/nlp-sample.schema';
 import { NlpSampleState } from '../schemas/types';
 import { NlpEntityService } from '../services/nlp-entity.service';
 import { NlpSampleEntityService } from '../services/nlp-sample-entity.service';
@@ -65,50 +45,13 @@ describe('NlpSampleController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [NlpSampleController],
       imports: [
         rootMongooseTestModule(async () => {
           await installNlpSampleEntityFixtures();
           await installAttachmentFixtures();
         }),
-        MongooseModule.forFeature([
-          NlpSampleModel,
-          NlpSampleEntityModel,
-          NlpEntityModel,
-          NlpValueModel,
-          SettingModel,
-          LanguageModel,
-        ]),
-      ],
-      providers: [
-        NlpSampleRepository,
-        NlpSampleEntityRepository,
-        NlpEntityService,
-        NlpEntityRepository,
-        NlpValueService,
-        NlpValueRepository,
-        NlpSampleService,
-        NlpSampleEntityService,
-        LanguageRepository,
-        LanguageService,
-        HelperService,
-        SettingRepository,
-        SettingService,
-        SettingSeeder,
-        {
-          provide: I18nService,
-          useValue: {
-            t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
       ],
     });
     [

--- a/api/src/nlp/controllers/nlp-value.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.spec.ts
@@ -6,9 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import {
@@ -22,12 +20,7 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpValueCreateDto } from '../dto/nlp-value.dto';
-import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
-import { NlpValueRepository } from '../repositories/nlp-value.repository';
-import { NlpEntityModel } from '../schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import { NlpValue, NlpValueModel } from '../schemas/nlp-value.schema';
+import { NlpValue } from '../schemas/nlp-value.schema';
 import { NlpEntityService } from '../services/nlp-entity.service';
 import { NlpValueService } from '../services/nlp-value.service';
 
@@ -43,28 +36,9 @@ describe('NlpValueController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [NlpValueController],
-      imports: [
-        rootMongooseTestModule(installNlpValueFixtures),
-        MongooseModule.forFeature([
-          NlpValueModel,
-          NlpSampleEntityModel,
-          NlpEntityModel,
-        ]),
-      ],
-      providers: [
-        NlpValueRepository,
-        NlpValueService,
-        NlpSampleEntityRepository,
-        NlpEntityService,
-        NlpEntityRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-          },
-        },
-      ],
+      imports: [rootMongooseTestModule(installNlpValueFixtures)],
     });
     [nlpValueController, nlpValueService, nlpEntityService] = await getMocks([
       NlpValueController,

--- a/api/src/nlp/repositories/nlp-entity.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-entity.repository.spec.ts
@@ -6,8 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import { installNlpValueFixtures } from '@/utils/test/fixtures/nlpvalue';
 import { getPageQuery } from '@/utils/test/pagination';
@@ -17,12 +15,9 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { NlpEntity, NlpEntityModel } from '../schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import { NlpValueModel } from '../schemas/nlp-value.schema';
+import { NlpEntity } from '../schemas/nlp-entity.schema';
 
 import { NlpEntityRepository } from './nlp-entity.repository';
-import { NlpSampleEntityRepository } from './nlp-sample-entity.repository';
 import { NlpValueRepository } from './nlp-value.repository';
 
 describe('NlpEntityRepository', () => {
@@ -32,19 +27,9 @@ describe('NlpEntityRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpValueFixtures),
-        MongooseModule.forFeature([
-          NlpEntityModel,
-          NlpValueModel,
-          NlpSampleEntityModel,
-        ]),
-      ],
-      providers: [
-        NlpEntityRepository,
-        NlpValueRepository,
-        NlpSampleEntityRepository,
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpValueFixtures)],
+      providers: [NlpEntityRepository],
     });
     [nlpEntityRepository, nlpValueRepository] = await getMocks([
       NlpEntityRepository,

--- a/api/src/nlp/repositories/nlp-sample-entity.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-sample-entity.repository.spec.ts
@@ -6,10 +6,8 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
+import { Language } from '@/i18n/schemas/language.schema';
 import { nlpSampleFixtures } from '@/utils/test/fixtures/nlpsample';
 import {
   installNlpSampleEntityFixtures,
@@ -24,18 +22,15 @@ import {
 import { TFixtures } from '@/utils/test/types';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { NlpEntity, NlpEntityModel } from '../schemas/nlp-entity.schema';
+import { NlpEntity } from '../schemas/nlp-entity.schema';
 import {
   NlpSampleEntity,
   NlpSampleEntityFull,
-  NlpSampleEntityModel,
 } from '../schemas/nlp-sample-entity.schema';
-import { NlpSampleModel } from '../schemas/nlp-sample.schema';
-import { NlpValueModel, NlpValueStub } from '../schemas/nlp-value.schema';
+import { NlpValueStub } from '../schemas/nlp-value.schema';
 
 import { NlpEntityRepository } from './nlp-entity.repository';
 import { NlpSampleEntityRepository } from './nlp-sample-entity.repository';
-import { NlpValueRepository } from './nlp-value.repository';
 
 describe('NlpSampleEntityRepository', () => {
   let nlpSampleEntityRepository: NlpSampleEntityRepository;
@@ -47,20 +42,12 @@ describe('NlpSampleEntityRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpSampleEntityFixtures),
-        MongooseModule.forFeature([
-          NlpSampleEntityModel,
-          NlpEntityModel,
-          NlpValueModel,
-          NlpSampleModel,
-          LanguageModel,
-        ]),
-      ],
+      models: ['NlpSampleModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpSampleEntityFixtures)],
       providers: [
         NlpSampleEntityRepository,
         NlpEntityRepository,
-        NlpValueRepository,
         LanguageRepository,
       ],
     });

--- a/api/src/nlp/repositories/nlp-sample.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-sample.repository.spec.ts
@@ -6,11 +6,10 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
 import { Types } from 'mongoose';
 
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
+import { Language } from '@/i18n/schemas/language.schema';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { nlpSampleFixtures } from '@/utils/test/fixtures/nlpsample';
 import { installNlpSampleEntityFixtures } from '@/utils/test/fixtures/nlpsampleentity';
@@ -22,16 +21,9 @@ import {
 import { TFixtures } from '@/utils/test/types';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import {
-  NlpSampleEntity,
-  NlpSampleEntityModel,
-} from '../schemas/nlp-sample-entity.schema';
-import {
-  NlpSample,
-  NlpSampleFull,
-  NlpSampleModel,
-} from '../schemas/nlp-sample.schema';
-import { NlpValue, NlpValueModel } from '../schemas/nlp-value.schema';
+import { NlpSampleEntity } from '../schemas/nlp-sample-entity.schema';
+import { NlpSample, NlpSampleFull } from '../schemas/nlp-sample.schema';
+import { NlpValue } from '../schemas/nlp-value.schema';
 
 import { NlpSampleEntityRepository } from './nlp-sample-entity.repository';
 import { NlpSampleRepository } from './nlp-sample.repository';
@@ -48,21 +40,9 @@ describe('NlpSampleRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpSampleEntityFixtures),
-        MongooseModule.forFeature([
-          NlpSampleModel,
-          NlpSampleEntityModel,
-          NlpValueModel,
-          LanguageModel,
-        ]),
-      ],
-      providers: [
-        NlpSampleRepository,
-        NlpSampleEntityRepository,
-        NlpValueRepository,
-        LanguageRepository,
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpSampleEntityFixtures)],
+      providers: [NlpSampleRepository, NlpValueRepository, LanguageRepository],
     });
     [
       nlpSampleRepository,

--- a/api/src/nlp/repositories/nlp-value.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.spec.ts
@@ -6,8 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import { installNlpSampleEntityFixtures } from '@/utils/test/fixtures/nlpsampleentity';
 import { nlpValueFixtures } from '@/utils/test/fixtures/nlpvalue';
@@ -19,13 +17,7 @@ import {
 import { TFixtures } from '@/utils/test/types';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { NlpEntityModel } from '../schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import {
-  NlpValue,
-  NlpValueFull,
-  NlpValueModel,
-} from '../schemas/nlp-value.schema';
+import { NlpValue, NlpValueFull } from '../schemas/nlp-value.schema';
 
 import { NlpSampleEntityRepository } from './nlp-sample-entity.repository';
 import { NlpValueRepository } from './nlp-value.repository';
@@ -37,15 +29,10 @@ describe('NlpValueRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpSampleEntityFixtures),
-        MongooseModule.forFeature([
-          NlpValueModel,
-          NlpSampleEntityModel,
-          NlpEntityModel,
-        ]),
-      ],
-      providers: [NlpValueRepository, NlpSampleEntityRepository],
+      models: ['NlpEntityModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpSampleEntityFixtures)],
+      providers: [NlpValueRepository],
     });
     [nlpValueRepository, nlpSampleEntityRepository] = await getMocks([
       NlpValueRepository,

--- a/api/src/nlp/services/nlp-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-entity.service.spec.ts
@@ -6,9 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import { installNlpValueFixtures } from '@/utils/test/fixtures/nlpvalue';
@@ -20,14 +17,10 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
-import { NlpEntity, NlpEntityModel } from '../schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import { NlpValueModel } from '../schemas/nlp-value.schema';
+import { NlpEntity } from '../schemas/nlp-entity.schema';
 
 import { NlpEntityService } from './nlp-entity.service';
-import { NlpValueService } from './nlp-value.service';
 
 describe('NlpEntityService', () => {
   let nlpEntityService: NlpEntityService;
@@ -36,29 +29,9 @@ describe('NlpEntityService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpValueFixtures),
-        MongooseModule.forFeature([
-          NlpEntityModel,
-          NlpValueModel,
-          NlpSampleEntityModel,
-        ]),
-      ],
-      providers: [
-        NlpEntityService,
-        NlpEntityRepository,
-        NlpValueService,
-        NlpValueRepository,
-        NlpSampleEntityRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            set: jest.fn(),
-            get: jest.fn(),
-          },
-        },
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpValueFixtures)],
+      providers: [NlpEntityService],
     });
     [nlpEntityService, nlpEntityRepository, nlpValueRepository] =
       await getMocks([

--- a/api/src/nlp/services/nlp-sample-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample-entity.service.spec.ts
@@ -60,7 +60,6 @@ describe('NlpSampleEntityService', () => {
       nlpSampleEntityRepository,
       nlpEntityRepository,
       languageRepository,
-      nlpSampleEntityService,
       nlpEntityService,
       nlpValueService,
     ] = await getMocks([
@@ -68,7 +67,6 @@ describe('NlpSampleEntityService', () => {
       NlpSampleEntityRepository,
       NlpEntityRepository,
       LanguageRepository,
-      NlpSampleEntityService,
       NlpEntityService,
       NlpValueService,
     ]);

--- a/api/src/nlp/services/nlp-sample-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample-entity.service.spec.ts
@@ -6,11 +6,8 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
+import { Language } from '@/i18n/schemas/language.schema';
 import { nlpSampleFixtures } from '@/utils/test/fixtures/nlpsample';
 import {
   installNlpSampleEntityFixtures,
@@ -28,19 +25,13 @@ import { buildTestingMocks } from '@/utils/test/utils';
 import { NlpSampleEntityCreateDto } from '../dto/nlp-sample-entity.dto';
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
-import { NlpValueRepository } from '../repositories/nlp-value.repository';
-import { NlpEntity, NlpEntityModel } from '../schemas/nlp-entity.schema';
+import { NlpEntity } from '../schemas/nlp-entity.schema';
 import {
   NlpSampleEntity,
   NlpSampleEntityFull,
-  NlpSampleEntityModel,
 } from '../schemas/nlp-sample-entity.schema';
-import { NlpSample, NlpSampleModel } from '../schemas/nlp-sample.schema';
-import {
-  NlpValue,
-  NlpValueModel,
-  NlpValueStub,
-} from '../schemas/nlp-value.schema';
+import { NlpSample } from '../schemas/nlp-sample.schema';
+import { NlpValue, NlpValueStub } from '../schemas/nlp-value.schema';
 
 import { NlpEntityService } from './nlp-entity.service';
 import { NlpSampleEntityService } from './nlp-sample-entity.service';
@@ -59,31 +50,10 @@ describe('NlpSampleEntityService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpSampleEntityFixtures),
-        MongooseModule.forFeature([
-          NlpSampleEntityModel,
-          NlpEntityModel,
-          NlpSampleModel,
-          NlpValueModel,
-          LanguageModel,
-        ]),
-      ],
-      providers: [
-        NlpSampleEntityRepository,
-        NlpEntityRepository,
-        NlpValueRepository,
-        LanguageRepository,
-        NlpSampleEntityService,
-        NlpEntityService,
-        NlpValueService,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-          },
-        },
-      ],
+      models: ['NlpSampleModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpSampleEntityFixtures)],
+      providers: [NlpSampleEntityService, LanguageRepository],
     });
     [
       nlpSampleEntityService,

--- a/api/src/nlp/services/nlp-sample.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample.service.spec.ts
@@ -6,13 +6,11 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
 import { NlpValueMatchPattern } from '@/chat/schemas/types/pattern';
 import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { Language, LanguageModel } from '@/i18n/schemas/language.schema';
+import { Language } from '@/i18n/schemas/language.schema';
 import { LanguageService } from '@/i18n/services/language.service';
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { nlpSampleFixtures } from '@/utils/test/fixtures/nlpsample';
@@ -25,25 +23,11 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpSampleEntityCreateDto } from '../dto/nlp-sample-entity.dto';
-import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
 import { NlpSampleRepository } from '../repositories/nlp-sample.repository';
-import { NlpValueRepository } from '../repositories/nlp-value.repository';
-import {
-  NlpEntity,
-  NlpEntityFull,
-  NlpEntityModel,
-} from '../schemas/nlp-entity.schema';
-import {
-  NlpSampleEntity,
-  NlpSampleEntityModel,
-} from '../schemas/nlp-sample-entity.schema';
-import {
-  NlpSample,
-  NlpSampleFull,
-  NlpSampleModel,
-} from '../schemas/nlp-sample.schema';
-import { NlpValueModel } from '../schemas/nlp-value.schema';
+import { NlpEntity, NlpEntityFull } from '../schemas/nlp-entity.schema';
+import { NlpSampleEntity } from '../schemas/nlp-sample-entity.schema';
+import { NlpSample, NlpSampleFull } from '../schemas/nlp-sample.schema';
 
 import { NlpEntityService } from './nlp-entity.service';
 import { NlpSampleEntityService } from './nlp-sample-entity.service';
@@ -65,37 +49,9 @@ describe('NlpSampleService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpSampleEntityFixtures),
-        MongooseModule.forFeature([
-          NlpSampleModel,
-          NlpSampleEntityModel,
-          NlpValueModel,
-          NlpEntityModel,
-          LanguageModel,
-        ]),
-      ],
-      providers: [
-        NlpSampleRepository,
-        NlpSampleEntityRepository,
-        NlpEntityRepository,
-        NlpValueRepository,
-        LanguageRepository,
-        NlpSampleService,
-        NlpSampleEntityService,
-        NlpEntityService,
-        NlpValueService,
-        LanguageService,
-
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpSampleEntityFixtures)],
+      providers: [NlpSampleService],
     });
     [
       nlpEntityService,

--- a/api/src/nlp/services/nlp-value.service.spec.ts
+++ b/api/src/nlp/services/nlp-value.service.spec.ts
@@ -6,9 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { BaseSchema } from '@/utils/generics/base-schema';
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import {
@@ -23,15 +20,9 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
-import { NlpEntity, NlpEntityModel } from '../schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import {
-  NlpValue,
-  NlpValueFull,
-  NlpValueModel,
-} from '../schemas/nlp-value.schema';
+import { NlpEntity } from '../schemas/nlp-entity.schema';
+import { NlpValue, NlpValueFull } from '../schemas/nlp-value.schema';
 
 import { NlpEntityService } from './nlp-entity.service';
 import { NlpValueService } from './nlp-value.service';
@@ -45,29 +36,9 @@ describe('NlpValueService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpValueFixtures),
-        MongooseModule.forFeature([
-          NlpValueModel,
-          NlpSampleEntityModel,
-          NlpEntityModel,
-        ]),
-      ],
-      providers: [
-        NlpValueRepository,
-        NlpSampleEntityRepository,
-        NlpEntityRepository,
-        NlpValueService,
-        NlpEntityService,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            set: jest.fn(),
-            get: jest.fn(),
-          },
-        },
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpValueFixtures)],
+      providers: [NlpValueService, NlpEntityService],
     });
     [
       nlpValueService,

--- a/api/src/nlp/services/nlp.service.spec.ts
+++ b/api/src/nlp/services/nlp.service.spec.ts
@@ -6,17 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { HelperService } from '@/helper/helper.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
-import { LanguageService } from '@/i18n/services/language.service';
-import { SettingRepository } from '@/setting/repositories/setting.repository';
-import { SettingModel } from '@/setting/schemas/setting.schema';
-import { SettingSeeder } from '@/setting/seeds/setting.seed';
-import { SettingService } from '@/setting/services/setting.service';
 import { installNlpValueFixtures } from '@/utils/test/fixtures/nlpvalue';
 import {
   closeInMongodConnection,
@@ -24,19 +13,6 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
-import { NlpSampleEntityRepository } from '../repositories/nlp-sample-entity.repository';
-import { NlpSampleRepository } from '../repositories/nlp-sample.repository';
-import { NlpValueRepository } from '../repositories/nlp-value.repository';
-import { NlpEntityModel } from '../schemas/nlp-entity.schema';
-import { NlpSampleEntityModel } from '../schemas/nlp-sample-entity.schema';
-import { NlpSampleModel } from '../schemas/nlp-sample.schema';
-import { NlpValueModel } from '../schemas/nlp-value.schema';
-
-import { NlpEntityService } from './nlp-entity.service';
-import { NlpSampleEntityService } from './nlp-sample-entity.service';
-import { NlpSampleService } from './nlp-sample.service';
-import { NlpValueService } from './nlp-value.service';
 import { NlpService } from './nlp.service';
 
 describe('NlpService', () => {
@@ -44,42 +20,9 @@ describe('NlpService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installNlpValueFixtures),
-        MongooseModule.forFeature([
-          NlpEntityModel,
-          NlpValueModel,
-          NlpSampleEntityModel,
-          NlpSampleModel,
-          LanguageModel,
-          SettingModel,
-        ]),
-      ],
-      providers: [
-        NlpService,
-        NlpEntityService,
-        NlpEntityRepository,
-        NlpValueService,
-        NlpSampleService,
-        NlpSampleEntityService,
-        HelperService,
-        LanguageService,
-        SettingService,
-        NlpValueRepository,
-        NlpSampleEntityRepository,
-        NlpSampleRepository,
-        SettingRepository,
-        SettingSeeder,
-        LanguageRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            set: jest.fn(),
-            get: jest.fn(),
-          },
-        },
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installNlpValueFixtures)],
+      providers: [NlpService],
     });
     [nlpService] = await getMocks([NlpService]);
   });

--- a/api/src/setting/controllers/setting.controller.spec.ts
+++ b/api/src/setting/controllers/setting.controller.spec.ts
@@ -6,9 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { I18nService } from '@/i18n/services/i18n.service';
 import {
   installSettingFixtures,
@@ -20,9 +17,7 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { SettingRepository } from '../repositories/setting.repository';
-import { Setting, SettingModel } from '../schemas/setting.schema';
-import { SettingSeeder } from '../seeds/setting.seed';
+import { Setting } from '../schemas/setting.schema';
 import { SettingService } from '../services/setting.service';
 
 import { SettingController } from './setting.controller';
@@ -33,27 +28,14 @@ describe('SettingController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [SettingController],
-      imports: [
-        rootMongooseTestModule(installSettingFixtures),
-        MongooseModule.forFeature([SettingModel]),
-      ],
+      imports: [rootMongooseTestModule(installSettingFixtures)],
       providers: [
-        SettingService,
-        SettingRepository,
-        SettingSeeder,
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/setting/repositories/setting.repository.spec.ts
+++ b/api/src/setting/repositories/setting.repository.spec.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { getModelToken, MongooseModule } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { installSettingFixtures } from '@/utils/test/fixtures/setting';
@@ -16,7 +16,7 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { Setting, SettingModel } from '../schemas/setting.schema';
+import { Setting } from '../schemas/setting.schema';
 import { SettingType } from '../schemas/types';
 
 import { SettingRepository } from './setting.repository';
@@ -27,10 +27,8 @@ describe('SettingRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installSettingFixtures),
-        MongooseModule.forFeature([SettingModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installSettingFixtures)],
       providers: [SettingRepository],
     });
     [settingRepository, settingModel] = await getMocks([

--- a/api/src/setting/services/setting.service.spec.ts
+++ b/api/src/setting/services/setting.service.spec.ts
@@ -6,9 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { I18nService } from '@/i18n/services/i18n.service';
 import {
   installSettingFixtures,
@@ -21,9 +18,8 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SettingRepository } from '../repositories/setting.repository';
-import { Setting, SettingModel } from '../schemas/setting.schema';
+import { Setting } from '../schemas/setting.schema';
 import { SettingType } from '../schemas/types';
-import { SettingSeeder } from '../seeds/setting.seed';
 
 import { SettingService } from './setting.service';
 
@@ -39,26 +35,14 @@ describe('SettingService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installSettingFixtures),
-        MongooseModule.forFeature([SettingModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installSettingFixtures)],
       providers: [
         SettingService,
-        SettingRepository,
-        SettingSeeder,
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/user/controllers/auth.controller.spec.ts
+++ b/api/src/user/controllers/auth.controller.spec.ts
@@ -6,24 +6,16 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import {
   InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { BadRequestException } from '@nestjs/common/exceptions/bad-request.exception';
 import { JwtService } from '@nestjs/jwt';
-import { MongooseModule } from '@nestjs/mongoose';
-import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { SentMessageInfo } from 'nodemailer';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LanguageService } from '@/i18n/services/language.service';
 import { getRandom } from '@/utils/helpers/safeRandom';
 import { installLanguageFixtures } from '@/utils/test/fixtures/language';
 import { installUserFixtures } from '@/utils/test/fixtures/user';
@@ -32,23 +24,12 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
-import { SocketEventDispatcherService } from '@/websocket/services/socket-event-dispatcher.service';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import { UserCreateDto } from '../dto/user.dto';
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { PermissionRepository } from '../repositories/permission.repository';
-import { RoleRepository } from '../repositories/role.repository';
-import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { Role, RoleModel } from '../schemas/role.schema';
-import { UserModel } from '../schemas/user.schema';
+import { Role } from '../schemas/role.schema';
 import { InvitationService } from '../services/invitation.service';
-import { PermissionService } from '../services/permission.service';
 import { RoleService } from '../services/role.service';
 import { UserService } from '../services/user.service';
-import { ValidateAccountService } from '../services/validate-account.service';
 
 import { LocalAuthController } from './auth.controller';
 
@@ -63,37 +44,17 @@ describe('AuthController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      models: ['PermissionModel'],
+      autoInjectFrom: ['all'],
       controllers: [LocalAuthController],
       imports: [
         rootMongooseTestModule(async () => {
           await installLanguageFixtures();
           await installUserFixtures();
         }),
-        MongooseModule.forFeature([
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          InvitationModel,
-          AttachmentModel,
-          LanguageModel,
-        ]),
       ],
       providers: [
-        UserService,
-        WebsocketGateway,
-        SocketEventDispatcherService,
-        AttachmentService,
-        AttachmentRepository,
-        UserRepository,
-        PermissionService,
         RoleService,
-        RoleRepository,
-        PermissionRepository,
-        InvitationRepository,
-        InvitationService,
-        LanguageRepository,
-        LanguageService,
-        JwtService,
         {
           provide: MailerService,
           useValue: {
@@ -102,15 +63,6 @@ describe('AuthController', () => {
             },
           },
         },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-        ValidateAccountService,
         {
           provide: I18nService,
           useValue: {

--- a/api/src/user/controllers/auth.controller.spec.ts
+++ b/api/src/user/controllers/auth.controller.spec.ts
@@ -45,7 +45,7 @@ describe('AuthController', () => {
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
       models: ['PermissionModel'],
-      autoInjectFrom: ['all'],
+      autoInjectFrom: ['controllers', 'providers'],
       controllers: [LocalAuthController],
       imports: [
         rootMongooseTestModule(async () => {

--- a/api/src/user/controllers/auth.controller.spec.ts
+++ b/api/src/user/controllers/auth.controller.spec.ts
@@ -6,13 +6,13 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import {
   InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { BadRequestException } from '@nestjs/common/exceptions/bad-request.exception';
 import { JwtService } from '@nestjs/jwt';
+import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { SentMessageInfo } from 'nodemailer';
 
 import { I18nService } from '@/i18n/services/i18n.service';

--- a/api/src/user/controllers/model.controller.spec.ts
+++ b/api/src/user/controllers/model.controller.spec.ts
@@ -30,7 +30,7 @@ describe('ModelController', () => {
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
       models: ['PermissionModel'],
-      autoInjectFrom: ['all'],
+      autoInjectFrom: ['controllers', 'providers'],
       controllers: [ModelController],
       imports: [rootMongooseTestModule(installModelFixtures)],
       providers: [PermissionService],

--- a/api/src/user/controllers/model.controller.spec.ts
+++ b/api/src/user/controllers/model.controller.spec.ts
@@ -6,12 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import {
   installModelFixtures,
   modelFixtures,
@@ -22,20 +16,9 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { ModelRepository } from '../repositories/model.repository';
-import { PermissionRepository } from '../repositories/permission.repository';
-import { RoleRepository } from '../repositories/role.repository';
-import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { ModelFull, ModelModel } from '../schemas/model.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { RoleModel } from '../schemas/role.schema';
-import { UserModel } from '../schemas/user.schema';
+import { ModelFull } from '../schemas/model.schema';
 import { ModelService } from '../services/model.service';
 import { PermissionService } from '../services/permission.service';
-import { RoleService } from '../services/role.service';
-import { UserService } from '../services/user.service';
 
 import { ModelController } from './model.controller';
 
@@ -46,39 +29,11 @@ describe('ModelController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      models: ['PermissionModel'],
+      autoInjectFrom: ['all'],
       controllers: [ModelController],
-      imports: [
-        rootMongooseTestModule(installModelFixtures),
-        MongooseModule.forFeature([
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          InvitationModel,
-          ModelModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        PermissionService,
-        AttachmentService,
-        AttachmentRepository,
-        ModelService,
-        ModelRepository,
-        UserService,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        PermissionRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      imports: [rootMongooseTestModule(installModelFixtures)],
+      providers: [PermissionService],
     });
     [modelController, modelService, permissionService] = await getMocks([
       ModelController,

--- a/api/src/user/controllers/permission.controller.spec.ts
+++ b/api/src/user/controllers/permission.controller.spec.ts
@@ -6,9 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
 import {
@@ -18,18 +16,9 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { PermissionCreateDto } from '../dto/permission.dto';
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { ModelRepository } from '../repositories/model.repository';
-import { PermissionRepository } from '../repositories/permission.repository';
-import { RoleRepository } from '../repositories/role.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { Model, ModelModel } from '../schemas/model.schema';
-import {
-  Permission,
-  PermissionFull,
-  PermissionModel,
-} from '../schemas/permission.schema';
-import { Role, RoleModel } from '../schemas/role.schema';
+import { Model } from '../schemas/model.schema';
+import { Permission, PermissionFull } from '../schemas/permission.schema';
+import { Role } from '../schemas/role.schema';
 import { ModelService } from '../services/model.service';
 import { PermissionService } from '../services/permission.service';
 import { RoleService } from '../services/role.service';
@@ -50,33 +39,10 @@ describe('PermissionController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      models: ['InvitationModel'],
+      autoInjectFrom: ['controllers'],
       controllers: [PermissionController],
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([
-          PermissionModel,
-          ModelModel,
-          RoleModel,
-          InvitationModel,
-        ]),
-      ],
-      providers: [
-        RoleService,
-        ModelService,
-        PermissionService,
-        PermissionRepository,
-        RoleRepository,
-        InvitationRepository,
-        ModelRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
     });
     [permissionController, roleService, modelService, permissionService] =
       await getMocks([

--- a/api/src/user/controllers/role.controller.spec.ts
+++ b/api/src/user/controllers/role.controller.spec.ts
@@ -6,14 +6,9 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 import { Request } from 'express';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
 import { roleFixtures } from '@/utils/test/fixtures/role';
 import { getPageQuery } from '@/utils/test/pagination';
@@ -24,14 +19,7 @@ import {
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { RoleCreateDto, RoleUpdateDto } from '../dto/role.dto';
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { PermissionRepository } from '../repositories/permission.repository';
-import { RoleRepository } from '../repositories/role.repository';
-import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { Role, RoleFull, RoleModel } from '../schemas/role.schema';
-import { UserModel } from '../schemas/user.schema';
+import { Role, RoleFull } from '../schemas/role.schema';
 import { PermissionService } from '../services/permission.service';
 import { RoleService } from '../services/role.service';
 import { UserService } from '../services/user.service';
@@ -48,36 +36,11 @@ describe('RoleController', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      models: ['InvitationModel'],
+      autoInjectFrom: ['all'],
       controllers: [RoleController],
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([
-          RoleModel,
-          PermissionModel,
-          UserModel,
-          InvitationModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        PermissionService,
-        UserService,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        PermissionRepository,
-        AttachmentService,
-        AttachmentRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
+      providers: [PermissionService],
     });
     [roleController, roleService, permissionService, userService] =
       await getMocks([

--- a/api/src/user/controllers/role.controller.spec.ts
+++ b/api/src/user/controllers/role.controller.spec.ts
@@ -37,7 +37,7 @@ describe('RoleController', () => {
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
       models: ['InvitationModel'],
-      autoInjectFrom: ['all'],
+      autoInjectFrom: ['controllers', 'providers'],
       controllers: [RoleController],
       imports: [rootMongooseTestModule(installPermissionFixtures)],
       providers: [PermissionService],

--- a/api/src/user/controllers/user.controller.spec.ts
+++ b/api/src/user/controllers/user.controller.spec.ts
@@ -6,9 +6,9 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { Session as ExpressSession } from 'express-session';
 import { SentMessageInfo } from 'nodemailer';
 

--- a/api/src/user/controllers/user.controller.spec.ts
+++ b/api/src/user/controllers/user.controller.spec.ts
@@ -6,21 +6,13 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
-import { JwtModule, JwtService } from '@nestjs/jwt';
-import { MongooseModule } from '@nestjs/mongoose';
 import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { Session as ExpressSession } from 'express-session';
 import { SentMessageInfo } from 'nodemailer';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LanguageService } from '@/i18n/services/language.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { installLanguageFixtures } from '@/utils/test/fixtures/language';
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
@@ -38,19 +30,11 @@ import {
   UserEditProfileDto,
   UserUpdateStateAndRolesDto,
 } from '../dto/user.dto';
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { PermissionRepository } from '../repositories/permission.repository';
-import { RoleRepository } from '../repositories/role.repository';
-import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { Role, RoleModel } from '../schemas/role.schema';
-import { User, UserFull, UserModel } from '../schemas/user.schema';
+import { Role } from '../schemas/role.schema';
+import { User, UserFull } from '../schemas/user.schema';
 import { PasswordResetService } from '../services/passwordReset.service';
-import { PermissionService } from '../services/permission.service';
 import { RoleService } from '../services/role.service';
 import { UserService } from '../services/user.service';
-import { ValidateAccountService } from '../services/validate-account.service';
 
 import { InvitationService } from './../services/invitation.service';
 import { ReadWriteUserController } from './user.controller';
@@ -68,28 +52,15 @@ describe('UserController', () => {
   let jwtService: JwtService;
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['controllers'],
       controllers: [ReadWriteUserController],
       imports: [
         rootMongooseTestModule(async () => {
           await installLanguageFixtures();
           await installPermissionFixtures();
         }),
-        MongooseModule.forFeature([
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          InvitationModel,
-          AttachmentModel,
-          LanguageModel,
-        ]),
-        JwtModule,
       ],
       providers: [
-        RoleService,
-        UserService,
-        InvitationService,
-        PasswordResetService,
-        PermissionService,
         {
           provide: MailerService,
           useValue: {
@@ -98,23 +69,6 @@ describe('UserController', () => {
             },
           },
         },
-        UserRepository,
-        RoleRepository,
-        PermissionRepository,
-        InvitationRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-        AttachmentService,
-        AttachmentRepository,
-        LanguageService,
-        LanguageRepository,
-        ValidateAccountService,
         {
           provide: I18nService,
           useValue: {

--- a/api/src/user/repositories/invitation.repository.spec.ts
+++ b/api/src/user/repositories/invitation.repository.spec.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
@@ -21,16 +21,9 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import {
-  Invitation,
-  InvitationFull,
-  InvitationModel,
-} from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { RoleModel } from '../schemas/role.schema';
+import { Invitation, InvitationFull } from '../schemas/invitation.schema';
 
 import { InvitationRepository } from './invitation.repository';
-import { PermissionRepository } from './permission.repository';
 import { RoleRepository } from './role.repository';
 
 describe('InvitationRepository', () => {
@@ -39,15 +32,10 @@ describe('InvitationRepository', () => {
   let invitationModel: Model<Invitation>;
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installInvitationFixtures),
-        MongooseModule.forFeature([
-          RoleModel,
-          PermissionModel,
-          InvitationModel,
-        ]),
-      ],
-      providers: [RoleRepository, InvitationRepository, PermissionRepository],
+      models: ['PermissionModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installInvitationFixtures)],
+      providers: [RoleRepository, InvitationRepository],
     });
     [roleRepository, invitationRepository, invitationModel] = await getMocks([
       RoleRepository,

--- a/api/src/user/repositories/model.repository.spec.ts
+++ b/api/src/user/repositories/model.repository.spec.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { modelFixtures } from '@/utils/test/fixtures/model';
@@ -19,8 +19,8 @@ import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelRepository } from '../repositories/model.repository';
 import { PermissionRepository } from '../repositories/permission.repository';
-import { ModelFull, ModelModel } from '../schemas/model.schema';
-import { Permission, PermissionModel } from '../schemas/permission.schema';
+import { ModelFull } from '../schemas/model.schema';
+import { Permission } from '../schemas/permission.schema';
 
 import { Model as ModelType } from './../schemas/model.schema';
 
@@ -33,10 +33,9 @@ describe('ModelRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([ModelModel, PermissionModel]),
-      ],
+      autoInjectFrom: ['providers'],
+      models: ['PermissionModel'],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
       providers: [ModelRepository, PermissionRepository],
     });
     [permissionRepository, modelRepository, modelModel] = await getMocks([

--- a/api/src/user/repositories/permission.repository.spec.ts
+++ b/api/src/user/repositories/permission.repository.spec.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import {
@@ -22,17 +22,10 @@ import { buildTestingMocks } from '@/utils/test/utils';
 import { ModelRepository } from '../repositories/model.repository';
 import { PermissionRepository } from '../repositories/permission.repository';
 import { RoleRepository } from '../repositories/role.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { ModelModel, Model as ModelSchema } from '../schemas/model.schema';
-import {
-  Permission,
-  PermissionFull,
-  PermissionModel,
-} from '../schemas/permission.schema';
-import { Role, RoleModel } from '../schemas/role.schema';
+import { Model as ModelSchema } from '../schemas/model.schema';
+import { Permission, PermissionFull } from '../schemas/permission.schema';
+import { Role } from '../schemas/role.schema';
 import { Action } from '../types/action.type';
-
-import { InvitationRepository } from './invitation.repository';
 
 describe('PermissionRepository', () => {
   let modelRepository: ModelRepository;
@@ -44,21 +37,10 @@ describe('PermissionRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([
-          ModelModel,
-          PermissionModel,
-          RoleModel,
-          InvitationModel,
-        ]),
-      ],
-      providers: [
-        ModelRepository,
-        RoleRepository,
-        PermissionRepository,
-        InvitationRepository,
-      ],
+      models: ['InvitationModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
+      providers: [ModelRepository, RoleRepository, PermissionRepository],
     });
     [roleRepository, modelRepository, permissionRepository, permissionModel] =
       await getMocks([

--- a/api/src/user/repositories/role.repository.spec.ts
+++ b/api/src/user/repositories/role.repository.spec.ts
@@ -6,7 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
@@ -20,13 +20,10 @@ import { buildTestingMocks } from '@/utils/test/utils';
 import { PermissionRepository } from '../repositories/permission.repository';
 import { RoleRepository } from '../repositories/role.repository';
 import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { Role, RoleFull, RoleModel } from '../schemas/role.schema';
-import { User, UserModel } from '../schemas/user.schema';
+import { Role, RoleFull } from '../schemas/role.schema';
+import { User } from '../schemas/user.schema';
 
 import { roleFixtures } from './../../utils/test/fixtures/role';
-import { InvitationRepository } from './invitation.repository';
 
 describe('RoleRepository', () => {
   let roleRepository: RoleRepository;
@@ -39,21 +36,10 @@ describe('RoleRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([
-          UserModel,
-          PermissionModel,
-          RoleModel,
-          InvitationModel,
-        ]),
-      ],
-      providers: [
-        UserRepository,
-        RoleRepository,
-        InvitationRepository,
-        PermissionRepository,
-      ],
+      models: ['UserModel', 'InvitationModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
+      providers: [UserRepository, RoleRepository, PermissionRepository],
     });
     [roleRepository, userRepository, permissionRepository, roleModel] =
       await getMocks([

--- a/api/src/user/repositories/user.repository.spec.ts
+++ b/api/src/user/repositories/user.repository.spec.ts
@@ -6,11 +6,9 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { getModelToken } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
 import { userFixtures } from '@/utils/test/fixtures/user';
@@ -21,15 +19,10 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { PermissionRepository } from '../repositories/permission.repository';
 import { RoleRepository } from '../repositories/role.repository';
 import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { Role, RoleModel } from '../schemas/role.schema';
-import { User, UserFull, UserModel } from '../schemas/user.schema';
-
-import { InvitationRepository } from './invitation.repository';
+import { Role } from '../schemas/role.schema';
+import { User, UserFull } from '../schemas/user.schema';
 
 describe('UserRepository', () => {
   let roleRepository: RoleRepository;
@@ -52,30 +45,10 @@ describe('UserRepository', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([
-          UserModel,
-          PermissionModel,
-          RoleModel,
-          InvitationModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        UserRepository,
-        RoleRepository,
-        InvitationRepository,
-        PermissionRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      models: ['PermissionModel', 'InvitationModel', 'AttachmentModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
+      providers: [UserRepository, RoleRepository],
     });
     [roleRepository, userRepository, userModel] = await getMocks([
       RoleRepository,

--- a/api/src/user/services/auth.service.spec.ts
+++ b/api/src/user/services/auth.service.spec.ts
@@ -6,12 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { JwtService } from '@nestjs/jwt';
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import { installUserFixtures } from '@/utils/test/fixtures/user';
 import {
   closeInMongodConnection,
@@ -19,17 +13,9 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { RoleRepository } from '../repositories/role.repository';
 import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { RoleModel } from '../schemas/role.schema';
-import { UserModel } from '../schemas/user.schema';
 
 import { AuthService } from './auth.service';
-import { RoleService } from './role.service';
-import { UserService } from './user.service';
 
 describe('AuthService', () => {
   let authService: AuthService;
@@ -37,27 +23,9 @@ describe('AuthService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installUserFixtures),
-        MongooseModule.forFeature([
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          InvitationModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        AuthService,
-        UserService,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        JwtService,
-        AttachmentService,
-        AttachmentRepository,
-      ],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installUserFixtures)],
+      providers: [AuthService],
     });
     [authService, userRepository] = await getMocks([
       AuthService,

--- a/api/src/user/services/invitation.service.spec.ts
+++ b/api/src/user/services/invitation.service.spec.ts
@@ -6,16 +6,11 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { JwtModule, JwtService } from '@nestjs/jwt';
-import { MongooseModule } from '@nestjs/mongoose';
 import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
+import { JwtModule, JwtService } from '@nestjs/jwt';
 import { SentMessageInfo } from 'nodemailer';
 
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LanguageService } from '@/i18n/services/language.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import {
   installInvitationFixtures,
@@ -30,15 +25,9 @@ import { buildTestingMocks } from '@/utils/test/utils';
 
 import { InvitationCreateDto } from '../dto/invitation.dto';
 import { InvitationRepository } from '../repositories/invitation.repository';
-import { PermissionRepository } from '../repositories/permission.repository';
 import { RoleRepository } from '../repositories/role.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { RoleModel } from '../schemas/role.schema';
 
 import { InvitationService } from './invitation.service';
-import { PermissionService } from './permission.service';
-import { RoleService } from './role.service';
 
 describe('InvitationService', () => {
   let invitationService: InvitationService;
@@ -50,35 +39,24 @@ describe('InvitationService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      models: ['PermissionModel'],
+      autoInjectFrom: ['providers'],
       imports: [
         rootMongooseTestModule(async () => {
           await installLanguageFixtures();
           await installInvitationFixtures();
         }),
-        MongooseModule.forFeature([
-          RoleModel,
-          PermissionModel,
-          InvitationModel,
-          LanguageModel,
-        ]),
         JwtModule,
       ],
       providers: [
-        PermissionService,
-        RoleService,
-        RoleRepository,
-        PermissionRepository,
-        InvitationRepository,
         InvitationService,
-        LanguageRepository,
-        LanguageService,
+        RoleRepository,
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
           },
         },
-        InvitationRepository,
         {
           provide: MailerService,
           useValue: {
@@ -86,14 +64,6 @@ describe('InvitationService', () => {
               (_options: ISendMailOptions): Promise<SentMessageInfo> =>
                 Promise.resolve('Mail sent successfully'),
             ),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/user/services/invitation.service.spec.ts
+++ b/api/src/user/services/invitation.service.spec.ts
@@ -6,8 +6,8 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { JwtModule, JwtService } from '@nestjs/jwt';
+import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { SentMessageInfo } from 'nodemailer';
 
 import { I18nService } from '@/i18n/services/i18n.service';

--- a/api/src/user/services/model.service.spec.ts
+++ b/api/src/user/services/model.service.spec.ts
@@ -6,8 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { modelFixtures } from '@/utils/test/fixtures/model';
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
 import {
@@ -18,8 +16,8 @@ import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelRepository } from '../repositories/model.repository';
 import { PermissionRepository } from '../repositories/permission.repository';
-import { Model, ModelFull, ModelModel } from '../schemas/model.schema';
-import { Permission, PermissionModel } from '../schemas/permission.schema';
+import { Model, ModelFull } from '../schemas/model.schema';
+import { Permission } from '../schemas/permission.schema';
 
 import { ModelService } from './model.service';
 
@@ -32,11 +30,10 @@ describe('ModelService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([ModelModel, PermissionModel]),
-      ],
-      providers: [ModelService, ModelRepository, PermissionRepository],
+      models: ['PermissionModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
+      providers: [ModelService, PermissionRepository],
     });
     [modelService, permissionRepository, modelRepository] = await getMocks([
       ModelService,

--- a/api/src/user/services/passwordReset.service.spec.ts
+++ b/api/src/user/services/passwordReset.service.spec.ts
@@ -6,22 +6,15 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { NotFoundException } from '@nestjs/common';
-import { JwtModule, JwtService } from '@nestjs/jwt';
-import { MongooseModule, getModelToken } from '@nestjs/mongoose';
 import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
+import { NotFoundException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { getModelToken } from '@nestjs/mongoose';
 import { compareSync } from 'bcryptjs';
 import { Model } from 'mongoose';
 import { SentMessageInfo } from 'nodemailer';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LanguageService } from '@/i18n/services/language.service';
 import { installLanguageFixtures } from '@/utils/test/fixtures/language';
 import { installUserFixtures, users } from '@/utils/test/fixtures/user';
 import {
@@ -30,17 +23,9 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { RoleRepository } from '../repositories/role.repository';
-import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { RoleModel } from '../schemas/role.schema';
-import { User, UserModel } from '../schemas/user.schema';
+import { User } from '../schemas/user.schema';
 
 import { PasswordResetService } from './passwordReset.service';
-import { RoleService } from './role.service';
-import { UserService } from './user.service';
 
 describe('PasswordResetService', () => {
   let passwordResetService: PasswordResetService;
@@ -49,31 +34,14 @@ describe('PasswordResetService', () => {
   let userModel: Model<User>;
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['providers'],
       imports: [
         rootMongooseTestModule(async () => {
           await installLanguageFixtures();
           await installUserFixtures();
         }),
-        MongooseModule.forFeature([
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          AttachmentModel,
-          LanguageModel,
-          InvitationModel,
-        ]),
-        JwtModule,
       ],
       providers: [
-        UserService,
-        UserRepository,
-        RoleService,
-        AttachmentService,
-        AttachmentRepository,
-        RoleRepository,
-        InvitationRepository,
-        LanguageService,
-        LanguageRepository,
         PasswordResetService,
         {
           provide: MailerService,
@@ -88,14 +56,6 @@ describe('PasswordResetService', () => {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/user/services/passwordReset.service.spec.ts
+++ b/api/src/user/services/passwordReset.service.spec.ts
@@ -6,10 +6,10 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { getModelToken } from '@nestjs/mongoose';
+import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { compareSync } from 'bcryptjs';
 import { Model } from 'mongoose';
 import { SentMessageInfo } from 'nodemailer';

--- a/api/src/user/services/permission.service.spec.ts
+++ b/api/src/user/services/permission.service.spec.ts
@@ -6,9 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
 import {
   installPermissionFixtures,
   permissionFixtures,
@@ -19,18 +16,12 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { InvitationRepository } from '../repositories/invitation.repository';
 import { ModelRepository } from '../repositories/model.repository';
 import { PermissionRepository } from '../repositories/permission.repository';
 import { RoleRepository } from '../repositories/role.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { ModelModel, Model as ModelSchema } from '../schemas/model.schema';
-import {
-  Permission,
-  PermissionFull,
-  PermissionModel,
-} from '../schemas/permission.schema';
-import { Role, RoleModel } from '../schemas/role.schema';
+import { Model as ModelSchema } from '../schemas/model.schema';
+import { Permission, PermissionFull } from '../schemas/permission.schema';
+import { Role } from '../schemas/role.schema';
 import { Action } from '../types/action.type';
 
 import { PermissionService } from './permission.service';
@@ -44,30 +35,10 @@ describe('PermissionService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([
-          ModelModel,
-          PermissionModel,
-          RoleModel,
-          InvitationModel,
-        ]),
-      ],
-      providers: [
-        ModelRepository,
-        PermissionService,
-        RoleRepository,
-        InvitationRepository,
-        PermissionRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      models: ['InvitationModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
+      providers: [PermissionService, RoleRepository, ModelRepository],
     });
     [permissionService, roleRepository, modelRepository, permissionRepository] =
       await getMocks([

--- a/api/src/user/services/role.service.spec.ts
+++ b/api/src/user/services/role.service.spec.ts
@@ -6,8 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { MongooseModule } from '@nestjs/mongoose';
-
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
 import { getPageQuery } from '@/utils/test/pagination';
 import {
@@ -16,14 +14,12 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { InvitationRepository } from '../repositories/invitation.repository';
 import { PermissionRepository } from '../repositories/permission.repository';
 import { RoleRepository } from '../repositories/role.repository';
 import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { Permission, PermissionModel } from '../schemas/permission.schema';
-import { Role, RoleFull, RoleModel } from '../schemas/role.schema';
-import { User, UserModel } from '../schemas/user.schema';
+import { Permission } from '../schemas/permission.schema';
+import { Role, RoleFull } from '../schemas/role.schema';
+import { User } from '../schemas/user.schema';
 
 import { roleFixtures } from './../../utils/test/fixtures/role';
 import { RoleService } from './role.service';
@@ -39,22 +35,10 @@ describe('RoleService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([
-          UserModel,
-          PermissionModel,
-          RoleModel,
-          InvitationModel,
-        ]),
-      ],
-      providers: [
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        PermissionRepository,
-      ],
+      models: ['PermissionModel', 'InvitationModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
+      providers: [RoleService, UserRepository, PermissionRepository],
     });
     [roleService, roleRepository, userRepository, permissionRepository] =
       await getMocks([

--- a/api/src/user/services/user.service.spec.ts
+++ b/api/src/user/services/user.service.spec.ts
@@ -6,12 +6,6 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { MongooseModule } from '@nestjs/mongoose';
-
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { installPermissionFixtures } from '@/utils/test/fixtures/permission';
 import { userFixtures } from '@/utils/test/fixtures/user';
@@ -22,17 +16,11 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { PermissionRepository } from '../repositories/permission.repository';
 import { RoleRepository } from '../repositories/role.repository';
 import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { Role, RoleModel } from '../schemas/role.schema';
-import { User, UserFull, UserModel } from '../schemas/user.schema';
+import { Role } from '../schemas/role.schema';
+import { User, UserFull } from '../schemas/user.schema';
 
-import { PermissionService } from './permission.service';
-import { RoleService } from './role.service';
 import { UserService } from './user.service';
 
 describe('UserService', () => {
@@ -55,35 +43,10 @@ describe('UserService', () => {
 
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
-      imports: [
-        rootMongooseTestModule(installPermissionFixtures),
-        MongooseModule.forFeature([
-          UserModel,
-          PermissionModel,
-          RoleModel,
-          InvitationModel,
-          AttachmentModel,
-        ]),
-      ],
-      providers: [
-        UserService,
-        AttachmentService,
-        AttachmentRepository,
-        UserRepository,
-        PermissionService,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        PermissionRepository,
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
-      ],
+      models: ['PermissionModel', 'InvitationModel', 'AttachmentModel'],
+      autoInjectFrom: ['providers'],
+      imports: [rootMongooseTestModule(installPermissionFixtures)],
+      providers: [UserService, RoleRepository],
     });
     [userService, roleRepository, userRepository] = await getMocks([
       UserService,

--- a/api/src/user/services/validate-account.service.spec.ts
+++ b/api/src/user/services/validate-account.service.spec.ts
@@ -6,19 +6,10 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { JwtModule } from '@nestjs/jwt';
-import { MongooseModule } from '@nestjs/mongoose';
 import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { SentMessageInfo } from 'nodemailer';
 
-import { AttachmentRepository } from '@/attachment/repositories/attachment.repository';
-import { AttachmentModel } from '@/attachment/schemas/attachment.schema';
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { LanguageRepository } from '@/i18n/repositories/language.repository';
-import { LanguageModel } from '@/i18n/schemas/language.schema';
 import { I18nService } from '@/i18n/services/i18n.service';
-import { LanguageService } from '@/i18n/services/language.service';
 import { installLanguageFixtures } from '@/utils/test/fixtures/language';
 import { installUserFixtures, users } from '@/utils/test/fixtures/user';
 import {
@@ -27,16 +18,6 @@ import {
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
-import { InvitationRepository } from '../repositories/invitation.repository';
-import { RoleRepository } from '../repositories/role.repository';
-import { UserRepository } from '../repositories/user.repository';
-import { InvitationModel } from '../schemas/invitation.schema';
-import { PermissionModel } from '../schemas/permission.schema';
-import { RoleModel } from '../schemas/role.schema';
-import { UserModel } from '../schemas/user.schema';
-
-import { RoleService } from './role.service';
-import { UserService } from './user.service';
 import { ValidateAccountService } from './validate-account.service';
 
 describe('ValidateAccountService', () => {
@@ -44,31 +25,16 @@ describe('ValidateAccountService', () => {
   let mailerService: MailerService;
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
+      autoInjectFrom: ['providers'],
       imports: [
         rootMongooseTestModule(async () => {
           await installLanguageFixtures();
           await installUserFixtures();
         }),
-        MongooseModule.forFeature([
-          UserModel,
-          RoleModel,
-          PermissionModel,
-          InvitationModel,
-          AttachmentModel,
-          LanguageModel,
-        ]),
-        JwtModule,
       ],
       providers: [
-        UserService,
-        AttachmentService,
-        AttachmentRepository,
-        UserRepository,
-        RoleService,
-        RoleRepository,
-        InvitationRepository,
-        LanguageService,
-        LanguageRepository,
+        ValidateAccountService,
+
         {
           provide: MailerService,
           useValue: {
@@ -78,19 +44,10 @@ describe('ValidateAccountService', () => {
             ),
           },
         },
-        ValidateAccountService,
         {
           provide: I18nService,
           useValue: {
             t: jest.fn().mockImplementation((t) => t),
-          },
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            del: jest.fn(),
-            get: jest.fn(),
-            set: jest.fn(),
           },
         },
       ],

--- a/api/src/utils/generics/lifecycle-hook-manager.spec.ts
+++ b/api/src/utils/generics/lifecycle-hook-manager.spec.ts
@@ -10,6 +10,8 @@ import { ModelDefinition } from '@nestjs/mongoose';
 
 import { LifecycleHookManager } from './lifecycle-hook-manager';
 
+afterEach(jest.clearAllMocks);
+
 describe('LifecycleHookManager', () => {
   let modelMock: ModelDefinition;
 
@@ -42,8 +44,10 @@ describe('LifecycleHookManager', () => {
   });
 
   it('should return hooks attached to a specific model', () => {
-    // Attach hooks to mock model
-    LifecycleHookManager.attach(modelMock);
+    if (!LifecycleHookManager.getModel(modelMock.name)) {
+      // Attach hooks to mock model
+      LifecycleHookManager.attach(modelMock);
+    }
 
     // Retrieve hooks
     const hooks = LifecycleHookManager.getHooks('TestModel');

--- a/api/src/utils/generics/lifecycle-hook-manager.ts
+++ b/api/src/utils/generics/lifecycle-hook-manager.ts
@@ -39,6 +39,12 @@ interface Registry {
 export class LifecycleHookManager {
   private static registry: Registry = {};
 
+  private static models: ModelDefinition[] = [];
+
+  public static getModel(name: string) {
+    return this.models.find((attachedModel) => attachedModel.name === name);
+  }
+
   private static createLifecycleCallback<H = PreHook | PostHook>(): H {
     let currentCallback = (..._args: any[]) => {};
 
@@ -57,6 +63,7 @@ export class LifecycleHookManager {
   }
 
   public static attach(model: ModelDefinition): ModelDefinition {
+    this.models.push(model);
     const { name, schema } = model;
     const operations: {
       [key in LifecycleOperation]: ('pre' | 'post')[];

--- a/api/src/utils/generics/lifecycle-hook-manager.ts
+++ b/api/src/utils/generics/lifecycle-hook-manager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -46,11 +46,11 @@ export class LifecycleHookManager {
   }
 
   private static addModel(model: ModelDefinition) {
-    if (this.models.has(model.name)) {
+    if (LifecycleHookManager.models.has(model.name)) {
       throw new Error(`Model with name ${model} already exists`);
     }
 
-    this.models.set(model.name, model);
+    LifecycleHookManager.models.set(model.name, model);
   }
 
   private static createLifecycleCallback<H = PreHook | PostHook>(): H {

--- a/api/src/utils/generics/lifecycle-hook-manager.ts
+++ b/api/src/utils/generics/lifecycle-hook-manager.ts
@@ -47,7 +47,7 @@ export class LifecycleHookManager {
 
   private static addModel(model: ModelDefinition) {
     if (LifecycleHookManager.models.has(model.name)) {
-      throw new Error(`Model with name ${model} already exists`);
+      throw new Error(`Model with name ${model.name} already exists`);
     }
 
     LifecycleHookManager.models.set(model.name, model);

--- a/api/src/utils/generics/lifecycle-hook-manager.ts
+++ b/api/src/utils/generics/lifecycle-hook-manager.ts
@@ -39,10 +39,18 @@ interface Registry {
 export class LifecycleHookManager {
   private static registry: Registry = {};
 
-  private static models: ModelDefinition[] = [];
+  private static models = new Map<string, ModelDefinition>();
 
   public static getModel(name: string) {
-    return this.models.find((attachedModel) => attachedModel.name === name);
+    return this.models.get(name);
+  }
+
+  private static addModel(model: ModelDefinition) {
+    if (this.models.has(model.name)) {
+      throw new Error(`model with Name ${model} already exist`);
+    }
+
+    this.models.set(model.name, model);
   }
 
   private static createLifecycleCallback<H = PreHook | PostHook>(): H {
@@ -63,7 +71,7 @@ export class LifecycleHookManager {
   }
 
   public static attach(model: ModelDefinition): ModelDefinition {
-    this.models.push(model);
+    this.addModel(model);
     const { name, schema } = model;
     const operations: {
       [key in LifecycleOperation]: ('pre' | 'post')[];

--- a/api/src/utils/generics/lifecycle-hook-manager.ts
+++ b/api/src/utils/generics/lifecycle-hook-manager.ts
@@ -71,7 +71,7 @@ export class LifecycleHookManager {
   }
 
   public static attach(model: ModelDefinition): ModelDefinition {
-    this.addModel(model);
+    LifecycleHookManager.addModel(model);
     const { name, schema } = model;
     const operations: {
       [key in LifecycleOperation]: ('pre' | 'post')[];

--- a/api/src/utils/generics/lifecycle-hook-manager.ts
+++ b/api/src/utils/generics/lifecycle-hook-manager.ts
@@ -47,7 +47,7 @@ export class LifecycleHookManager {
 
   private static addModel(model: ModelDefinition) {
     if (this.models.has(model.name)) {
-      throw new Error(`model with Name ${model} already exist`);
+      throw new Error(`Model with name ${model} already exists`);
     }
 
     this.models.set(model.name, model);

--- a/api/src/utils/generics/lifecycle-hook-manager.ts
+++ b/api/src/utils/generics/lifecycle-hook-manager.ts
@@ -42,7 +42,7 @@ export class LifecycleHookManager {
   private static models = new Map<string, ModelDefinition>();
 
   public static getModel(name: string) {
-    return this.models.get(name);
+    return LifecycleHookManager.models.get(name);
   }
 
   private static addModel(model: ModelDefinition) {

--- a/api/src/utils/test/utils.ts
+++ b/api/src/utils/test/utils.ts
@@ -69,9 +69,19 @@ const extractInstances =
   async <T extends TTypeOrToken>(types: T) =>
     await findInstances(type, module, types);
 
+/**
+ * Retrieves a provider metadata
+ * @param provider - provider
+ * @returns a provider metadata
+ */
 const getParamTypes = (provider: Provider) =>
   Reflect.getMetadata('design:paramtypes', provider) || [];
 
+/**
+ * Retrieves an array of providers
+ * @param parentClass - parent provider class
+ * @returns an array of providers
+ */
 const getClassDependencies = (parentClass: Provider): Provider[] => {
   const dependencies: Provider[] = [];
   const seenClasses = new Set<Provider>();
@@ -99,6 +109,12 @@ const getClassDependencies = (parentClass: Provider): Provider[] => {
   return dependencies;
 };
 
+/**
+ * Retrieves a model
+ * @param name - model name
+ * @param suffix - model name suffix
+ * @returns a model
+ */
 const getModel = (name: string, suffix = ''): ModelDefinition => {
   const modelName = name.replace(suffix, '');
   const model = LifecycleHookManager.getModel(modelName);
@@ -110,6 +126,12 @@ const getModel = (name: string, suffix = ''): ModelDefinition => {
   return model;
 };
 
+/**
+ * Retrieves an array of nested models
+ * @param extendedProviders - array of providers (Repositories)
+ * @param suffix - suffix
+ * @returns an array of nested models
+ */
 const getNestedModels = (
   extendedProviders: Provider[],
   suffix = '',
@@ -126,6 +148,11 @@ const getNestedModels = (
 const filterNestedDependencies = (dependency: Provider) =>
   dependency.valueOf().toString().slice(0, 6) === 'class ';
 
+/**
+ * Checks if a the imports includes a MongooseModule
+ * @param providers - array of providers
+ * @returns an array of nested dependencies
+ */
 const getNestedDependencies = (providers: Provider[]): Provider[] => {
   const nestedDependencies = new Set<Provider>();
 
@@ -148,11 +175,21 @@ const getNestedDependencies = (providers: Provider[]): Provider[] => {
   return [...nestedDependencies];
 };
 
+/**
+ * Checks if a the imports includes a MongooseModule
+ * @param imports - array of modules
+ * @returns true if the imports includes a MongooseModule
+ */
 const canInjectModels = (imports: buildTestingMocksProps['imports']): boolean =>
   (imports || []).some(
     (module) => 'module' in module && module.module.name === 'MongooseModule',
   );
 
+/**
+ * Retrieves models
+ * @param models - array of models
+ * @returns an array of models
+ */
 const getModels = (models: TModel[]): ModelDefinition[] =>
   models.map((model) =>
     typeof model === 'string' ? getModel(model, 'Model') : model,

--- a/api/src/utils/test/utils.ts
+++ b/api/src/utils/test/utils.ts
@@ -36,7 +36,7 @@ type buildTestingMocksProps<
     | {
         providers: NonNullable<P>;
         controllers: NonNullable<C>;
-        autoInjectFrom: 'all'[];
+        autoInjectFrom: ('providers' | 'controllers')[];
       }
     | {
         providers: NonNullable<P>;
@@ -171,17 +171,16 @@ export const buildTestingMocks = async ({
 }: buildTestingMocksProps) => {
   const nestedProviders = new Set<Provider>();
   const injectionFrom = autoInjectFrom as ToUnionArray<typeof autoInjectFrom>;
-  const canAutoInjectFromAll = injectionFrom?.includes('all');
   const canAutoInjectFromProviders = injectionFrom?.includes('providers');
   const canAutoInjectFromControllers = injectionFrom?.includes('controllers');
 
-  if (canAutoInjectFromAll || canAutoInjectFromProviders) {
+  if (canAutoInjectFromProviders) {
     [...providers, ...getNestedDependencies(providers)].forEach((provider) =>
       nestedProviders.add(provider),
     );
   }
 
-  if (canAutoInjectFromAll || canAutoInjectFromControllers) {
+  if (canAutoInjectFromControllers) {
     [...getNestedDependencies(controllers)].forEach((controller) =>
       nestedProviders.add(controller),
     );

--- a/api/src/utils/test/utils.ts
+++ b/api/src/utils/test/utils.ts
@@ -36,11 +36,10 @@ type buildTestingMocksProps<
     | {
         providers: NonNullable<P>;
         controllers: NonNullable<C>;
-        autoInjectFrom?: 'all'[];
+        autoInjectFrom: 'all'[];
       }
     | {
         providers: NonNullable<P>;
-        controllers?: undefined;
         autoInjectFrom?: 'providers'[];
       }
     | {
@@ -188,7 +187,7 @@ export const buildTestingMocks = async ({
         ? [
             MongooseModule.forFeature([
               ...getModels(models),
-              ...(!!autoInjectFrom
+              ...(autoInjectFrom
                 ? getNestedModels(nestedProviders, 'Repository')
                 : []),
             ]),

--- a/api/src/utils/test/utils.ts
+++ b/api/src/utils/test/utils.ts
@@ -104,7 +104,7 @@ const getModel = (name: string, suffix = ''): ModelDefinition => {
   const model = LifecycleHookManager.getModel(modelName);
 
   if (!model) {
-    throw new Error(`Unable to find model for name '${modelName}!`);
+    throw new Error(`Unable to find model for name '${modelName}!'`);
   }
 
   return model;


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to introduce the automated DI into unit tests.

Example 
We have a service named user.service.ts by updating the constructor to inject an extra JwtService the unit test will break (limitation)

Fixes #1136

# Advantages : 
- Enhance unit tests code readability
- Save time implementing new unit tests
- Enhance flexibility to update dependencies without impacting unit tests    

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Streamlined and simplified test setups across numerous modules by removing redundant imports, providers, and explicit model registrations.
  - Enhanced test utilities with recursive dependency resolution and flexible automatic injection of models and providers, reducing boilerplate.
  - Consolidated and minimized mock and provider declarations, focusing on essential dependencies for each test.
  - Updated test suites to rely on automatic injection options (`autoInjectFrom`), improving maintainability and clarity.
  - Improved test isolation by adding global mock cleanup between tests in lifecycle hook manager tests.
- **New Features**
  - Added static properties and methods to internal utilities to track and retrieve models, enhancing test model management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->