### PR TITLE
fix(api): update lastvisit and retainedfrom defaultvalues

### DIFF
--- a/api/src/chat/schemas/subscriber.schema.ts
+++ b/api/src/chat/schemas/subscriber.schema.ts
@@ -90,13 +90,13 @@ export class SubscriberStub extends BaseSchema {
 
   @Prop({
     type: Date,
-    default: () => Date.now() + 7 * 24 * 60 * 60 * 1000,
+    default: () => Date.now(),
   })
   lastvisit?: Date;
 
   @Prop({
     type: Date,
-    default: () => Date.now() + 7 * 24 * 60 * 60 * 1000,
+    default: () => Date.now(),
   })
   retainedFrom?: Date;
 

--- a/api/src/utils/test/fixtures/subscriber.ts
+++ b/api/src/utils/test/fixtures/subscriber.ts
@@ -23,8 +23,8 @@ export const subscriberDefaultValues: TSubscriberFixtures['defaultValues'] = {
   timezone: 0,
   assignedTo: null,
   assignedAt: null,
-  lastvisit: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-  retainedFrom: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  lastvisit: new Date(),
+  retainedFrom: new Date(),
   avatar: null,
   context: {
     vars: {},


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to update lastvisit and retainedfrom defaultvalues.

Fixes #1171

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated default date values for subscriber visit and retention timestamps to reflect the current date and time. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->