### PR TITLE
fix(frontend): clear React Query cache ondisconnect

### DIFF
--- a/frontend/src/hooks/entities/auth-hooks.ts
+++ b/frontend/src/hooks/entities/auth-hooks.ts
@@ -22,7 +22,7 @@ import { useSocket } from "@/websocket/socket-hooks";
 
 import { useFind } from "../crud/useFind";
 import { useApiClient } from "../useApiClient";
-import { CURRENT_USER_KEY, useAuth, useLogoutRedirection } from "../useAuth";
+import { useAuth, useLogoutRedirection } from "../useAuth";
 import { useToast } from "../useToast";
 import { useTranslate } from "../useTranslate";
 
@@ -71,12 +71,10 @@ export const useLogout = (
     async mutationFn() {
       socket?.disconnect();
 
-      queryClient.clear();
-
       return await apiClient.logout();
     },
     onSuccess: async () => {
-      queryClient.removeQueries([CURRENT_USER_KEY]);
+      queryClient.clear();
       postMessage({ event: "logout" });
       await logoutRedirection();
       toast.success(t("message.logout_success"));

--- a/frontend/src/hooks/entities/auth-hooks.ts
+++ b/frontend/src/hooks/entities/auth-hooks.ts
@@ -71,6 +71,8 @@ export const useLogout = (
     async mutationFn() {
       socket?.disconnect();
 
+      queryClient.clear();
+
       return await apiClient.logout();
     },
     onSuccess: async () => {


### PR DESCRIPTION
# Motivation
The main motivation is to clean React Query cache after the disconnection.

Fixes #1173

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout process to ensure all cached data is cleared upon logging out, enhancing data privacy and session management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->