### PR TITLE
fix(frontend): add support to target_block_id

### DIFF
--- a/frontend/src/components/settings/SettingInput.tsx
+++ b/frontend/src/components/settings/SettingInput.tsx
@@ -153,6 +153,21 @@ const SettingInput: React.FC<RenderSettingInputProps> = ({
             {...rest}
           />
         );
+      } else if (setting.label === "target_block_id") {
+        const { onChange, ...rest } = field;
+
+        return (
+          <AutoCompleteEntitySelect<IBlock, "name", false>
+            searchFields={["name"]}
+            entity={EntityType.BLOCK}
+            format={Format.BASIC}
+            labelKey="name"
+            label={label}
+            multiple={false}
+            onChange={(_e, selected, ..._) => onChange(selected?.id || "")}
+            {...rest}
+          />
+        );
       }
 
       return (


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to add support to target_block_id label.

Fixes #1177

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
