### PR TITLE
refactor(api): replace findPage & findPageAndPopulate deprecated methods

### DIFF
--- a/api/src/chat/repositories/label.repository.spec.ts
+++ b/api/src/chat/repositories/label.repository.spec.ts
@@ -80,11 +80,11 @@ describe('LabelRepository', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should find labels, and foreach label populate its corresponding users', async () => {
       const pageQuery = getPageQuery<Label>();
       jest.spyOn(labelModel, 'find');
-      const result = await labelRepository.findPageAndPopulate({}, pageQuery);
+      const result = await labelRepository.findAndPopulate({}, pageQuery);
       const labelsWithUsers = labelFixtures.map((label) => ({
         ...label,
         users,

--- a/api/src/chat/repositories/message.repository.spec.ts
+++ b/api/src/chat/repositories/message.repository.spec.ts
@@ -72,11 +72,11 @@ describe('MessageRepository', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should find one messages, and foreach message populate its sender and recipient', async () => {
       jest.spyOn(messageModel, 'find');
       const pageQuery = getPageQuery<AnyMessage>();
-      const result = await messageRepository.findPageAndPopulate({}, pageQuery);
+      const result = await messageRepository.findAndPopulate({}, pageQuery);
       const allSubscribers = await subscriberRepository.findAll();
       const allUsers = await userRepository.findAll();
       const allMessages = await messageRepository.findAll();

--- a/api/src/chat/repositories/subscriber.repository.spec.ts
+++ b/api/src/chat/repositories/subscriber.repository.spec.ts
@@ -114,14 +114,11 @@ describe('SubscriberRepository', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     const pageQuery = getPageQuery<Subscriber>();
     it('should find subscribers, and foreach subscriber populate the corresponding labels', async () => {
       jest.spyOn(subscriberModel, 'find');
-      const result = await subscriberRepository.findPageAndPopulate(
-        {},
-        pageQuery,
-      );
+      const result = await subscriberRepository.findAndPopulate({}, pageQuery);
 
       expect(subscriberModel.find).toHaveBeenCalledWith({}, undefined);
       expect(result).toEqualPayload(

--- a/api/src/chat/services/block.service.spec.ts
+++ b/api/src/chat/services/block.service.spec.ts
@@ -1005,7 +1005,7 @@ describe('BlockService', () => {
         false,
         'conv_id',
       );
-      const elements = await contentService.findPage(
+      const elements = await contentService.find(
         { status: true, entity: contentType.id },
         { skip: 0, limit: 2, sort: ['createdAt', 'desc'] },
       );
@@ -1039,7 +1039,7 @@ describe('BlockService', () => {
         false,
         'conv_id',
       );
-      const elements = await contentService.findPage(
+      const elements = await contentService.find(
         { status: true, entity: contentType.id },
         { skip: 2, limit: 2, sort: ['createdAt', 'desc'] },
       );

--- a/api/src/chat/services/label.service.spec.ts
+++ b/api/src/chat/services/label.service.spec.ts
@@ -68,10 +68,10 @@ describe('LabelService', () => {
   describe('findPageAndPopulate', () => {
     const pageQuery = getPageQuery<Label>();
     it('should find labels, and foreach label populate its corresponding users', async () => {
-      jest.spyOn(labelRepository, 'findPageAndPopulate');
-      const result = await labelService.findPageAndPopulate({}, pageQuery);
+      jest.spyOn(labelRepository, 'findAndPopulate');
+      const result = await labelService.findAndPopulate({}, pageQuery);
 
-      expect(labelRepository.findPageAndPopulate).toHaveBeenCalled();
+      expect(labelRepository.findAndPopulate).toHaveBeenCalled();
       expect(result).toEqualPayload(labelsWithUsers.sort(sortRowsBy));
     });
   });

--- a/api/src/chat/services/label.service.spec.ts
+++ b/api/src/chat/services/label.service.spec.ts
@@ -65,7 +65,7 @@ describe('LabelService', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     const pageQuery = getPageQuery<Label>();
     it('should find labels, and foreach label populate its corresponding users', async () => {
       jest.spyOn(labelRepository, 'findAndPopulate');

--- a/api/src/chat/services/message.service.spec.ts
+++ b/api/src/chat/services/message.service.spec.ts
@@ -126,8 +126,8 @@ describe('MessageService', () => {
   describe('findPageAndPopulate', () => {
     const pageQuery = getPageQuery<Message>();
     it('should find messages, and foreach message populate the corresponding sender and recipient', async () => {
-      jest.spyOn(messageRepository, 'findPageAndPopulate');
-      const result = await messageService.findPageAndPopulate({}, pageQuery);
+      jest.spyOn(messageRepository, 'findAndPopulate');
+      const result = await messageService.findAndPopulate({}, pageQuery);
       const messagesWithSenderAndRecipient = allMessages.map((message) => ({
         ...message,
         sender: allSubscribers.find(({ id }) => id === message.sender),
@@ -135,9 +135,10 @@ describe('MessageService', () => {
         sentBy: allUsers.find(({ id }) => id === message.sentBy)?.id,
       }));
 
-      expect(messageRepository.findPageAndPopulate).toHaveBeenCalledWith(
+      expect(messageRepository.findAndPopulate).toHaveBeenCalledWith(
         {},
         pageQuery,
+        undefined,
       );
       expect(result).toEqualPayload(messagesWithSenderAndRecipient);
     });

--- a/api/src/chat/services/message.service.spec.ts
+++ b/api/src/chat/services/message.service.spec.ts
@@ -123,7 +123,7 @@ describe('MessageService', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     const pageQuery = getPageQuery<Message>();
     it('should find messages, and foreach message populate the corresponding sender and recipient', async () => {
       jest.spyOn(messageRepository, 'findAndPopulate');

--- a/api/src/chat/services/subscriber.service.spec.ts
+++ b/api/src/chat/services/subscriber.service.spec.ts
@@ -134,8 +134,8 @@ describe('SubscriberService', () => {
   describe('findPageAndPopulate', () => {
     const pageQuery = getPageQuery<Subscriber>();
     it('should find subscribers, and foreach subscriber populate its corresponding labels', async () => {
-      jest.spyOn(subscriberRepository, 'findPageAndPopulate');
-      const result = await subscriberService.findPageAndPopulate({}, pageQuery);
+      jest.spyOn(subscriberRepository, 'findAndPopulate');
+      const result = await subscriberService.findAndPopulate({}, pageQuery);
       const subscribersWithLabels = allSubscribers.map((subscriber) => ({
         ...subscriber,
         labels: allLabels.filter((label) =>
@@ -144,7 +144,7 @@ describe('SubscriberService', () => {
         assignedTo: allUsers.find(({ id }) => subscriber.assignedTo === id),
       }));
 
-      expect(subscriberRepository.findPageAndPopulate).toHaveBeenCalled();
+      expect(subscriberRepository.findAndPopulate).toHaveBeenCalled();
       expect(result).toEqualPayload(subscribersWithLabels.sort(sortRowsBy));
     });
   });

--- a/api/src/chat/services/subscriber.service.spec.ts
+++ b/api/src/chat/services/subscriber.service.spec.ts
@@ -131,7 +131,7 @@ describe('SubscriberService', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     const pageQuery = getPageQuery<Subscriber>();
     it('should find subscribers, and foreach subscriber populate its corresponding labels', async () => {
       jest.spyOn(subscriberRepository, 'findAndPopulate');

--- a/api/src/cms/repositories/content.repository.spec.ts
+++ b/api/src/cms/repositories/content.repository.spec.ts
@@ -67,13 +67,13 @@ describe('ContentRepository', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should find contents and populate their content types', async () => {
       const pageQuery = getPageQuery<Content>({
         limit: 1,
         sort: ['_id', 'asc'],
       });
-      const result = await contentRepository.findPageAndPopulate({}, pageQuery);
+      const result = await contentRepository.findAndPopulate({}, pageQuery);
       expect(result).toEqualPayload([
         {
           ...contentFixtures.find(({ title }) => title === 'Jean'),

--- a/api/src/cms/services/content.service.spec.ts
+++ b/api/src/cms/services/content.service.spec.ts
@@ -75,12 +75,12 @@ describe('ContentService', () => {
   describe('findPage', () => {
     const pageQuery = getPageQuery<Content>({ limit: 1, sort: ['_id', 'asc'] });
     it('should return contents and populate their corresponding content types', async () => {
-      const findSpy = jest.spyOn(contentRepository, 'findPageAndPopulate');
-      const results = await contentService.findPageAndPopulate({}, pageQuery);
+      const findSpy = jest.spyOn(contentRepository, 'findAndPopulate');
+      const results = await contentService.findAndPopulate({}, pageQuery);
       const contentType = await contentTypeService.findOne(
         results[0].entity.id,
       );
-      expect(findSpy).toHaveBeenCalledWith({}, pageQuery);
+      expect(findSpy).toHaveBeenCalledWith({}, pageQuery, undefined);
       expect(results).toEqualPayload([
         {
           ...contentFixtures.find(({ title }) => title === 'Jean'),
@@ -103,7 +103,7 @@ describe('ContentService', () => {
     };
 
     it('should get content that is published', async () => {
-      const actualData = await contentService.findPage(
+      const actualData = await contentService.find(
         { status: true },
         { skip: 0, limit: 10, sort: ['createdAt', 'desc'] },
       );
@@ -117,7 +117,7 @@ describe('ContentService', () => {
 
     it('should get content for a specific entity', async () => {
       const contentType = await contentTypeService.findOne({ name: 'Product' });
-      const actualData = await contentService.findPage(
+      const actualData = await contentService.find(
         { status: true, entity: contentType!.id },
         { skip: 0, limit: 10, sort: ['createdAt', 'desc'] },
       );
@@ -135,7 +135,7 @@ describe('ContentService', () => {
     it('should get content using query', async () => {
       contentOptions.entity = 1;
       const contentType = await contentTypeService.findOne({ name: 'Product' });
-      const actualData = await contentService.findPage(
+      const actualData = await contentService.find(
         { status: true, entity: contentType!.id, title: /^Jean/ },
         { skip: 0, limit: 10, sort: ['createdAt', 'desc'] },
       );
@@ -152,7 +152,7 @@ describe('ContentService', () => {
     });
 
     it('should get content skiping 2 elements', async () => {
-      const actualData = await contentService.findPage(
+      const actualData = await contentService.find(
         { status: true },
         { skip: 2, limit: 2, sort: ['createdAt', 'desc'] },
       );

--- a/api/src/cms/services/content.service.spec.ts
+++ b/api/src/cms/services/content.service.spec.ts
@@ -72,7 +72,7 @@ describe('ContentService', () => {
     });
   });
 
-  describe('findPage', () => {
+  describe('find', () => {
     const pageQuery = getPageQuery<Content>({ limit: 1, sort: ['_id', 'asc'] });
     it('should return contents and populate their corresponding content types', async () => {
       const findSpy = jest.spyOn(contentRepository, 'findAndPopulate');

--- a/api/src/i18n/controllers/language.controller.spec.ts
+++ b/api/src/i18n/controllers/language.controller.spec.ts
@@ -70,7 +70,7 @@ describe('LanguageController', () => {
     });
   });
 
-  describe('findPage', () => {
+  describe('find', () => {
     const pageQuery = getPageQuery<Language>({ sort: ['code', 'asc'] });
     it('should find languages', async () => {
       jest.spyOn(languageService, 'find');

--- a/api/src/i18n/controllers/translation.controller.spec.ts
+++ b/api/src/i18n/controllers/translation.controller.spec.ts
@@ -82,7 +82,7 @@ describe('TranslationController', () => {
     });
   });
 
-  describe('findPage', () => {
+  describe('find', () => {
     const pageQuery = getPageQuery<Translation>();
     it('should find translations', async () => {
       jest.spyOn(translationService, 'find');

--- a/api/src/nlp/repositories/nlp-sample-entity.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-sample-entity.repository.spec.ts
@@ -83,12 +83,12 @@ describe('NlpSampleEntityRepository', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should return all nlp entities with populate', async () => {
       const pageQuery = getPageQuery<NlpSampleEntity>({
         sort: ['value', 'asc'],
       });
-      const result = await nlpSampleEntityRepository.findPageAndPopulate(
+      const result = await nlpSampleEntityRepository.findAndPopulate(
         {},
         pageQuery,
       );

--- a/api/src/nlp/repositories/nlp-sample.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-sample.repository.spec.ts
@@ -84,15 +84,12 @@ describe('NlpSampleRepository', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should return all nlp samples with populate', async () => {
       const pageQuery = getPageQuery<NlpSample>({
         sort: ['text', 'desc'],
       });
-      const result = await nlpSampleRepository.findPageAndPopulate(
-        {},
-        pageQuery,
-      );
+      const result = await nlpSampleRepository.findAndPopulate({}, pageQuery);
       const nlpSamples = await nlpSampleRepository.findAll();
       const nlpSampleEntities = await nlpSampleEntityRepository.findAll();
 

--- a/api/src/nlp/services/nlp-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-entity.service.spec.ts
@@ -77,7 +77,7 @@ describe('NlpEntityService', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should return all nlp entities with populate', async () => {
       const pageQuery = getPageQuery<NlpEntity>({ sort: ['name', 'desc'] });
       const firstNameNlpEntity = await nlpEntityRepository.findOne({

--- a/api/src/nlp/services/nlp-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-entity.service.spec.ts
@@ -83,7 +83,7 @@ describe('NlpEntityService', () => {
       const firstNameNlpEntity = await nlpEntityRepository.findOne({
         name: 'firstname',
       });
-      const result = await nlpEntityService.findPageAndPopulate(
+      const result = await nlpEntityService.findAndPopulate(
         { _id: firstNameNlpEntity!.id },
         pageQuery,
       );

--- a/api/src/nlp/services/nlp-sample-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample-entity.service.spec.ts
@@ -97,7 +97,7 @@ describe('NlpSampleEntityService', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should return all nlp sample entities with populate', async () => {
       const pageQuery = getPageQuery<NlpSampleEntity>({
         sort: ['value', 'asc'],

--- a/api/src/nlp/services/nlp-sample-entity.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample-entity.service.spec.ts
@@ -102,7 +102,7 @@ describe('NlpSampleEntityService', () => {
       const pageQuery = getPageQuery<NlpSampleEntity>({
         sort: ['value', 'asc'],
       });
-      const result = await nlpSampleEntityService.findPageAndPopulate(
+      const result = await nlpSampleEntityService.findAndPopulate(
         {},
         pageQuery,
       );

--- a/api/src/nlp/services/nlp-sample.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample.service.spec.ts
@@ -100,7 +100,7 @@ describe('NlpSampleService', () => {
   describe('findPageAndPopulate', () => {
     it('should return all nlp samples with populate', async () => {
       const pageQuery = getPageQuery<NlpSample>({ sort: ['text', 'desc'] });
-      const result = await nlpSampleService.findPageAndPopulate({}, pageQuery);
+      const result = await nlpSampleService.findAndPopulate({}, pageQuery);
       const nlpSamples = await nlpSampleRepository.findAll();
       const nlpSampleEntities = await nlpSampleEntityRepository.findAll();
 

--- a/api/src/nlp/services/nlp-sample.service.spec.ts
+++ b/api/src/nlp/services/nlp-sample.service.spec.ts
@@ -97,7 +97,7 @@ describe('NlpSampleService', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should return all nlp samples with populate', async () => {
       const pageQuery = getPageQuery<NlpSample>({ sort: ['text', 'desc'] });
       const result = await nlpSampleService.findAndPopulate({}, pageQuery);

--- a/api/src/user/controllers/user.controller.spec.ts
+++ b/api/src/user/controllers/user.controller.spec.ts
@@ -129,8 +129,8 @@ describe('UserController', () => {
     const pageQuery = getPageQuery<User>({ sort: ['_id', 'asc'] });
 
     it('should find users, and for each user populate the corresponding roles', async () => {
-      jest.spyOn(userService, 'findPageAndPopulate');
-      const result = await userService.findPageAndPopulate({}, pageQuery);
+      jest.spyOn(userService, 'findAndPopulate');
+      const result = await userService.findAndPopulate({}, pageQuery);
 
       const usersWithRoles = userFixtures.reduce(
         (acc, currUser) => {
@@ -144,10 +144,7 @@ describe('UserController', () => {
         [] as Omit<UserFull, 'id' | 'createdAt' | 'updatedAt'>[],
       );
 
-      expect(userService.findPageAndPopulate).toHaveBeenCalledWith(
-        {},
-        pageQuery,
-      );
+      expect(userService.findAndPopulate).toHaveBeenCalledWith({}, pageQuery);
       expect(result).toEqualPayload(usersWithRoles, [
         ...IGNORED_FIELDS,
         'password',

--- a/api/src/user/repositories/invitation.repository.spec.ts
+++ b/api/src/user/repositories/invitation.repository.spec.ts
@@ -73,14 +73,13 @@ describe('InvitationRepository', () => {
       });
     });
   });
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should find users, and for each user populate the corresponding roles', async () => {
       jest.spyOn(invitationModel, 'find');
       const pageQuery: PageQueryDto<Invitation> = getPageQuery<Invitation>();
-      jest.spyOn(invitationRepository, 'findPageAndPopulate');
       const allInvitations = await invitationRepository.findAll();
       const allRoles = await roleRepository.findAll();
-      const result = await invitationRepository.findPageAndPopulate(
+      const result = await invitationRepository.findAndPopulate(
         {},
         {
           ...pageQuery,

--- a/api/src/user/repositories/role.repository.spec.ts
+++ b/api/src/user/repositories/role.repository.spec.ts
@@ -75,15 +75,14 @@ describe('RoleRepository', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should find roles, and for each role populate the corresponding permissions and users', async () => {
       const pageQuery = getPageQuery<Role>({ sort: ['_id', 'asc'] });
       jest.spyOn(roleModel, 'find');
-      jest.spyOn(roleRepository, 'findPageAndPopulate');
       const allRoles = await roleRepository.findAll();
       const allPermissions = await permissionRepository.findAll();
       const allUsers = await userRepository.findAll();
-      const result = await roleRepository.findPageAndPopulate({}, pageQuery);
+      const result = await roleRepository.findAndPopulate({}, pageQuery);
       const rolesWithPermissionsAndUsers = allRoles.reduce((acc, currRole) => {
         const roleWithPermissionsAndUsers = {
           ...currRole,

--- a/api/src/user/repositories/user.repository.spec.ts
+++ b/api/src/user/repositories/user.repository.spec.ts
@@ -78,14 +78,13 @@ describe('UserRepository', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should find users, and for each user populate the corresponding roles', async () => {
       jest.spyOn(userModel, 'find');
       const pageQuery = getPageQuery<User>({ sort: ['_id', 'asc'] });
-      jest.spyOn(userRepository, 'findPageAndPopulate');
       const allUsers = await userRepository.findAll();
       const allRoles = await roleRepository.findAll();
-      const result = await userRepository.findPageAndPopulate({}, pageQuery);
+      const result = await userRepository.findAndPopulate({}, pageQuery);
       const usersWithRoles = allUsers.reduce((acc, currUser) => {
         acc.push({
           ...currUser,

--- a/api/src/user/services/role.service.spec.ts
+++ b/api/src/user/services/role.service.spec.ts
@@ -78,11 +78,11 @@ describe('RoleService', () => {
   describe('findPageAndPopulate', () => {
     it('should find roles, and for each role populate the corresponding permissions and users', async () => {
       const pageQuery = getPageQuery<Role>({ sort: ['_id', 'asc'] });
-      jest.spyOn(roleRepository, 'findPageAndPopulate');
+      jest.spyOn(roleRepository, 'findAndPopulate');
       const allRoles = await roleRepository.findAll();
       const allPermissions = await permissionRepository.findAll();
       const allUsers = await userRepository.findAll();
-      const result = await roleService.findPageAndPopulate({}, pageQuery);
+      const result = await roleService.findAndPopulate({}, pageQuery);
       const rolesWithPermissionsAndUsers = allRoles.reduce((acc, currRole) => {
         const roleWithPermissionsAndUsers = {
           ...currRole,
@@ -97,9 +97,10 @@ describe('RoleService', () => {
         return acc;
       }, [] as RoleFull[]);
 
-      expect(roleRepository.findPageAndPopulate).toHaveBeenCalledWith(
+      expect(roleRepository.findAndPopulate).toHaveBeenCalledWith(
         {},
         pageQuery,
+        undefined,
       );
       expect(result).toEqualPayload(rolesWithPermissionsAndUsers);
     });

--- a/api/src/user/services/role.service.spec.ts
+++ b/api/src/user/services/role.service.spec.ts
@@ -75,7 +75,7 @@ describe('RoleService', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should find roles, and for each role populate the corresponding permissions and users', async () => {
       const pageQuery = getPageQuery<Role>({ sort: ['_id', 'asc'] });
       jest.spyOn(roleRepository, 'findAndPopulate');

--- a/api/src/user/services/user.service.spec.ts
+++ b/api/src/user/services/user.service.spec.ts
@@ -79,7 +79,7 @@ describe('UserService', () => {
     });
   });
 
-  describe('findPageAndPopulate', () => {
+  describe('findAndPopulate', () => {
     it('should find users, and for each user populate the corresponding roles', async () => {
       const pageQuery = getPageQuery<User>({ sort: ['_id', 'asc'] });
       jest.spyOn(userRepository, 'findAndPopulate');

--- a/api/src/user/services/user.service.spec.ts
+++ b/api/src/user/services/user.service.spec.ts
@@ -82,9 +82,9 @@ describe('UserService', () => {
   describe('findPageAndPopulate', () => {
     it('should find users, and for each user populate the corresponding roles', async () => {
       const pageQuery = getPageQuery<User>({ sort: ['_id', 'asc'] });
-      jest.spyOn(userRepository, 'findPageAndPopulate');
+      jest.spyOn(userRepository, 'findAndPopulate');
       const allUsers = await userRepository.findAll();
-      const result = await userService.findPageAndPopulate({}, pageQuery);
+      const result = await userService.findAndPopulate({}, pageQuery);
       const usersWithRoles = allUsers.reduce(
         (acc, { avatar: _avatar, roles: _roles, ...rest }) => {
           acc.push({
@@ -97,9 +97,10 @@ describe('UserService', () => {
         [] as UserFull[],
       );
 
-      expect(userRepository.findPageAndPopulate).toHaveBeenCalledWith(
+      expect(userRepository.findAndPopulate).toHaveBeenCalledWith(
         {},
         pageQuery,
+        undefined,
       );
       expect(result).toEqualPayload(usersWithRoles);
     });


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to replace findPage and findPageAndPopulate deprecated methods.

Fixes #405

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test descriptions and method calls from "findPageAndPopulate" to "findAndPopulate" across multiple test suites.
  * Updated some test blocks and method calls from "findPage" to "find" for consistency.
  * No changes to test logic, assertions, or outcomes—only naming updates for clarity and alignment.
  * No changes to any exported or public entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->