### PR TITLE
fix(widget): centered disconnected content

### DIFF
--- a/widget/src/components/ConnectionLost.scss
+++ b/widget/src/components/ConnectionLost.scss
@@ -8,12 +8,13 @@
   position: relative;
   height: 100%;
   width: 100%;
+  display: grid;
+  place-items: center;
+  overflow: auto;
+  padding: 14px 0;
 }
 .sc-chat--disconnected-icon {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translateY(-50%) translateX(-50%);
+  position: relative;
   text-align: center;
 }
 .sc-chat--disconnected-text {


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to centered the widget disconnected content.

Fixes #1183

# Screen recording fix
<video src="https://github.com/user-attachments/assets/1d843685-fc5d-45d4-98f0-2bfd5f650819"></video>

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved alignment and spacing of the disconnected icon in the chat widget.
  * Added scroll behavior for content overflow in the disconnected icon wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->