### PR TITLE
feat(frontend): introduce ButtonActionsGroup component

### DIFF
--- a/frontend/src/app-components/buttons/ButtonActionsGroup.tsx
+++ b/frontend/src/app-components/buttons/ButtonActionsGroup.tsx
@@ -9,6 +9,7 @@
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { Button, ButtonGroup, ButtonProps } from "@mui/material";
+import React from "react";
 
 import { useHasPermission } from "@/hooks/useHasPermission";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -63,7 +64,7 @@ export const ButtonActionsGroup = ({
         };
 
         if (hasAbility || hasAbilities) {
-          if (typeof rest.children === "object") {
+          if (React.isValidElement(rest.children)) {
             return rest.children;
           } else {
             return <Button key={`button_${index}`} {...extendedProps} />;

--- a/frontend/src/app-components/buttons/ButtonActionsGroup.tsx
+++ b/frontend/src/app-components/buttons/ButtonActionsGroup.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { Button, ButtonGroup, ButtonProps } from "@mui/material";
+
+import { useHasPermission } from "@/hooks/useHasPermission";
+import { useTranslate } from "@/hooks/useTranslate";
+import { EntityType } from "@/services/types";
+import { PermissionAction } from "@/types/permission.types";
+
+const COMMON_BUTTON_PROPS: Partial<ButtonProps> = {
+  variant: "contained",
+};
+
+export const ButtonActionsGroup = ({
+  entity,
+  buttons,
+}: {
+  entity?: EntityType;
+  buttons: (
+    | Partial<ButtonProps> & {
+        permissions?: Partial<Record<EntityType, PermissionAction>>;
+        permissionAction?: PermissionAction;
+      }
+  )[];
+}) => {
+  const { t } = useTranslate();
+  const hasPermission = useHasPermission();
+  const defaultProps: Partial<Record<PermissionAction, Partial<ButtonProps>>> =
+    {
+      [PermissionAction.CREATE]: {
+        children: t("button.add"),
+        startIcon: <AddIcon />,
+      },
+      [PermissionAction.DELETE]: {
+        color: "error",
+        children: t("button.delete"),
+        startIcon: <DeleteIcon />,
+      },
+    };
+
+  return (
+    <ButtonGroup sx={{ ml: "auto" }}>
+      {buttons.map(({ permissions, permissionAction, ...rest }, index) => {
+        const hasAbility =
+          entity && permissionAction && hasPermission(entity, permissionAction);
+        const hasAbilities =
+          permissions &&
+          Object.entries(permissions).every(([entity, permissionAction]) =>
+            hasPermission(entity as EntityType, permissionAction),
+          );
+        const extendedProps = {
+          ...COMMON_BUTTON_PROPS,
+          ...(permissionAction && defaultProps[permissionAction]),
+          ...rest,
+        };
+
+        if (hasAbility || hasAbilities) {
+          if (typeof rest.children === "object") {
+            return rest.children;
+          } else {
+            return <Button key={`button_${index}`} {...extendedProps} />;
+          }
+        }
+
+        return null;
+      })}
+    </ButtonGroup>
+  );
+};

--- a/frontend/src/components/categories/index.tsx
+++ b/frontend/src/components/categories/index.tsx
@@ -6,13 +6,12 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import AddIcon from "@mui/icons-material/Add";
-import DeleteIcon from "@mui/icons-material/Delete";
 import FolderIcon from "@mui/icons-material/Folder";
-import { Button, ButtonGroup, Grid, Paper } from "@mui/material";
+import { Grid, Paper } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useState } from "react";
 
+import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { FilterTextfield } from "@/app-components/inputs/FilterTextfield";
 import {
@@ -25,7 +24,6 @@ import { useDelete } from "@/hooks/crud/useDelete";
 import { useDeleteMany } from "@/hooks/crud/useDeleteMany";
 import { useFind } from "@/hooks/crud/useFind";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useHasPermission } from "@/hooks/useHasPermission";
 import { useSearch } from "@/hooks/useSearch";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -42,7 +40,6 @@ export const Categories = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
-  const hasPermission = useHasPermission();
   const { onSearch, searchPayload, searchText } = useSearch<ICategory>(
     {
       $iLike: ["label"],
@@ -147,23 +144,17 @@ export const Categories = () => {
             <Grid item>
               <FilterTextfield onChange={onSearch} defaultValue={searchText} />
             </Grid>
-            <ButtonGroup sx={{ ml: "auto" }}>
-              {hasPermission(EntityType.CATEGORY, PermissionAction.CREATE) ? (
-                <Button
-                  startIcon={<AddIcon />}
-                  variant="contained"
-                  onClick={() =>
-                    dialogs.open(CategoryFormDialog, { defaultValues: null })
-                  }
-                >
-                  {t("button.add")}
-                </Button>
-              ) : null}
-              {hasPermission(EntityType.CATEGORY, PermissionAction.DELETE) ? (
-                <Button
-                  color="error"
-                  variant="contained"
-                  onClick={async () => {
+            <ButtonActionsGroup
+              entity={EntityType.CATEGORY}
+              buttons={[
+                {
+                  permissionAction: PermissionAction.CREATE,
+                  onClick: () =>
+                    dialogs.open(CategoryFormDialog, { defaultValues: null }),
+                },
+                {
+                  permissionAction: PermissionAction.DELETE,
+                  onClick: async () => {
                     const isConfirmed = await dialogs.confirm(
                       ConfirmDialogBody,
                       {
@@ -175,14 +166,11 @@ export const Categories = () => {
                     if (isConfirmed) {
                       deleteCategories(selectedCategories);
                     }
-                  }}
-                  disabled={!selectedCategories.length}
-                  startIcon={<DeleteIcon />}
-                >
-                  {t("button.delete")}
-                </Button>
-              ) : null}
-            </ButtonGroup>
+                  },
+                  disabled: !selectedCategories.length,
+                },
+              ]}
+            />
           </Grid>
         </PageHeader>
       </Grid>

--- a/frontend/src/components/content-types/index.tsx
+++ b/frontend/src/components/content-types/index.tsx
@@ -7,10 +7,10 @@
  */
 
 import { faAlignLeft } from "@fortawesome/free-solid-svg-icons";
-import AddIcon from "@mui/icons-material/Add";
-import { Button, Grid, Paper } from "@mui/material";
+import { Grid, Paper } from "@mui/material";
 import { useRouter } from "next/router";
 
+import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { FilterTextfield } from "@/app-components/inputs/FilterTextfield";
 import {
@@ -22,7 +22,6 @@ import { DataGrid } from "@/app-components/tables/DataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useFind } from "@/hooks/crud/useFind";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useHasPermission } from "@/hooks/useHasPermission";
 import { useSearch } from "@/hooks/useSearch";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -60,7 +59,6 @@ export const ContentTypes = () => {
       toast.error(error.message || t("message.internal_server_error"));
     },
   });
-  const hasPermission = useHasPermission();
   const actionColumns = useActionColumns<IContentType>(
     EntityType.CONTENT_TYPE,
     [
@@ -104,19 +102,18 @@ export const ContentTypes = () => {
           <Grid item>
             <FilterTextfield onChange={onSearch} defaultValue={searchText} />
           </Grid>
-          {hasPermission(EntityType.CONTENT_TYPE, PermissionAction.CREATE) ? (
-            <Button
-              startIcon={<AddIcon />}
-              variant="contained"
-              onClick={() =>
-                dialogs.open(ContentTypeFormDialog, {
-                  defaultValues: null,
-                })
-              }
-            >
-              {t("button.add")}
-            </Button>
-          ) : null}
+          <ButtonActionsGroup
+            entity={EntityType.CONTENT_TYPE}
+            buttons={[
+              {
+                permissionAction: PermissionAction.CREATE,
+                onClick: () =>
+                  dialogs.open(ContentTypeFormDialog, {
+                    defaultValues: null,
+                  }),
+              },
+            ]}
+          />
         </Grid>
       </PageHeader>
       <Grid item xs={12}>

--- a/frontend/src/components/contents/index.tsx
+++ b/frontend/src/components/contents/index.tsx
@@ -7,21 +7,13 @@
  */
 
 import { faAlignLeft } from "@fortawesome/free-solid-svg-icons";
-import AddIcon from "@mui/icons-material/Add";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import {
-  Button,
-  ButtonGroup,
-  Chip,
-  Grid,
-  Paper,
-  Switch,
-  Typography,
-} from "@mui/material";
+import { Button, Chip, Grid, Paper, Switch, Typography } from "@mui/material";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useQueryClient } from "react-query";
 
+import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import FileUploadButton from "@/app-components/inputs/FileInput";
 import { FilterTextfield } from "@/app-components/inputs/FilterTextfield";
@@ -162,27 +154,29 @@ export const Contents = () => {
             <Grid item>
               <FilterTextfield onChange={onSearch} defaultValue={searchText} />
             </Grid>
-            {hasPermission(EntityType.CONTENT, PermissionAction.CREATE) ? (
-              <ButtonGroup sx={{ marginLeft: "auto" }}>
-                <Button
-                  startIcon={<AddIcon />}
-                  variant="contained"
-                  onClick={() =>
+            <ButtonActionsGroup
+              entity={EntityType.CONTENT}
+              buttons={[
+                {
+                  permissionAction: PermissionAction.CREATE,
+                  onClick: () =>
                     dialogs.open(ContentFormDialog, {
                       presetValues: contentType,
-                    })
-                  }
-                >
-                  {t("button.add")}
-                </Button>
-                <FileUploadButton
-                  accept="text/csv"
-                  label={t("button.import")}
-                  onChange={handleImportChange}
-                  isLoading={isLoading}
-                />
-              </ButtonGroup>
-            ) : null}
+                    }),
+                },
+                {
+                  permissionAction: PermissionAction.CREATE,
+                  children: (
+                    <FileUploadButton
+                      accept="text/csv"
+                      label={t("button.import")}
+                      onChange={handleImportChange}
+                      isLoading={isLoading}
+                    />
+                  ),
+                },
+              ]}
+            />
           </Grid>
         </PageHeader>
       </Grid>

--- a/frontend/src/components/context-vars/index.tsx
+++ b/frontend/src/components/context-vars/index.tsx
@@ -7,12 +7,11 @@
  */
 
 import { faAsterisk } from "@fortawesome/free-solid-svg-icons";
-import AddIcon from "@mui/icons-material/Add";
-import DeleteIcon from "@mui/icons-material/Delete";
-import { Button, ButtonGroup, Grid, Paper, Switch } from "@mui/material";
+import { Grid, Paper, Switch } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useState } from "react";
 
+import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { FilterTextfield } from "@/app-components/inputs/FilterTextfield";
 import {
@@ -181,24 +180,17 @@ export const ContextVars = () => {
           <Grid item>
             <FilterTextfield onChange={onSearch} defaultValue={searchText} />
           </Grid>
-          <ButtonGroup sx={{ ml: "auto" }}>
-            {hasPermission(EntityType.CONTEXT_VAR, PermissionAction.CREATE) ? (
-              <Button
-                startIcon={<AddIcon />}
-                variant="contained"
-                onClick={() =>
-                  dialogs.open(ContextVarFormDialog, { defaultValues: null })
-                }
-              >
-                {t("button.add")}
-              </Button>
-            ) : null}
-            {hasPermission(EntityType.CONTEXT_VAR, PermissionAction.DELETE) ? (
-              <Button
-                startIcon={<DeleteIcon />}
-                variant="contained"
-                color="error"
-                onClick={async () => {
+          <ButtonActionsGroup
+            entity={EntityType.CONTEXT_VAR}
+            buttons={[
+              {
+                permissionAction: PermissionAction.CREATE,
+                onClick: () =>
+                  dialogs.open(ContextVarFormDialog, { defaultValues: null }),
+              },
+              {
+                permissionAction: PermissionAction.DELETE,
+                onClick: async () => {
                   const isConfirmed = await dialogs.confirm(ConfirmDialogBody, {
                     mode: "selection",
                     count: selectedContextVars.length,
@@ -207,13 +199,11 @@ export const ContextVars = () => {
                   if (isConfirmed) {
                     deleteContextVars(selectedContextVars);
                   }
-                }}
-                disabled={!selectedContextVars.length}
-              >
-                {t("button.delete")}
-              </Button>
-            ) : null}
-          </ButtonGroup>
+                },
+                disabled: !selectedContextVars.length,
+              },
+            ]}
+          />
         </Grid>
       </PageHeader>
       <Grid item xs={12}>

--- a/frontend/src/components/labels/index.tsx
+++ b/frontend/src/components/labels/index.tsx
@@ -7,12 +7,11 @@
  */
 
 import { faTags } from "@fortawesome/free-solid-svg-icons";
-import AddIcon from "@mui/icons-material/Add";
-import DeleteIcon from "@mui/icons-material/Delete";
-import { Button, ButtonGroup, Grid, Paper } from "@mui/material";
+import { Grid, Paper } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useState } from "react";
 
+import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { FilterTextfield } from "@/app-components/inputs/FilterTextfield";
 import {
@@ -25,7 +24,6 @@ import { useDelete } from "@/hooks/crud/useDelete";
 import { useDeleteMany } from "@/hooks/crud/useDeleteMany";
 import { useFind } from "@/hooks/crud/useFind";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useHasPermission } from "@/hooks/useHasPermission";
 import { useSearch } from "@/hooks/useSearch";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -41,7 +39,6 @@ export const Labels = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
-  const hasPermission = useHasPermission();
   const { onSearch, searchPayload, searchText } = useSearch<ILabel>(
     {
       $or: ["name", "title"],
@@ -178,23 +175,17 @@ export const Labels = () => {
           <Grid item>
             <FilterTextfield onChange={onSearch} defaultValue={searchText} />
           </Grid>
-          <ButtonGroup sx={{ ml: "auto" }}>
-            {hasPermission(EntityType.LABEL, PermissionAction.CREATE) ? (
-              <Button
-                startIcon={<AddIcon />}
-                variant="contained"
-                onClick={() =>
-                  dialogs.open(LabelFormDialog, { defaultValues: null })
-                }
-              >
-                {t("button.add")}
-              </Button>
-            ) : null}
-            {hasPermission(EntityType.LABEL, PermissionAction.DELETE) ? (
-              <Button
-                color="error"
-                variant="contained"
-                onClick={async () => {
+          <ButtonActionsGroup
+            entity={EntityType.LABEL}
+            buttons={[
+              {
+                permissionAction: PermissionAction.CREATE,
+                onClick: () =>
+                  dialogs.open(LabelFormDialog, { defaultValues: null }),
+              },
+              {
+                permissionAction: PermissionAction.DELETE,
+                onClick: async () => {
                   const isConfirmed = await dialogs.confirm(ConfirmDialogBody, {
                     mode: "selection",
                     count: selectedLabels.length,
@@ -203,14 +194,11 @@ export const Labels = () => {
                   if (isConfirmed) {
                     deleteLabels(selectedLabels);
                   }
-                }}
-                disabled={!selectedLabels.length}
-                startIcon={<DeleteIcon />}
-              >
-                {t("button.delete")}
-              </Button>
-            ) : null}
-          </ButtonGroup>
+                },
+                disabled: !selectedLabels.length,
+              },
+            ]}
+          />
         </Grid>
       </PageHeader>
       <Grid item xs={12}>

--- a/frontend/src/components/nlp/components/NlpEntity.tsx
+++ b/frontend/src/components/nlp/components/NlpEntity.tsx
@@ -6,14 +6,13 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import AddIcon from "@mui/icons-material/Add";
-import DeleteIcon from "@mui/icons-material/Delete";
-import { Button, ButtonGroup, Chip, Grid } from "@mui/material";
+import { Chip, Grid } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
 
+import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { FilterTextfield } from "@/app-components/inputs/FilterTextfield";
 import {
@@ -27,7 +26,6 @@ import { useDeleteMany } from "@/hooks/crud/useDeleteMany";
 import { useFind } from "@/hooks/crud/useFind";
 import { useApiClient } from "@/hooks/useApiClient";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useHasPermission } from "@/hooks/useHasPermission";
 import { useSearch } from "@/hooks/useSearch";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -44,7 +42,6 @@ const NlpEntity = () => {
   const dialogs = useDialogs();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const hasPermission = useHasPermission();
   const { mutate: deleteNlpEntity } = useDelete(EntityType.NLP_ENTITY, {
     onError: () => {
       toast.error(t("message.internal_server_error"));
@@ -229,24 +226,17 @@ const NlpEntity = () => {
         <Grid item>
           <FilterTextfield onChange={onSearch} defaultValue={searchText} />
         </Grid>
-        <ButtonGroup sx={{ ml: "auto" }}>
-          {hasPermission(EntityType.NLP_ENTITY, PermissionAction.CREATE) ? (
-            <Button
-              startIcon={<AddIcon />}
-              variant="contained"
-              onClick={() =>
-                dialogs.open(NlpEntityFormDialog, { defaultValues: null })
-              }
-            >
-              {t("button.add")}
-            </Button>
-          ) : null}
-          {hasPermission(EntityType.NLP_ENTITY, PermissionAction.DELETE) ? (
-            <Button
-              startIcon={<DeleteIcon />}
-              variant="contained"
-              color="error"
-              onClick={async () => {
+        <ButtonActionsGroup
+          entity={EntityType.NLP_ENTITY}
+          buttons={[
+            {
+              permissionAction: PermissionAction.CREATE,
+              onClick: () =>
+                dialogs.open(NlpEntityFormDialog, { defaultValues: null }),
+            },
+            {
+              permissionAction: PermissionAction.DELETE,
+              onClick: async () => {
                 const isConfirmed = await dialogs.confirm(ConfirmDialogBody, {
                   mode: "selection",
                   count: selectedNlpEntities.length,
@@ -255,13 +245,11 @@ const NlpEntity = () => {
                 if (isConfirmed) {
                   deleteNlpEntities(selectedNlpEntities);
                 }
-              }}
-              disabled={!selectedNlpEntities.length}
-            >
-              {t("button.delete")}
-            </Button>
-          ) : null}
-        </ButtonGroup>
+              },
+              disabled: !selectedNlpEntities.length,
+            },
+          ]}
+        />
       </Grid>
 
       <Grid mt={3}>

--- a/frontend/src/components/nlp/components/NlpSample.tsx
+++ b/frontend/src/components/nlp/components/NlpSample.tsx
@@ -8,12 +8,9 @@
 
 import CircleIcon from "@mui/icons-material/Circle";
 import ClearIcon from "@mui/icons-material/Clear";
-import DeleteIcon from "@mui/icons-material/Delete";
 import DownloadIcon from "@mui/icons-material/Download";
 import {
   Box,
-  Button,
-  ButtonGroup,
   Chip,
   Grid,
   IconButton,
@@ -26,6 +23,7 @@ import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useState } from "react";
 import { useQueryClient } from "react-query";
 
+import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { ChipEntity } from "@/app-components/displays/ChipEntity";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
@@ -47,7 +45,6 @@ import { useGetFromCache } from "@/hooks/crud/useGet";
 import { useImport } from "@/hooks/crud/useImport";
 import { useConfig } from "@/hooks/useConfig";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useHasPermission } from "@/hooks/useHasPermission";
 import { useSearch } from "@/hooks/useSearch";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -82,7 +79,6 @@ export default function NlpSample() {
   const [type, setType] = useState<NlpSampleType | "all">("all");
   const [language, setLanguage] = useState<string | undefined>(undefined);
   const [patterns, setPatterns] = useState<NlpPattern[]>([]);
-  const hasPermission = useHasPermission();
   const getNlpEntityFromCache = useGetFromCache(EntityType.NLP_ENTITY);
   const getNlpValueFromCache = useGetFromCache(EntityType.NLP_VALUE);
   const getSampleEntityFromCache = useGetFromCache(
@@ -385,42 +381,38 @@ export default function NlpSample() {
               ),
             )}
           </Input>
-          <ButtonGroup sx={{ ml: "auto" }}>
-            {hasPermission(EntityType.NLP_SAMPLE, PermissionAction.CREATE) &&
-            hasPermission(
-              EntityType.NLP_SAMPLE_ENTITY,
-              PermissionAction.CREATE,
-            ) ? (
-              <FileUploadButton
-                accept="text/csv"
-                label={t("button.import")}
-                onChange={handleImportChange}
-                isLoading={isLoading}
-              />
-            ) : null}
-            {hasPermission(EntityType.NLP_SAMPLE, PermissionAction.READ) &&
-            hasPermission(
-              EntityType.NLP_SAMPLE_ENTITY,
-              PermissionAction.READ,
-            ) ? (
-              <Button
-                variant="contained"
-                href={buildURL(
+          <ButtonActionsGroup
+            entity={EntityType.NLP_SAMPLE}
+            buttons={[
+              {
+                permissions: {
+                  [EntityType.NLP_SAMPLE]: PermissionAction.CREATE,
+                  [EntityType.NLP_SAMPLE_ENTITY]: PermissionAction.CREATE,
+                },
+                children: (
+                  <FileUploadButton
+                    accept="text/csv"
+                    label={t("button.import")}
+                    onChange={handleImportChange}
+                    isLoading={isLoading}
+                  />
+                ),
+              },
+              {
+                permissions: {
+                  [EntityType.NLP_SAMPLE]: PermissionAction.READ,
+                  [EntityType.NLP_SAMPLE_ENTITY]: PermissionAction.READ,
+                },
+                startIcon: <DownloadIcon />,
+                children: t("button.export"),
+                href: buildURL(
                   apiUrl,
                   `nlpsample/export${type ? `?type=${type}` : ""}`,
-                )}
-                startIcon={<DownloadIcon />}
-                disabled={dataGridProps?.rows?.length === 0}
-              >
-                {t("button.export")}
-              </Button>
-            ) : null}
-            {hasPermission(EntityType.NLP_SAMPLE, PermissionAction.DELETE) ? (
-              <Button
-                startIcon={<DeleteIcon />}
-                variant="contained"
-                color="error"
-                onClick={async () => {
+                ),
+              },
+              {
+                permissionAction: PermissionAction.DELETE,
+                onClick: async () => {
                   const isConfirmed = await dialogs.confirm(ConfirmDialogBody, {
                     mode: "selection",
                     count: selectedNlpSamples.length,
@@ -429,13 +421,11 @@ export default function NlpSample() {
                   if (isConfirmed) {
                     deleteNlpSamples(selectedNlpSamples);
                   }
-                }}
-                disabled={!selectedNlpSamples.length}
-              >
-                {t("button.delete")}
-              </Button>
-            ) : null}
-          </ButtonGroup>
+                },
+                disabled: !selectedNlpSamples.length,
+              },
+            ]}
+          />
         </Grid>
         <Grid
           container

--- a/frontend/src/components/nlp/components/NlpValue.tsx
+++ b/frontend/src/components/nlp/components/NlpValue.tsx
@@ -7,14 +7,13 @@
  */
 
 import { faGraduationCap } from "@fortawesome/free-solid-svg-icons";
-import AddIcon from "@mui/icons-material/Add";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import DeleteIcon from "@mui/icons-material/Delete";
-import { Box, Button, ButtonGroup, Chip, Grid, Slide } from "@mui/material";
+import { Box, Button, Chip, Grid, Slide } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
+import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { FilterTextfield } from "@/app-components/inputs/FilterTextfield";
 import {
@@ -28,7 +27,6 @@ import { useDeleteMany } from "@/hooks/crud/useDeleteMany";
 import { useFind } from "@/hooks/crud/useFind";
 import { useGet } from "@/hooks/crud/useGet";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useHasPermission } from "@/hooks/useHasPermission";
 import { useSearch } from "@/hooks/useSearch";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -46,7 +44,6 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
   const dialogs = useDialogs();
   const router = useRouter();
   const [direction, setDirection] = useState<"up" | "down">("up");
-  const hasPermission = useHasPermission();
   const { data: nlpEntity, refetch: refetchEntity } = useGet(entityId, {
     entity: EntityType.NLP_ENTITY,
     format: Format.FULL,
@@ -238,38 +235,23 @@ export const NlpValues = ({ entityId }: { entityId: string }) => {
                     defaultValue={searchText}
                   />
                 </Grid>
-                <ButtonGroup sx={{ ml: "auto" }}>
-                  {hasPermission(
-                    EntityType.NLP_VALUE,
-                    PermissionAction.CREATE,
-                  ) ? (
-                    <Button
-                      startIcon={<AddIcon />}
-                      variant="contained"
-                      onClick={() =>
+                <ButtonActionsGroup
+                  entity={EntityType.NLP_VALUE}
+                  buttons={[
+                    {
+                      permissionAction: PermissionAction.CREATE,
+                      onClick: () =>
                         dialogs.open(NlpValueFormDialog, {
                           presetValues: nlpEntity,
-                        })
-                      }
-                    >
-                      {t("button.add")}
-                    </Button>
-                  ) : null}
-                  {hasPermission(
-                    EntityType.NLP_VALUE,
-                    PermissionAction.DELETE,
-                  ) ? (
-                    <Button
-                      color="error"
-                      variant="contained"
-                      onClick={handleDeleteNlpValues}
-                      startIcon={<DeleteIcon />}
-                      disabled={!selectedNlpValues.length}
-                    >
-                      {t("button.delete")}
-                    </Button>
-                  ) : null}
-                </ButtonGroup>
+                        }),
+                    },
+                    {
+                      permissionAction: PermissionAction.DELETE,
+                      onClick: handleDeleteNlpValues,
+                      disabled: !selectedNlpValues.length,
+                    },
+                  ]}
+                />
               </Grid>
             </PageHeader>
             <Grid padding={1} marginTop={2} container>


### PR DESCRIPTION
# Motivation
The main motivation is to centralize repeated ButtonGroup logic

Fixes #1194

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable button group component that automatically manages permission-based visibility and localization for action buttons across various sections.

* **Refactor**
  * Replaced manual button rendering and permission checks with the new button group component in multiple areas, simplifying the UI code and centralizing permission handling for actions like create, delete, import, and export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->