### PR TITLE
fix(api): add subscriber WebSocket room permission checks [1209<-1031]

### DIFF
--- a/api/src/chat/services/message.service.spec.ts
+++ b/api/src/chat/services/message.service.spec.ts
@@ -8,8 +8,6 @@
 
 import { UserRepository } from '@/user/repositories/user.repository';
 import { User } from '@/user/schemas/user.schema';
-import { PermissionService } from '@/user/services/permission.service';
-import { UserService } from '@/user/services/user.service';
 import {
   installMessageFixtures,
   messageFixtures,
@@ -54,8 +52,6 @@ describe('MessageService', () => {
     success: true,
     subscribe: Room.MESSAGE,
   };
-  let userService: UserService;
-  let permissionService: PermissionService;
   let buildReqRes: (
     method: 'GET' | 'POST',
     subscriberId: string,
@@ -68,21 +64,13 @@ describe('MessageService', () => {
       imports: [rootMongooseTestModule(installMessageFixtures)],
       providers: [MessageService, SubscriberRepository, UserRepository],
     });
-    [
-      messageService,
-      messageRepository,
-      subscriberRepository,
-      userRepository,
-      userService,
-      permissionService,
-    ] = await getMocks([
-      MessageService,
-      MessageRepository,
-      SubscriberRepository,
-      UserRepository,
-      UserService,
-      PermissionService,
-    ]);
+    [messageService, messageRepository, subscriberRepository, userRepository] =
+      await getMocks([
+        MessageService,
+        MessageRepository,
+        SubscriberRepository,
+        UserRepository,
+      ]);
     allSubscribers = await subscriberRepository.findAll();
     allUsers = await userRepository.findAll();
     allMessages = await messageRepository.findAll();
@@ -99,12 +87,7 @@ describe('MessageService', () => {
     mockGateway = {
       joinNotificationSockets: jest.fn(),
     };
-    mockMessageService = new MessageService(
-      {} as any,
-      mockGateway as any,
-      userService,
-      permissionService,
-    );
+    mockMessageService = new MessageService({} as any, mockGateway as any);
     buildReqRes = (method: 'GET' | 'POST', userId: string) => [
       {
         sessionID: SESSION_ID,
@@ -127,8 +110,9 @@ describe('MessageService', () => {
       await mockMessageService.subscribe(req, res);
 
       expect(mockGateway.joinNotificationSockets).toHaveBeenCalledWith(
-        SESSION_ID,
+        req,
         Room.MESSAGE,
+        'message',
       );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(SUCCESS_PAYLOAD);
@@ -139,8 +123,9 @@ describe('MessageService', () => {
       await mockMessageService.subscribe(req, res);
 
       expect(mockGateway.joinNotificationSockets).toHaveBeenCalledWith(
-        SESSION_ID,
+        req,
         Room.MESSAGE,
+        'message',
       );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(SUCCESS_PAYLOAD);

--- a/api/src/chat/services/subscriber.service.spec.ts
+++ b/api/src/chat/services/subscriber.service.spec.ts
@@ -18,8 +18,6 @@ import {
 } from '@/attachment/types';
 import { UserRepository } from '@/user/repositories/user.repository';
 import { User } from '@/user/schemas/user.schema';
-import { PermissionService } from '@/user/services/permission.service';
-import { UserService } from '@/user/services/user.service';
 import { installSubscriberFixtures } from '@/utils/test/fixtures/subscriber';
 import { getPageQuery } from '@/utils/test/pagination';
 import { sortRowsBy } from '@/utils/test/sort';
@@ -59,8 +57,6 @@ describe('SubscriberService', () => {
     success: true,
     subscribe: Room.SUBSCRIBER,
   };
-  let permissionService: PermissionService;
-  let userService: UserService;
   let buildReqRes: (
     method: 'GET' | 'POST',
     subscriberId: string,
@@ -79,16 +75,12 @@ describe('SubscriberService', () => {
       subscriberService,
       subscriberRepository,
       attachmentService,
-      permissionService,
-      userService,
     ] = await getMocks([
       LabelRepository,
       UserRepository,
       SubscriberService,
       SubscriberRepository,
       AttachmentService,
-      PermissionService,
-      UserService,
     ]);
     allSubscribers = await subscriberRepository.findAll();
     allLabels = await labelRepository.findAll();
@@ -100,8 +92,6 @@ describe('SubscriberService', () => {
       subscriberRepository,
       {} as any,
       mockGateway as any,
-      userService,
-      permissionService,
     );
     buildReqRes = (method: 'GET' | 'POST', userId: string) => [
       {
@@ -125,8 +115,9 @@ describe('SubscriberService', () => {
       await mockSubscriberService.subscribe(req, res);
 
       expect(mockGateway.joinNotificationSockets).toHaveBeenCalledWith(
-        SESSION_ID,
+        req,
         Room.SUBSCRIBER,
+        'subscriber',
       );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(SUCCESS_PAYLOAD);
@@ -137,8 +128,9 @@ describe('SubscriberService', () => {
       await mockSubscriberService.subscribe(req, res);
 
       expect(mockGateway.joinNotificationSockets).toHaveBeenCalledWith(
-        SESSION_ID,
+        req,
         Room.SUBSCRIBER,
+        'subscriber',
       );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(SUCCESS_PAYLOAD);

--- a/api/src/chat/services/subscriber.service.ts
+++ b/api/src/chat/services/subscriber.service.ts
@@ -6,11 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import {
-  ForbiddenException,
-  Injectable,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import mime from 'mime';
 import { v4 as uuidv4 } from 'uuid';
@@ -23,8 +19,6 @@ import {
   AttachmentResourceRef,
 } from '@/attachment/types';
 import { config } from '@/config';
-import { PermissionService } from '@/user/services/permission.service';
-import { UserService } from '@/user/services/user.service';
 import { BaseService } from '@/utils/generics/base-service';
 import { TFilterQuery } from '@/utils/types/filter.types';
 import {
@@ -59,8 +53,6 @@ export class SubscriberService extends BaseService<
     readonly repository: SubscriberRepository,
     protected readonly attachmentService: AttachmentService,
     private readonly gateway: WebsocketGateway,
-    private readonly userService: UserService,
-    private readonly permissionService: PermissionService,
   ) {
     super(repository);
   }
@@ -79,36 +71,19 @@ export class SubscriberService extends BaseService<
     @SocketRes() res: SocketResponse,
   ): Promise<IOOutgoingSubscribeMessage> {
     try {
-      const user = await this.userService.findOne(
-        req.session.passport?.user?.id || '',
-      );
-
-      if (!user?.roles) {
-        throw new ForbiddenException('User is required!');
-      }
-
-      const canAccess = await this.permissionService.canAccess(
-        req.method.toUpperCase(),
-        user.roles,
+      await this.gateway.joinNotificationSockets(
+        req,
+        Room.SUBSCRIBER,
         'subscriber',
       );
 
-      if (canAccess) {
-        await this.gateway.joinNotificationSockets(
-          req.sessionID,
-          Room.SUBSCRIBER,
-        );
-
-        return res.status(200).json({
-          success: true,
-          subscribe: Room.SUBSCRIBER,
-        });
-      }
-
-      throw new ForbiddenException('Not able to access');
-    } catch (e) {
-      this.logger.error('Websocket subscription');
-      throw new InternalServerErrorException(e);
+      return res.status(200).json({
+        success: true,
+        subscribe: Room.SUBSCRIBER,
+      });
+    } catch (err) {
+      this.logger.error('Websocket subscriber room subscription error', err);
+      throw new InternalServerErrorException(err);
     }
   }
 

--- a/api/src/utils/test/fixtures/model.ts
+++ b/api/src/utils/test/fixtures/model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -18,10 +18,21 @@ export const modelFixtures: ModelCreateDto[] = [
     attributes: { att: 'att' },
     relation: 'role',
   },
-
   {
     name: 'Content',
     identity: 'content',
+    attributes: { att: 'att' },
+    relation: 'role',
+  },
+  {
+    name: 'Message',
+    identity: 'message',
+    attributes: { att: 'att' },
+    relation: 'role',
+  },
+  {
+    name: 'Subscriber',
+    identity: 'subscriber',
     attributes: { att: 'att' },
     relation: 'role',
   },

--- a/api/src/utils/test/fixtures/permission.ts
+++ b/api/src/utils/test/fixtures/permission.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -38,6 +38,30 @@ export const permissionFixtures: PermissionCreateDto[] = [
     model: '0',
     action: Action.UPDATE,
     role: '0',
+    relation: 'role',
+  },
+  {
+    model: '2',
+    action: Action.CREATE,
+    role: '1',
+    relation: 'role',
+  },
+  {
+    model: '2',
+    action: Action.READ,
+    role: '1',
+    relation: 'role',
+  },
+  {
+    model: '3',
+    action: Action.CREATE,
+    role: '1',
+    relation: 'role',
+  },
+  {
+    model: '3',
+    action: Action.READ,
+    role: '1',
     relation: 'role',
   },
 ];

--- a/api/src/utils/test/fixtures/subscriber.ts
+++ b/api/src/utils/test/fixtures/subscriber.ts
@@ -15,7 +15,7 @@ import { getFixturesWithDefaultValues } from '../defaultValues';
 import { FixturesTypeBuilder } from '../types';
 
 import { installLabelFixtures } from './label';
-import { installUserFixtures } from './user';
+import { installPermissionFixtures } from './permission';
 
 type TSubscriberFixtures = FixturesTypeBuilder<Subscriber, SubscriberCreateDto>;
 
@@ -106,7 +106,7 @@ export const installSubscriberFixtures = async () => {
     SubscriberModel.name,
     SubscriberModel.schema,
   );
-  const { users } = await installUserFixtures();
+  const { users } = await installPermissionFixtures();
   const labels = await installLabelFixtures();
   const subscribers = await Subscriber.insertMany(
     subscriberFixtures.map((subscriberFixture) => ({


### PR DESCRIPTION
# Motivation
This PR introduces permission checks for Web Socket global rooms(subscriber, message)., ensuring that only authorized users can access and interact within them.

Fixes #1031

# Demo
<video src="https://github.com/user-attachments/assets/504f581d-76d2-460a-af1a-ad555e19bc37"></video>

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-based permission checks for subscribing to message and subscriber notifications, ensuring only authorized users can join notification rooms.
  * Introduced a method to verify user access rights based on HTTP method, user roles, and target resource.
  * Integrated a new global authorization module to centralize permission and user role management.
  * Enhanced websocket gateway to enforce authorization before joining notification rooms.

* **Bug Fixes**
  * Improved error handling for unauthorized access attempts when subscribing to notifications.

* **Tests**
  * Expanded and improved test coverage for permission checks and subscription logic.
  * Added new model and permission fixtures to support enhanced testing scenarios.
  * Updated tests to use richer request/response mocks and included user fixture data for realistic scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->