### PR TITLE
chore: ensure consistency in environment variable declarations in frontend dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -47,9 +47,9 @@ WORKDIR /app
 
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 
-COPY frontend/package*.json ./frontend/  
+COPY frontend/package*.json ./frontend/
 
-COPY widget/package*.json ./widget/  
+COPY widget/package*.json ./widget/
 
 RUN npm install
 
@@ -59,7 +59,7 @@ COPY ./widget ./widget
 
 
 # used to by pass Next.js paching lock file
-ENV NEXT_IGNORE_INCORRECT_LOCKFILE=true 
+ENV NEXT_IGNORE_INCORRECT_LOCKFILE=true
 ENV NODE_ENV=development
 ENV CHOKIDAR_USEPOLLING=true
 ENV WATCHPACK_POLLING=true
@@ -72,11 +72,11 @@ CMD ["npm", "run", "dev", "--", "-p", "8080"]
 FROM base AS production
 WORKDIR /app
 
-# used to by pass Next.js paching lock file 
-ENV NEXT_IGNORE_INCORRECT_LOCKFILE=true 
+# used to by pass Next.js paching lock file
+ENV NEXT_IGNORE_INCORRECT_LOCKFILE=true
 ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -96,7 +96,7 @@ USER nextjs
 
 EXPOSE 8080
 
-ENV PORT 8080
+ENV PORT=8080
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output


### PR DESCRIPTION
# Motivation

This PR updates the syntax for setting environment variables in the frontend/Dockerfile from `ENV VAR value` to `ENV VAR=value`. This change eliminates build-time warnings that appear with the old syntax and aligns the Dockerfile with best practices and the official Docker documentation. No functional changes are introduced.

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
