### PR TITLE
fix(frontend): serialize queryKey third item

### DIFF
--- a/frontend/src/hooks/crud/useCount.tsx
+++ b/frontend/src/hooks/crud/useCount.tsx
@@ -21,7 +21,7 @@ export const useCount = <TE extends THook["entity"]>(
       { count: number },
       Error,
       { count: number },
-      [QueryType, EntityType, unknown]
+      [QueryType, EntityType, string]
     >,
     "queryFn"
   >,

--- a/frontend/src/hooks/crud/useFind.tsx
+++ b/frontend/src/hooks/crud/useFind.tsx
@@ -74,7 +74,7 @@ export const useFind = <
 
       return result;
     },
-    queryKey: [QueryType.collection, entity, normalizedParams],
+    queryKey: [QueryType.collection, entity, JSON.stringify(normalizedParams)],
     onSuccess: (ids) => {
       if (onSuccess) {
         onSuccess(

--- a/frontend/src/hooks/crud/useInfiniteFind.ts
+++ b/frontend/src/hooks/crud/useInfiniteFind.ts
@@ -35,7 +35,8 @@ export const useInfiniteFind = <
       string[],
       Error,
       string[],
-      [QueryType, EntityType, any]
+      TBasic[],
+      [QueryType, EntityType, string]
     >,
     "queryFn" | "onSuccess"
   > & { onSuccess?: (result: TBasic[]) => void },

--- a/frontend/src/hooks/crud/useNormalizedInfiniteQuery.ts
+++ b/frontend/src/hooks/crud/useNormalizedInfiniteQuery.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -38,7 +38,7 @@ export const useNormalizedInfiniteQuery = <
       string[],
       Error,
       string[],
-      [QueryType, EntityType, any]
+      [QueryType, EntityType, string]
     >,
     "queryFn" | "queryKey" | "onSuccess"
   > & { onSuccess?: (result: TBasic[]) => void },
@@ -66,7 +66,7 @@ export const useNormalizedInfiniteQuery = <
   // @TODO : fix the following
   // @ts-ignore
   const { data: infiniteData, ...infiniteQuery } = useInfiniteQuery({
-    queryKey: [QueryType.infinite, entity, config?.params],
+    queryKey: [QueryType.infinite, entity, JSON.stringify(config?.params)],
     initialPageParam: {
       limit: PAGE_SIZE,
       skip: 0,


### PR DESCRIPTION
# Motivation
The main motivation of this PR are : 
- To Serialize queryKey third item (useFind, useNormalizedInfiniteQuery)
- To fix queryKey third item to be string (useCount, useInfiniteFind, useNormalizedInfiniteQuery)

Fixes #1227

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
