### PR TITLE
feat: add unicode aware support for slot extraction

### DIFF
--- a/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
+++ b/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
@@ -290,6 +290,22 @@ describe('BaseNlpHelper', () => {
       ]);
     });
 
+    it('should not return matches when expressions are not bounded by whitespace (e.g., surrounded by quotes)', () => {
+      const entity: NlpEntityFull = {
+        name: 'color',
+        values: [
+          { value: 'blue', expressions: ['azure', 'navy'] },
+          { value: 'green', expressions: ['emerald', 'lime'] },
+        ],
+      } as any;
+
+      const result = helper.extractKeywordBasedSlots(
+        `The sky is "azure" and "emerald"`,
+        entity,
+      );
+      expect(result).toEqual([]);
+    });
+
     it('should not match partial keywords and return an empty result', () => {
       const entity: NlpEntityFull = {
         name: 'items',

--- a/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
+++ b/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
@@ -270,6 +270,38 @@ describe('BaseNlpHelper', () => {
       ]);
     });
 
+    it('should correctly match keywords with French accents (Unicode characters) and return accurate start and end indices', () => {
+      const entity: NlpEntityFull = {
+        name: 'items',
+        values: [{ value: 'key', expressions: ['clé', 'porte-clés'] }],
+      } as any;
+      const result = helper.extractKeywordBasedSlots(
+        'il a perdu son porte-clés',
+        entity,
+      );
+      expect(result).toEqual([
+        {
+          entity: 'items',
+          value: 'key',
+          start: 15,
+          end: 25,
+          confidence: 1,
+        },
+      ]);
+    });
+
+    it('should not match partial keywords and return an empty result', () => {
+      const entity: NlpEntityFull = {
+        name: 'items',
+        values: [{ value: 'key', expressions: ['clé', 'porte-clés'] }],
+      } as any;
+      const result = helper.extractKeywordBasedSlots(
+        'Dieu est clément',
+        entity,
+      );
+      expect(result).toEqual([]);
+    });
+
     it('should return empty array if no values present', () => {
       const result = helper.extractKeywordBasedSlots('anything', {
         name: 'empty',

--- a/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
+++ b/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
@@ -415,7 +415,7 @@ describe('BaseNlpHelper', () => {
         name: 'state',
         values: [
           {
-            value: 'endommagé',
+            value: 'damage',
             metadata: {
               pattern: 'endommag[ée](e|é|s|es)?',
               wordBoundary: true,
@@ -431,7 +431,7 @@ describe('BaseNlpHelper', () => {
       expect(result).toEqual([
         {
           entity: 'state',
-          canonicalValue: 'endommagé',
+          canonicalValue: 'damage',
           value: 'endommagée',
           start: 12,
           end: 22,

--- a/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
+++ b/api/src/helper/lib/__test__/base-nlp-helper.spec.ts
@@ -221,7 +221,7 @@ describe('BaseNlpHelper', () => {
   });
 
   describe('extractKeywordBasedSlots', () => {
-    it('should return matches for exact keywords and synonyms', () => {
+    it('should return matches for keywords and synonyms in English using Latin script', () => {
       const entity: NlpEntityFull = {
         name: 'color',
         values: [
@@ -247,6 +247,24 @@ describe('BaseNlpHelper', () => {
           value: 'green',
           start: 21,
           end: 28,
+          confidence: 1,
+        },
+      ]);
+    });
+
+    it('should return matches for keywords in Arabic using non-Latin Unicode script', () => {
+      const entity: NlpEntityFull = {
+        name: 'color',
+        values: [{ value: 'blue', expressions: ['أزرق', 'ازرق', 'زرقاء'] }],
+      } as any;
+
+      const result = helper.extractKeywordBasedSlots('السماء زرقاء', entity);
+      expect(result).toEqual([
+        {
+          entity: 'color',
+          value: 'blue',
+          start: 7,
+          end: 12,
           confidence: 1,
         },
       ]);

--- a/api/src/helper/lib/base-nlp-helper.ts
+++ b/api/src/helper/lib/base-nlp-helper.ts
@@ -6,6 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
+import escapeRegExp from 'lodash/escapeRegExp';
 import { v4 as uuidv4 } from 'uuid';
 
 import { LoggerService } from '@/logger/logger.service';
@@ -227,8 +228,8 @@ export default abstract class BaseNlpHelper<
   ): Promise<NLU.ParseEntities>;
 
   private buildUnicodeRegexExpression(term: string): RegExp {
-    const escapedTerm = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`(^|\\P{L})(${escapedTerm})(?=\\P{L}|$)`, 'gu');
+    const escapedTerm = escapeRegExp(term);
+    return new RegExp(`(?<=^|\\P{L})(${escapedTerm})(?=\\P{L}|$)`, 'gu');
   }
 
   /**
@@ -263,16 +264,13 @@ export default abstract class BaseNlpHelper<
 
           // Map matches to FoundEntity format
           return matches
-            .map((match) => {
-              const prefixLength = match[1]?.length ?? 0;
-              return {
-                entity: entity.name,
-                value,
-                start: match.index! + prefixLength,
-                end: match.index! + prefixLength + term.length,
-                confidence: 1,
-              };
-            })
+            .map((match) => ({
+              entity: entity.name,
+              value,
+              start: match.index!,
+              end: match.index! + term.length,
+              confidence: 1,
+            }))
             .shift();
         });
       })

--- a/api/src/helper/lib/base-nlp-helper.ts
+++ b/api/src/helper/lib/base-nlp-helper.ts
@@ -229,7 +229,7 @@ export default abstract class BaseNlpHelper<
 
   private buildUnicodeRegexExpression(term: string): RegExp {
     const escapedTerm = escapeRegExp(term);
-    return new RegExp(`(?<=^|\\P{L})(${escapedTerm})(?=\\P{L}|$)`, 'gu');
+    return new RegExp(`(?<=^|\\s)(${escapedTerm})(?=\\s|$)`, 'gu');
   }
 
   /**

--- a/api/src/helper/lib/base-nlp-helper.ts
+++ b/api/src/helper/lib/base-nlp-helper.ts
@@ -241,7 +241,7 @@ export default abstract class BaseNlpHelper<
    */
   private buildUnicodeRegexExpression(term: string): RegExp {
     const escapedTerm = escapeRegExp(term);
-    return new RegExp(`(?<!\\p{L})${escapedTerm}(?!\\p{L})`, 'gu');
+    return new RegExp(`(?<!\\p{L})${escapedTerm}(?!\\p{L})`, 'gui');
   }
 
   /**

--- a/api/src/helper/lib/base-nlp-helper.ts
+++ b/api/src/helper/lib/base-nlp-helper.ts
@@ -226,7 +226,19 @@ export default abstract class BaseNlpHelper<
     threshold?: boolean,
     project?: string,
   ): Promise<NLU.ParseEntities>;
-
+  /**
+   * Builds a Unicode-aware regular expression to match a term as a whole word in NLU samples.
+   *
+   * This method uses Unicode property escapes and lookbehind/lookahead to ensure the term is not part of a larger word,
+   * making it robust for non-Latin scripts (e.g., Arabic, Cyrillic, accented characters).
+   *
+   * @param term - The keyword or expression to match literally in the text.
+   * @returns A RegExp that matches the term as a whole word, using Unicode boundaries.
+   *
+   * @notes
+   * - The returned RegExp uses the 'gu' flags (global, unicode).
+   * - The term is escaped to avoid regex injection.
+   */
   private buildUnicodeRegexExpression(term: string): RegExp {
     const escapedTerm = escapeRegExp(term);
     return new RegExp(`(?<!\\p{L})${escapedTerm}(?!\\p{L})`, 'gu');

--- a/api/src/helper/lib/base-nlp-helper.ts
+++ b/api/src/helper/lib/base-nlp-helper.ts
@@ -228,7 +228,7 @@ export default abstract class BaseNlpHelper<
 
   private buildUnicodeRegexExpression(term: string): RegExp {
     const escapedTerm = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`(^|\\P{L})${escapedTerm}(?=\\P{L}|$)`, 'gu');
+    return new RegExp(`(^|\\P{L})(${escapedTerm})(?=\\P{L}|$)`, 'gu');
   }
 
   /**


### PR DESCRIPTION
# Motivation

The following PR adds support for Unicode-aware keyword matching in the `extractKeywordBasedSlots` method to ensure compatibility with scripts such as Arabic and others using non-Latin characters.

### Key Changes

- Introduced a `buildUnicodeRegexExpression()` helper that uses Unicode property escapes (`\P{L}`) and the `gu` regex flag to match word boundaries safely across all scripts.
- Updated the match position calculation to account for potential prefix characters.
- Ensured compatibility with both Latin and non-Latin scripts by escaping special characters and relying on Unicode-safe regular expressions.


Fixes # ([1231](https://github.com/Hexastack/Hexabot/issues/1231))

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced keyword and pattern matching to fully support Unicode scripts, including Arabic and French accented characters, improving entity extraction accuracy.  
* **Tests**
  * Added comprehensive test cases validating Unicode-aware keyword and pattern recognition, ensuring precise entity detection and correct handling of partial matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->