### PR TITLE
Flatten arrays in TranslationController for block and setting strings retrieval

### DIFF
--- a/api/src/i18n/controllers/translation.controller.ts
+++ b/api/src/i18n/controllers/translation.controller.ts
@@ -108,8 +108,10 @@ export class TranslationController extends BaseController<Translation> {
         {} as { [key: string]: string },
       );
     // Scan Blocks
-    let strings = await this.translationService.getAllBlockStrings();
-    const settingStrings = await this.translationService.getSettingStrings();
+    let strings = (await this.translationService.getAllBlockStrings()).flat();
+    const settingStrings = (
+      await this.translationService.getSettingStrings()
+    ).flat();
     // Scan global settings
     strings = strings.concat(settingStrings);
     // Filter unique and not empty messages


### PR DESCRIPTION
Ensure that arrays are flattened when retrieving block strings and setting strings in the TranslationController. This improves the handling of string data.