### PR TITLE
Fix/max attempts

### DIFF
--- a/api/src/chat/services/bot.service.spec.ts
+++ b/api/src/chat/services/bot.service.spec.ts
@@ -460,6 +460,27 @@ describe('BotService', () => {
       jest.resetAllMocks();
     });
 
+    it('should return true when fallback is active and max attempts not exceeded', () => {
+      const result = botService.shouldAttemptLocalFallback(
+        {
+          ...conversationGetStarted,
+          context: { ...conversationGetStarted.context, attempt: 1 },
+          current: {
+            ...conversationGetStarted.current,
+            options: {
+              fallback: {
+                active: true,
+                max_attempts: 1,
+                message: ['Please pick an option.'],
+              },
+            },
+          },
+        },
+        mockEvent,
+      );
+      expect(result).toBe(true);
+    });
+
     it('should return true when fallback is active and max attempts not reached', () => {
       const result = botService.shouldAttemptLocalFallback(
         {
@@ -506,7 +527,7 @@ describe('BotService', () => {
       const result = botService.shouldAttemptLocalFallback(
         {
           ...conversationGetStarted,
-          context: { ...conversationGetStarted.context, attempt: 3 },
+          context: { ...conversationGetStarted.context, attempt: 4 },
           current: {
             ...conversationGetStarted.current,
             options: {

--- a/api/src/chat/services/bot.service.ts
+++ b/api/src/chat/services/bot.service.ts
@@ -332,7 +332,7 @@ export class BotService {
       event.getMessageType() === IncomingMessageType.message &&
       !!fallbackOptions?.active &&
       maxAttempts > 0 &&
-      convo.context.attempt + 1 < maxAttempts
+      convo.context.attempt <= maxAttempts
     );
   }
 

--- a/api/src/chat/services/bot.service.ts
+++ b/api/src/chat/services/bot.service.ts
@@ -327,10 +327,12 @@ export class BotService {
     event: EventWrapper<any, any>,
   ): boolean {
     const fallbackOptions = this.blockService.getFallbackOptions(convo.current);
+    const maxAttempts = fallbackOptions?.max_attempts ?? 0;
     return (
       event.getMessageType() === IncomingMessageType.message &&
       !!fallbackOptions?.active &&
-      convo.context.attempt < (fallbackOptions?.max_attempts ?? 0)
+      maxAttempts > 0 &&
+      convo.context.attempt + 1 < maxAttempts
     );
   }
 


### PR DESCRIPTION
# Motivation

When configuring a Local Fallback block in Hexabot with maxAttempts set to 1, the user is not given a chance to retry their input. This can lead to a confusing or misleading experience from a UX perspective, especially in cases where a single typo or minor misunderstanding causes the flow to end prematurely.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of fallback attempts to ensure the fallback is allowed when the attempt count exactly matches the maximum allowed attempts.

* **Tests**
  * Added and updated test cases to cover boundary conditions for fallback attempt logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->