### PR TITLE
fix(frontend): update useInfiniteFind typing

### DIFF
--- a/frontend/src/hooks/crud/useInfiniteFind.ts
+++ b/frontend/src/hooks/crud/useInfiniteFind.ts
@@ -9,12 +9,7 @@
 import { useInfiniteQuery, UseInfiniteQueryOptions } from "react-query";
 
 import { EntityType, Format, QueryType } from "@/services/types";
-import {
-  IBaseSchema,
-  IFindConfigProps,
-  POPULATE_BY_TYPE,
-  THook,
-} from "@/types/base.types";
+import { IFindConfigProps, POPULATE_BY_TYPE, THook } from "@/types/base.types";
 
 import { useEntityApiClient } from "../useApiClient";
 
@@ -23,13 +18,13 @@ import { useGetFromCache } from "./useGet";
 
 export const useInfiniteFind = <
   T extends THook["params"],
-  TAttr = THook<T>["attributes"],
-  TBasic extends IBaseSchema = THook<T>["basic"],
-  TFull extends IBaseSchema = THook<T>["full"],
+  TAttr extends THook<T>["attributes"],
+  TBasic extends THook<T>["basic"],
+  TFull extends THook<T>["full"],
   P = THook<T>["populate"],
 >(
   { entity, format }: THook<T>["params"],
-  config?: IFindConfigProps,
+  config?: IFindConfigProps<TAttr>,
   options?: Omit<
     UseInfiniteQueryOptions<
       string[],

--- a/frontend/src/hooks/crud/useInfiniteFind.ts
+++ b/frontend/src/hooks/crud/useInfiniteFind.ts
@@ -20,11 +20,12 @@ export const useInfiniteFind = <
   T extends THook["params"],
   TAttr extends THook<T>["attributes"],
   TBasic extends THook<T>["basic"],
+  TFilters extends THook<T>["filters"],
   TFull extends THook<T>["full"],
   P = THook<T>["populate"],
 >(
   { entity, format }: THook<T>["params"],
-  config?: IFindConfigProps<TAttr>,
+  config?: IFindConfigProps<TFilters>,
   options?: Omit<
     UseInfiniteQueryOptions<
       string[],

--- a/frontend/src/hooks/crud/useNormalizedInfiniteQuery.ts
+++ b/frontend/src/hooks/crud/useNormalizedInfiniteQuery.ts
@@ -9,12 +9,7 @@
 import { useInfiniteQuery, UseInfiniteQueryOptions } from "react-query";
 
 import { EntityType, Format, QueryType } from "@/services/types";
-import {
-  IBaseSchema,
-  IFindConfigProps,
-  POPULATE_BY_TYPE,
-  THook,
-} from "@/types/base.types";
+import { IFindConfigProps, POPULATE_BY_TYPE, THook } from "@/types/base.types";
 
 import { useEntityApiClient } from "../useApiClient";
 import { toPageQueryPayload } from "../usePagination";
@@ -26,13 +21,13 @@ const PAGE_SIZE = 20;
 
 export const useNormalizedInfiniteQuery = <
   T extends THook["params"],
-  TAttr = THook<T>["attributes"],
-  TBasic extends IBaseSchema = THook<T>["basic"],
-  TFull extends IBaseSchema = THook<T>["full"],
+  TAttr extends THook<T>["attributes"],
+  TBasic extends THook<T>["basic"],
+  TFull extends THook<T>["full"],
   P = THook<T>["populate"],
 >(
   { entity, format }: THook<T>["params"],
-  config?: IFindConfigProps,
+  config?: IFindConfigProps<TAttr>,
   options?: Omit<
     UseInfiniteQueryOptions<
       string[],

--- a/frontend/src/types/base.types.ts
+++ b/frontend/src/types/base.types.ts
@@ -249,7 +249,7 @@ export type THook<
   attributes: TType<TE>["attributes"];
 };
 
-export interface IFindConfigProps<T = unknown> {
+export interface IFindConfigProps<T> {
   params?: SearchPayload<T>;
   hasCount?: boolean;
   initialSortState?: GridSortModel;


### PR DESCRIPTION
# Description:
The params in useInfiniteFind hook currently uses any type. This is unsafe and can cause bugs.

# Solution:
Add proper TypeScript types to the params option.

# Why?
- Catches errors early 🚨
- Makes the code easier to understand 📖
- Better autocomplete in IDEs 💡

Fixes #1247

# Type of change:

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes