### PR TITLE
Remove unused CUSTOM_BLOCK_TEMPLATE

### DIFF
--- a/frontend/src/components/visual-editor/constants.ts
+++ b/frontend/src/components/visual-editor/constants.ts
@@ -11,7 +11,6 @@ import {
   ButtonType,
   FileType,
   OutgoingMessageFormat,
-  PayloadType,
   QuickReplyType,
   StdOutgoingListMessage,
 } from "@/types/message.types";
@@ -118,30 +117,6 @@ export const LIST_BLOCK_TEMPLATE: Partial<IBlockAttributes> = {
   },
   message: { elements: true } as unknown as StdOutgoingListMessage,
   starts_conversation: false,
-};
-
-export const CUSTOM_BLOCK_TEMPLATE: Partial<IBlockAttributes> = {
-  patterns: [
-    {
-      label: "User location",
-      value: "",
-      type: PayloadType.location,
-    },
-  ],
-  capture_vars: [],
-  options: {
-    typing: 0,
-    fallback: { active: false, max_attempts: 0, message: [] },
-  },
-  starts_conversation: false,
-  message: {
-    plugin: "storelocator",
-    args: {
-      fallback_msg: ["Sorry but no data is available for the moment :("],
-      max_results: 3,
-      btn_title: "Go !",
-    },
-  },
 };
 
 export const ZOOM_LEVEL = {


### PR DESCRIPTION
Remove the CUSTOM_BLOCK_TEMPLATE as it is no longer needed in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the store locator block template from the visual editor options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->