### PR TITLE
fix(frontend): centralize TMutationOptions type logic

### DIFF
--- a/frontend/src/hooks/crud/useCreate.tsx
+++ b/frontend/src/hooks/crud/useCreate.tsx
@@ -22,10 +22,7 @@ export const useCreate = <
   TFull extends IBaseSchema = THook<{ entity: TE }>["full"],
 >(
   entity: TE,
-  options?: Omit<
-    TMutationOptions<TBasic, Error, TAttr, TBasic>,
-    "mutationFn" | "mutationKey"
-  >,
+  options?: TMutationOptions<TBasic, Error, TAttr, TBasic>,
 ) => {
   const api = useEntityApiClient<TAttr, TBasic, TFull>(entity);
   const queryClient = useQueryClient();

--- a/frontend/src/hooks/crud/useDelete.tsx
+++ b/frontend/src/hooks/crud/useDelete.tsx
@@ -22,10 +22,7 @@ export const useDelete = <
   TFull extends IBaseSchema = THook<{ entity: TE }>["full"],
 >(
   entity: TE,
-  options?: Omit<
-    TMutationOptions<string, Error, string, TBasic>,
-    "mutationFn" | "mutationKey"
-  >,
+  options?: TMutationOptions<string, Error, string, TBasic>,
 ) => {
   const api = useEntityApiClient<TAttr, TBasic, TFull>(entity);
   const queryClient = useQueryClient();

--- a/frontend/src/hooks/crud/useDeleteMany.tsx
+++ b/frontend/src/hooks/crud/useDeleteMany.tsx
@@ -22,10 +22,7 @@ export const useDeleteMany = <
   TFull extends IBaseSchema = THook<{ entity: TE }>["full"],
 >(
   entity: TE,
-  options?: Omit<
-    TMutationOptions<string, Error, string[], TBasic>,
-    "mutationFn" | "mutationKey"
-  >,
+  options?: TMutationOptions<string, Error, string[], TBasic>,
 ) => {
   const api = useEntityApiClient<TAttr, TBasic, TFull>(entity);
   const queryClient = useQueryClient();

--- a/frontend/src/hooks/crud/useImport.tsx
+++ b/frontend/src/hooks/crud/useImport.tsx
@@ -21,10 +21,7 @@ export const useImport = <
   TBasic extends IBaseSchema = THook<{ entity: TE }>["basic"],
 >(
   entity: TE,
-  options: Omit<
-    TMutationOptions<TBasic[], Error, TAttr, TBasic[]>,
-    "mutationFn" | "mutationKey"
-  > = {},
+  options: TMutationOptions<TBasic[], Error, TAttr, TBasic[]> = {},
   params: Record<string, any> = {},
 ) => {
   const api = useEntityApiClient<TAttr, TBasic>(entity);

--- a/frontend/src/hooks/crud/useUpdate.tsx
+++ b/frontend/src/hooks/crud/useUpdate.tsx
@@ -24,14 +24,11 @@ export const useUpdate = <
   TFull extends IBaseSchema = THook<{ entity: TE }>["full"],
 >(
   entity: TE,
-  options?: Omit<
-    TMutationOptions<
-      TBasic,
-      Error,
-      { id: string; params: Partial<TAttr> },
-      TBasic
-    >,
-    "mutationFn" | "mutationKey"
+  options?: TMutationOptions<
+    TBasic,
+    Error,
+    { id: string; params: Partial<TAttr> },
+    TBasic
   >,
 ) => {
   const api = useEntityApiClient<TAttr, TBasic, TFull>(entity);

--- a/frontend/src/hooks/crud/useUpdateMany.tsx
+++ b/frontend/src/hooks/crud/useUpdateMany.tsx
@@ -22,17 +22,14 @@ export const useUpdateMany = <
   TFull extends IBaseSchema = THook<{ entity: TE }>["full"],
 >(
   entity: TE,
-  options?: Omit<
-    TMutationOptions<
-      string,
-      Error,
-      {
-        ids: string[];
-        payload: Partial<TAttr>;
-      },
-      TBasic
-    >,
-    "mutationFn" | "mutationKey"
+  options?: TMutationOptions<
+    string,
+    Error,
+    {
+      ids: string[];
+      payload: Partial<TAttr>;
+    },
+    TBasic
   >,
 ) => {
   const api = useEntityApiClient<TAttr, TBasic, TFull>(entity);

--- a/frontend/src/hooks/crud/useUpload.tsx
+++ b/frontend/src/hooks/crud/useUpload.tsx
@@ -23,14 +23,11 @@ export const useUpload = <
   TFull extends IBaseSchema = THook<{ entity: TE }>["full"],
 >(
   entity: TE,
-  options?: Omit<
-    TMutationOptions<
-      TBasic,
-      Error,
-      { file: File; resourceRef: AttachmentResourceRef },
-      TBasic
-    >,
-    "mutationFn" | "mutationKey"
+  options?: TMutationOptions<
+    TBasic,
+    Error,
+    { file: File; resourceRef: AttachmentResourceRef },
+    TBasic
   >,
 ) => {
   const api = useEntityApiClient<TAttr, TBasic, TFull>(entity);

--- a/frontend/src/hooks/entities/auth-hooks.ts
+++ b/frontend/src/hooks/entities/auth-hooks.ts
@@ -27,10 +27,7 @@ import { useToast } from "../useToast";
 import { useTranslate } from "../useTranslate";
 
 export const useLogin = (
-  options?: Omit<
-    TMutationOptions<IUser, Error, ILoginAttributes>,
-    "mutationFn"
-  >,
+  options?: TMutationOptions<IUser, Error, ILoginAttributes>,
 ) => {
   const { apiClient } = useApiClient();
   const { postMessage } = useBroadcastChannel();
@@ -48,14 +45,11 @@ export const useLogin = (
 };
 
 export const useLogout = (
-  options?: Omit<
-    TMutationOptions<
-      {
-        status: "ok";
-      },
-      Error
-    >,
-    "mutationFn"
+  options?: TMutationOptions<
+    {
+      status: "ok";
+    },
+    Error
   >,
 ) => {
   const queryClient = useQueryClient();
@@ -116,15 +110,12 @@ export const useUserPermissions = () => {
 };
 
 export const useAcceptInvite = (
-  options?: Omit<
-    TMutationOptions<
-      {
-        success: boolean;
-      },
-      Error,
-      Partial<IUserAttributes> & { token: string }
-    >,
-    "mutationFn"
+  options?: TMutationOptions<
+    {
+      success: boolean;
+    },
+    Error,
+    Partial<IUserAttributes> & { token: string }
   >,
 ) => {
   const { apiClient } = useApiClient();
@@ -138,10 +129,7 @@ export const useAcceptInvite = (
 };
 
 export const useConfirmAccount = (
-  options?: Omit<
-    TMutationOptions<never, Error, { token: string }>,
-    "mutationFn"
-  >,
+  options?: TMutationOptions<never, Error, { token: string }>,
 ) => {
   const { apiClient } = useApiClient();
 
@@ -181,10 +169,7 @@ export const useLoadSettings = () => {
 };
 
 export const useUpdateProfile = (
-  options?: Omit<
-    TMutationOptions<IUserStub, Error, Partial<IProfileAttributes>>,
-    "mutationFn"
-  >,
+  options?: TMutationOptions<IUserStub, Error, Partial<IProfileAttributes>>,
 ) => {
   const { apiClient } = useApiClient();
   const { user } = useAuth();

--- a/frontend/src/hooks/entities/invitation-hooks.ts
+++ b/frontend/src/hooks/entities/invitation-hooks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -18,9 +18,11 @@ import {
 import { useApiClient } from "../useApiClient";
 
 export const useSendInvitation = (
-  options?: Omit<
-    TMutationOptions<IInvitationStub, Error, IInvitationAttributes, unknown>,
-    "mutationFn"
+  options?: TMutationOptions<
+    IInvitationStub,
+    Error,
+    IInvitationAttributes,
+    unknown
   >,
 ) => {
   const { apiClient } = useApiClient();

--- a/frontend/src/hooks/entities/reset-hooks.ts
+++ b/frontend/src/hooks/entities/reset-hooks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -14,10 +14,7 @@ import { IResetPayload, IResetRequest } from "@/types/reset.types";
 import { useApiClient } from "../useApiClient";
 
 export const useRequestResetPassword = (
-  options?: Omit<
-    TMutationOptions<void, Error, IResetRequest, unknown>,
-    "mutationFn"
-  >,
+  options?: TMutationOptions<void, Error, IResetRequest, unknown>,
 ) => {
   const { apiClient } = useApiClient();
 
@@ -31,10 +28,7 @@ export const useRequestResetPassword = (
 
 export const useResetPassword = (
   token: string,
-  options?: Omit<
-    TMutationOptions<void, Error, IResetPayload, unknown>,
-    "mutationFn"
-  >,
+  options?: TMutationOptions<void, Error, IResetPayload, unknown>,
 ) => {
   const { apiClient } = useApiClient();
 

--- a/frontend/src/hooks/entities/translation-hooks.ts
+++ b/frontend/src/hooks/entities/translation-hooks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -13,16 +13,13 @@ import { TMutationOptions } from "@/services/types";
 import { useApiClient } from "../useApiClient";
 
 export const useRefreshTranslations = (
-  options?: Omit<
-    TMutationOptions<
-      {
-        acknowledged: boolean;
-        deletedCount: number;
-      },
-      Error,
-      unknown
-    >,
-    "mutationFn"
+  options?: TMutationOptions<
+    {
+      acknowledged: boolean;
+      deletedCount: number;
+    },
+    Error,
+    unknown
   >,
 ) => {
   const { apiClient } = useApiClient();

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -82,9 +82,12 @@ export type TMutationOptions<
   TError = unknown,
   TVariables = void,
   TContext = unknown,
-> = UseMutationOptions<TData, TError, TVariables, TContext> & {
-  invalidate?: boolean;
-};
+> = Omit<
+  UseMutationOptions<TData, TError, TVariables, TContext> & {
+    invalidate?: boolean;
+  },
+  "mutationFn" | "mutationKey"
+>;
 
 export type TSetCacheProps<TData> = {
   id: string;


### PR DESCRIPTION
# Motivation
Moves the Omit logic for TMutationOptions to one shared file

# What this PR does:
- Moves the Omit logic for TMutationOptions to one shared file
- Replaces all the duplicate Omit types with the new centralized version

# Why this is good:
✅ No more repeating the same code everywhere
✅ Easier to make changes in one place
✅ Less chance of mistakes

Fixes #1255

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
