### PR TITLE
feat: display timestamps for messages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@projectstorm/react-diagrams": "^7.0.4",
     "autolinker": "^4.1.5",
     "axios": "^1.8.1",
+    "date-fns": "^4.1.0",
     "eazychart-css": "^0.2.1-alpha.0",
     "eazychart-react": "^0.8.0-alpha.0",
     "hexabot-chat-widget": "*",

--- a/frontend/src/components/inbox/components/Chat.tsx
+++ b/frontend/src/components/inbox/components/Chat.tsx
@@ -25,6 +25,7 @@ import { EntityType } from "@/services/types";
 import { normalizeDate } from "@/utils/date";
 
 import {
+  formatSmartDate,
   getAvatarSrc,
   getMessageContent,
   getMessagePosition,
@@ -131,7 +132,10 @@ export function Chat() {
                         />,
                       ]
                     : []),
-                  ...getMessageContent(message),
+                  ...getMessageContent(
+                    message,
+                    formatSmartDate(message.createdAt),
+                  ),
                 ]}
               />
             );


### PR DESCRIPTION
# Motivation

The following PR enhances the Inbox UI by introducing timestamp visibility for each message, helping users better understand when messages were received or sent.

# Features
- **Timestamp Display**: Each message now shows a timestamp.
- **Relative "Timeago" Format**: Recent messages display times like:
  - `5 minutes ago`
  - `Yesterday 4:20 PM`
- **Full Date/Time Forma**t: Older messages fall back to:
  - `July 10, 2025 at 14:32`
Fixes # ([1251](https://github.com/Hexastack/Hexabot/issues/1251))

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
