### PR TITLE
Fix syntax for Carousel styled component

### DIFF
--- a/frontend/src/components/inbox/components/Carousel.tsx
+++ b/frontend/src/components/inbox/components/Carousel.tsx
@@ -37,9 +37,9 @@ const StyledIconButton = styled(IconButton)({
   transition: "all 0.1s",
   ".carousel-wrapper:hover &": {
     opacity: 1,
-    backgroundColor: "#fff"
+    backgroundColor: "#fff",
   },
-  backgroundColor: "#fff"
+  backgroundColor: "#fff",
 });
 const StyledCarouselDiv = styled("div")({
   display: "flex",
@@ -52,8 +52,8 @@ const StyledCarouselDiv = styled("div")({
   padding: "2px 0px",
   position: "relative",
 
-  "-ms-overflow-style": "none",
-  "scrollbar-width": "none",
+  msOverflowStyle: "none",
+  scrollbarWidth: "none",
   "&::-webkit-scrollbar": {
     display: "none",
   },


### PR DESCRIPTION
The CSS properties ms-overflow-style and scrollbar-width were using kebab-case. I've converted them to camelCase (msOverflowStyle and scrollbarWidth) to resolve the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected style property names in the carousel component to ensure proper application of custom scrollbar styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->