### PR TITLE
Add support for '$in' operator in SearchFilterPipe and frontend filtering

### DIFF
--- a/api/src/utils/pipes/search-filter.pipe.spec.ts
+++ b/api/src/utils/pipes/search-filter.pipe.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -18,6 +18,7 @@ type PipeTest = {
   id: string;
   roles: string[];
   status: string;
+  channel: string;
 };
 
 jest.mock('@nestjs/common', () => ({
@@ -34,6 +35,7 @@ describe('SearchFilterPipe', () => {
     'id',
     'status',
     'roles',
+    'channel',
   ] as (keyof PipeTest)[];
 
   const pipe = new SearchFilterPipe<PipeTest>({
@@ -156,6 +158,54 @@ describe('SearchFilterPipe', () => {
 
     expect(result).toEqual({
       $and: [{ roles: ['1', '2'] }],
+    });
+  });
+
+  it('should transform $in queries correctly', async () => {
+    const input = {
+      where: {
+        channel: { $in: ['web-channel', 'console-channel'] },
+      },
+    };
+
+    const result = await pipe.transform(input, {} as any);
+
+    expect(result).toEqual({
+      $and: [{ channel: { $in: ['web-channel', 'console-channel'] } }],
+    });
+  });
+
+  it('should transform $in queries in OR context correctly', async () => {
+    const input = {
+      where: {
+        or: [
+          { channel: { $in: ['web-channel', 'console-channel'] } },
+          { name: { contains: 'John' } },
+        ],
+      },
+    };
+
+    const result = await pipe.transform(input, {} as any);
+
+    expect(result).toEqual({
+      $or: [
+        { channel: { $in: ['web-channel', 'console-channel'] } },
+        { name: /John/i },
+      ],
+    });
+  });
+
+  it('should handle $in with single value correctly', async () => {
+    const input = {
+      where: {
+        channel: { $in: 'web-channel' },
+      },
+    };
+
+    const result = await pipe.transform(input, {} as any);
+
+    expect(result).toEqual({
+      $and: [{ channel: { $in: ['web-channel'] } }],
     });
   });
 });

--- a/api/src/utils/pipes/search-filter.pipe.ts
+++ b/api/src/utils/pipes/search-filter.pipe.ts
@@ -158,7 +158,7 @@ export class SearchFilterPipe<T>
             ...acc,
             $nor: [...(acc?.$nor || []), { ...filter, ...data }],
           };
-        case 'in':
+        case 'in': {
           // Handle $in operator - convert to MongoDB $in syntax
           const inQuery = Object.entries(data || {}).reduce(
             (inAcc, [field, values]) => {
@@ -187,6 +187,7 @@ export class SearchFilterPipe<T>
                 ...inQuery,
               };
           }
+        }
         default:
           switch (_context) {
             case 'or':

--- a/api/src/utils/pipes/search-filter.pipe.ts
+++ b/api/src/utils/pipes/search-filter.pipe.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -88,6 +88,21 @@ export class SearchFilterPipe<T>
           [field]: this.getNullableValue(val['!=']),
         },
       };
+    } else if (val?.[`$in`]) {
+      const inValues = (Array.isArray(val[`$in`]) ? val[`$in`] : [val[`$in`]])
+        .map((v) => this.getNullableValue(String(v)))
+        .filter((v) => v);
+
+      if (inValues.length === 0) {
+        return {};
+      }
+
+      return {
+        _operator: `in`,
+        data: {
+          [field]: inValues,
+        },
+      };
     }
 
     return {
@@ -143,6 +158,35 @@ export class SearchFilterPipe<T>
             ...acc,
             $nor: [...(acc?.$nor || []), { ...filter, ...data }],
           };
+        case 'in':
+          // Handle $in operator - convert to MongoDB $in syntax
+          const inQuery = Object.entries(data || {}).reduce(
+            (inAcc, [field, values]) => {
+              return {
+                ...inAcc,
+                [field]: { $in: values },
+              };
+            },
+            {},
+          );
+
+          switch (_context) {
+            case 'or':
+              return {
+                ...acc,
+                $or: [...(acc?.$or || []), { ...filter, ...inQuery }],
+              };
+            case 'and':
+              return {
+                ...acc,
+                $and: [...(acc?.$and || []), { ...filter, ...inQuery }],
+              };
+            default:
+              return {
+                ...acc,
+                ...inQuery,
+              };
+          }
         default:
           switch (_context) {
             case 'or':

--- a/api/src/utils/pipes/search-filter.pipe.ts
+++ b/api/src/utils/pipes/search-filter.pipe.ts
@@ -115,6 +115,37 @@ export class SearchFilterPipe<T>
     };
   }
 
+  /**
+   * Merges a filter clause into the MongoDB query accumulator based on logical context (and/or/default).
+   *
+   * @param acc The current accumulator object for the MongoDB query.
+   * @param _context The logical context for the filter ('and', 'or', or undefined).
+   * @param filter The filter object to merge (excluding operator and data).
+   * @param payload The filter data or query fragment to merge.
+   * @returns The updated accumulator object with the new filter merged in the correct context.
+   */
+  private mergeMongoQueryByContext(
+    acc: any,
+    _context: string | undefined,
+    filter: any,
+    payload: any,
+  ) {
+    switch (_context) {
+      case 'or':
+        return {
+          ...acc,
+          $or: [...(acc?.$or || []), { ...filter, ...payload }],
+        };
+      case 'and':
+        return {
+          ...acc,
+          $and: [...(acc?.$and || []), { ...filter, ...payload }],
+        };
+      default:
+        return acc;
+    }
+  }
+
   async transform(value: TSearchFilterValue<T>, _metadata: ArgumentMetadata) {
     const whereParams = value['where'] ?? {};
     const filters: TTransformFieldProps[] = [];
@@ -169,40 +200,19 @@ export class SearchFilterPipe<T>
             },
             {},
           );
-
-          switch (_context) {
-            case 'or':
-              return {
-                ...acc,
-                $or: [...(acc?.$or || []), { ...filter, ...inQuery }],
-              };
-            case 'and':
-              return {
-                ...acc,
-                $and: [...(acc?.$and || []), { ...filter, ...inQuery }],
-              };
-            default:
-              return {
-                ...acc,
-                ...inQuery,
-              };
+          if (_context === 'or' || _context === 'and') {
+            return this.mergeMongoQueryByContext(
+              acc,
+              _context,
+              filter,
+              inQuery,
+            );
+          } else {
+            return { ...acc, ...inQuery };
           }
         }
         default:
-          switch (_context) {
-            case 'or':
-              return {
-                ...acc,
-                $or: [...(acc?.$or || []), { ...filter, ...data }],
-              };
-            case 'and':
-              return {
-                ...acc,
-                $and: [...(acc?.$and || []), { ...filter, ...data }],
-              };
-            default:
-              return acc; // Handle any other cases if necessary
-          }
+          return this.mergeMongoQueryByContext(acc, _context, filter, data);
       }
     }, {} as TFilterQuery<T>);
   }

--- a/api/src/utils/types/filter.types.ts
+++ b/api/src/utils/types/filter.types.ts
@@ -114,7 +114,7 @@ type TNorField<T> = {
 
 export type TSearchFilterValue<T> = TOrField<T> | TAndField<T> | TNorField<T>;
 
-type TOperator = 'eq' | 'iLike' | 'neq';
+type TOperator = 'eq' | 'iLike' | 'neq' | 'in';
 type TContext = 'and' | 'or';
 
 export type TTransformFieldProps = {

--- a/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
+++ b/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
@@ -14,7 +14,6 @@ import { useNormalizedInfiniteQuery } from "@/hooks/crud/useNormalizedInfiniteQu
 import { useUpdateCache } from "@/hooks/crud/useUpdate";
 import { useAuth } from "@/hooks/useAuth";
 import { EntityType, QueryType } from "@/services/types";
-import { TNestedPaths } from "@/types/base.types";
 import { SearchPayload } from "@/types/search.types";
 import { ISubscriber } from "@/types/subscriber.types";
 import { useSubscribe } from "@/websocket/socket-hooks";
@@ -32,17 +31,13 @@ export const useInfiniteLiveSubscribers = (props: {
   const queryClient = useQueryClient();
   const params = {
     where: {
+      // Firstname and lastname keyword search
       ...props.searchPayload.where,
+      // Channel filter using $in operator
       ...(props.channels.length > 0 && {
-        or: [
-          ...(props.searchPayload.where?.or || []),
-          ...props.channels.map(
-            (channel): Partial<TNestedPaths<ISubscriber>> => ({
-              "channel.name": channel,
-            }),
-          ),
-        ],
+        "channel.name": { $in: props.channels },
       }),
+      // Assignment filter
       ...(props.assignedTo === AssignedTo.ME
         ? { assignedTo: user?.id }
         : props.assignedTo === AssignedTo.OTHERS
@@ -102,7 +97,7 @@ export const useInfiniteLiveSubscribers = (props: {
         });
       }
     },
-    [queryClient],
+    [queryClient, normalizeAndCache, updateCachedSubscriber],
   );
 
   useSubscribe<SocketSubscriberEvents>("subscriber", handleSubscriberEvent);

--- a/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
+++ b/frontend/src/components/inbox/hooks/useInfiniteLiveSubscribers.ts
@@ -34,9 +34,7 @@ export const useInfiniteLiveSubscribers = (props: {
       // Firstname and lastname keyword search
       ...props.searchPayload.where,
       // Channel filter using $in operator
-      ...(props.channels.length > 0 && {
-        "channel.name": { $in: props.channels },
-      }),
+      "channel.name": { $in: props.channels },
       // Assignment filter
       ...(props.assignedTo === AssignedTo.ME
         ? { assignedTo: user?.id }

--- a/frontend/src/types/search.types.ts
+++ b/frontend/src/types/search.types.ts
@@ -50,6 +50,9 @@ export type SearchItem<T> = {
     | (T[K] extends string ? { contains?: T[K] } : undefined)
     | {
         "!="?: T[K];
+      }
+    | {
+        $in?: T[K][];
       };
 };
 export type SearchPayload<T, N = TNestedPaths<T>> = EqParam<N> & {

--- a/frontend/src/types/search.types.ts
+++ b/frontend/src/types/search.types.ts
@@ -52,7 +52,7 @@ export type SearchItem<T> = {
         "!="?: T[K];
       }
     | {
-        $in?: T[K][];
+        $in?: T[K] | T[K][];
       };
 };
 export type SearchPayload<T, N = TNestedPaths<T>> = EqParam<N> & {


### PR DESCRIPTION
This pull request introduces support for the `$in` operator in API search queries, allowing for more efficient filtering of subscribers by multiple channels in the inbox.

### Motivation

Previously, filtering subscribers by multiple channels was not cleanly supported. This change enhances the `SearchFilterPipe` on the backend to correctly parse and apply `$in` operators for array-based filtering. The `useInfiniteLiveSubscribers` hook on the frontend has been updated to leverage this new functionality, sending a `{ "channel.name": { $in: [...] } }` payload. This approach is more efficient and keeps the client-side code cleaner. Additionally, the pipe now correctly handles empty arrays for the `$in` operator, preventing unnecessary or invalid database queries.

Fixes # (issue)

### Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `$in` operator in search filters, enabling filtering by multiple values for a given field.
  * Extended search types to include `$in` condition for more flexible queries.

* **Bug Fixes**
  * Improved handling of single-value `$in` queries to ensure consistent behavior.

* **Tests**
  * Added new test cases to verify correct transformation and handling of `$in` queries in search filters.

* **Documentation**
  * Clarified filter usage with comments in relevant code sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->