### PR TITLE
fix(widget): resolve cropped  right chevron in carousel

### DIFF
--- a/widget/src/components/messages/CarouselMessage.scss
+++ b/widget/src/components/messages/CarouselMessage.scss
@@ -1,7 +1,7 @@
 .sc-message--carousel {
   border-radius: 0.5rem;
   position: relative;
-  width: 275px;
+  width: 100%;
   overflow: hidden;
 
   .sc-message--carousel-inner {


### PR DESCRIPTION
# What this PR does:
- Fixes the cropped right arrow icon in our carousel
- Makes sure the chevron displays fully

# Why it matters:
➡️ The right arrow was half-hidden before
✅ Now looks correct and clickable

# Changes made:
- Adjusted carousel CSS width

Fixes #1240

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
