### PR TITLE
fix: correct attachment timestamp layout

### DIFF
--- a/frontend/src/components/inbox/components/AttachmentViewer.tsx
+++ b/frontend/src/components/inbox/components/AttachmentViewer.tsx
@@ -43,7 +43,7 @@ const componentMap: { [key in FileType]: FC<AttachmentInterface> } = {
           onError={() => setImageErrored(true)}
           width="auto"
           height={200}
-          style={{ objectFit: "contain", cursor: "pointer" }}
+          style={{ objectFit: "contain", cursor: "pointer", display: "block" }}
           alt={url}
           src={url}
           onClick={() =>


### PR DESCRIPTION
# Motivation

The following PR fixes the timestamp attachment layout. In the inbox page,  the image viewer and timestamp do not appear on the same line anymore.

Fixes # ([1271](https://github.com/Hexastack/Hexabot/issues/1271))

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
