### PR TITLE
fix: enable husky pre-push main branch protection

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,7 +2,7 @@ BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
 RESTRICTED_BRANCHES="^(main)$"
 
-# if echo "$BRANCH_NAME" | grep -Eq "$RESTRICTED_BRANCHES"; then
-# 	echo "Cannot push directly to branch: '${BRANCH_NAME}'"
-# 	exit 1
-# fi
+if echo "$BRANCH_NAME" | grep -Eq "$RESTRICTED_BRANCHES"; then
+	echo "Cannot push directly to branch: '${BRANCH_NAME}'"
+	exit 1
+fi


### PR DESCRIPTION
# What this PR does:
- Stops accidental pushes directly to main branch
- Adds a Husky pre-push hook to check branch name

# Why this matters:
🚫 Prevents risky direct pushes to main
✅ Enforces safer git workflow

Fixes #1276

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
