### PR TITLE
fix(api): resolve translation generation issue

### DIFF
--- a/api/src/i18n/services/translation.service.ts
+++ b/api/src/i18n/services/translation.service.ts
@@ -81,7 +81,7 @@ export class TranslationService extends BaseService<Translation> {
                 strings = strings.concat(value);
               } else if (typeof value === 'string') {
                 this.logger.warn(
-                  `The plugin ${plugin?.name} settings are incompatible with the settings.ts`,
+                  `The plugin ${plugin?.name} setting '${key}' is incompatible with the settings.ts`,
                 );
                 this.logger.warn(
                   `Expected type "array" received type "string"`,
@@ -95,14 +95,13 @@ export class TranslationService extends BaseService<Translation> {
                 strings.push(value);
               } else if (Array.isArray(value)) {
                 this.logger.warn(
-                  `The plugin ${plugin?.name} settings are incompatible with the settings.ts`,
+                  `The plugin ${plugin?.name} setting '${key}' is incompatible with the settings.ts`,
                 );
                 this.logger.warn(
                   'Expected type "string" received type "array"',
                 );
                 strings.push(...value.flat());
               }
-
               break;
             default:
               break;

--- a/api/src/i18n/services/translation.service.ts
+++ b/api/src/i18n/services/translation.service.ts
@@ -77,11 +77,32 @@ export class TranslationService extends BaseService<Translation> {
 
           switch (settingType) {
             case SettingType.multiple_text:
-              strings = strings.concat(value);
+              if (Array.isArray(value)) {
+                strings = strings.concat(value);
+              } else if (typeof value === 'string') {
+                this.logger.warn(
+                  `The plugin ${plugin?.name} settings are incompatible with the settings.ts`,
+                );
+                this.logger.warn(
+                  `Expected type "array" received type "string"`,
+                );
+                strings = strings.concat([value]);
+              }
               break;
             case SettingType.text:
             case SettingType.textarea:
-              strings.push(value);
+              if (typeof value === 'string') {
+                strings.push(value);
+              } else if (Array.isArray(value)) {
+                this.logger.warn(
+                  `The plugin ${plugin?.name} settings are incompatible with the settings.ts`,
+                );
+                this.logger.warn(
+                  'Expected type "string" received type "array"',
+                );
+                strings.push(...value.flat());
+              }
+
               break;
             default:
               break;
@@ -143,6 +164,7 @@ export class TranslationService extends BaseService<Translation> {
       const strings = await this.getBlockStrings(block);
       allStrings.push(...strings);
     }
+
     return allStrings;
   }
 

--- a/api/src/i18n/services/translation.service.ts
+++ b/api/src/i18n/services/translation.service.ts
@@ -87,6 +87,10 @@ export class TranslationService extends BaseService<Translation> {
                   `Expected type "array" received type "string"`,
                 );
                 strings = strings.concat([value]);
+              } else {
+                this.logger.warn(
+                  `Setting expected type "array" is different from the value type "${typeof value}"`,
+                );
               }
               break;
             case SettingType.text:
@@ -101,6 +105,10 @@ export class TranslationService extends BaseService<Translation> {
                   'Expected type "string" received type "array"',
                 );
                 strings.push(...value.flat());
+              } else {
+                this.logger.warn(
+                  `Setting expected type "string" is different from the value type "${typeof value}"`,
+                );
               }
               break;
             default:


### PR DESCRIPTION
# What this PR fixes:
- Makes translations work whether they expect strings or arrays
- Prevents errors when wrong type is provided

# Why it matters:
🐛 Before: Crashed if translation expected array but got string (or vice versa)
✅ Now: Handles both cases smoothly

# Changes made:
- Added type checks for translations
- Auto-convert between strings ↔ arrays when needed

Fixes #1242

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plugin settings to ensure correct processing of text values, with added safeguards and warnings for unexpected data types.
* **Chores**
  * Enhanced logging for better visibility into potential data type issues during translation processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->