### PR TITLE
Fix handling of undefined block in getFallbackOptions method

### DIFF
--- a/api/src/chat/services/block.service.ts
+++ b/api/src/chat/services/block.service.ts
@@ -784,8 +784,10 @@ export class BlockService extends BaseService<
    * @param block - The block to retrieve fallback options from.
    * @returns The fallback options for the block, or default options if not specified.
    */
-  getFallbackOptions<T extends BlockStub>(block: T): FallbackOptions {
-    return block.options?.fallback ?? getDefaultFallbackOptions();
+  getFallbackOptions<T extends BlockStub>(
+    block: T | undefined,
+  ): FallbackOptions {
+    return block?.options?.fallback ?? getDefaultFallbackOptions();
   }
 
   /**


### PR DESCRIPTION
This PR addresses a runtime error that occurs when getFallbackOptions is called with an undefined block, resulting in a TypeError: Cannot read properties of undefined (reading 'options'). This can happen if the conversation's current block is missing (e.g., deleted, not populated, or due to data corruption).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or undefined blocks when retrieving fallback options, ensuring more robust and error-free operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->