### PR TITLE
fix: clean up deprecated Husky config

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'


### PR DESCRIPTION
**What this PR does:**  
- Removes old `#!/usr/bin/env sh` lines from Husky files  
- Updates to current Husky standards  

**Why it matters:**  
🧹 Cleans up unnecessary code  
✅ Follows latest Husky recommendations  
🚫 Removes deprecated syntax  

**Before:**  
```sh
#!/usr/bin/env sh  
# (old Husky hooks)
```

**After:**  
```sh
# (clean modern config)
```

Fixes #1230

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes