### PR TITLE
feat: Add label Mutex Group UI (CRUD)

### DIFF
--- a/api/src/user/seeds/model.seed-model.ts
+++ b/api/src/user/seeds/model.seed-model.ts
@@ -80,6 +80,11 @@ export const modelModels: ModelCreateDto[] = [
     attributes: {},
   },
   {
+    name: 'LabelGroup',
+    identity: 'labelgroup',
+    attributes: {},
+  },
+  {
     name: 'ContextVar',
     identity: 'contextvar',
     attributes: {},

--- a/api/src/user/types/model.type.ts
+++ b/api/src/user/types/model.type.ts
@@ -21,6 +21,7 @@ export type TModel =
   | 'block'
   | 'category'
   | 'label'
+  | 'labelgroup'
   | 'contextvar'
   | 'conversation'
   | 'message'

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -243,7 +243,8 @@
     "log_entry": "Log entry",
     "dashboard": "Dashboard",
     "warning": "Warning",
-    "console": "Admin Chat Console"
+    "console": "Admin Chat Console",
+    "group_label": "Group Label"
   },
   "label": {
     "terms": "I have read and approve the terms and conditions.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -243,7 +243,8 @@
     "log_entry": "Journal des entrées",
     "dashboard": "Tableau de bord",
     "warning": "Avertissement",
-    "console": "Console de Chat Admin"
+    "console": "Console de Chat Admin",
+    "group_label": "Groupe de l'étiquette"
   },
   "label": {
     "terms": "J'ai lu et approuvé les termes et conditions.",

--- a/frontend/src/app-components/inputs/AutoCompleteEntitySelect.tsx
+++ b/frontend/src/app-components/inputs/AutoCompleteEntitySelect.tsx
@@ -41,6 +41,7 @@ type AutoCompleteEntitySelectProps<
   entity: keyof IEntityMapTypes;
   format: Format;
   searchFields: string[];
+  disableSearch?: boolean;
   error?: boolean;
   helperText?: string | null | undefined;
   preprocess?: (data: Value[]) => Value[];
@@ -56,6 +57,7 @@ const AutoCompleteEntitySelect = <
     entity,
     format,
     searchFields,
+    disableSearch,
     preprocess,
     idKey = "id",
     sortKey = "id",
@@ -64,9 +66,16 @@ const AutoCompleteEntitySelect = <
   }: AutoCompleteEntitySelectProps<Value, Label, Multiple>,
   ref,
 ) => {
-  const { onSearch, searchPayload } = useSearch<typeof entity>({
-    $or: (searchFields as TFilterStringFields<unknown>) || [idKey, labelKey],
-  });
+  const { onSearch, searchPayload } = useSearch<typeof entity>(
+    disableSearch
+      ? {}
+      : {
+          $or: (searchFields as TFilterStringFields<unknown>) || [
+            idKey,
+            labelKey,
+          ],
+        },
+  );
   const idRef = useRef(generateId());
   const params = {
     where: {
@@ -88,7 +97,8 @@ const AutoCompleteEntitySelect = <
   const flattenedData = data?.pages
     ?.flat()
     .filter(
-      (a, idx, self) => self.findIndex((b) => a[idKey] === b[idKey]) === idx,
+      (a, idx, self) =>
+        self.findIndex((b) => a?.[idKey] === b?.[idKey]) === idx,
     )
     .sort((a, b) => -b[sortKey]?.localeCompare(a[sortKey]));
   const options =

--- a/frontend/src/app-components/inputs/AutoCompleteSelect.tsx
+++ b/frontend/src/app-components/inputs/AutoCompleteSelect.tsx
@@ -95,7 +95,7 @@ const AutoCompleteSelect = <
         >)
       : ((multiple
           ? options.filter((o) => value?.includes(o[idKey]))
-          : options.find((o) => o[idKey] === value) ||
+          : options.find((o) => o?.[idKey] === value) ||
             (multiple ? [] : null)) as AutocompleteValue<
           Value,
           Multiple,

--- a/frontend/src/components/labels/LabelForm.tsx
+++ b/frontend/src/components/labels/LabelForm.tsx
@@ -158,7 +158,7 @@ export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
             multiple={false}
             value={labelGroup}
             onChange={(_e, selected) => {
-              if (selected?.id === "0" && "name" in selected) {
+              if (selected && !selected.id && "name" in selected) {
                 createGroupLabel({
                   name: selected.name.slice(addLabelGroupTitle.length + 2, -1),
                 });
@@ -175,7 +175,7 @@ export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
 
               if (inputValue !== "" && !isExisting) {
                 filtered.push({
-                  id: "0",
+                  id: "",
                   name: `${addLabelGroupTitle} "${inputValue}"`,
                   format: Format.BASIC,
                   createdAt: new Date(),
@@ -188,24 +188,26 @@ export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
             renderOption={(props, { id, name }) => (
               <ListItem {...props} key={id}>
                 <ListItemText primary={name} />
-                <InputAdornment
-                  position="end"
-                  onClick={async () => {
-                    const isConfirmed = await dialogs.confirm(
-                      ConfirmDialogBody,
-                    );
+                {id ? (
+                  <InputAdornment
+                    position="end"
+                    onClick={async () => {
+                      const isConfirmed = await dialogs.confirm(
+                        ConfirmDialogBody,
+                      );
 
-                    if (isConfirmed) {
-                      deleteGroupLabel(id);
-                    }
-                  }}
-                >
-                  <Tooltip title={t("button.delete")} placement="left" arrow>
-                    <IconButton size="small" sx={{ marginRight: 1 }}>
-                      <DeleteOutlineIcon fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
-                </InputAdornment>
+                      if (isConfirmed) {
+                        deleteGroupLabel(id);
+                      }
+                    }}
+                  >
+                    <Tooltip title={t("button.delete")} placement="left" arrow>
+                      <IconButton size="small" sx={{ marginRight: 1 }}>
+                        <DeleteOutlineIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ) : null}
               </ListItem>
             )}
           />

--- a/frontend/src/components/labels/LabelForm.tsx
+++ b/frontend/src/components/labels/LabelForm.tsx
@@ -6,19 +6,38 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import { FC, Fragment, useEffect } from "react";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import {
+  createFilterOptions,
+  IconButton,
+  InputAdornment,
+  ListItem,
+  ListItemText,
+  Tooltip,
+} from "@mui/material";
+import { FC, Fragment, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
-import { ContentContainer, ContentItem } from "@/app-components/dialogs";
+import {
+  ConfirmDialogBody,
+  ContentContainer,
+  ContentItem,
+} from "@/app-components/dialogs";
+import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import { Input } from "@/app-components/inputs/Input";
 import { useCreate } from "@/hooks/crud/useCreate";
+import { useDelete } from "@/hooks/crud/useDelete";
 import { useUpdate } from "@/hooks/crud/useUpdate";
+import { useDialogs } from "@/hooks/useDialogs";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
-import { EntityType } from "@/services/types";
+import { EntityType, Format } from "@/services/types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
+import { ILabelGroup } from "@/types/label-group.types";
 import { ILabel, ILabelAttributes } from "@/types/label.types";
 import { slugify } from "@/utils/string";
+
+const filter = createFilterOptions<ILabelGroup>();
 
 export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
   data: { defaultValues: label },
@@ -28,6 +47,7 @@ export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
 }) => {
   const { t } = useTranslate();
   const { toast } = useToast();
+  const dialogs = useDialogs();
   const options = {
     onError: (error: Error) => {
       rest.onError?.();
@@ -38,7 +58,21 @@ export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
       toast.success(t("message.success_save"));
     },
   };
+  const addLabelGroupTitle = t("button.add");
+  const [labelGroup, setLabelGroup] = useState<string | null>(
+    label?.group || null,
+  );
   const { mutate: createLabel } = useCreate(EntityType.LABEL, options);
+  const { mutate: createGroupLabel } = useCreate(EntityType.LABEL_GROUP, {
+    onSuccess: () => {
+      toast.success(t("message.success_save"));
+    },
+  });
+  const { mutate: deleteGroupLabel } = useDelete(EntityType.LABEL_GROUP, {
+    onSuccess: () => {
+      toast.success(t("message.item_delete_success"));
+    },
+  });
   const { mutate: updateLabel } = useUpdate(EntityType.LABEL, options);
   const {
     reset,
@@ -62,9 +96,22 @@ export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
   };
   const onSubmitForm = (params: ILabelAttributes) => {
     if (label) {
-      updateLabel({ id: label.id, params });
+      updateLabel({
+        id: label.id,
+        params: {
+          group: labelGroup,
+          ...params,
+        },
+      });
     } else {
-      createLabel(params);
+      createLabel(
+        { group: labelGroup, ...params },
+        {
+          onSuccess(data) {
+            setLabelGroup(data.id);
+          },
+        },
+      );
     }
   };
 
@@ -100,6 +147,68 @@ export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
               helperText={errors.title ? errors.title.message : null}
             />
           </ContentItem>
+          <AutoCompleteEntitySelect<ILabelGroup, "name", false>
+            fullWidth={true}
+            searchFields={["name"]}
+            disableSearch
+            entity={EntityType.LABEL_GROUP}
+            format={Format.BASIC}
+            labelKey="name"
+            label={t("title.group_label")}
+            multiple={false}
+            value={labelGroup}
+            onChange={(_e, selected) => {
+              if (selected?.id === "0" && "name" in selected) {
+                createGroupLabel({
+                  name: selected.name.slice(addLabelGroupTitle.length + 2, -1),
+                });
+              } else {
+                setLabelGroup(selected?.id || null);
+              }
+            }}
+            filterOptions={(options, params) => {
+              const filtered = filter(options, params);
+              const { inputValue } = params;
+              const isExisting = options.some(
+                (option) => inputValue === option.name,
+              );
+
+              if (inputValue !== "" && !isExisting) {
+                filtered.push({
+                  id: "0",
+                  name: `${addLabelGroupTitle} "${inputValue}"`,
+                  format: Format.BASIC,
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                });
+              }
+
+              return filtered;
+            }}
+            renderOption={(props, { id, name }) => (
+              <ListItem {...props} key={id}>
+                <ListItemText primary={name} />
+                <InputAdornment
+                  position="end"
+                  onClick={async () => {
+                    const isConfirmed = await dialogs.confirm(
+                      ConfirmDialogBody,
+                    );
+
+                    if (isConfirmed) {
+                      deleteGroupLabel(id);
+                    }
+                  }}
+                >
+                  <Tooltip title={t("button.delete")} placement="left" arrow>
+                    <IconButton size="small" sx={{ marginRight: 1 }}>
+                      <DeleteOutlineIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              </ListItem>
+            )}
+          />
           <ContentItem>
             <Input
               placeholder={t("placeholder.name")}

--- a/frontend/src/components/labels/index.tsx
+++ b/frontend/src/components/labels/index.tsx
@@ -23,6 +23,7 @@ import { DataGrid } from "@/app-components/tables/DataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useDeleteMany } from "@/hooks/crud/useDeleteMany";
 import { useFind } from "@/hooks/crud/useFind";
+import { useGetFromCache } from "@/hooks/crud/useGet";
 import { useDialogs } from "@/hooks/useDialogs";
 import { useSearch } from "@/hooks/useSearch";
 import { useToast } from "@/hooks/useToast";
@@ -88,6 +89,7 @@ export const Labels = () => {
     t("label.operations"),
   );
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
+  const getEntityFromCache = useGetFromCache(EntityType.LABEL_GROUP);
   const columns: GridColDef<ILabel>[] = [
     { field: "id", headerName: "ID" },
     {
@@ -97,6 +99,19 @@ export const Labels = () => {
       disableColumnMenu: true,
       renderHeader,
       headerAlign: "left",
+    },
+    {
+      minWidth: 110,
+      field: "group",
+      headerName: t("title.group_label"),
+      disableColumnMenu: true,
+      renderHeader,
+      headerAlign: "center",
+      valueGetter: (groupId) => {
+        const group = getEntityFromCache(groupId);
+
+        return group?.name;
+      },
     },
     {
       flex: 1,

--- a/frontend/src/services/api.class.ts
+++ b/frontend/src/services/api.class.ts
@@ -47,6 +47,7 @@ export const ROUTES = {
   // Entities
   [EntityType.SUBSCRIBER]: "/subscriber",
   [EntityType.LABEL]: "/label",
+  [EntityType.LABEL_GROUP]: "/labelgroup",
   [EntityType.ROLE]: "/role",
   [EntityType.USER]: "/user",
   [EntityType.PERMISSION]: "/permission",
@@ -310,8 +311,8 @@ export class EntityApiClient<TAttr, TBasic, TFull> extends ApiClient {
       `${ROUTES[this.type]}/import`,
       formData,
       {
-        params: { _csrf , ...params },
-      }
+        params: { _csrf, ...params },
+      },
     );
 
     return data;

--- a/frontend/src/services/entities.ts
+++ b/frontend/src/services/entities.ts
@@ -70,10 +70,20 @@ export const SubscriberEntity = new schema.Entity(
   },
 );
 
+export const LabelGroupEntity = new schema.Entity(
+  EntityType.LABEL_GROUP,
+  {},
+  {
+    idAttribute: ({ id }) => id,
+    processStrategy: processCommonStrategy,
+  },
+);
+
 export const LabelEntity = new schema.Entity(
   EntityType.LABEL,
   {
     users: [SubscriberEntity],
+    group: LabelGroupEntity,
   },
   {
     idAttribute: ({ id }) => id,
@@ -323,6 +333,7 @@ export const StorageHelperEntity = new schema.Entity(
 export const ENTITY_MAP = {
   [EntityType.SUBSCRIBER]: SubscriberEntity,
   [EntityType.LABEL]: LabelEntity,
+  [EntityType.LABEL_GROUP]: LabelGroupEntity,
   [EntityType.ROLE]: RoleEntity,
   [EntityType.USER]: UserEntity,
   [EntityType.PERMISSION]: PermissionEntity,

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -11,6 +11,7 @@ import { UseMutationOptions } from "react-query";
 export enum EntityType {
   SUBSCRIBER = "Subscriber",
   LABEL = "Label",
+  LABEL_GROUP = "LabelGroup",
   ROLE = "Role",
   USER = "User",
   PERMISSION = "Permission",

--- a/frontend/src/types/base.types.ts
+++ b/frontend/src/types/base.types.ts
@@ -29,6 +29,7 @@ import { IContentType, IContentTypeAttributes } from "./content-type.types";
 import { IContent, IContentAttributes, IContentFull } from "./content.types";
 import { IContextVar, IContextVarAttributes } from "./context-var.types";
 import { IHelper, IHelperAttributes } from "./helper.types";
+import { ILabelGroup, ILabelGroupAttributes } from "./label-group.types";
 import { ILabel, ILabelAttributes, ILabelFull } from "./label.types";
 import { ILanguage, ILanguageAttributes } from "./language.types";
 import {
@@ -92,7 +93,8 @@ export const POPULATE_BY_TYPE = {
   [EntityType.CONTEXT_VAR]: [],
   [EntityType.ROLE]: ["users", "permissions"],
   [EntityType.USER]: ["roles", "avatar"],
-  [EntityType.LABEL]: ["users"],
+  [EntityType.LABEL]: ["users", "group"],
+  [EntityType.LABEL_GROUP]: [],
   [EntityType.MODEL]: ["permissions"],
   [EntityType.PERMISSION]: ["model", "role"],
   [EntityType.SUBSCRIBER]: ["labels", "assignedTo"],
@@ -172,6 +174,7 @@ export interface IEntityMapTypes {
     ICustomBlockSettingFilters
   >;
   [EntityType.LABEL]: IEntityTypes<ILabel, ILabelAttributes, never, ILabelFull>;
+  [EntityType.LABEL_GROUP]: IEntityTypes<ILabelGroup, ILabelGroupAttributes>;
   [EntityType.MENU]: IEntityTypes<
     IMenuItem,
     IMenuItemAttributes,

--- a/frontend/src/types/label-group.types.ts
+++ b/frontend/src/types/label-group.types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2024 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { Format } from "@/services/types";
+
+import { IBaseSchema, IFormat } from "./base.types";
+
+export interface ILabelGroupStub extends IBaseSchema {
+  name: string;
+}
+
+export interface ILabelGroupAttributes {
+  name: string;
+}
+
+export interface ILabelGroup extends ILabelGroupStub, IFormat<Format.BASIC> {}

--- a/frontend/src/types/label.types.ts
+++ b/frontend/src/types/label.types.ts
@@ -16,12 +16,14 @@ export interface ILabelAttributes {
   name: string;
   description: string;
   builtin?: boolean;
+  group?: string | null;
 }
 
 export interface ILabelStub
   extends IBaseSchema,
     OmitPopulate<ILabelAttributes, EntityType.LABEL> {
   subscriber_count: number;
+  group?: string | null;
 }
 
 export interface ILabel extends ILabelStub, IFormat<Format.BASIC> {}


### PR DESCRIPTION
## Motivation 
The main motivation is to add the UI side of the label Mutex feature.

## What's New:
- Added **mutex group** selection in the UI  
- **Delete confirmation** dialog for safety  
- **updates** when changes are made  

## Why It's Better:
✅ Prevents accidental deletions (with confirmation)  
🤖 Smarter auto-selection saves clicks  
🔄 Updates UI instantly after changes  

## Screen recording
<video src="https://github.com/user-attachments/assets/a5d0b27a-cffc-4631-acf9-aa6cd01a479f"></video> 

Fixes #1283 

- [x] Apply changes to the frontend : Add "Group" column to the labels data grid as well as a autocomplete input "group" in the label edit/create form.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes