### PR TITLE
Feat/UI autocomplete entity select distinct component

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -244,7 +244,8 @@
     "dashboard": "Dashboard",
     "warning": "Warning",
     "console": "Admin Chat Console",
-    "group_label": "Group Label"
+    "group_label": "Group Label",
+    "default_group": "Default Group"
   },
   "label": {
     "terms": "I have read and approve the terms and conditions.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -244,7 +244,8 @@
     "dashboard": "Tableau de bord",
     "warning": "Avertissement",
     "console": "Console de Chat Admin",
-    "group_label": "Groupe de l'étiquette"
+    "group_label": "Groupe de l'étiquette",
+    "default_group": "Groupe par défaut"
   },
   "label": {
     "terms": "J'ai lu et approuvé les termes et conditions.",

--- a/frontend/src/app-components/inputs/AutoCompleteEntityDistinctSelect.tsx
+++ b/frontend/src/app-components/inputs/AutoCompleteEntityDistinctSelect.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { Box, ChipTypeMap, ListSubheader } from "@mui/material";
+import { AutocompleteProps } from "@mui/material/Autocomplete";
+import { forwardRef, useEffect, useRef } from "react";
+
+import { useGetFromCache } from "@/hooks/crud/useGet";
+import { useInfiniteFind } from "@/hooks/crud/useInfiniteFind";
+import { useSearch } from "@/hooks/useSearch";
+import { Format, QueryType } from "@/services/types";
+import { IEntityMapTypes, THook } from "@/types/base.types";
+import { TFilterStringFields } from "@/types/search.types";
+import { generateId } from "@/utils/generateId";
+
+import AutoCompleteSelect from "./AutoCompleteSelect";
+
+type AutoCompleteEntityDistinctSelectProps<
+  TE extends THook["entity"],
+  Value extends THook<{ entity: TE }>["full"] = THook<{ entity: TE }>["full"],
+  Label extends keyof Value = keyof Value,
+> = Omit<
+  AutocompleteProps<Value, true, false, false, ChipTypeMap["defaultComponent"]>,
+  "renderInput" | "options" | "value" | "defaultValue" | "multiple"
+> & {
+  value?: string[];
+  label: string;
+  idKey?: string;
+  sortKey?: string;
+  groupKey: string;
+  defaultGroupTitle: string;
+  labelKey: Label;
+  entity: keyof IEntityMapTypes;
+  sortEntity: keyof IEntityMapTypes;
+  searchFields: string[];
+  disableSearch?: boolean;
+  error?: boolean;
+  helperText?: string | null | undefined;
+  preprocess?: (data: Value[]) => Value[];
+  noOptionsWarning?: string;
+};
+
+const AutoCompleteEntityDistinctSelect = <
+  TE extends THook["entity"],
+  Value extends THook<{ entity: TE }>["full"] = THook<{ entity: TE }>["full"],
+  Label extends keyof Value = keyof Value,
+>(
+  {
+    entity,
+    sortEntity,
+    groupKey,
+    defaultGroupTitle,
+    searchFields,
+    disableSearch,
+    preprocess,
+    idKey = "id",
+    sortKey = "id",
+    labelKey,
+    ...rest
+  }: AutoCompleteEntityDistinctSelectProps<TE, Value, Label>,
+  ref,
+) => {
+  const { onSearch, searchPayload } = useSearch<typeof entity>(
+    disableSearch
+      ? {}
+      : {
+          $or: (searchFields as TFilterStringFields<unknown>) || [
+            idKey,
+            labelKey,
+          ],
+        },
+  );
+  const idRef = useRef(generateId());
+  const getEntityFromCache = useGetFromCache(entity);
+  const getSortEntityFromCache = useGetFromCache(sortEntity);
+  const params = {
+    where: {
+      or: searchPayload.where?.or || [],
+    },
+  };
+  const { data, isFetching, fetchNextPage } = useInfiniteFind(
+    { entity, format: Format.FULL },
+    {
+      params,
+      hasCount: false,
+    },
+    {
+      keepPreviousData: true,
+      queryKey: [QueryType.collection, entity, `autocomplete/${idRef.current}`],
+    },
+  );
+  // flatten & filter unique & sort
+  const flattenedData = data?.pages
+    ?.flat()
+    .filter(
+      (a, idx, self) =>
+        self.findIndex((b) => a?.[idKey] === b?.[idKey]) === idx,
+    )
+    .sort((a, b) => (a[sortKey] ?? "").localeCompare(b[sortKey] ?? ""));
+  const options =
+    preprocess && flattenedData
+      ? preprocess((flattenedData || []) as unknown as Value[])
+      : ((flattenedData || []) as Value[]);
+
+  useEffect(() => {
+    fetchNextPage({ pageParam: params });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(searchPayload)]);
+
+  return (
+    <AutoCompleteSelect<Value, Label, true>
+      ref={ref}
+      idKey={idKey}
+      labelKey={labelKey}
+      options={options || []}
+      onSearch={onSearch}
+      loading={isFetching}
+      getOptionDisabled={(option) => {
+        const selectedOptions = rest.value;
+
+        if (Array.isArray(selectedOptions)) {
+          const selectedGroups = [
+            ...new Set(
+              selectedOptions?.map(
+                (option) => getEntityFromCache(option)?.[sortKey] || "",
+              ),
+            ),
+          ];
+
+          return (
+            !rest.value?.includes(option[idKey]) &&
+            selectedGroups.includes(option[sortKey])
+          );
+        }
+
+        return false;
+      }}
+      groupBy={(option) => {
+        if (option[sortKey]) {
+          return (
+            getSortEntityFromCache(option[sortKey])?.[groupKey] ||
+            defaultGroupTitle
+          );
+        }
+
+        return defaultGroupTitle;
+      }}
+      renderGroup={({ key, group, children }) => (
+        <Box key={key}>
+          <ListSubheader
+            sx={{
+              top: "-8px",
+              border: "0.5px solid #eee",
+              bgcolor: "#fafafaee",
+              fontSize: "1rem",
+              fontWeight: "bold",
+            }}
+            color="primary"
+          >
+            {group}
+          </ListSubheader>
+          {children}
+        </Box>
+      )}
+      multiple
+      {...rest}
+    />
+  );
+};
+
+AutoCompleteEntityDistinctSelect.displayName =
+  "AutoCompleteEntityDistinctSelect";
+
+export default forwardRef(AutoCompleteEntityDistinctSelect) as <
+  TE extends THook["entity"],
+>(
+  props: AutoCompleteEntityDistinctSelectProps<TE> & {
+    ref?: React.ForwardedRef<HTMLDivElement>;
+    entity: TE;
+  },
+) => ReturnType<typeof AutoCompleteEntityDistinctSelect>;

--- a/frontend/src/app-components/inputs/AutoCompleteEntityDistinctSelect.tsx
+++ b/frontend/src/app-components/inputs/AutoCompleteEntityDistinctSelect.tsx
@@ -36,7 +36,7 @@ type AutoCompleteEntityDistinctSelectProps<
   defaultGroupTitle: string;
   labelKey: Label;
   entity: keyof IEntityMapTypes;
-  sortEntity: keyof IEntityMapTypes;
+  subEntity: keyof IEntityMapTypes;
   searchFields: string[];
   disableSearch?: boolean;
   error?: boolean;
@@ -52,7 +52,7 @@ const AutoCompleteEntityDistinctSelect = <
 >(
   {
     entity,
-    sortEntity,
+    subEntity,
     groupKey,
     defaultGroupTitle,
     searchFields,
@@ -77,7 +77,7 @@ const AutoCompleteEntityDistinctSelect = <
   );
   const idRef = useRef(generateId());
   const getEntityFromCache = useGetFromCache(entity);
-  const getSortEntityFromCache = useGetFromCache(sortEntity);
+  const getSubEntityFromCache = useGetFromCache(subEntity);
   const params = {
     where: {
       or: searchPayload.where?.or || [],
@@ -104,7 +104,7 @@ const AutoCompleteEntityDistinctSelect = <
     .sort((a, b) => (a[sortKey] ?? "").localeCompare(b[sortKey] ?? ""));
   const options =
     preprocess && flattenedData
-      ? preprocess((flattenedData || []) as unknown as Value[])
+      ? preprocess((flattenedData || []) as Value[])
       : ((flattenedData || []) as Value[]);
 
   useEffect(() => {
@@ -122,6 +122,8 @@ const AutoCompleteEntityDistinctSelect = <
       loading={isFetching}
       getOptionDisabled={(option) => {
         const selectedOptions = rest.value;
+        const selectedGroup = option[sortKey];
+        const isOptionSelected = selectedOptions?.includes(option[idKey]);
 
         if (Array.isArray(selectedOptions)) {
           const selectedGroups = [
@@ -131,21 +133,19 @@ const AutoCompleteEntityDistinctSelect = <
               ),
             ),
           ];
+          const isOptionGroupSelected = selectedGroups.includes(selectedGroup);
 
-          return (
-            !rest.value?.includes(option[idKey]) &&
-            selectedGroups.includes(option[sortKey])
-          );
+          return !isOptionSelected && isOptionGroupSelected;
         }
 
         return false;
       }}
       groupBy={(option) => {
         if (option[sortKey]) {
-          return (
-            getSortEntityFromCache(option[sortKey])?.[groupKey] ||
-            defaultGroupTitle
-          );
+          const sortEntityId = option[sortKey];
+          const groupTitle = getSubEntityFromCache(sortEntityId)?.[groupKey];
+
+          return groupTitle || defaultGroupTitle;
         }
 
         return defaultGroupTitle;

--- a/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -85,7 +85,7 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                       <AutoCompleteEntityDistinctSelect
                         searchFields={["name"]}
                         entity={EntityType.LABEL}
-                        sortEntity={EntityType.LABEL_GROUP}
+                        subEntity={EntityType.LABEL_GROUP}
                         labelKey="name"
                         label={t("label.labels")}
                         error={!!errors.labels}

--- a/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -11,7 +11,7 @@ import { FC, Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
-import AutoCompleteEntitySelectDistinct from "@/app-components/inputs/AutoCompleteEntityDistinctSelect";
+import AutoCompleteEntityDistinctSelect from "@/app-components/inputs/AutoCompleteEntityDistinctSelect";
 import { Input } from "@/app-components/inputs/Input";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { useToast } from "@/hooks/useToast";
@@ -82,14 +82,12 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                     const { onChange, ...rest } = field;
 
                     return (
-                      <AutoCompleteEntitySelectDistinct
-                        autoFocus
+                      <AutoCompleteEntityDistinctSelect
                         searchFields={["name"]}
                         entity={EntityType.LABEL}
                         sortEntity={EntityType.LABEL_GROUP}
                         labelKey="name"
                         label={t("label.labels")}
-                        {...field}
                         error={!!errors.labels}
                         helperText={
                           errors.labels ? errors.labels.message : null
@@ -97,7 +95,7 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                         onChange={(_e, selected) =>
                           onChange(selected.map(({ id }) => id))
                         }
-                        sortKey=""
+                        sortKey="group"
                         groupKey="name"
                         defaultGroupTitle={t("title.default_group")}
                         {...rest}

--- a/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -85,8 +85,6 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                       <AutoCompleteEntityDistinctSelect
                         entity={EntityType.LABEL}
                         subEntity={EntityType.LABEL_GROUP}
-                        labelKey="name"
-                        label={t("label.labels")}
                         error={!!errors.labels}
                         helperText={
                           errors.labels ? errors.labels.message : null
@@ -94,6 +92,8 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                         onChange={(_e, selected) =>
                           onChange(selected.map(({ id }) => id))
                         }
+                        label={t("label.labels")}
+                        labelKey="name"
                         sortKey="group"
                         groupKey="name"
                         defaultGroupTitle={t("title.default_group")}

--- a/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -83,7 +83,6 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
 
                     return (
                       <AutoCompleteEntityDistinctSelect
-                        searchFields={["name"]}
                         entity={EntityType.LABEL}
                         subEntity={EntityType.LABEL_GROUP}
                         labelKey="name"

--- a/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -11,14 +11,13 @@ import { FC, Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
-import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
+import AutoCompleteEntitySelectDistinct from "@/app-components/inputs/AutoCompleteEntityDistinctSelect";
 import { Input } from "@/app-components/inputs/Input";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
-import { EntityType, Format } from "@/services/types";
+import { EntityType } from "@/services/types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
-import { ILabel } from "@/types/label.types";
 import { ISubscriber, ISubscriberAttributes } from "@/types/subscriber.types";
 
 const getFullName = (subscriber: ISubscriber | null) =>
@@ -83,14 +82,13 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                     const { onChange, ...rest } = field;
 
                     return (
-                      <AutoCompleteEntitySelect<ILabel>
+                      <AutoCompleteEntitySelectDistinct
                         autoFocus
                         searchFields={["name"]}
                         entity={EntityType.LABEL}
-                        format={Format.BASIC}
+                        sortEntity={EntityType.LABEL_GROUP}
                         labelKey="name"
                         label={t("label.labels")}
-                        multiple
                         {...field}
                         error={!!errors.labels}
                         helperText={
@@ -99,6 +97,9 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                         onChange={(_e, selected) =>
                           onChange(selected.map(({ id }) => id))
                         }
+                        sortKey=""
+                        groupKey="name"
+                        defaultGroupTitle={t("title.default_group")}
                         {...rest}
                       />
                     );

--- a/frontend/src/components/visual-editor/form/OptionsForm.tsx
+++ b/frontend/src/components/visual-editor/form/OptionsForm.tsx
@@ -25,7 +25,12 @@ import LocalFallbackInput from "./inputs/options/LocalFallbackInput";
 export const OptionsForm = () => {
   const { t } = useTranslate();
   const block = useBlock();
-  const { control, register, watch } = useFormContext<IBlockAttributes>();
+  const {
+    control,
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext<IBlockAttributes>();
   const computed = watch("options.typing");
 
   return (
@@ -54,11 +59,15 @@ export const OptionsForm = () => {
               <AutoCompleteEntityDistinctSelect
                 entity={EntityType.LABEL}
                 subEntity={EntityType.LABEL_GROUP}
-                labelKey="title"
-                label={t("label.assign_labels")}
+                error={!!errors.assign_labels}
+                helperText={
+                  errors.assign_labels ? errors.assign_labels.message : null
+                }
                 onChange={(_e, selected) =>
                   onChange(selected.map(({ id }) => id))
                 }
+                label={t("label.assign_labels")}
+                labelKey="title"
                 sortKey="group"
                 groupKey="name"
                 defaultGroupTitle={t("title.default_group")}

--- a/frontend/src/components/visual-editor/form/OptionsForm.tsx
+++ b/frontend/src/components/visual-editor/form/OptionsForm.tsx
@@ -52,7 +52,6 @@ export const OptionsForm = () => {
 
             return (
               <AutoCompleteEntityDistinctSelect
-                searchFields={["title", "name"]}
                 entity={EntityType.LABEL}
                 subEntity={EntityType.LABEL_GROUP}
                 labelKey="title"

--- a/frontend/src/components/visual-editor/form/OptionsForm.tsx
+++ b/frontend/src/components/visual-editor/form/OptionsForm.tsx
@@ -10,12 +10,12 @@ import { Typography } from "@mui/material";
 import { Controller, useFormContext } from "react-hook-form";
 
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
+import AutoCompleteEntityDistinctSelect from "@/app-components/inputs/AutoCompleteEntityDistinctSelect";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import { Input } from "@/app-components/inputs/Input";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType, Format } from "@/services/types";
 import { IBlockAttributes } from "@/types/block.types";
-import { ILabelFull } from "@/types/label.types";
 import { IUser } from "@/types/user.types";
 
 import { useBlock } from "./BlockFormProvider";
@@ -51,16 +51,18 @@ export const OptionsForm = () => {
             const { onChange, ...rest } = field;
 
             return (
-              <AutoCompleteEntitySelect<ILabelFull>
+              <AutoCompleteEntityDistinctSelect
                 searchFields={["title", "name"]}
                 entity={EntityType.LABEL}
-                format={Format.BASIC}
+                sortEntity={EntityType.LABEL_GROUP}
                 labelKey="title"
                 label={t("label.assign_labels")}
-                multiple={true}
                 onChange={(_e, selected) =>
                   onChange(selected.map(({ id }) => id))
                 }
+                sortKey="group"
+                groupKey="name"
+                defaultGroupTitle={t("title.default_group")}
                 {...rest}
               />
             );

--- a/frontend/src/components/visual-editor/form/OptionsForm.tsx
+++ b/frontend/src/components/visual-editor/form/OptionsForm.tsx
@@ -54,7 +54,7 @@ export const OptionsForm = () => {
               <AutoCompleteEntityDistinctSelect
                 searchFields={["title", "name"]}
                 entity={EntityType.LABEL}
-                sortEntity={EntityType.LABEL_GROUP}
+                subEntity={EntityType.LABEL_GROUP}
                 labelKey="title"
                 label={t("label.assign_labels")}
                 onChange={(_e, selected) =>

--- a/frontend/src/types/label.types.ts
+++ b/frontend/src/types/label.types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
@@ -9,6 +9,7 @@
 import { EntityType, Format } from "@/services/types";
 
 import { IBaseSchema, IFormat, OmitPopulate } from "./base.types";
+import { ILabelGroup } from "./label-group.types";
 import { IUser } from "./user.types";
 
 export interface ILabelAttributes {
@@ -23,11 +24,13 @@ export interface ILabelStub
   extends IBaseSchema,
     OmitPopulate<ILabelAttributes, EntityType.LABEL> {
   subscriber_count: number;
+}
+
+export interface ILabel extends ILabelStub, IFormat<Format.BASIC> {
   group?: string | null;
 }
 
-export interface ILabel extends ILabelStub, IFormat<Format.BASIC> {}
-
 export interface ILabelFull extends ILabelStub, IFormat<Format.FULL> {
   users: IUser[];
+  group: ILabelGroup;
 }


### PR DESCRIPTION
**What this PR adds:**  
- A reusable component for grouped items  
- Lets users pick just one item per group  

**How it works:**  
☑️ Shows items in neat groups  
🔘 Only one selection allowed per group  

**Why it's useful:**  
✅ Solves our single-selection needs  
♻️ Works for any type of items  

# Screen recording 
<video src="https://github.com/user-attachments/assets/16f2dace-aedb-4bf2-ab1e-3dc7b6c2f024"></video>
<video src="https://github.com/user-attachments/assets/9106ea81-8da1-43a9-a8c1-da7066ec5ea4"></video>

Fixes #1278

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new multi-select autocomplete component that allows users to select distinct entities grouped by a specified key, with improved grouping and sorting options.
  * Updated label selection in subscriber and visual editor forms to use the new grouped autocomplete, enhancing the organization and selection of labels.

* **Localization**
  * Added translations for "Default Group" in both English and French locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->