### PR TITLE
Automatically select newly created group label in LabelForm

### DIFF
--- a/frontend/src/components/labels/LabelForm.tsx
+++ b/frontend/src/components/labels/LabelForm.tsx
@@ -64,8 +64,10 @@ export const LabelForm: FC<ComponentFormProps<ILabel>> = ({
   );
   const { mutate: createLabel } = useCreate(EntityType.LABEL, options);
   const { mutate: createGroupLabel } = useCreate(EntityType.LABEL_GROUP, {
-    onSuccess: () => {
+    onSuccess: (createdGroup: ILabelGroup) => {
       toast.success(t("message.success_save"));
+      // Automatically select the newly created group label
+      setLabelGroup(createdGroup.id);
     },
   });
   const { mutate: deleteGroupLabel } = useDelete(EntityType.LABEL_GROUP, {


### PR DESCRIPTION
Enhance the LabelForm to automatically select a newly created group label upon successful creation.

Fixes #1296

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
