### PR TITLE
fix(widget): add refresh i18n translations

### DIFF
--- a/widget/src/components/ConnectionLost.tsx
+++ b/widget/src/components/ConnectionLost.tsx
@@ -53,7 +53,7 @@ const ConnectionLost: React.FC = () => {
             }}
             onClick={handleClick}
           >
-            Refresh
+            {t("user_subscription.refresh")}
           </button>
         </div>
       )}

--- a/widget/src/translations/en/translation.json
+++ b/widget/src/translations/en/translation.json
@@ -2,7 +2,8 @@
   "user_subscription": {
     "get_started": "Get Started",
     "first_name": "First Name",
-    "last_name": "Last Name"
+    "last_name": "Last Name",
+    "refresh": "Refresh"
   },
   "settings": {
     "greeting": "Welcome !",

--- a/widget/src/translations/fr/translation.json
+++ b/widget/src/translations/fr/translation.json
@@ -2,7 +2,8 @@
   "user_subscription": {
     "get_started": "Commencer",
     "first_name": "Prénom",
-    "last_name": "Nom"
+    "last_name": "Nom",
+    "refresh": "Actualiser"
   },
   "settings": {
     "greeting": "Bienvenue !",


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to add refresh translations.

Fixes # (issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “Refresh” button on the connection-lost screen is now localized, displaying translated text based on the user’s language.
  * Added English and French translations to ensure consistent localization for the refresh action across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->