### PR TITLE
fix(frontend): resolve missing trigger icon

### DIFF
--- a/frontend/src/components/visual-editor/v2/CustomDiagramNodes/NodeWidget.tsx
+++ b/frontend/src/components/visual-editor/v2/CustomDiagramNodes/NodeWidget.tsx
@@ -291,8 +291,7 @@ class NodeWidget extends React.Component<
         </div>
         <div className="node-block-field-container">
           <div className="node-block-field">
-            <TriggerIcon color={this.config.color} />
-
+            <TriggerIcon color={this.config.color} style={{ flexShrink: 0 }} />
             {this.props.node.patterns.length > 0 ? (
               this.props.node.patterns
                 .map((pattern: Pattern) => {


### PR DESCRIPTION
# Motivation:
The main motivation of this PR is to resolve missing trigger icon.

# Screenshots: 
Before the fix
<img width="863" height="240" alt="image" src="https://github.com/user-attachments/assets/f4d84847-5fbe-46c0-a625-e17060cd0771" />

After the fix
<img width="863" height="240" alt="image" src="https://github.com/user-attachments/assets/04be7b02-0f2c-4e3e-b04d-001615a1ea48" />


Fixes #1245

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Visual Editor: Prevented the trigger icon in node fields from shrinking under flex layouts, ensuring consistent size and alignment across different screen widths.
  - Improved layout stability and spacing within node headers, reducing visual jitter and preserving icon readability during resizing and complex diagrams.
  - Enhances overall UI consistency in the visual editor when interacting with nodes, especially in dense canvases or when panels are resized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->