### PR TITLE
fix: revert __getcookie endpoint

### DIFF
--- a/api/src/app.controller.ts
+++ b/api/src/app.controller.ts
@@ -35,4 +35,11 @@ export class AppController {
         : '',
     };
   }
+
+  @Roles('public')
+  @Get('__getcookie')
+  cookies(@Req() req: Request): string {
+    req.session.anonymous = true;
+    return '';
+  }
 }


### PR DESCRIPTION
# Motivation

Revert endpoint `__getcookie` to preserve support for older versions of the chat widget.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public GET endpoint at /__getcookie. When called, it creates an anonymous session and responds with an empty body. No authentication required. The route sets session state via cookies and can be invoked by browsers or API clients without additional headers. Does not affect existing endpoints or response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->