### PR TITLE
fix: use cookie expires instead of _expires

### DIFF
--- a/api/src/websocket/websocket.gateway.ts
+++ b/api/src/websocket/websocket.gateway.ts
@@ -190,8 +190,7 @@ export class WebsocketGateway
             path: cookie.path,
             httpOnly: cookie.httpOnly,
             secure: cookie.secure,
-            // @ts-expect-error type mismatch Cookie vs CookieOptions
-            expires: cookie._expires,
+            expires: cookie.expires,
           });
 
           headers['Set-Cookie'] = cookies;


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to use the typed expires property instead of  using the not typed _expires property.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cookie expiration handling during WebSocket connection setup, ensuring session cookies expire as expected across browsers and environments.
  * Improves reliability of authentication state during real-time connections, reducing sporadic issues with lingering or prematurely expiring sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->