### PR TITLE
fix(widget): add subscribeUser event broadcast cross tabs

### DIFF
--- a/widget/src/components/UserSubscription.tsx
+++ b/widget/src/components/UserSubscription.tsx
@@ -9,6 +9,7 @@
 import React, { useCallback, useState } from "react";
 
 import { useTranslation } from "../hooks/useTranslation";
+import { useBroadcastChannel } from "../providers/BroadcastChannelProvider";
 import { preprocessMessages, useChat } from "../providers/ChatProvider";
 import { useColors } from "../providers/ColorProvider";
 import { useSettings } from "../providers/SettingsProvider";
@@ -33,6 +34,7 @@ const UserSubscription: React.FC = () => {
     subscribe,
     sendGetStarted,
   } = useChat();
+  const { postMessage } = useBroadcastChannel();
   const [firstName, setFirstName] = useState<string>("");
   const [lastName, setLastName] = useState<string>("");
   const handleSubmit = useCallback(
@@ -59,8 +61,9 @@ const UserSubscription: React.FC = () => {
         setMessages(arrangedMessages);
         setParticipants(participantsList);
         if (messages.length === 0) {
-          sendGetStarted(profile.foreign_id);
+          await sendGetStarted(profile.foreign_id);
         }
+        postMessage({ event: "subscribed" });
         setConnectionState(ConnectionState.connected);
       } catch (error) {
         if (

--- a/widget/src/providers/BroadcastChannelProvider.tsx
+++ b/widget/src/providers/BroadcastChannelProvider.tsx
@@ -17,7 +17,7 @@ import {
 
 export enum EBCEvent {
   LOGOUT = "logout",
-  SUBSCRIBE_USER = "subscribeUser",
+  SUBSCRIBED = "subscribed",
 }
 
 type BroadcastChannelMessage = {

--- a/widget/src/providers/BroadcastChannelProvider.tsx
+++ b/widget/src/providers/BroadcastChannelProvider.tsx
@@ -17,6 +17,7 @@ import {
 
 export enum EBCEvent {
   LOGOUT = "logout",
+  SUBSCRIBE_USER = "subscribeUser",
 }
 
 type BroadcastChannelMessage = {

--- a/widget/src/providers/ChatProvider.tsx
+++ b/widget/src/providers/ChatProvider.tsx
@@ -40,6 +40,7 @@ import {
 } from "../types/state.types";
 import { SocketIoClientError } from "../utils/SocketIoClientError";
 
+import { useBroadcastChannel } from "./BroadcastChannelProvider";
 import { useConfig } from "./ConfigProvider";
 import { ChannelSettings, useSettings } from "./SettingsProvider";
 import { useSocket, useSubscribe } from "./SocketProvider";
@@ -263,6 +264,7 @@ const ChatProvider: React.FC<{
 }> = ({ wantToConnect, defaultConnectionState = 0, children }) => {
   const config = useConfig();
   const settings = useSettings();
+  const { postMessage } = useBroadcastChannel();
   const { setScreen } = useWidget();
   const { setScroll, syncState, isOpen } = useWidget();
   const { socket, socketErrorHandlers } = useSocket();
@@ -460,6 +462,17 @@ const ChatProvider: React.FC<{
 
   useSubscribeBroadcastChannel("logout", () => {
     socket.disconnect();
+  });
+
+  useSubscribeBroadcastChannel("subscribeUser", () => {
+    socket.disconnect();
+    socket.connect();
+  });
+
+  useSubscribe("message", ({ author }: { author: string }) => {
+    if (author === "chatbot" && messages.length === 1) {
+      postMessage({ event: "subscribeUser" });
+    }
   });
 
   useSubscribe("error", ({ message, statusCode }: SocketErrorResponse) => {

--- a/widget/src/providers/ChatProvider.tsx
+++ b/widget/src/providers/ChatProvider.tsx
@@ -40,7 +40,6 @@ import {
 } from "../types/state.types";
 import { SocketIoClientError } from "../utils/SocketIoClientError";
 
-import { useBroadcastChannel } from "./BroadcastChannelProvider";
 import { useConfig } from "./ConfigProvider";
 import { ChannelSettings, useSettings } from "./SettingsProvider";
 import { useSocket, useSubscribe } from "./SocketProvider";
@@ -264,7 +263,6 @@ const ChatProvider: React.FC<{
 }> = ({ wantToConnect, defaultConnectionState = 0, children }) => {
   const config = useConfig();
   const settings = useSettings();
-  const { postMessage } = useBroadcastChannel();
   const { setScreen } = useWidget();
   const { setScroll, syncState, isOpen } = useWidget();
   const { socket, socketErrorHandlers } = useSocket();
@@ -464,15 +462,9 @@ const ChatProvider: React.FC<{
     socket.disconnect();
   });
 
-  useSubscribeBroadcastChannel("subscribeUser", () => {
+  useSubscribeBroadcastChannel("subscribed", () => {
     socket.disconnect();
     socket.connect();
-  });
-
-  useSubscribe("message", ({ author }: { author: string }) => {
-    if (author === "chatbot" && messages.length === 1) {
-      postMessage({ event: "subscribeUser" });
-    }
   });
 
   useSubscribe("error", ({ message, statusCode }: SocketErrorResponse) => {


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to make synchronized tabs via subscriberUser event.


# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-context subscription notification: when a user subscribes, other open contexts are notified so UI state stays in sync.
  * Ensures initial setup completes before continuing so conversations start reliably after subscribing.

* **Bug Fixes**
  * Chat now triggers an automatic reconnect when a subscription event occurs, improving message delivery and reducing missed or delayed messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->