### PR TITLE
fix: inbox messages sort

### DIFF
--- a/frontend/src/components/inbox/hooks/useInfiniteLiveMessages.ts
+++ b/frontend/src/components/inbox/hooks/useInfiniteLiveMessages.ts
@@ -24,11 +24,14 @@ export const useInfinitedLiveMessages = () => {
   const { subscriber: activeChat } = useChat();
   const queryClient = useQueryClient();
   const normalizeAndCache = useNormalizeAndCache(EntityType.MESSAGE);
-  const params: SearchPayload<IMessage> = {
-    where: {
-      or: [{ recipient: activeChat?.id }, { sender: activeChat?.id }],
-    },
-  };
+  const params = useMemo<SearchPayload<IMessage>>(
+    () => ({
+      where: {
+        or: [{ recipient: activeChat?.id }, { sender: activeChat?.id }],
+      },
+    }),
+    [activeChat?.id],
+  );
   const {
     data,
     hasNextPage,

--- a/frontend/src/components/inbox/hooks/useInfiniteLiveMessages.ts
+++ b/frontend/src/components/inbox/hooks/useInfiniteLiveMessages.ts
@@ -73,6 +73,7 @@ export const useInfinitedLiveMessages = () => {
         );
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [queryClient, activeChat?.id],
   );
 
@@ -80,9 +81,15 @@ export const useInfinitedLiveMessages = () => {
 
   const messages = useMemo(
     () =>
-      (data?.pages.reverse().map((p) => p.reverse()) || [])
+      (data?.pages || [])
         .flat()
-        .filter((m, idx, self) => self.indexOf(m) === idx),
+        .filter((m, idx, self) => self.indexOf(m) === idx)
+        .sort((a, b) => {
+          return (
+            new Date(a.createdAt ?? 0).getTime() -
+            new Date(b.createdAt ?? 0).getTime()
+          );
+        }),
     [data],
   );
 

--- a/frontend/src/components/inbox/hooks/useInfiniteLiveMessages.ts
+++ b/frontend/src/components/inbox/hooks/useInfiniteLiveMessages.ts
@@ -79,19 +79,26 @@ export const useInfinitedLiveMessages = () => {
 
   useSubscribe<SocketMessageEvents>("message", addMessage);
 
-  const messages = useMemo(
-    () =>
-      (data?.pages || [])
-        .flat()
-        .filter((m, idx, self) => self.indexOf(m) === idx)
-        .sort((a, b) => {
-          return (
-            new Date(a.createdAt ?? 0).getTime() -
-            new Date(b.createdAt ?? 0).getTime()
-          );
-        }),
-    [data],
-  );
+  const messages = useMemo(() => {
+    const seen = new Set<string>();
+
+    return (data?.pages || [])
+      .flat()
+      .reduce<IMessage[]>((acc, m) => {
+        if (!seen.has(m.id)) {
+          seen.add(m.id);
+          acc.push(m);
+        }
+
+        return acc;
+      }, [])
+      .sort((a, b) => {
+        return (
+          new Date(a.createdAt ?? 0).getTime() -
+          new Date(b.createdAt ?? 0).getTime()
+        );
+      });
+  }, [data]);
 
   return {
     replyTo:


### PR DESCRIPTION
# Motivation

The motivation of this PR is to sort cached messages since we could have a racing condition when receiving WS messages.

Fixes https://github.com/Hexastack/Hexabot/issues/1304

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Live inbox messages now display in true chronological order across all loaded pages.
  * Eliminates duplicate messages that could appear when loading more content.
  * More consistent behavior when new messages arrive during infinite scrolling.

* **Refactor**
  * Improved message aggregation and memoization for more reliable ordering and display without changing user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->