### PR TITLE
fix: avoid “Channel is closed” error in BroadcastChannelProvider under React 18 StrictMode

### DIFF
--- a/widget/src/providers/BroadcastChannelProvider.tsx
+++ b/widget/src/providers/BroadcastChannelProvider.tsx
@@ -67,6 +67,11 @@ export const BroadcastChannelProvider: FC<IBroadcastChannelProps> = ({
 
     return () => {
       channel.removeEventListener("message", handleMessage);
+      
+      if (channelRef.current === channel) {
+        channelRef.current = undefined;
+      }
+
       channel.close();
     };
   }, [channelName]);


### PR DESCRIPTION
# Motivation

This PR fixes an InvalidStateError: Failed to execute 'postMessage' on 'BroadcastChannel': Channel is closed that occurred when using the widget in development. In React 18 StrictMode, effects are intentionally mounted, cleaned up, and mounted again. Our provider created the BroadcastChannel outside the effect but closed it inside the effect cleanup, leaving the ref pointing to a closed channel after StrictMode’s first pass.

## Root cause
- channelRef was initialized with new BroadcastChannel(channelName) at render time.
- The effect’s cleanup called channelRef.current.close().
- On StrictMode’s double-invoke, the channel was closed during the first cleanup but not re-created, so subsequent postMessage calls threw.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved reliability of cross-tab messaging.
  - Channel now reconnects when its name changes.
  - Prevents event-listener leaks and startup race conditions when posting messages.

- Refactor
  - Lazily initializes the messaging channel and streamlines lifecycle/cleanup.
  - Minor internal naming cleanup with no impact on behavior or public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->