### PR TITLE
fix(api): enhance socket event metadata types

### DIFF
--- a/api/src/websocket/services/socket-event-dispatcher.service.ts
+++ b/api/src/websocket/services/socket-event-dispatcher.service.ts
@@ -108,10 +108,13 @@ export class SocketEventDispatcherService implements OnModuleInit {
 
   onModuleInit() {
     const allProviders = Array.from(this.modulesContainer.values())
-      .map((module) => module.providers.values())
+      .map(
+        (module) =>
+          module.providers.values() as MapIterator<InstanceWrapper<object>>,
+      )
       .reduce(
         (prev, curr) => prev.concat(Array.from(curr)),
-        [] as InstanceWrapper<unknown>[],
+        [] as InstanceWrapper<object>[],
       )
       .filter((provider) => !!provider.instance);
 

--- a/api/src/websocket/storage/socket-event-metadata.storage.ts
+++ b/api/src/websocket/storage/socket-event-metadata.storage.ts
@@ -6,22 +6,41 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
+import { Socket } from 'socket.io-client';
+
+import { IOIncomingMessage } from '../pipes/io-message.pipe';
+
+type SocketEventMetadata = {
+  path: string;
+  method: (payload: IOIncomingMessage, client: Socket) => Promise<any>;
+  propertyKey: string | symbol;
+  socketMethod:
+    | 'get'
+    | 'post'
+    | 'put'
+    | 'patch'
+    | 'delete'
+    | 'options'
+    | 'head';
+};
+
 export class SocketEventMetadataStorage {
-  private static metadata = new Map<string, any>();
+  private static metadata = new Map<string, SocketEventMetadata[]>();
 
   static addEventMetadata(
-    target: any,
-    propertyKey: string | symbol,
-    metadata: any,
+    target: object,
+    propertyKey: SocketEventMetadata['propertyKey'],
+    metadata: Omit<SocketEventMetadata, 'propertyKey'>,
   ) {
     const key = target.constructor.name;
     if (!this.metadata.has(key)) {
       this.metadata.set(key, []);
     }
-    this.metadata.get(key).push({ propertyKey, ...metadata });
+
+    this.metadata.get(key)?.push({ propertyKey, ...metadata });
   }
 
-  static getMetadataFor(target: any): any[] {
+  static getMetadataFor(target: object) {
     return this.metadata.get(target.constructor.name) || [];
   }
 }


### PR DESCRIPTION
# Motivation
The main motivation is to enhance socket event metadata types by removing any types and replace them by the equivalent types. 

Fixes #1344

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Strengthened type safety around WebSocket event metadata and provider initialization to improve reliability.
  - Refined method signatures for metadata handling to ensure stricter contracts.
- Chores
  - Internal cleanup of metadata storage to reduce potential type-related issues.

No user-facing changes; behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->