### PR TITLE
feat(widget): sync expiration after send & subscription

### DIFF
--- a/widget/src/ChatWidget.tsx
+++ b/widget/src/ChatWidget.tsx
@@ -7,7 +7,9 @@
  */
 
 import "normalize.css";
+import { useState } from "react";
 import "./ChatWidget.css";
+
 import Launcher from "./components/Launcher";
 import UserSubscription from "./components/UserSubscription";
 import BroadcastChannelProvider from "./providers/BroadcastChannelProvider";
@@ -21,14 +23,21 @@ import WidgetProvider from "./providers/WidgetProvider";
 import { Config } from "./types/config.types";
 
 function ChatWidget(props: Partial<Config>) {
+  const [, setEvents] = useState<string[]>([]);
+
   return (
     <ConfigProvider {...props}>
       <TranslationProvider>
         <SocketProvider
           socketErrorHandlers={{
             "401": (err) => {
-              err.socket.disconnect();
-              err.socket.connect();
+              const isReceiver = err.message === "Unauthorized";
+
+              if (!isReceiver) {
+                setEvents((setEvents) => [...setEvents, "unauthorized"]);
+                err.socket.disconnect();
+                err.socket.connect();
+              }
             },
           }}
         >
@@ -36,7 +45,7 @@ function ChatWidget(props: Partial<Config>) {
             <ColorProvider>
               <WidgetProvider>
                 <BroadcastChannelProvider channelName="main-channel">
-                  <ChatProvider>
+                  <ChatProvider setEvents={setEvents}>
                     <Launcher PreChat={UserSubscription} />
                   </ChatProvider>
                 </BroadcastChannelProvider>

--- a/widget/src/components/UserSubscription.tsx
+++ b/widget/src/components/UserSubscription.tsx
@@ -9,7 +9,6 @@
 import React, { useCallback, useState } from "react";
 
 import { useTranslation } from "../hooks/useTranslation";
-import { useBroadcastChannel } from "../providers/BroadcastChannelProvider";
 import { preprocessMessages, useChat } from "../providers/ChatProvider";
 import { useColors } from "../providers/ColorProvider";
 import { useSettings } from "../providers/SettingsProvider";
@@ -33,8 +32,8 @@ const UserSubscription: React.FC = () => {
     setSuggestions,
     subscribe,
     sendGetStarted,
+    broadcastEventToTabs,
   } = useChat();
-  const { postMessage } = useBroadcastChannel();
   const [firstName, setFirstName] = useState<string>("");
   const [lastName, setLastName] = useState<string>("");
   const handleSubmit = useCallback(
@@ -63,7 +62,9 @@ const UserSubscription: React.FC = () => {
         if (messages.length === 0) {
           await sendGetStarted(profile.foreign_id);
         }
-        postMessage({ event: "subscribed" });
+
+        broadcastEventToTabs("profileCreated", true);
+
         setConnectionState(ConnectionState.connected);
       } catch (error) {
         if (

--- a/widget/src/providers/BroadcastChannelProvider.tsx
+++ b/widget/src/providers/BroadcastChannelProvider.tsx
@@ -17,7 +17,8 @@ import {
 
 export enum EBCEvent {
   LOGOUT = "logout",
-  SUBSCRIBED = "subscribed",
+  PROFILE_EXPIRED = "profileExpired",
+  PROFILE_CREATED = "profileCreated",
 }
 
 type BroadcastChannelMessage = {
@@ -67,7 +68,7 @@ export const BroadcastChannelProvider: FC<IBroadcastChannelProps> = ({
 
     return () => {
       channel.removeEventListener("message", handleMessage);
-      
+
       if (channelRef.current === channel) {
         channelRef.current = undefined;
       }


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to include synchronization between multiple tabs when : 
- Sending a message with an expired session
- Subscribe from a single tab

Fixes # (issue)

# Demo
<video src="https://github.com/user-attachments/assets/7f97a482-13e4-44dd-a776-64dc0cad7a8a"></video>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Multi-tab synchronization for profile lifecycle events: tabs now broadcast and react to “profile created” and “profile expired,” keeping sessions in sync.
  - Improved internal event tracking to support coordinated actions across components.

- Bug Fixes
  - Reduced unnecessary reconnects on certain 401 socket errors, improving connection stability and avoiding disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->