### PR TITLE
fix: ws connection mutex

### DIFF
--- a/widget/src/ChatWidget.tsx
+++ b/widget/src/ChatWidget.tsx
@@ -27,8 +27,7 @@ function ChatWidget(props: Partial<Config>) {
         <SocketProvider
           socketErrorHandlers={{
             "401": (err) => {
-              err.socket.disconnect();
-              err.socket.connect();
+              err.socket.forceReconnect();
             },
           }}
         >

--- a/widget/src/components/ScreenTemplate.tsx
+++ b/widget/src/components/ScreenTemplate.tsx
@@ -27,8 +27,7 @@ const Template: React.FC<{ name: string; Icon: React.FC }> = ({
   const handleClick = () => {
     setConnectionState(ConnectionState.tryingToConnect);
 
-    socket.disconnect();
-    socket.connect();
+    socket.forceReconnect();
   };
   const loading = connectionState === ConnectionState.tryingToConnect;
 

--- a/widget/src/components/UserSubscription.tsx
+++ b/widget/src/components/UserSubscription.tsx
@@ -9,7 +9,6 @@
 import React, { useCallback, useState } from "react";
 
 import { useTranslation } from "../hooks/useTranslation";
-import { useBroadcastChannel } from "../providers/BroadcastChannelProvider";
 import { preprocessMessages, useChat } from "../providers/ChatProvider";
 import { useColors } from "../providers/ColorProvider";
 import { useSettings } from "../providers/SettingsProvider";
@@ -34,7 +33,6 @@ const UserSubscription: React.FC = () => {
     subscribe,
     sendGetStarted,
   } = useChat();
-  const { postMessage } = useBroadcastChannel();
   const [firstName, setFirstName] = useState<string>("");
   const [lastName, setLastName] = useState<string>("");
   const handleSubmit = useCallback(
@@ -63,7 +61,6 @@ const UserSubscription: React.FC = () => {
         if (messages.length === 0) {
           await sendGetStarted(profile.foreign_id);
         }
-        postMessage({ event: "subscribed" });
         setConnectionState(ConnectionState.connected);
       } catch (error) {
         if (

--- a/widget/src/hooks/useSubscribeBroadcastChannel.ts
+++ b/widget/src/hooks/useSubscribeBroadcastChannel.ts
@@ -13,10 +13,14 @@ import { useBroadcastChannel } from "../providers/BroadcastChannelProvider";
 export const useSubscribeBroadcastChannel: ReturnType<
   typeof useBroadcastChannel
 >["subscribe"] = (...props) => {
-  const { subscribe } = useBroadcastChannel();
+  const { subscribe, unsubscribe } = useBroadcastChannel();
 
   useEffect(() => {
     subscribe(...props);
+
+    return () => {
+      unsubscribe(...props);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [subscribe]);
 };

--- a/widget/src/main.tsx
+++ b/widget/src/main.tsx
@@ -1,12 +1,11 @@
 /*
- * Copyright © 2024 Hexastack. All rights reserved.
+ * Copyright © 2025 Hexastack. All rights reserved.
  *
  * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
  * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
-import React from "react";
 import ReactDOM from "react-dom/client";
 
 import ChatWidget from "./ChatWidget.tsx";
@@ -14,13 +13,13 @@ import ChatWidget from "./ChatWidget.tsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <ChatWidget
-      {...{
-        apiUrl: process.env.REACT_APP_WIDGET_API_URL || "http://localhost:4000",
-        channel: process.env.REACT_APP_WIDGET_CHANNEL || "web-channel",
-        language: "en",
-      }}
-    />
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <ChatWidget
+    {...{
+      apiUrl: process.env.REACT_APP_WIDGET_API_URL || "http://localhost:4000",
+      channel: process.env.REACT_APP_WIDGET_CHANNEL || "web-channel",
+      language: "en",
+    }}
+  />,
+  // </React.StrictMode>,
 );

--- a/widget/src/main.tsx
+++ b/widget/src/main.tsx
@@ -6,6 +6,7 @@
  * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
  */
 
+import React from "react";
 import ReactDOM from "react-dom/client";
 
 import ChatWidget from "./ChatWidget.tsx";
@@ -13,13 +14,13 @@ import ChatWidget from "./ChatWidget.tsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  // <React.StrictMode>
-  <ChatWidget
-    {...{
-      apiUrl: process.env.REACT_APP_WIDGET_API_URL || "http://localhost:4000",
-      channel: process.env.REACT_APP_WIDGET_CHANNEL || "web-channel",
-      language: "en",
-    }}
-  />,
-  // </React.StrictMode>,
+  <React.StrictMode>
+    <ChatWidget
+      {...{
+        apiUrl: process.env.REACT_APP_WIDGET_API_URL || "http://localhost:4000",
+        channel: process.env.REACT_APP_WIDGET_CHANNEL || "web-channel",
+        language: "en",
+      }}
+    />
+  </React.StrictMode>,
 );

--- a/widget/src/providers/BroadcastChannelProvider.tsx
+++ b/widget/src/providers/BroadcastChannelProvider.tsx
@@ -35,6 +35,10 @@ interface IBroadcastChannelContext {
     event: `${EBCEvent}`,
     callback: (message: BroadcastChannelMessage) => void,
   ) => void;
+  unsubscribe: (
+    event: `${EBCEvent}`,
+    callback: (message: BroadcastChannelMessage) => void,
+  ) => void;
   postMessage: (message: BroadcastChannelMessage) => void;
 }
 
@@ -67,7 +71,7 @@ export const BroadcastChannelProvider: FC<IBroadcastChannelProps> = ({
 
     return () => {
       channel.removeEventListener("message", handleMessage);
-      
+
       if (channelRef.current === channel) {
         channelRef.current = undefined;
       }
@@ -91,6 +95,16 @@ export const BroadcastChannelProvider: FC<IBroadcastChannelProps> = ({
       }
     };
   };
+  const unsubscribe: IBroadcastChannelContext["unsubscribe"] = (
+    event,
+    callback,
+  ) => {
+    subscribersRef.current[event] = (
+      subscribersRef.current?.[event] || []
+    ).filter((cb) => {
+      return cb !== callback;
+    });
+  };
   const postMessage: IBroadcastChannelContext["postMessage"] = (message) => {
     channelRef.current?.postMessage(message);
   };
@@ -99,6 +113,7 @@ export const BroadcastChannelProvider: FC<IBroadcastChannelProps> = ({
     <BroadcastChannelContext.Provider
       value={{
         subscribe,
+        unsubscribe,
         postMessage,
       }}
     >

--- a/widget/src/providers/ChatProvider.tsx
+++ b/widget/src/providers/ChatProvider.tsx
@@ -460,8 +460,7 @@ const ChatProvider: React.FC<{
   });
 
   useSubscribeBroadcastChannel("subscribed", () => {
-    socket.disconnect();
-    socket.connect();
+    socket.forceReconnect();
   });
 
   useSubscribe("error", ({ message, statusCode }: SocketErrorResponse) => {
@@ -473,9 +472,7 @@ const ChatProvider: React.FC<{
   useSubscribe("settings", ({ profile, messages = [] }: ChannelSettings) => {
     setProfile(profile);
 
-    if (config.channel === "web-channel" && profile && messages.length === 0) {
-      sendGetStarted(profile.foreign_id);
-    } else if (config.channel === "console-channel" && !profile) {
+    if (config.channel === "console-channel" && !profile) {
       handleSubscription();
     }
 

--- a/widget/src/providers/ChatProvider.tsx
+++ b/widget/src/providers/ChatProvider.tsx
@@ -40,6 +40,7 @@ import {
 } from "../types/state.types";
 import { SocketIoClientError } from "../utils/SocketIoClientError";
 
+import { useBroadcastChannel } from "./BroadcastChannelProvider";
 import { useConfig } from "./ConfigProvider";
 import { ChannelSettings, useSettings } from "./SettingsProvider";
 import { useSocket, useSubscribe } from "./SocketProvider";
@@ -261,6 +262,7 @@ const ChatProvider: React.FC<{
   children: ReactNode;
   socketErrorHandlers?: SocketErrorHandlers;
 }> = ({ wantToConnect, defaultConnectionState = 0, children }) => {
+  const { postMessage } = useBroadcastChannel();
   const config = useConfig();
   const settings = useSettings();
   const { setScreen } = useWidget();
@@ -434,6 +436,11 @@ const ChatProvider: React.FC<{
         author: foreign_id,
       },
     });
+
+    // Notify other tabs that we've subscribed and sent the 1st msg (so they reload)
+    setTimeout(() => {
+      postMessage({ event: "subscribed" });
+    }, 500);
   };
 
   useSubscribe<TMessage>(StdEventType.message, handleNewIOMessage);

--- a/widget/src/providers/SocketProvider.tsx
+++ b/widget/src/providers/SocketProvider.tsx
@@ -83,7 +83,7 @@ export const useSocketLifecycle = () => {
   const { socket } = useSocket();
 
   useEffect(() => {
-    socket.connect();
+    socket.forceReconnect();
 
     return () => {
       socket.disconnect();

--- a/widget/src/utils/SocketIoClient.ts
+++ b/widget/src/utils/SocketIoClient.ts
@@ -122,18 +122,8 @@ export class SocketIoClient {
    * Waits for disconnecttion of the socket client.
    */
   public waitForDisconnect() {
-    return new Promise<void>((resolve, reject) => {
-      const onClose = () => {
-        this.socket.io.off("error", onError);
-        resolve();
-      };
-      const onError = () => {
-        this.socket.io.off("close", onClose);
-        reject(new Error("Error while disconnecting"));
-      };
-
-      this.socket.io.once("close", onClose);
-      this.socket.io.once("error", onError);
+    return new Promise<void>((resolve) => {
+      this.socket.once("disconnect", () => resolve());
 
       this.socket.disconnect();
     });
@@ -168,12 +158,12 @@ export class SocketIoClient {
             reject(e);
           };
 
-          socket.io.once("open", onConnect);
-          socket.io.once("error", onErr);
+          socket.once("connect", onConnect);
+          socket.once("connect_error", onErr);
 
           off.push(
-            () => socket.io.off("open", onConnect),
-            () => socket.io.off("error", onErr),
+            () => socket.off("connect", onConnect),
+            () => socket.off("connect_error", onErr),
           );
 
           // Force a fresh handshake if we were connected or mid-attempt

--- a/widget/src/utils/SocketIoClient.ts
+++ b/widget/src/utils/SocketIoClient.ts
@@ -119,7 +119,7 @@ export class SocketIoClient {
   }
 
   /**
-   * Waits for disconnecttion of the socket client.
+   * Waits for disconnection of the socket client.
    */
   public waitForDisconnect() {
     return new Promise<void>((resolve) => {

--- a/widget/src/utils/SocketIoClient.ts
+++ b/widget/src/utils/SocketIoClient.ts
@@ -162,9 +162,7 @@ export class SocketIoClient {
           );
 
           const onConnect = () => {
-            setTimeout(() => {
-              resolve();
-            }, timeoutMs * 0.05);
+            resolve();
           };
           const onErr = (e: unknown) => {
             reject(e);


### PR DESCRIPTION
# Motivation
This PR introduces a safer, cross-tab–aware reconnect() for our Socket.IO client.
It uses the Web Locks API to serialize reconnection attempts across tabs, adds timeouts and error handling, and ensures listener cleanup so the lock is never held indefinitely. It also switches state checks to socket.connected for correctness.

## Problem

When multiple tabs try to reconnect at the same time, we can:
- spin up parallel WS handshakes and duplicate server-side session work,
- deadlock if connect never fires (no timeout / no reject),
- leak listeners, keeping the lock until reload,
- rely on socket.active, which is not a reliable indicator of connection state.

## Solution
- Wrap the reconnect flow in navigator.locks.request('ws_connection', { mode: 'exclusive' }, …) to serialize attempts across tabs.
- Use a promise with timeout (default: 10s) and listen to connect, connect_error, and error to resolve/reject deterministically.
- Always cleanup (remove listeners + clear timeout) in a finally block to guarantee lock release.
- Prefer socket.connected to short-circuit when already connected and to decide if we should force a fresh handshake.
- Graceful fallback: if Web Locks isn’t available, run the reconnect logic without a lock (behavior matches current, but with safer timeout/error handling).

## Other updates
- Prevent from subscribing multiple times to broadcast channel when we have multiple renders
- Prevent "get started" from being sent multiple times

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-tab coordinated reconnect so the widget recovers reliably across browser tabs.
  * Added an unsubscribe API for broadcast subscriptions.

* **Bug Fixes**
  * Added unsubscribe/cleanup to prevent duplicate broadcast subscriptions and stray handlers.
  * Improved handling of socket/auth interruptions to reduce reconnection stalls.
  * Removed a redundant cross-tab broadcast call in one component.

* **Refactor**
  * Unified reconnection flow to use a single reconnect action across UI flows.

* **Chores**
  * Updated copyright year to 2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->