### PR TITLE
Add maxZoom parameter to zoomToFitSelectedNodes in Diagrams component

### DIFF
--- a/frontend/src/components/visual-editor/v2/Diagrams.tsx
+++ b/frontend/src/components/visual-editor/v2/Diagrams.tsx
@@ -865,7 +865,10 @@ const Diagrams = () => {
                     <Button
                       sx={{ p: "6px 2px 8px 2px" }}
                       onClick={() => {
-                        engine?.zoomToFitSelectedNodes({ margin: 0 });
+                        engine?.zoomToFitSelectedNodes({
+                          maxZoom: 1,
+                          margin: 0,
+                        });
                       }}
                     >
                       <FitScreenIcon />


### PR DESCRIPTION
Add a maxZoom parameter to the zoomToFitSelectedNodes function, enhancing control over the zoom level in the Diagrams component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Fit to selection” behavior in the visual editor. The view now respects a maximum zoom level when fitting to selected nodes, preventing overly zoomed-in results on small selections. This delivers more consistent framing, better visibility, and smoother navigation while preserving existing margins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->