### PR TITLE
feat: add JS docs and unit tests for nlpValue.findWithCount

### DIFF
--- a/api/src/nlp/controllers/nlp-value.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.spec.ts
@@ -8,6 +8,7 @@
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 
+import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { getUpdateOneError } from '@/utils/test/errors/messages';
 import {
   installNlpValueFixtures,
@@ -18,6 +19,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { Format } from '@/utils/types/format.types';
 
 import { NlpValueCreateDto } from '../dto/nlp-value.dto';
 import { NlpValue } from '../schemas/nlp-value.schema';
@@ -189,6 +191,26 @@ describe('NlpValueController', () => {
       await expect(
         nlpValueController.deleteMany(nonExistentIds),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+  describe('findWithCount', () => {
+    it('should call service with correct format based on populate', async () => {
+      jest.spyOn(nlpValueService, 'findWithCount');
+
+      const filters = {};
+      const pageQuery: PageQueryDto<NlpValue> = {
+        limit: 10,
+        skip: 0,
+        sort: ['value', 'asc'],
+      };
+
+      await nlpValueController.findWithCount(pageQuery, ['entity'], filters);
+
+      expect(nlpValueService.findWithCount).toHaveBeenCalledWith(
+        Format.FULL,
+        pageQuery,
+        filters,
+      );
     });
   });
 });

--- a/api/src/nlp/controllers/nlp-value.controller.spec.ts
+++ b/api/src/nlp/controllers/nlp-value.controller.spec.ts
@@ -19,6 +19,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { TFilterQuery } from '@/utils/types/filter.types';
 import { Format } from '@/utils/types/format.types';
 
 import { NlpValueCreateDto } from '../dto/nlp-value.dto';
@@ -197,7 +198,7 @@ describe('NlpValueController', () => {
     it('should call service with correct format based on populate', async () => {
       jest.spyOn(nlpValueService, 'findWithCount');
 
-      const filters = {};
+      const filters: TFilterQuery<NlpValue> = {};
       const pageQuery: PageQueryDto<NlpValue> = {
         limit: 10,
         skip: 0,

--- a/api/src/nlp/repositories/nlp-value.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '@/utils/test/test';
 import { TFixtures } from '@/utils/test/types';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { TFilterQuery } from '@/utils/types/filter.types';
 import { Format } from '@/utils/types/format.types';
 
 import { NlpValue, NlpValueFull } from '../schemas/nlp-value.schema';
@@ -242,7 +243,7 @@ describe('NlpValueRepository', () => {
         sort: ['value', 'asc'],
       };
 
-      const filters = {};
+      const filters: TFilterQuery<NlpValue> = {};
 
       const results = await nlpValueService.findWithCount(
         Format.STUB,

--- a/api/src/nlp/repositories/nlp-value.repository.spec.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.spec.ts
@@ -9,6 +9,7 @@
 import LlmNluHelper from '@/extensions/helpers/llm-nlu/index.helper';
 import { HelperService } from '@/helper/helper.service';
 import { SettingService } from '@/setting/services/setting.service';
+import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
 import { installNlpSampleEntityFixtures } from '@/utils/test/fixtures/nlpsampleentity';
@@ -20,6 +21,7 @@ import {
 } from '@/utils/test/test';
 import { TFixtures } from '@/utils/test/types';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { Format } from '@/utils/types/format.types';
 
 import { NlpValue, NlpValueFull } from '../schemas/nlp-value.schema';
 import { NlpValueService } from '../services/nlp-value.service';
@@ -230,6 +232,34 @@ describe('NlpValueRepository', () => {
       const result = await nlpValueRepository.findOne(updatedNlpValue.id);
 
       expect(result).toEqualPayload(updatedNlpValue);
+    });
+  });
+  describe('findWithCount', () => {
+    it('should return NLP values with counts of training samples', async () => {
+      const pageQuery: PageQueryDto<NlpValue> = {
+        limit: 10,
+        skip: 0,
+        sort: ['value', 'asc'],
+      };
+
+      const filters = {};
+
+      const results = await nlpValueService.findWithCount(
+        Format.STUB,
+        pageQuery,
+        filters,
+      );
+
+      expect(results.length).toBeGreaterThan(0);
+
+      results.forEach((r) => {
+        expect(r).toHaveProperty('nlpSamplesCount');
+        expect(typeof r.nlpSamplesCount).toBe('number');
+      });
+
+      // Check a specific value count
+      const positive = results.find((r) => r.value === 'positive');
+      expect(positive!.nlpSamplesCount).toBeGreaterThan(0);
     });
   });
 });

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -188,7 +188,7 @@ export class NlpValueRepository extends BaseRepository<
    * @param format - Specifies whether the result should be in FULL or STUB format.
    * @param pageQuery - Pagination parameters (limit, skip, sort).
    * @param filterQuery - Filtering criteria for NLP values and entities.
-   * @returns A list of NLP value results with their training sample counts,
+   * @returns A promise that resolves to a list of NLP value results with their training sample counts,
    *          typed according to the requested format.
    * @throws Logs and rethrows any errors that occur during aggregation or transformation.
    */

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -48,6 +48,16 @@ export class NlpValueRepository extends BaseRepository<
 
   /**
    * Performs an aggregation to retrieve NLP values with their sample counts.
+   * * The aggregation:
+   * - Applies filter criteria on NLP values.
+   * - Optionally applies `$and` conditions, including entity-based filters.
+   * - Joins with the `nlpsampleentities` collection to link values to samples.
+   * - Joins with the `nlpsamples` collection and restricts results to samples
+   *   where `type = "train"`.
+   * - Counts the number of associated training samples per NLP value.
+   * - Optionally enriches the result with the linked `entity` document if
+   *   the format is set to FULL.
+   * - Applies pagination (skip, limit) and sorting.
    *
    * @param format - The format can be full or stub
    * @param pageQuery - The pagination parameters
@@ -100,6 +110,25 @@ export class NlpValueRepository extends BaseRepository<
         },
       },
       {
+        $lookup: {
+          from: 'nlpsamples',
+          localField: '_sampleEntities.sample',
+          foreignField: '_id',
+          as: '_samples',
+        },
+      },
+      {
+        $unwind: {
+          path: '$_samples',
+          preserveNullAndEmptyArrays: true,
+        },
+      },
+      {
+        $match: {
+          '_samples.type': 'train',
+        },
+      },
+      {
         $group: {
           _id: '$_id',
           _originalDoc: {
@@ -146,6 +175,17 @@ export class NlpValueRepository extends BaseRepository<
     return await this.model.aggregate<TNlpValueCount<F>>(pipeline).exec();
   }
 
+  /**
+   * Retrieves NLP values along with their sample counts, applying pagination,
+   * filtering, and formatting.
+   *
+   * @param format - Specifies whether the result should be in FULL or STUB format.
+   * @param pageQuery - Pagination parameters (limit, skip, sort).
+   * @param filterQuery - Filtering criteria for NLP values and entities.
+   * @returns A list of NLP value results with their training sample counts,
+   *          typed according to the requested format.
+   * @throws Logs and rethrows any errors that occur during aggregation or transformation.
+   */
   async findWithCount<F extends Format>(
     format: F,
     pageQuery: PageQueryDto<NlpValue>,
@@ -168,7 +208,7 @@ export class NlpValueRepository extends BaseRepository<
         excludePrefixes: ['_'],
       }) as TNlpValueCount<F>[];
     } catch (error) {
-      this.logger.error(`Error in findWithCount: ${error.message}`, error);
+      this.logger.error(`Error in : ${error.message}`, error);
       throw error;
     }
   }

--- a/api/src/nlp/repositories/nlp-value.repository.ts
+++ b/api/src/nlp/repositories/nlp-value.repository.ts
@@ -90,12 +90,6 @@ export class NlpValueRepository extends BaseRepository<
         },
       },
       {
-        $skip: skip,
-      },
-      {
-        $limit: limit,
-      },
-      {
         $lookup: {
           from: 'nlpsampleentities',
           localField: '_id',
@@ -124,11 +118,6 @@ export class NlpValueRepository extends BaseRepository<
         },
       },
       {
-        $match: {
-          '_samples.type': 'train',
-        },
-      },
-      {
         $group: {
           _id: '$_id',
           _originalDoc: {
@@ -137,7 +126,18 @@ export class NlpValueRepository extends BaseRepository<
             },
           },
           nlpSamplesCount: {
-            $sum: { $cond: [{ $ifNull: ['$_sampleEntities', false] }, 1, 0] },
+            $sum: {
+              $cond: [
+                {
+                  $and: [
+                    { $ifNull: ['$_sampleEntities', false] },
+                    { $eq: ['$_samples.type', 'train'] },
+                  ],
+                },
+                1,
+                0,
+              ],
+            },
           },
         },
       },
@@ -169,6 +169,12 @@ export class NlpValueRepository extends BaseRepository<
           [sort[0]]: this.getSortDirection(sort[1]),
           _id: this.getSortDirection(sort[1]),
         },
+      },
+      {
+        $skip: skip,
+      },
+      {
+        $limit: limit,
       },
     ];
 

--- a/api/src/nlp/services/nlp-value.service.spec.ts
+++ b/api/src/nlp/services/nlp-value.service.spec.ts
@@ -7,17 +7,17 @@
  */
 
 import { BaseSchema } from '@/utils/generics/base-schema';
+import { PageQueryDto } from '@/utils/pagination/pagination-query.dto';
 import { nlpEntityFixtures } from '@/utils/test/fixtures/nlpentity';
-import {
-  installNlpValueFixtures,
-  nlpValueFixtures,
-} from '@/utils/test/fixtures/nlpvalue';
+import { installNlpSampleEntityFixtures } from '@/utils/test/fixtures/nlpsampleentity';
+import { nlpValueFixtures } from '@/utils/test/fixtures/nlpvalue';
 import { getPageQuery } from '@/utils/test/pagination';
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { Format } from '@/utils/types/format.types';
 
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
 import { NlpValueRepository } from '../repositories/nlp-value.repository';
@@ -37,7 +37,7 @@ describe('NlpValueService', () => {
   beforeAll(async () => {
     const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['providers'],
-      imports: [rootMongooseTestModule(installNlpValueFixtures)],
+      imports: [rootMongooseTestModule(installNlpSampleEntityFixtures)],
       providers: [NlpValueService, NlpEntityService],
     });
     [
@@ -195,6 +195,33 @@ describe('NlpValueService', () => {
       await expect(
         nlpValueService.storeValues(sampleText, sampleEntities),
       ).rejects.toThrow('Unable to find the stored entity unknownEntity');
+    });
+  });
+  describe('findWithCount', () => {
+    it('should return NLP values with counts from repository', async () => {
+      jest.spyOn(nlpValueRepository, 'findWithCount');
+
+      const pageQuery: PageQueryDto<NlpValue> = {
+        limit: 10,
+        skip: 0,
+        sort: ['value', 'asc'],
+      };
+
+      const filters = {};
+
+      const results = await nlpValueService.findWithCount(
+        Format.STUB,
+        pageQuery,
+        filters,
+      );
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]).toHaveProperty('nlpSamplesCount');
+      expect(nlpValueRepository.findWithCount).toHaveBeenLastCalledWith(
+        Format.STUB,
+        pageQuery,
+        filters,
+      );
     });
   });
 });

--- a/api/src/nlp/services/nlp-value.service.spec.ts
+++ b/api/src/nlp/services/nlp-value.service.spec.ts
@@ -17,6 +17,7 @@ import {
   rootMongooseTestModule,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { TFilterQuery } from '@/utils/types/filter.types';
 import { Format } from '@/utils/types/format.types';
 
 import { NlpEntityRepository } from '../repositories/nlp-entity.repository';
@@ -207,7 +208,7 @@ describe('NlpValueService', () => {
         sort: ['value', 'asc'],
       };
 
-      const filters = {};
+      const filters: TFilterQuery<NlpValue> = {};
 
       const results = await nlpValueService.findWithCount(
         Format.STUB,

--- a/api/src/nlp/services/nlp-value.service.ts
+++ b/api/src/nlp/services/nlp-value.service.ts
@@ -244,7 +244,7 @@ export class NlpValueService extends BaseService<
    * @param format - Desired result format: FULL or STUB.
    * @param pageQuery - Pagination parameters (limit, skip, sort).
    * @param filters - Filtering criteria for NLP values.
-   * @returns A list of NLP values with their training sample counts,
+   * @returns A promise that resolves to a list of NLP values with their training sample counts,
    *          typed according to the requested format.
    */
   async findWithCount<F extends Format>(

--- a/api/src/nlp/services/nlp-value.service.ts
+++ b/api/src/nlp/services/nlp-value.service.ts
@@ -238,6 +238,15 @@ export class NlpValueService extends BaseService<
     return Promise.all(promises);
   }
 
+  /**
+   * Retrieves NLP values with their training sample counts from the repository,
+   * applying pagination, filters, and formatting.
+   * @param format - Desired result format: FULL or STUB.
+   * @param pageQuery - Pagination parameters (limit, skip, sort).
+   * @param filters - Filtering criteria for NLP values.
+   * @returns A list of NLP values with their training sample counts,
+   *          typed according to the requested format.
+   */
   async findWithCount<F extends Format>(
     format: F,
     pageQuery: PageQueryDto<NlpValue>,


### PR DESCRIPTION
# Motivation
This PR has the following functions:
- Added JSDoc comments to the repository and service layers for findWithCount
- Implemented repository-layer integration/unit tests using temporary test DB
- Ensures aggregation pipeline returns NLP values with training sample counts
- Tested both STUB and FULL formats

Fixes # ([1353](https://github.com/Hexastack/Hexabot/issues/1353))

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added filtering when retrieving NLP values alongside their sample counts, while preserving pagination and sorting.

- Bug Fixes
  - Fixed sample counting to include only training samples, improving count accuracy.

- Chores
  - Expanded automated tests to cover filtering, population behavior, and sample-count accuracy.

- Documentation
  - Clarified method behavior and usage in updated docblocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->