### PR TITLE
feat: add sanitize query pipe unit tests

### DIFF
--- a/api/src/utils/pipes/sanitize-query.pipe.spec.ts
+++ b/api/src/utils/pipes/sanitize-query.pipe.spec.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2025 Hexastack. All rights reserved.
+ *
+ * Licensed under the GNU Affero General Public License v3.0 (AGPLv3) with the following additional terms:
+ * 1. The name "Hexabot" is a trademark of Hexastack. You may not use this name in derivative works without express written permission.
+ * 2. All derivative works must include clear attribution to the original creator and software, Hexastack and Hexabot, in a prominent location (e.g., in the software's "About" section, documentation, and README file).
+ */
+
+import { SanitizeQueryPipe } from './sanitize-query.pipe';
+
+describe('SanitizeQueryPipe', () => {
+  let pipe: SanitizeQueryPipe;
+
+  beforeEach(() => {
+    pipe = new SanitizeQueryPipe(20); // max length 20 for testing
+  });
+
+  it('should return empty string for non-string input', () => {
+    expect(SanitizeQueryPipe.sanitize(123 as any)).toBe('');
+    expect(SanitizeQueryPipe.sanitize(null)).toBe('');
+    expect(SanitizeQueryPipe.sanitize(undefined)).toBe('');
+  });
+
+  it('should trim whitespace', () => {
+    expect(SanitizeQueryPipe.sanitize('  hello  ')).toBe('hello');
+  });
+
+  it('should remove control characters and DEL', () => {
+    const input = 'hello\u0000\u001F\u007Fworld';
+    expect(SanitizeQueryPipe.sanitize(input)).toBe('helloworld');
+  });
+
+  it('should remove dangerous MongoDB/shell characters', () => {
+    const input = 'price$ = {100}; \\ /';
+    expect(SanitizeQueryPipe.sanitize(input)).toBe('price  =  100');
+  });
+
+  it('should remove quotes', () => {
+    const input = `"hello" 'world'`;
+    expect(SanitizeQueryPipe.sanitize(input)).toBe('hello   world');
+  });
+
+  it('should remove regex/meta characters', () => {
+    const input = '^*?+()[]|';
+    expect(SanitizeQueryPipe.sanitize(input)).toBe('');
+  });
+
+  it('should enforce maxLength', () => {
+    const input = 'new-mongo-query-performed'; // 21 chars
+    expect(SanitizeQueryPipe.sanitize(input, 10)).toBe('new-mongo-');
+  });
+
+  it('should combine all sanitizations', () => {
+    const input = `  $hello^world* 'test' {abc} \\ `;
+    const sanitized = SanitizeQueryPipe.sanitize(input);
+    expect(sanitized).toBe('hello world   test   abc');
+  });
+
+  describe('transform (instance method)', () => {
+    it('should call sanitize with the instance maxLength', () => {
+      const input = 'new-mongo-query-performed'; // 21 chars
+      expect(pipe.transform(input, {} as any)).toBe(
+        'new-mongo-query-performed'.slice(0, 20),
+      );
+    });
+
+    it('should handle non-string input', () => {
+      expect(pipe.transform(42, {} as any)).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

This PR adds comprehensive unit tests for the `SanitizeQueryPipe` class, which previously had no test coverage. The tests ensure that query sanitization logic behaves correctly across various input scenarios, including edge cases and invalid inputs.

Fixes # [1363](https://github.com/Hexastack/Hexabot/issues/1363)

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive unit tests for query sanitization, covering whitespace trimming, control/DEL character removal, filtering of potentially dangerous characters (e.g., quotes, regex/meta, MongoDB/shell-related), and enforcement of maximum length.
  - Includes combined scenarios to validate sequential sanitization behavior.
  - Verifies instance-based transformation respects configured limits and safely handles non-string inputs.
  - Improves confidence in input handling and robustness without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->