### PR TITLE
Prevent loading state from blocking search results

### DIFF
--- a/frontend/src/components/visual-editor/BlockSearchPanel.tsx
+++ b/frontend/src/components/visual-editor/BlockSearchPanel.tsx
@@ -236,7 +236,7 @@ export const BlockSearchPanel: React.FC<BlockSearchPanelProps> = ({
           <NoDataOverlay i18nKey="message.no_matching_results" />
         ) : null}
 
-        {blockSearchResults.length > 0 && searchText ? (
+        {!isLoadingResults && blockSearchResults.length > 0 && searchText ? (
           <>
             <ResultCount>
               <Typography variant="caption">


### PR DESCRIPTION
Ensure that the loading state does not prevent the display of search results and enhance the layout of the skeleton during loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Block Search Panel: Results no longer appear while a search is still loading. The panel now consistently shows a loading skeleton during fetches and only renders results after loading completes, preventing flicker and stale/partial results. This improves visual consistency, reduces confusion during rapid searches, and provides a smoother, more predictable experience when refining queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->