### PR TITLE
fix(frontend): remove unsued instruction from categories

### DIFF
--- a/frontend/src/components/categories/index.tsx
+++ b/frontend/src/components/categories/index.tsx
@@ -58,7 +58,6 @@ export const Categories = () => {
       toast.error(error);
     },
     onSuccess: () => {
-      setSelectedCategories([]);
       toast.success(t("message.item_delete_success"));
     },
   };


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to remove unused instruction from categories.

Fixes #1381