### PR TITLE
fix(frontend): modernize datagrid design

### DIFF
--- a/frontend/src/app-components/tables/DataGrid.tsx
+++ b/frontend/src/app-components/tables/DataGrid.tsx
@@ -16,6 +16,8 @@ import {
   DataGrid as MuiDataGrid,
 } from "@mui/x-data-grid";
 
+import { borderLine } from "@/layout/themes/theme";
+
 import { renderHeader } from "./columns/renderHeader";
 import { styledPaginationSlots } from "./DataGridStyledPagination";
 import { ErrorOverlay } from "./ErrorOverlay";
@@ -43,6 +45,8 @@ export const StyledDataGrid = <T extends GridValidRowModel = any>(
           },
         },
         minHeight: 400,
+        backgroundColor: theme.palette.background.paper,
+        border: borderLine,
         ...sx,
       }}
     />
@@ -57,7 +61,7 @@ export const DataGrid = <T extends GridValidRowModel = any>({
   slots,
   showCellVerticalBorder = false,
   showColumnVerticalBorder = false,
-  sx = { border: "none" },
+  sx = {},
   error,
   ...rest
 }: DataGridProps<T> & { error?: boolean }) => {

--- a/frontend/src/components/categories/index.tsx
+++ b/frontend/src/components/categories/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import FolderIcon from "@mui/icons-material/Folder";
-import { Grid, Paper } from "@mui/material";
+import { Grid } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useState } from "react";
 
@@ -175,17 +175,13 @@ export const Categories = () => {
           </Grid>
         </PageHeader>
       </Grid>
-      <Grid item xs={12}>
-        <Paper sx={{ padding: 2 }}>
-          <Grid>
-            <DataGrid
-              columns={columns}
-              {...dataGridProps}
-              checkboxSelection
-              onRowSelectionModelChange={handleSelectionChange}
-            />
-          </Grid>
-        </Paper>
+      <Grid xs={12}>
+        <DataGrid
+          columns={columns}
+          {...dataGridProps}
+          checkboxSelection
+          onRowSelectionModelChange={handleSelectionChange}
+        />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/content-types/index.tsx
+++ b/frontend/src/components/content-types/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { faAlignLeft } from "@fortawesome/free-solid-svg-icons";
-import { Grid, Paper } from "@mui/material";
+import { Grid } from "@mui/material";
 import { useRouter } from "next/router";
 
 import { ButtonActionsGroup } from "@/app-components/buttons/ButtonActionsGroup";
@@ -117,44 +117,38 @@ export const ContentTypes = () => {
           />
         </Grid>
       </PageHeader>
-      <Grid item xs={12}>
-        <Paper>
-          <Grid padding={2} container>
-            <Grid item width="100%">
-              <DataGrid
-                {...dataGridProps}
-                disableColumnFilter
-                columns={[
-                  { flex: 1, field: "name", headerName: t("label.name") },
-                  {
-                    maxWidth: 140,
-                    field: "createdAt",
-                    headerName: t("label.createdAt"),
-                    disableColumnMenu: true,
-                    renderHeader,
-                    resizable: false,
-                    headerAlign: "left",
-                    valueGetter: (params) =>
-                      t("datetime.created_at", getDateTimeFormatter(params)),
-                  },
-                  {
-                    maxWidth: 140,
-                    field: "updatedAt",
-                    headerName: t("label.updatedAt"),
-                    disableColumnMenu: true,
-                    renderHeader,
-                    resizable: false,
-                    headerAlign: "left",
-                    valueGetter: (params) =>
-                      t("datetime.updated_at", getDateTimeFormatter(params)),
-                  },
+      <Grid xs={12}>
+        <DataGrid
+          {...dataGridProps}
+          disableColumnFilter
+          columns={[
+            { flex: 1, field: "name", headerName: t("label.name") },
+            {
+              maxWidth: 140,
+              field: "createdAt",
+              headerName: t("label.createdAt"),
+              disableColumnMenu: true,
+              renderHeader,
+              resizable: false,
+              headerAlign: "left",
+              valueGetter: (params) =>
+                t("datetime.created_at", getDateTimeFormatter(params)),
+            },
+            {
+              maxWidth: 140,
+              field: "updatedAt",
+              headerName: t("label.updatedAt"),
+              disableColumnMenu: true,
+              renderHeader,
+              resizable: false,
+              headerAlign: "left",
+              valueGetter: (params) =>
+                t("datetime.updated_at", getDateTimeFormatter(params)),
+            },
 
-                  actionColumns,
-                ]}
-              />
-            </Grid>
-          </Grid>
-        </Paper>
+            actionColumns,
+          ]}
+        />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/contents/index.tsx
+++ b/frontend/src/components/contents/index.tsx
@@ -8,7 +8,7 @@
 
 import { faAlignLeft } from "@fortawesome/free-solid-svg-icons";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import { Button, Chip, Grid, Paper, Switch, Typography } from "@mui/material";
+import { Button, Chip, Grid, Switch, Typography } from "@mui/material";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useQueryClient } from "react-query";
@@ -180,85 +180,75 @@ export const Contents = () => {
           </Grid>
         </PageHeader>
       </Grid>
-      <Grid item>
-        <Paper>
-          <Grid padding={2} container>
-            <Grid item width="100%">
-              <DataGrid<IContent>
-                {...dataGridProps}
-                disableColumnFilter
-                showCellVerticalBorder={false}
-                showColumnVerticalBorder={false}
-                sx={{ border: "none" }}
-                columns={[
-                  { field: "title", headerName: t("label.title"), flex: 1 },
-                  {
-                    field: "entity",
-                    headerName: t("label.entity"),
-                    flex: 1,
-                    valueGetter: (entityId) => {
-                      const contentType = getEntityFromCache(entityId);
+      <Grid xs={12}>
+        <DataGrid<IContent>
+          {...dataGridProps}
+          disableColumnFilter
+          showCellVerticalBorder={false}
+          showColumnVerticalBorder={false}
+          columns={[
+            { field: "title", headerName: t("label.title"), flex: 1 },
+            {
+              field: "entity",
+              headerName: t("label.entity"),
+              flex: 1,
+              valueGetter: (entityId) => {
+                const contentType = getEntityFromCache(entityId);
 
-                      return contentType?.name;
-                    },
-                  },
-                  {
-                    maxWidth: 120,
-                    field: "status",
-                    headerName: t("label.status"),
-                    disableColumnMenu: true,
-                    renderHeader,
-                    headerAlign: "left",
-                    renderCell: (params) => (
-                      <Switch
-                        checked={params.value}
-                        color="primary"
-                        inputProps={{ "aria-label": "primary checkbox" }}
-                        disabled={
-                          !hasPermission(
-                            EntityType.CONTENT,
-                            PermissionAction.UPDATE,
-                          )
-                        }
-                        onChange={() => {
-                          updateContent({
-                            id: params.row.id,
-                            params: {
-                              status: !params.row.status,
-                            },
-                          });
-                        }}
-                      />
-                    ),
-                  },
-                  {
-                    maxWidth: 140,
-                    field: "createdAt",
-                    headerName: t("label.createdAt"),
-                    disableColumnMenu: true,
-                    renderHeader,
-                    resizable: false,
-                    headerAlign: "left",
-                    valueGetter: (params) =>
-                      t("datetime.created_at", getDateTimeFormatter(params)),
-                  },
-                  {
-                    maxWidth: 140,
-                    field: "updatedAt",
-                    headerName: t("label.updatedAt"),
-                    disableColumnMenu: true,
-                    renderHeader,
-                    resizable: false,
-                    headerAlign: "left",
-                    valueGetter: (params) =>
-                      t("datetime.updated_at", getDateTimeFormatter(params)),
-                  },
-                  actionColumns,
-                ]}
-              />
-            </Grid>
-          </Grid>
-        </Paper>
+                return contentType?.name;
+              },
+            },
+            {
+              maxWidth: 120,
+              field: "status",
+              headerName: t("label.status"),
+              disableColumnMenu: true,
+              renderHeader,
+              headerAlign: "left",
+              renderCell: (params) => (
+                <Switch
+                  checked={params.value}
+                  color="primary"
+                  inputProps={{ "aria-label": "primary checkbox" }}
+                  disabled={
+                    !hasPermission(EntityType.CONTENT, PermissionAction.UPDATE)
+                  }
+                  onChange={() => {
+                    updateContent({
+                      id: params.row.id,
+                      params: {
+                        status: !params.row.status,
+                      },
+                    });
+                  }}
+                />
+              ),
+            },
+            {
+              maxWidth: 140,
+              field: "createdAt",
+              headerName: t("label.createdAt"),
+              disableColumnMenu: true,
+              renderHeader,
+              resizable: false,
+              headerAlign: "left",
+              valueGetter: (params) =>
+                t("datetime.created_at", getDateTimeFormatter(params)),
+            },
+            {
+              maxWidth: 140,
+              field: "updatedAt",
+              headerName: t("label.updatedAt"),
+              disableColumnMenu: true,
+              renderHeader,
+              resizable: false,
+              headerAlign: "left",
+              valueGetter: (params) =>
+                t("datetime.updated_at", getDateTimeFormatter(params)),
+            },
+            actionColumns,
+          ]}
+        />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/context-vars/index.tsx
+++ b/frontend/src/components/context-vars/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { faAsterisk } from "@fortawesome/free-solid-svg-icons";
-import { Grid, Paper, Switch } from "@mui/material";
+import { Grid, Switch } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useState } from "react";
 
@@ -207,17 +207,13 @@ export const ContextVars = () => {
           />
         </Grid>
       </PageHeader>
-      <Grid item xs={12}>
-        <Paper sx={{ padding: 2 }}>
-          <Grid>
-            <DataGrid
-              columns={columns}
-              {...dataGridProps}
-              checkboxSelection
-              onRowSelectionModelChange={handleSelectionChange}
-            />
-          </Grid>
-        </Paper>
+      <Grid xs={12}>
+        <DataGrid
+          columns={columns}
+          {...dataGridProps}
+          checkboxSelection
+          onRowSelectionModelChange={handleSelectionChange}
+        />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/labels/index.tsx
+++ b/frontend/src/components/labels/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import { faTags } from "@fortawesome/free-solid-svg-icons";
-import { Grid, Paper } from "@mui/material";
+import { Grid } from "@mui/material";
 import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { useState } from "react";
 
@@ -216,17 +216,13 @@ export const Labels = () => {
           />
         </Grid>
       </PageHeader>
-      <Grid item xs={12}>
-        <Paper sx={{ padding: 2 }}>
-          <Grid>
-            <DataGrid
-              columns={columns}
-              {...dataGridProps}
-              checkboxSelection
-              onRowSelectionModelChange={handleSelectionChange}
-            />
-          </Grid>
-        </Paper>
+      <Grid xs={12}>
+        <DataGrid
+          columns={columns}
+          {...dataGridProps}
+          checkboxSelection
+          onRowSelectionModelChange={handleSelectionChange}
+        />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/languages/index.tsx
+++ b/frontend/src/components/languages/index.tsx
@@ -8,7 +8,7 @@
 
 import { Flag } from "@mui/icons-material";
 import AddIcon from "@mui/icons-material/Add";
-import { Button, Grid, Paper, Switch } from "@mui/material";
+import { Button, Grid, Switch } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 import { useQueryClient } from "react-query";
 
@@ -216,12 +216,8 @@ export const Languages = () => {
           ) : null}
         </Grid>
       </PageHeader>
-      <Grid item xs={12}>
-        <Paper sx={{ padding: 2 }}>
-          <Grid>
-            <DataGrid columns={columns} {...dataGridProps} />
-          </Grid>
-        </Paper>
+      <Grid xs={12}>
+        <DataGrid columns={columns} {...dataGridProps} />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/roles/index.tsx
+++ b/frontend/src/components/roles/index.tsx
@@ -8,7 +8,7 @@
 
 import { faUniversalAccess } from "@fortawesome/free-solid-svg-icons";
 import AddIcon from "@mui/icons-material/Add";
-import { Button, Grid, Paper } from "@mui/material";
+import { Button, Grid } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
@@ -161,10 +161,8 @@ export const Roles = () => {
           ) : null}
         </Grid>
       </PageHeader>
-      <Grid item xs={12}>
-        <Paper sx={{ padding: 2 }}>
-          <DataGrid columns={columns} {...dataGridProps} />
-        </Paper>
+      <Grid xs={12}>
+        <DataGrid columns={columns} {...dataGridProps} />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/subscribers/index.tsx
+++ b/frontend/src/components/subscribers/index.tsx
@@ -8,7 +8,7 @@
 
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import DeleteIcon from "@mui/icons-material/Close";
-import { Grid, IconButton, MenuItem, Paper } from "@mui/material";
+import { Grid, IconButton, MenuItem } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 import { useState } from "react";
 
@@ -222,12 +222,8 @@ export const Subscribers = () => {
           </Input>
         </Grid>
       </PageHeader>
-      <Grid item xs={12}>
-        <Paper sx={{ padding: 2 }}>
-          <Grid>
-            <DataGrid columns={columns} {...dataGridProps} />
-          </Grid>
-        </Paper>
+      <Grid xs={12}>
+        <DataGrid columns={columns} {...dataGridProps} />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/translations/index.tsx
+++ b/frontend/src/components/translations/index.tsx
@@ -8,7 +8,7 @@
 
 import { faLanguage } from "@fortawesome/free-solid-svg-icons";
 import AutorenewIcon from "@mui/icons-material/Autorenew";
-import { Button, Chip, Grid, Paper, Stack } from "@mui/material";
+import { Button, Chip, Grid, Stack } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
@@ -172,14 +172,8 @@ export const Translations = () => {
           ) : null}
         </Grid>
       </PageHeader>
-      <Grid item xs={12}>
-        <Paper>
-          <Grid padding={2} container>
-            <Grid item width="100%">
-              <DataGrid {...dataGridProps} columns={columns} />
-            </Grid>
-          </Grid>
-        </Paper>
+      <Grid xs={12}>
+        <DataGrid {...dataGridProps} columns={columns} />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/users/index.tsx
+++ b/frontend/src/components/users/index.tsx
@@ -8,7 +8,7 @@
 
 import { faUsers } from "@fortawesome/free-solid-svg-icons";
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
-import { Button, Grid, Paper, Switch } from "@mui/material";
+import { Button, Grid, Switch } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 
 import { ChipEntity } from "@/app-components/displays/ChipEntity";
@@ -222,12 +222,8 @@ export const Users = () => {
           ) : null}
         </Grid>
       </PageHeader>
-      <Grid item xs={12}>
-        <Paper sx={{ padding: 3 }}>
-          <Grid>
-            <DataGrid columns={columns} {...dataGridProps} />
-          </Grid>
-        </Paper>
+      <Grid xs={12}>
+        <DataGrid columns={columns} {...dataGridProps} />
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
# Motivation
The main motivations of this PR are :
- To modernize the datagrid design
- To remove unnecessary code

Fixes #1380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Data grids now display a visible border and a paper-like background by default, creating a clearer, more consistent look across pages (Categories, Content Types, Contents, Context Vars, Labels, Languages, Roles, Subscribers, Translations, Users). Border styling remains customizable.
- Refactor
  - Simplified layouts by removing extra card-like wrappers and nested grids around data tables, reducing padding and visual noise. Core table behaviors (columns, selection, actions) remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->