### PR TITLE
fix(frontend): add wordBreak to the visual editor long name

### DIFF
--- a/frontend/src/components/visual-editor/Aside.tsx
+++ b/frontend/src/components/visual-editor/Aside.tsx
@@ -60,6 +60,7 @@ const StyledGrid = styled(Grid)<{ disabled: boolean }>(({ disabled }) =>
   SXStyleOptions({
     opacity: disabled ? "0.5" : "0.9",
     borderRadius: 1,
+    wordBreak: "break-word",
   }),
 );
 


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to add wordBreak to the visual editor long name

Fixes #477 