### PR TITLE
fix(frontend): resolve unrecognized isSingleton prop

### DIFF
--- a/frontend/src/contexts/dialogs.context.tsx
+++ b/frontend/src/contexts/dialogs.context.tsx
@@ -57,7 +57,7 @@ function DialogsProvider(props: DialogProviderProps) {
       payload: P,
       options: OpenDialogOptions<R> = {},
     ) {
-      const { onClose = async () => {}, ...rest } = options;
+      const { onClose = async () => {}, isSingleton, ...rest } = options;
       let resolve: ((result: R) => void) | undefined;
       const promise = new Promise<R>((resolveImpl) => {
         resolve = resolveImpl;
@@ -82,7 +82,7 @@ function DialogsProvider(props: DialogProviderProps) {
         msgProps: rest,
       };
 
-      if (selectComponent !== Component || !rest.isSingleton) {
+      if (selectComponent !== Component || !isSingleton) {
         selectComponent = Component;
         setStack((prevStack) => [...prevStack, newEntry]);
       }


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to resolve unrecognized isSingleton prop.

Fixes #742

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents duplicate dialogs when a dialog is marked as single-instance; reopening now reuses the existing dialog instead of adding a new one.
  - Improves dialog stack handling for more consistent behavior when toggling or re-invoking the same dialog.
- **Stability**
  - No changes to how dialogs close or resolve; existing behavior remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->