### PR TITLE
Created solution Filter Inferred Intent Confidence Scores

### DIFF
--- a/api/src/nlp/controllers/nlp-sample.controller.ts
+++ b/api/src/nlp/controllers/nlp-sample.controller.ts
@@ -9,22 +9,22 @@
 import { Readable } from 'stream';
 
 import {
-  BadRequestException,
-  Body,
-  Controller,
-  Delete,
-  Get,
-  HttpCode,
-  InternalServerErrorException,
-  NotFoundException,
-  Param,
-  Patch,
-  Post,
-  Query,
-  Res,
-  StreamableFile,
-  UploadedFile,
-  UseInterceptors,
+    BadRequestException,
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    InternalServerErrorException,
+    NotFoundException,
+    Param,
+    Patch,
+    Post,
+    Query,
+    Res,
+    StreamableFile,
+    UploadedFile,
+    UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { CsrfCheck } from '@tekuconcept/nestjs-csrf';
@@ -32,8 +32,8 @@ import { Response } from 'express';
 import { z } from 'zod';
 
 import {
-  NlpValueMatchPattern,
-  nlpValueMatchPatternSchema,
+    NlpValueMatchPattern,
+    nlpValueMatchPatternSchema,
 } from '@/chat/schemas/types/pattern';
 import { HelperService } from '@/helper/helper.service';
 import { HelperType } from '@/helper/types';
@@ -50,15 +50,16 @@ import { TFilterQuery } from '@/utils/types/filter.types';
 
 import { NlpSampleDto, TNlpSampleDto } from '../dto/nlp-sample.dto';
 import {
-  NlpSample,
-  NlpSampleFull,
-  NlpSamplePopulate,
-  NlpSampleStub,
+    NlpSample,
+    NlpSampleFull,
+    NlpSamplePopulate,
+    NlpSampleStub,
 } from '../schemas/nlp-sample.schema';
 import { NlpSampleState } from '../schemas/types';
 import { NlpEntityService } from '../services/nlp-entity.service';
 import { NlpSampleEntityService } from '../services/nlp-sample-entity.service';
 import { NlpSampleService } from '../services/nlp-sample.service';
+import { NlpValueService } from '../services/nlp-value.service';
 
 @UseInterceptors(CsrfInterceptor)
 @Controller('nlpsample')
@@ -73,6 +74,7 @@ export class NlpSampleController extends BaseController<
     private readonly nlpSampleService: NlpSampleService,
     private readonly nlpSampleEntityService: NlpSampleEntityService,
     private readonly nlpEntityService: NlpEntityService,
+    private readonly nlpValueService: NlpValueService,
     private readonly languageService: LanguageService,
     private readonly helperService: HelperService,
   ) {
@@ -204,15 +206,56 @@ export class NlpSampleController extends BaseController<
 
   /**
    * Analyzes the input text using the NLP service and returns the parsed result.
+   * Filters out entities and values that are not defined in the user's Hexabot configuration.
    *
    * @param text - The input text to be analyzed.
    *
-   * @returns The result of the NLP parsing process.
+   * @returns The result of the NLP parsing process with only user-defined entities.
    */
   @Get('message')
   async message(@Query('text') text: string) {
     const helper = await this.helperService.getDefaultHelper(HelperType.NLU);
-    return helper.predict(text);
+    const prediction = await helper.predict(text);
+
+    // Get all user-defined entities and their values
+    const nlpMap = await this.nlpEntityService.getNlpMap();
+
+    // Filter entities to only include those that exist in user's configuration
+    const filteredEntities = await Promise.all(
+      prediction.entities.map(async (entity) => {
+        const nlpEntity = nlpMap.get(entity.entity);
+
+        // If entity doesn't exist in user's configuration, exclude it
+        if (!nlpEntity) {
+          return null;
+        }
+
+        // For trait entities (like intent), check if the value exists
+        if (nlpEntity.lookups?.includes('trait')) {
+          // Get all values for this entity
+          const entityValues = await this.nlpValueService.find({
+            entity: nlpEntity.id,
+          });
+
+          // Check if the predicted value exists in user-defined values
+          const valueExists = entityValues.some(
+            (v) => v.value === entity.value,
+          );
+
+          // If value doesn't exist, exclude this entity
+          if (!valueExists) {
+            return null;
+          }
+        }
+
+        return entity;
+      }),
+    );
+
+    // Remove null entries (filtered out entities)
+    return {
+      entities: filteredEntities.filter((e) => e !== null),
+    };
   }
 
   /**


### PR DESCRIPTION
Fixes #738 
# Solution: Filter Inferred Intent Confidence Scores


## Problem

The frontend displayed intent confidence scores for intents that users never defined. Ludwig NLU infers intents from its training data, causing confusion when high confidence scores appear for non-existent user intents.

**Example**: User enters "Bonsoir" → Ludwig returns `greetings_goodevening` with 99.68% confidence → User never created this intent → Confusion!

---

## Solution

Implemented **server-side filtering** in the `/nlpsample/message` endpoint to return only user-defined entities and values.

### What Changed

**Modified**: `api/src/nlp/controllers/nlp-sample.controller.ts`
- Added `NlpValueService` dependency injection
- Implemented filtering logic in `message()` endpoint that:
  - Retrieves user's NLP configuration
  - Validates each predicted entity exists in user's config
  - For trait entities (like intent), validates the predicted value exists
  - Filters out non-user-defined entities/values

**Added Tests**: `api/src/nlp/controllers/nlp-sample.controller.spec.ts`
- Test for filtering non-user-defined intent values
- Test for preserving user-defined entities

---

## How It Works

```
User Input → Ludwig NLU → Raw Prediction → Backend Filter → Only User-Defined → Frontend
```

**Filtering Process**:
1. Get user's NLP entity configuration (cached)
2. For each predicted entity:
   - Check if entity exists in user's config
   - For trait entities: validate the value exists
   - Filter out if not found
3. Return only validated entities

---

## Impact

### Before ❌
- Shows confidence for intents user never created
- Misleading high confidence scores
- Users confused about intent origin

### After ✅
- Shows only user-defined intents
- Accurate representation of user's configuration
- Clear, honest UX

---

## Testing

**Run tests**:
```bash
cd api
npm test -- nlp-sample.controller.spec.ts
```

**Manual test**:
1. Create intent value `greeting`
2. Enter "Bonsoir" → Only language shown (no inferred intent)
3. Enter "Hello" → Your `greeting` intent shown with confidence ✅

---

## Files Modified

- `api/src/nlp/controllers/nlp-sample.controller.ts` (~45 lines)
- `api/src/nlp/controllers/nlp-sample.controller.spec.ts` (~90 lines)

---

## Benefits

✅ Eliminates user confusion
✅ Accurate confidence scores
✅ Backward compatible
✅ Well-tested
✅ Performance optimized (uses caching)

---

## Summary

This fix filters out Ludwig NLU's inferred intents that don't exist in the user's configuration. Users now see confidence scores **only for intents they've explicitly defined**, providing an accurate representation of their chatbot's NLP capabilities.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NLP message responses now include only user-configured intents and entities, excluding inferred or unsupported items.
  * Trait-like entities are validated against allowed values to prevent incorrect matches.
  * Improves accuracy and consistency of detected entities in responses.

* **Tests**
  * Added comprehensive tests to verify filtering behavior for mixed and fully user-defined entities, ensuring correct propagation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->