### PR TITLE
Feat/ci

### DIFF
--- a/.github/workflows/v2-pull_request.yml
+++ b/.github/workflows/v2-pull_request.yml
@@ -1,7 +1,10 @@
-name: running unit tests on pull request
+name: running unit tests on pull request (v2)
 run-name: workflow ${{github.run_number}} of branch ${{github.head_ref}}
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   Frontend-Tests:

--- a/.github/workflows/v3-dev-ci.yml
+++ b/.github/workflows/v3-dev-ci.yml
@@ -1,0 +1,43 @@
+name: v3 dev CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  quality-checks:
+    name: Run typecheck/lint/test/build for all packages
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: 🔎 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ⏳ Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          standalone: true
+          run_install: false
+
+      - name: ⏳ Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🧪 Typecheck (all packages via Turbo)
+        run: pnpm typecheck
+
+      - name: 🧹 Lint (all packages via Turbo)
+        run: pnpm lint
+
+      - name: 🔬 Unit tests (all packages via Turbo)
+        run: pnpm test
+
+      - name: 🛠️ Build (all packages via Turbo)
+        run: pnpm build

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,50 @@
+# Release & Branching Guide
+
+Hexabot keeps two parallel release trains:
+
+- `main` tracks **v2**. All stable releases for production are cut from this branch.
+- `dev` tracks **v3**. Alpha builds are produced here until we graduate to a stable release.
+
+## Continuous Integration
+
+- **v2 (main)** → `.github/workflows/v2-pull_request.yml`  
+  Runs the legacy package-specific checks whenever a pull request targets `main`.
+- **v3 (dev)** → `.github/workflows/v3-dev-ci.yml`  
+  Runs `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm build` (fan-out via Turbo) whenever a pull request targets `dev`. This ensures every package is validated before merging into the v3 branch.
+
+## Publishing
+
+### Stable (v2)
+
+`bump-version.sh` remains the entry point for releasing v2 artifacts from `main`. It accepts `patch` or `minor` to bump versions, tags the release, and pushes back to `main`.
+
+### Alpha (v3)
+
+Use `./bump-version-v3.sh <release-type>` from the `dev` branch to publish `@hexabot-ai/api`, `@hexabot-ai/cli`, and `@hexabot-ai/widget` under the `alpha` npm dist-tag. The script also bumps `@hexabot-ai/frontend` so its static build (copied into the API output) stays in sync, even though we do not publish the frontend package yet.
+
+Allowed `<release-type>` values:
+
+- `prepatch` → bumps to the next patch pre-release (e.g., `3.0.1-alpha.0`)
+- `preminor` → bumps to the next minor pre-release (e.g., `3.1.0-alpha.0`)
+- `prerelease` → increments the existing alpha identifier (e.g., `3.0.1-alpha.1`)
+
+What the script does:
+
+1. Ensures you are on a clean `dev` branch and authenticated with npm.
+2. Bumps the version for the API, CLI, widget, and frontend packages with the `alpha` pre-release id (frontend is versioned but not published).
+3. Synchronizes the root `package.json` version.
+4. Runs `pnpm install`, builds each package, and publishes them with `pnpm publish --tag alpha`.
+5. Commits the version bump, tags it as `v<version>`, and pushes back to `origin dev`.
+
+Before running:
+
+- Install dependencies (`pnpm install`) and ensure the repository is clean.
+- Authenticate with npm (`npm login` or use an `NPM_TOKEN`).
+
+Example alpha release that increments the current prerelease tag:
+
+```bash
+./bump-version-v3.sh prerelease
+```
+
+This will create/publish `@hexabot-ai/api`, `@hexabot-ai/cli`, and `@hexabot-ai/widget` tagged as `alpha` on npm while leaving the v2 workflow untouched.

--- a/bump-version-v3.sh
+++ b/bump-version-v3.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <release-type>"
+  echo "release-type: prepatch | preminor | prerelease"
+  exit 1
+fi
+
+RELEASE_TYPE=$1
+ROOT_DIR=$(pwd)
+TARGET_BRANCH="dev"
+PUBLISH_PACKAGES=("@hexabot-ai/api" "@hexabot-ai/cli" "@hexabot-ai/widget")
+BUMP_ONLY_PACKAGES=("@hexabot-ai/frontend")
+VERSION_PACKAGES=("${PUBLISH_PACKAGES[@]}" "${BUMP_ONLY_PACKAGES[@]}")
+ALLOWED_RELEASE_TYPES=("prepatch" "preminor" "prerelease")
+
+if [[ ! " ${ALLOWED_RELEASE_TYPES[*]} " =~ " ${RELEASE_TYPE} " ]]; then
+  echo "Invalid release type. Use one of: ${ALLOWED_RELEASE_TYPES[*]}"
+  exit 1
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "$TARGET_BRANCH" ]]; then
+  echo "This script must be executed from the '$TARGET_BRANCH' branch."
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree is dirty. Commit or stash your changes before releasing."
+  exit 1
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm is required but not found on PATH."
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but not found on PATH."
+  exit 1
+fi
+
+if ! npm whoami >/dev/null 2>&1; then
+  echo "You must be logged into npm (npm whoami failed)."
+  exit 1
+fi
+
+echo "Executing v3 alpha release: $RELEASE_TYPE"
+
+for pkg in "${VERSION_PACKAGES[@]}"; do
+  echo "Bumping $pkg to next $RELEASE_TYPE (alpha)..."
+  pnpm --filter "$pkg" version "$RELEASE_TYPE" --preid alpha --git-tag-version false --commit-hooks false
+done
+
+NEW_VERSION=$(jq -r '.version' "$ROOT_DIR/packages/api/package.json")
+
+if [[ -z "$NEW_VERSION" ]]; then
+  echo "Failed to retrieve the new version from packages/api/package.json."
+  exit 1
+fi
+
+update_version() {
+  local file=$1
+  echo "Updating version in $file to $NEW_VERSION"
+  jq --arg newVersion "$NEW_VERSION" '.version = $newVersion' "$file" > tmp.$$.json && mv tmp.$$.json "$file"
+}
+
+if [[ -f "$ROOT_DIR/package.json" ]]; then
+  update_version "$ROOT_DIR/package.json"
+fi
+
+echo "Installing dependencies to ensure build consistency..."
+pnpm install --frozen-lockfile
+
+echo "Building packages prior to publish..."
+for pkg in "${VERSION_PACKAGES[@]}"; do
+  pnpm --filter "$pkg" run build
+done
+
+echo "Publishing packages to npm under 'alpha' tag..."
+for pkg in "${PUBLISH_PACKAGES[@]}"; do
+  pnpm --filter "$pkg" publish --tag alpha --access public --no-git-checks
+done
+
+echo "Committing and tagging release..."
+git add .
+git commit -m "build(v3): v$NEW_VERSION"
+git tag "v$NEW_VERSION"
+git push --no-verify origin "$TARGET_BRANCH" --tags
+
+echo "v3 alpha release ($NEW_VERSION) completed successfully."

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -12,9 +12,16 @@ fi
 
 RELEASE_TYPE=$1
 ROOT_DIR=$(pwd)
+TARGET_BRANCH="main"
 
 if [[ "$RELEASE_TYPE" != "patch" && "$RELEASE_TYPE" != "minor" ]]; then
   echo "Invalid release type. Use 'patch' or 'minor'."
+  exit 1
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "$TARGET_BRANCH" ]]; then
+  echo "This script must be executed from the '$TARGET_BRANCH' branch (current: $CURRENT_BRANCH)."
   exit 1
 fi
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hexabot-ai/api",
   "private": false,
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "description": "Hexabot is a solution for creating and managing chatbots across multiple channels, leveraging AI for advanced conversational capabilities. It provides a user-friendly interface for building, training, and deploying chatbots with integrated support for various messaging platforms.",
   "author": "Hexastack",
   "license": "FCL-1.0-ALv2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hexabot-ai/cli",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "description": "Official Hexabot CLI for creating and managing AI chatbot/agent projects built with Hexabot.",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hexabot-ai/frontend",
   "private": true,
-  "version": "2.3.0",
+  "version": "3.0.0-alpha.0",
   "description": "Hexabot is a solution for creating and managing chatbots across multiple channels, leveraging AI for advanced conversational capabilities. It provides a user-friendly interface for building, training, and deploying chatbots with integrated support for various messaging platforms.",
   "author": "Hexastack",
   "license": "FCL-1.0-ALv2",

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hexabot-ai/widget",
-  "version": "2.3.0",
+  "version": "3.0.0-alpha.0",
   "description": "Hexabot is a solution for creating and managing chatbots across multiple channels, leveraging AI for advanced conversational capabilities. It provides a user-friendly interface for building, training, and deploying chatbots with integrated support for various messaging platforms.",
   "author": "Hexastack",
   "license": "FCL-1.0-ALv2",


### PR DESCRIPTION
# Motivation

- Added bump-version-v3.sh, a guarded script that bumps API/CLI/widget/frontend to alpha prereleases, rebuilds, publishes the npm packages with --tag alpha, syncs the root version, tags the release, and pushes back to dev.
- Split GitHub Actions: renamed the legacy workflow to v2-pull_request and limited it to PRs targeting main, and introduced v3-dev-ci to run pnpm typecheck/lint/test/build for every PR into dev.
- Documented the dual-branch strategy plus the new release flow in RELEASING.md, including when to use prepatch, preminor, or prerelease.
- Hardened the v2 bump-version.sh to require running on main.
- Ensured the v3 release bumps/builds the frontend package (to keep embedded static assets in-sync) even though it isn’t published yet.

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
