### PR TITLE
Fix/v2 GitHub actions

### DIFF
--- a/.github/workflows/cli-npm.yml
+++ b/.github/workflows/cli-npm.yml
@@ -3,7 +3,7 @@ name: Publish Hexabot CLI NPM Package
 on:
   push:
     tags:
-      - "v*"
+      - "v2.*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-api.yml
+++ b/.github/workflows/docker-api.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - 'v*'
+      - 'v2.*'
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - 'v*'
+      - 'v2.*'
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker-ui.yml
+++ b/.github/workflows/docker-ui.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     tags:
-      - 'v*'
+      - 'v2.*'
 
 jobs:
   build-and-push:

--- a/.github/workflows/hexabot-npm.yml
+++ b/.github/workflows/hexabot-npm.yml
@@ -3,7 +3,7 @@ name: Publish Hexabot (API Typescript) NPM Package
 on:
   push:
     tags:
-      - "v*"
+      - "v2.*"
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/.github/workflows/widget-npm.yml
+++ b/.github/workflows/widget-npm.yml
@@ -3,7 +3,7 @@ name: Publish Hexabot Widget NPM Package
 on:
   push:
     tags:
-      - "v*"
+      - "v2.*"
   workflow_dispatch: # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
# Motivation

Tightened CI/CD triggers so all existing npm and Docker workflows (cli/hexabot/widget publishers + docker base/api/ui builds) only react to tags matching v2.*, keeping v3 prerelease tags from triggering the v2 automation.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
