### PR TITLE
fix(api): check api port availability before starting the unit tests

### DIFF
--- a/packages/api/test/global-setup.ts
+++ b/packages/api/test/global-setup.ts
@@ -7,19 +7,37 @@
 import net from 'net';
 import 'tsconfig-paths/register';
 
-const API_PORT = 3000;
-const isReservedPort = async (port: number) =>
-  new Promise((resolve) => {
+const API_PORT = Number(process.env.API_PORT ?? 3000);
+
+function isPortInUse(port: number): Promise<boolean> {
+  return new Promise((resolve, reject) => {
     const server = net.createServer();
+    const onError = (err: NodeJS.ErrnoException) => {
+      // Typical “port already in use”
+      if (err.code === 'EADDRINUSE') {
+        resolve(true);
+      } else {
+        reject(err);
+      }
+    };
+    const onListen = () => {
+      server.close(() => resolve(false));
+    };
+
+    server.once('error', onError);
+    server.once('listening', onListen);
+
     server.unref();
-    server.listen(port, () => {
-      server.close();
-      resolve(false);
-    });
-    server.on('error', resolve);
+    server.listen(port);
   });
+}
+
 export = async function globalSetup() {
-  if (await isReservedPort(API_PORT)) {
-    throw `Not available required port ${API_PORT}`;
+  const inUse = await isPortInUse(API_PORT);
+
+  if (inUse) {
+    throw new Error(
+      `Port ${API_PORT} is already in use. Please stop the running service before executing Jest tests.`,
+    );
   }
 };


### PR DESCRIPTION
# Motivation
Checks API port availability before starting the unit tests

Fixes # (issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
