### PR TITLE
refactor(api): simplify channels logic

### DIFF
--- a/packages/api/src/channel/lib/Handler.ts
+++ b/packages/api/src/channel/lib/Handler.ts
@@ -13,6 +13,7 @@ import {
   NotFoundException,
   OnModuleInit,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { JwtService, JwtSignOptions, JwtVerifyOptions } from '@nestjs/jwt';
 import { NextFunction, Request, Response } from 'express';
 import mime from 'mime';
@@ -36,6 +37,7 @@ import {
   StdOutgoingMessage,
 } from '@/chat/types/message';
 import { config } from '@/config';
+import { I18nService } from '@/i18n';
 import { LoggerService } from '@/logger/logger.service';
 import { SettingService } from '@/setting/services/setting.service';
 import { Extension } from '@/utils/generics/extension';
@@ -58,11 +60,26 @@ export default abstract class ChannelHandler<
 {
   private readonly settings: ChannelSetting<N>[];
 
+  @Inject(I18nService)
+  protected readonly i18n: I18nService;
+
+  @Inject(EventEmitter2)
+  protected readonly eventEmitter: EventEmitter2;
+
+  @Inject(LoggerService)
+  protected readonly logger: LoggerService;
+
   @Inject(AttachmentService)
   public readonly attachmentService: AttachmentService;
 
   @Inject(JwtService)
   protected readonly jwtService: JwtService;
+
+  @Inject(SettingService)
+  protected readonly settingService: SettingService;
+
+  @Inject(ChannelService)
+  protected readonly channelService: ChannelService;
 
   protected readonly jwtSignOptions: JwtSignOptions = {
     secret: config.parameters.signedUrl.secret,
@@ -71,12 +88,7 @@ export default abstract class ChannelHandler<
     encoding: 'utf-8',
   };
 
-  constructor(
-    name: N,
-    protected readonly settingService: SettingService,
-    private readonly channelService: ChannelService,
-    protected readonly logger: LoggerService,
-  ) {
+  constructor(name: N) {
     super(name);
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     this.settings = require(path.join(this.getPath(), 'settings')).default;

--- a/packages/api/src/extensions/channels/console/index.channel.ts
+++ b/packages/api/src/extensions/channels/console/index.channel.ts
@@ -5,17 +5,6 @@
  */
 
 import { Injectable } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
-
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ChannelService } from '@/channel/channel.service';
-import { MessageService } from '@/chat/services/message.service';
-import { SubscriberService } from '@/chat/services/subscriber.service';
-import { MenuService } from '@/cms/services/menu.service';
-import { I18nService } from '@/i18n/services/i18n.service';
-import { LoggerService } from '@/logger/logger.service';
-import { SettingService } from '@/setting/services/setting.service';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import BaseWebChannelHandler from '../web/base-web-channel';
 
@@ -25,31 +14,8 @@ import { CONSOLE_CHANNEL_NAME } from './settings';
 export default class ConsoleChannelHandler extends BaseWebChannelHandler<
   typeof CONSOLE_CHANNEL_NAME
 > {
-  constructor(
-    settingService: SettingService,
-    channelService: ChannelService,
-    logger: LoggerService,
-    eventEmitter: EventEmitter2,
-    i18n: I18nService,
-    subscriberService: SubscriberService,
-    attachmentService: AttachmentService,
-    messageService: MessageService,
-    menuService: MenuService,
-    websocketGateway: WebsocketGateway,
-  ) {
-    super(
-      CONSOLE_CHANNEL_NAME,
-      settingService,
-      channelService,
-      logger,
-      eventEmitter,
-      i18n,
-      subscriberService,
-      attachmentService,
-      messageService,
-      menuService,
-      websocketGateway,
-    );
+  constructor() {
+    super(CONSOLE_CHANNEL_NAME);
   }
 
   getPath(): string {

--- a/packages/api/src/extensions/channels/web/__test__/index.spec.ts
+++ b/packages/api/src/extensions/channels/web/__test__/index.spec.ts
@@ -9,6 +9,7 @@ import { TestingModule } from '@nestjs/testing';
 import { Request } from 'express';
 
 import { AttachmentService } from '@/attachment/services/attachment.service';
+import { ChannelService } from '@/channel/channel.service';
 import {
   attachmentMessage,
   buttonsMessage,
@@ -16,6 +17,7 @@ import {
   quickRepliesMessage,
   textMessage,
 } from '@/channel/lib/__test__/common.mock';
+import { MessageService } from '@/chat/services/message.service';
 import { SubscriberService } from '@/chat/services/subscriber.service';
 import { OutgoingMessageFormat } from '@/chat/types/message';
 import { MenuService } from '@/cms/services/menu.service';
@@ -63,6 +65,8 @@ describe('WebChannelHandler', () => {
     const testing = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [
+        ChannelService,
+        MessageService,
         JwtService,
         WebChannelHandler,
         I18nServiceProvider,

--- a/packages/api/src/extensions/channels/web/__test__/wrapper.spec.ts
+++ b/packages/api/src/extensions/channels/web/__test__/wrapper.spec.ts
@@ -9,6 +9,7 @@ import { TestingModule } from '@nestjs/testing';
 
 import { Attachment } from '@/attachment/dto/attachment.dto';
 import { AttachmentService } from '@/attachment/services/attachment.service';
+import { ChannelService } from '@/channel/channel.service';
 import { MessageService } from '@/chat/services/message.service';
 import { IncomingMessageType, StdEventType } from '@/chat/types/message';
 import { MenuService } from '@/cms/services/menu.service';
@@ -58,6 +59,7 @@ describe(`Web event wrapper`, () => {
     const testing = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [
+        ChannelService,
         JwtService,
         WebChannelHandler,
         I18nServiceProvider,

--- a/packages/api/src/extensions/channels/web/index.channel.ts
+++ b/packages/api/src/extensions/channels/web/index.channel.ts
@@ -5,17 +5,6 @@
  */
 
 import { Injectable } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
-
-import { AttachmentService } from '@/attachment/services/attachment.service';
-import { ChannelService } from '@/channel/channel.service';
-import { MessageService } from '@/chat/services/message.service';
-import { SubscriberService } from '@/chat/services/subscriber.service';
-import { MenuService } from '@/cms/services/menu.service';
-import { I18nService } from '@/i18n/services/i18n.service';
-import { LoggerService } from '@/logger/logger.service';
-import { SettingService } from '@/setting/services/setting.service';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import BaseWebChannelHandler from './base-web-channel';
 import { WEB_CHANNEL_NAME } from './settings';
@@ -24,31 +13,8 @@ import { WEB_CHANNEL_NAME } from './settings';
 export default class WebChannelHandler extends BaseWebChannelHandler<
   typeof WEB_CHANNEL_NAME
 > {
-  constructor(
-    settingService: SettingService,
-    channelService: ChannelService,
-    logger: LoggerService,
-    eventEmitter: EventEmitter2,
-    i18n: I18nService,
-    subscriberService: SubscriberService,
-    attachmentService: AttachmentService,
-    messageService: MessageService,
-    menuService: MenuService,
-    websocketGateway: WebsocketGateway,
-  ) {
-    super(
-      WEB_CHANNEL_NAME,
-      settingService,
-      channelService,
-      logger,
-      eventEmitter,
-      i18n,
-      subscriberService,
-      attachmentService,
-      messageService,
-      menuService,
-      websocketGateway,
-    );
+  constructor() {
+    super(WEB_CHANNEL_NAME);
   }
 
   getPath(): string {

--- a/packages/api/types/express-session.d.ts
+++ b/packages/api/types/express-session.d.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { SubscriberStub } from '@/chat/dto/subscriber.dto';
+import { Subscriber } from '@/chat/dto/subscriber.dto';
 
 declare module 'express-session' {
   interface SessionUser {
@@ -20,7 +20,7 @@ declare module 'express-session' {
       user?: SessionUser;
     };
     web?: {
-      profile?: SubscriberStub;
+      profile?: Subscriber;
       isSocket: boolean;
       messageQueue: any[];
       polling: boolean;


### PR DESCRIPTION
# Motivation
- Simplify Console, Web channels logic
- Remove unused type casts
- Update unit tests providers
- Re-order this.getSettings to be after exit condition 

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
