### PR TITLE
Feat/jsonata custom fn

### DIFF
--- a/packages/agentic/DSL.md
+++ b/packages/agentic/DSL.md
@@ -25,6 +25,7 @@ This document describes the YAML DSL used in `workflow.yml` to orchestrate AI an
   - `$iteration`: loop locals (`item`, `index`) available inside `loop.steps`.
   - `$accumulator`: loop accumulator state when `accumulate` is used.
 - Expressions can declare locals (e.g., `=$route := ...; ...`) and use JSONata helpers like `$exists`, `$size`, `$join`, and `$append`.
+- Additional JSONata helpers can be registered at compile time via `Workflow.fromYaml/fromDefinition` using the `jsonataFunctions` option; they are available to every expression (e.g., `text: "=$i18n('Bye bye')"`).
 
 ## Task definitions
 

--- a/packages/agentic/README.md
+++ b/packages/agentic/README.md
@@ -74,7 +74,7 @@ const actions = { call_api }; // keys are task.action names
 
 class AppContext extends BaseWorkflowContext<{ user_id: string }> {}
 
-const workflow = Workflow.fromYaml(yamlSource, actions);
+const workflow = Workflow.fromYaml(yamlSource, { actions });
 
 const emitter = new WorkflowEventEmitter();
 emitter.on('hook:step:start', ({ step }) => console.log('start', step.id));
@@ -121,6 +121,22 @@ inputs:
     user_id:
       type: string
 ```
+
+## Custom JSONata functions
+
+You can inject additional JSONata functions when compiling a workflow:
+
+```ts
+const workflow = Workflow.fromYaml(yamlSource, {
+  actions,
+  jsonataFunctions: {
+    i18n: (text: string) => translate(text, 'fr'),
+    slugify: { implementation: (value: string) => value.toLowerCase(), signature: 's' },
+  },
+});
+```
+
+These helpers are registered on every expression and can be referenced from YAML, e.g. `text: "=$i18n('Bye bye')"` inside a task input.
 
 ## Suspension and human-in-the-loop
 

--- a/packages/agentic/examples/full/workflow.ts
+++ b/packages/agentic/examples/full/workflow.ts
@@ -16,7 +16,9 @@ const workflowPath = path.join(__dirname, 'workflow.yml');
 
 async function main() {
   const yamlSource = fs.readFileSync(workflowPath, 'utf8');
-  const workflow = Workflow.fromYaml(yamlSource, exampleActions);
+  const workflow = Workflow.fromYaml(yamlSource, {
+    actions: exampleActions,
+  });
   const emitter = new WorkflowEventEmitter();
   const context = new ExampleContext(
     {

--- a/packages/agentic/examples/suspend-resume/workflow.ts
+++ b/packages/agentic/examples/suspend-resume/workflow.ts
@@ -16,7 +16,9 @@ const workflowPath = path.join(__dirname, 'workflow.yml');
 
 async function main() {
   const yamlSource = fs.readFileSync(workflowPath, 'utf8');
-  const workflow = Workflow.fromYaml(yamlSource, suspendResumeActions);
+  const workflow = Workflow.fromYaml(yamlSource, {
+    actions: suspendResumeActions,
+  });
   const emitter = new WorkflowEventEmitter();
   const context = new SuspendResumeContext({ channel: 'chat' }, emitter);
 

--- a/packages/agentic/src/__tests__/workflow-compiler.test.ts
+++ b/packages/agentic/src/__tests__/workflow-compiler.test.ts
@@ -129,7 +129,9 @@ describe('compileWorkflow', () => {
         },
       },
     };
-    const compiled = compileWorkflow(definition, { worker_action: action });
+    const compiled = compileWorkflow(definition, {
+      actions: { worker_action: action },
+    });
 
     expect(parseSettings).toHaveBeenCalledWith({
       timeout_ms: 50,
@@ -200,10 +202,12 @@ describe('compileWorkflow', () => {
     };
 
     expect(() =>
-      compileWorkflow(
-        definition,
-        {} as Record<string, Action<unknown, unknown, TestContext, Settings>>,
-      ),
+      compileWorkflow(definition, {
+        actions: {} as Record<
+          string,
+          Action<unknown, unknown, TestContext, Settings>
+        >,
+      }),
     ).toThrow(/No action implementations provided/);
   });
 });

--- a/packages/agentic/src/__tests__/workflow-runner.test.ts
+++ b/packages/agentic/src/__tests__/workflow-runner.test.ts
@@ -195,9 +195,11 @@ describe('WorkflowRunner', () => {
     );
 
     const compiled = compileWorkflow(definition, {
-      first_action: firstAction,
-      second_action: secondAction,
-      echo_action: echoAction,
+      actions: {
+        first_action: firstAction,
+        second_action: secondAction,
+        echo_action: echoAction,
+      },
     });
     const runner = new WorkflowRunner(compiled, { runId: 'run-1' });
     const context = new TestContext({});
@@ -256,7 +258,9 @@ describe('WorkflowRunner', () => {
       outputs: { reply: '=$output.wait_step.reply' },
     };
     const compiled = compileWorkflow(definition, {
-      suspend_action: suspendAction,
+      actions: {
+        suspend_action: suspendAction,
+      },
     });
     const runner = new WorkflowRunner(compiled, { runId: 'run-2' });
     const context = new TestContext({});
@@ -300,7 +304,9 @@ describe('WorkflowRunner', () => {
       flow: [{ do: 'ping_step' }],
       outputs: { ok: '=$output.ping_step.ok' },
     };
-    const compiled = compileWorkflow(definition, { ping_action: pingAction });
+    const compiled = compileWorkflow(definition, {
+      actions: { ping_action: pingAction },
+    });
     const emitter = new MemoryEmitter();
     const events: Array<{
       event: keyof WorkflowEventMap;
@@ -386,7 +392,9 @@ describe('WorkflowRunner', () => {
         },
       },
     };
-    const compiled = compileWorkflow(definition, { emit_action: emitAction });
+    const compiled = compileWorkflow(definition, {
+      actions: { emit_action: emitAction },
+    });
     const runner = new WorkflowRunner(compiled, { runId: 'ctx-run' });
     const context = new TestContext({});
     context.eventEmitter = emitter;
@@ -426,7 +434,9 @@ describe('WorkflowRunner', () => {
       outputs: { value: '=$output.fail_step.value' },
     };
     const compiled = compileWorkflow(definition, {
-      failing_action: failingAction,
+      actions: {
+        failing_action: failingAction,
+      },
     });
     const runner = new WorkflowRunner(compiled);
     const result = await runner.start({
@@ -497,8 +507,10 @@ describe('WorkflowRunner', () => {
       },
     };
     const compiled = compileWorkflow(definition, {
-      resume_suspend_action: suspendAction,
-      follow_action: followAction,
+      actions: {
+        resume_suspend_action: suspendAction,
+        follow_action: followAction,
+      },
     });
     const runner = new WorkflowRunner(compiled);
     const startResult = await runner.start({
@@ -551,7 +563,9 @@ describe('WorkflowRunner', () => {
       flow: [{ do: 'raw_step' }],
       outputs: { final: '=$output.raw_step' },
     };
-    const compiled = compileWorkflow(definition, { raw_action: rawAction });
+    const compiled = compileWorkflow(definition, {
+      actions: { raw_action: rawAction },
+    });
     const runner = new WorkflowRunner(compiled);
     const result = await runner.start({
       inputData: {},
@@ -590,7 +604,9 @@ describe('WorkflowRunner', () => {
       flow: [{ do: 'only_step' }],
       outputs: { ok: '=$output.only_step.ok' },
     };
-    const compiled = compileWorkflow(definition, { noop_action: noopAction });
+    const compiled = compileWorkflow(definition, {
+      actions: { noop_action: noopAction },
+    });
     const persistedState: ExecutionState = {
       input: {},
       memory: {},
@@ -653,7 +669,9 @@ describe('WorkflowRunner', () => {
       },
     };
     const compiled = compileWorkflow(definition, {
-      loop_suspend_action: suspendAction,
+      actions: {
+        loop_suspend_action: suspendAction,
+      },
     });
     const runner = new WorkflowRunner(compiled);
     const context = new TestContext({});
@@ -695,5 +713,45 @@ describe('WorkflowRunner', () => {
     if (resumeResult.status === 'finished') {
       expect(resumeResult.output.reply).toBe('Pong');
     }
+  });
+
+  it('registers custom JSONata functions during compilation', async () => {
+    const translate = jest.fn((text: string) => `i18n:${text}`);
+    const sendAction = defineAction<
+      { text: string },
+      { delivered: string },
+      TestContext,
+      Settings
+    >({
+      name: 'send_action',
+      inputSchema: z.object({ text: z.string() }),
+      outputSchema: z.object({ delivered: z.string() }),
+      execute: async ({ input }) => ({ delivered: input.text }),
+    });
+    const definition: WorkflowDefinition = {
+      workflow: { name: 'i18n_flow', version: '1.0.0' },
+      tasks: {
+        send_goodbye: {
+          action: 'send_action',
+          inputs: { text: "=$i18n('Bye bye')" },
+          outputs: { delivered: '=$result.delivered' },
+        },
+      },
+      flow: [{ do: 'send_goodbye' }],
+      outputs: { message: '=$output.send_goodbye.delivered' },
+    };
+    const compiled = compileWorkflow(definition, {
+      actions: { send_action: sendAction },
+      jsonataFunctions: { i18n: translate },
+    });
+    const runner = new WorkflowRunner(compiled);
+    const context = new TestContext({});
+    const result = await runner.start({ inputData: {}, context });
+
+    expect(result.status).toBe('finished');
+    if (result.status === 'finished') {
+      expect(result.output.message).toBe('i18n:Bye bye');
+    }
+    expect(translate).toHaveBeenCalledWith('Bye bye');
   });
 });

--- a/packages/agentic/src/__tests__/workflow-values.test.ts
+++ b/packages/agentic/src/__tests__/workflow-values.test.ts
@@ -23,6 +23,22 @@ class TestContext extends BaseWorkflowContext {
 }
 
 describe('workflow values', () => {
+  it('registers custom JSONata functions on expressions', async () => {
+    const translate = jest.fn((text: string) => `translated:${text}`);
+    const compiled = compileValue("=$i18n('Bye bye')", {
+      jsonataFunctions: { i18n: translate },
+    });
+    const result = await evaluateValue(compiled, {
+      input: {},
+      context: new TestContext().state,
+      memory: {},
+      output: {},
+    });
+
+    expect(result).toBe('translated:Bye bye');
+    expect(translate).toHaveBeenCalledWith('Bye bye');
+  });
+
   it('compiles expressions and evaluates against the runtime scope', async () => {
     const compiled = compileValue(
       '=$input.amount + $memory.offset + $iteration.index + $accumulator',

--- a/packages/agentic/src/__tests__/workflow.test.ts
+++ b/packages/agentic/src/__tests__/workflow.test.ts
@@ -94,7 +94,7 @@ describe('Workflow execution', () => {
       },
     };
     const workflow = Workflow.fromDefinition(definition, {
-      greet_action: greetAction,
+      actions: { greet_action: greetAction },
     });
     const result = await workflow.run({ name: '  Ada  ' }, new TestContext());
 
@@ -136,7 +136,7 @@ describe('Workflow execution', () => {
       outputs: { reply: '=$output.ask_user.reply' },
     };
     const workflow = Workflow.fromDefinition(definition, {
-      await_reply: suspendingAction,
+      actions: { await_reply: suspendingAction },
     });
     const runner = await workflow.buildAsyncRunner();
     const startResult = await runner.start({
@@ -204,7 +204,7 @@ describe('Workflow execution', () => {
     );
 
     const workflow = Workflow.fromDefinition(definition, {
-      double_value: noopAction,
+      actions: { double_value: noopAction },
     });
     const runner = await workflow.buildAsyncRunner();
     const context = new TestContext();
@@ -225,7 +225,9 @@ describe('Workflow execution', () => {
 
   it('throws on invalid YAML input', () => {
     expect(() =>
-      Workflow.fromYaml('workflow: {}', {} as Record<string, never>),
+      Workflow.fromYaml('workflow: {}', {
+        actions: {} as Record<string, never>,
+      }),
     ).toThrow(/Workflow validation failed/);
   });
 
@@ -253,7 +255,7 @@ describe('Workflow execution', () => {
       outputs: { result: '=$output.failing_task.result' },
     };
     const workflow = Workflow.fromDefinition(definition, {
-      failing_action: failingAction,
+      actions: { failing_action: failingAction },
     });
     const context = new TestContext();
 
@@ -297,7 +299,7 @@ describe('Workflow execution', () => {
       outputs: { reply: '=$output.pause_step.reply' },
     };
     const workflow = Workflow.fromDefinition(definition, {
-      suspending_action: suspendingAction,
+      actions: { suspending_action: suspendingAction },
     });
     const context = new TestContext();
 

--- a/packages/agentic/src/index.ts
+++ b/packages/agentic/src/index.ts
@@ -42,6 +42,7 @@ export {
   Workflow,
   WorkflowEventEmitter,
   WorkflowRunner,
+  type WorkflowCompileOptions,
   type WorkflowResumeResult,
   type WorkflowRunOptions,
   type WorkflowStartResult,
@@ -80,6 +81,10 @@ export {
   evaluateMapping,
   evaluateValue,
   mergeSettings,
+  type CompileValueOptions,
+  type JsonataFunctionConfig,
+  type JsonataFunctionImplementation,
+  type JsonataFunctionRegistry,
 } from './workflow-values';
 
 export { createDeferred } from './utils/deferred';

--- a/packages/agentic/src/workflow-compiler.ts
+++ b/packages/agentic/src/workflow-compiler.ts
@@ -25,7 +25,18 @@ import type {
   LoopStep,
   ParallelStep,
 } from './workflow-types';
-import { compileValue, mergeSettings } from './workflow-values';
+import {
+  compileValue,
+  mergeSettings,
+  type CompileValueOptions,
+} from './workflow-values';
+
+export type WorkflowCompileOptions = CompileValueOptions & {
+  actions: Record<
+    string,
+    Action<unknown, unknown, BaseWorkflowContext, Settings>
+  >;
+};
 
 /** Build a stable identifier for a step using its path and label. */
 const buildStepId = (path: Array<number | string>, label: string): string => {
@@ -95,13 +106,17 @@ const buildInputParser = (schema?: Record<string, InputField>): ZodTypeAny => {
 /** Compile a raw mapping object into expression-aware value mappings. */
 const compileMapping = (
   values?: Record<string, unknown>,
+  options?: WorkflowCompileOptions,
 ): CompiledMapping | undefined => {
   if (!values) {
     return undefined;
   }
 
   return Object.fromEntries(
-    Object.entries(values).map(([key, value]) => [key, compileValue(value)]),
+    Object.entries(values).map(([key, value]) => [
+      key,
+      compileValue(value, options),
+    ]),
   );
 };
 /** Ensure every task references a provided action implementation. */
@@ -128,20 +143,17 @@ const assertActionsBound = (
 /** Parse settings, compile inputs/outputs, and bind actions for each task. */
 const compileTasks = (
   definition: WorkflowDefinition,
-  actions: Record<
-    string,
-    Action<unknown, unknown, BaseWorkflowContext, Settings>
-  >,
+  options: WorkflowCompileOptions,
 ): Record<string, CompiledTask> => {
   const compiled: Record<string, CompiledTask> = {};
   const defaultSettings = definition.defaults?.settings;
 
-  assertActionsBound(definition.tasks, actions);
+  assertActionsBound(definition.tasks, options.actions);
 
   for (const [taskName, task] of Object.entries(definition.tasks)) {
     assertSnakeCaseName(taskName, 'action');
 
-    const action = actions[task.action];
+    const action = options.actions[task.action];
     const settingsPayload = mergeSettings(defaultSettings, task.settings);
     const parsedSettings = action.parseSettings(settingsPayload);
 
@@ -150,8 +162,8 @@ const compileTasks = (
       actionName: task.action,
       definition: task,
       action,
-      inputs: compileMapping(task.inputs) ?? {},
-      outputs: compileMapping(task.outputs) ?? {},
+      inputs: compileMapping(task.inputs, options) ?? {},
+      outputs: compileMapping(task.outputs, options) ?? {},
       settings: parsedSettings,
     };
   }
@@ -162,6 +174,7 @@ const compileTasks = (
 const compileFlowSteps = (
   steps: FlowStep[],
   path: Array<number | string> = [],
+  options?: WorkflowCompileOptions,
 ): CompiledStep[] =>
   steps.map<CompiledStep>((step, index) => {
     const stepPath = [...path, index];
@@ -190,7 +203,11 @@ const compileFlowSteps = (
         },
         description: step.parallel.description,
         strategy: step.parallel.strategy ?? 'wait_all',
-        steps: compileFlowSteps(step.parallel.steps, [...stepPath, 'parallel']),
+        steps: compileFlowSteps(
+          step.parallel.steps,
+          [...stepPath, 'parallel'],
+          options,
+        ),
       } as ParallelStep;
     }
 
@@ -199,12 +216,14 @@ const compileFlowSteps = (
         (branch, branchIdx) => ({
           id: buildStepId([...stepPath, 'branch', branchIdx], 'conditional'),
           condition:
-            'condition' in branch ? compileValue(branch.condition) : undefined,
-          steps: compileFlowSteps(branch.steps, [
-            ...stepPath,
-            'branch',
-            branchIdx,
-          ]),
+            'condition' in branch
+              ? compileValue(branch.condition, options)
+              : undefined,
+          steps: compileFlowSteps(
+            branch.steps,
+            [...stepPath, 'branch', branchIdx],
+            options,
+          ),
         }),
       );
 
@@ -233,32 +252,36 @@ const compileFlowSteps = (
       },
       name: loop.name,
       description: loop.description,
-      forEach: { item: loop.for_each.item, in: compileValue(loop.for_each.in) },
+      forEach: {
+        item: loop.for_each.item,
+        in: compileValue(loop.for_each.in, options),
+      },
       maxConcurrency: loop.max_concurrency,
-      until: loop.until ? compileValue(loop.until) : undefined,
+      until: loop.until ? compileValue(loop.until, options) : undefined,
       accumulate: loop.accumulate
         ? {
             as: loop.accumulate.as,
             initial: loop.accumulate.initial,
-            merge: compileValue(loop.accumulate.merge),
+            merge: compileValue(loop.accumulate.merge, options),
           }
         : undefined,
-      steps: compileFlowSteps(loop.steps, [...stepPath, loop.name ?? 'loop']),
+      steps: compileFlowSteps(
+        loop.steps,
+        [...stepPath, loop.name ?? 'loop'],
+        options,
+      ),
     } as LoopStep;
   });
 
 /** Compile a workflow definition into structures consumable by the runtime. */
 export const compileWorkflow = (
   definition: WorkflowDefinition,
-  actions: Record<
-    string,
-    Action<unknown, unknown, BaseWorkflowContext, Settings>
-  >,
+  options: WorkflowCompileOptions,
 ): CompiledWorkflow => {
   const inputParser = buildInputParser(definition.inputs?.schema);
-  const tasks = compileTasks(definition, actions);
-  const flow = compileFlowSteps(definition.flow);
-  const outputMapping = compileMapping(definition.outputs) ?? {};
+  const tasks = compileTasks(definition, options);
+  const flow = compileFlowSteps(definition.flow, [], options);
+  const outputMapping = compileMapping(definition.outputs, options) ?? {};
 
   return {
     definition,

--- a/packages/agentic/src/workflow-values.ts
+++ b/packages/agentic/src/workflow-values.ts
@@ -4,6 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
+import type { Expression, Focus } from 'jsonata';
+// eslint-disable-next-line no-duplicate-imports
 import jsonata from 'jsonata';
 
 import type { Settings } from './dsl.types';
@@ -13,17 +15,65 @@ import type {
   EvaluationScope,
 } from './workflow-types';
 
+export type JsonataFunctionImplementation = (
+  this: Focus,
+  ...args: any[]
+) => unknown;
+
+export type JsonataFunctionConfig =
+  | JsonataFunctionImplementation
+  | {
+      implementation: JsonataFunctionImplementation;
+      signature?: string;
+    };
+
+export type JsonataFunctionRegistry = Record<string, JsonataFunctionConfig>;
+
+export type CompileValueOptions = {
+  jsonataFunctions?: JsonataFunctionRegistry;
+};
+
 /** Basic object guard that rejects arrays and null. */
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
+const registerJsonataFunctions = (
+  expression: Expression,
+  registry?: JsonataFunctionRegistry,
+) => {
+  if (!registry) {
+    return;
+  }
+
+  for (const [name, config] of Object.entries(registry)) {
+    if (typeof config === 'function') {
+      expression.registerFunction(name, config);
+      continue;
+    }
+
+    if (config && typeof config.implementation === 'function') {
+      expression.registerFunction(
+        name,
+        config.implementation,
+        config.signature,
+      );
+      continue;
+    }
+
+    throw new Error(`Invalid JSONata function config for "${name}"`);
+  }
+};
 
 /**
  * Prepares a workflow value for evaluation.
  * Strings prefixed with `=` are treated as JSONata expressions; everything else is a literal.
  */
-export const compileValue = (value: unknown): CompiledValue => {
+export const compileValue = (
+  value: unknown,
+  options?: CompileValueOptions,
+): CompiledValue => {
   if (typeof value === 'string' && value.startsWith('=')) {
     const expression = jsonata(value.slice(1));
+    registerJsonataFunctions(expression, options?.jsonataFunctions);
 
     return { kind: 'expression', source: value, expression };
   }

--- a/packages/agentic/src/workflow.ts
+++ b/packages/agentic/src/workflow.ts
@@ -4,16 +4,17 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { Action } from './action/action.types';
 import type { BaseWorkflowContext, WorkflowSnapshot } from './context';
 import {
-  Settings,
   WorkflowDefinition,
   WorkflowDefinitionSchema,
   validateWorkflow,
 } from './dsl.types';
 import { WorkflowSuspendedError } from './runtime-error';
-import { compileWorkflow } from './workflow-compiler';
+import {
+  compileWorkflow,
+  type WorkflowCompileOptions,
+} from './workflow-compiler';
 import { WorkflowRunner } from './workflow-runner';
 import type {
   CompiledWorkflow,
@@ -33,6 +34,8 @@ export type {
   WorkflowStartResult,
 } from './workflow-types';
 
+export type { WorkflowCompileOptions } from './workflow-compiler';
+
 /**
  * Entry point for preparing and executing workflows from YAML or object definitions.
  * Instances are thin wrappers around a compiled workflow graph.
@@ -50,13 +53,10 @@ export class Workflow {
    */
   static fromDefinition(
     definition: WorkflowDefinition,
-    actions: Record<
-      string,
-      Action<unknown, unknown, BaseWorkflowContext, Settings>
-    >,
+    options: WorkflowCompileOptions,
   ): Workflow {
     const parsed = WorkflowDefinitionSchema.parse(definition);
-    const compiled = compileWorkflow(parsed, actions);
+    const compiled = compileWorkflow(parsed, options);
 
     return new Workflow(compiled);
   }
@@ -65,13 +65,7 @@ export class Workflow {
    * Create a workflow from YAML source.
    * YAML is validated and compiled before being wrapped in a {@link Workflow} instance.
    */
-  static fromYaml(
-    yaml: string,
-    actions: Record<
-      string,
-      Action<unknown, unknown, BaseWorkflowContext, Settings>
-    >,
-  ): Workflow {
+  static fromYaml(yaml: string, options: WorkflowCompileOptions): Workflow {
     const validation = validateWorkflow(yaml);
     if (!validation.success) {
       throw new Error(
@@ -79,7 +73,7 @@ export class Workflow {
       );
     }
 
-    const compiled = compileWorkflow(validation.data, actions);
+    const compiled = compileWorkflow(validation.data, options);
 
     return new Workflow(compiled);
   }

--- a/packages/api/src/workflow/services/agentic.service.ts
+++ b/packages/api/src/workflow/services/agentic.service.ts
@@ -110,7 +110,9 @@ export class AgenticService {
     const logContext = this.buildRunLogContext(run, options.mode, event);
     const workflowInstance = AgentWorkflow.fromDefinition(
       run.workflow.definition,
-      this.buildActionsRegistry(),
+      {
+        actions: this.buildActionsRegistry(),
+      },
     );
     const context = this.workflowContext.buildFromRun(run, event);
     const contextState = this.getContextState(context);


### PR DESCRIPTION
# Motivation

Add the ability for the agentic library to extend JSONata by registering functions (It would be useful for example to provide i18n support). 

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
