### PR TITLE
fix(frontend): make content as subpage of content types page

### DIFF
--- a/packages/frontend/src/components/content-types/index.tsx
+++ b/packages/frontend/src/components/content-types/index.tsx
@@ -47,7 +47,7 @@ export const ContentTypes = () => {
     [
       {
         label: ActionColumnLabel.Content,
-        action: (row) => router.push(`/content/${row.id}/list`),
+        action: (row) => router.push(`/content-types/content/${row.id}`),
       },
       {
         label: ActionColumnLabel.Edit,

--- a/packages/frontend/src/components/contents/index.tsx
+++ b/packages/frontend/src/components/contents/index.tsx
@@ -208,7 +208,7 @@ export const Contents = () => {
       headerLeftButtons={
         <Button
           component={RouterLink}
-          to="/content/types"
+          to="/content-types"
           variant="text"
           startIcon={<ArrowLeft size={18} />}
         >

--- a/packages/frontend/src/layout/VerticalMenu.tsx
+++ b/packages/frontend/src/layout/VerticalMenu.tsx
@@ -157,7 +157,7 @@ const getMenuItems = (ssoEnabled: boolean): MenuItem[] => [
       },
       {
         text: "menu.cms",
-        href: "/content/types",
+        href: "/content-types",
         Icon: AlignLeft,
         requires: {
           [EntityType.CONTENT_TYPE]: [PermissionAction.READ],

--- a/packages/frontend/src/routes/routeConfig.tsx
+++ b/packages/frontend/src/routes/routeConfig.tsx
@@ -108,14 +108,14 @@ export const routes: RouteObjectItem[] = [
     },
   },
   {
-    path: "/content/types",
+    path: "/content-types",
     Component: ContentTypes,
     handle: {
       requiredPermissions: [[EntityType.CONTENT_TYPE, PermissionAction.READ]],
     },
   },
   {
-    path: "/content/:id/list",
+    path: "/content-types/content/:id",
     Component: Contents,
     handle: {
       requiredPermissions: [[EntityType.CONTENT, PermissionAction.READ]],


### PR DESCRIPTION
# Motivation
Make content Page a subpage of content types page

# Before the update
<img width="961" height="723" alt="image" src="https://github.com/user-attachments/assets/e562349d-e2fb-4e8b-acc8-ef80742b51ed" />

# After the update
<img width="961" height="723" alt="image" src="https://github.com/user-attachments/assets/564d21d0-2106-4be7-8f40-6c5b60fc960a" />
