### PR TITLE
fix(frontend): resolve mui dialog close button position

### DIFF
--- a/packages/frontend/src/layout/theme/customizations/feedback.tsx
+++ b/packages/frontend/src/layout/theme/customizations/feedback.tsx
@@ -38,6 +38,18 @@ export const feedbackCustomizations: Components<Theme> = {
       }),
     },
   },
+  MuiDialogTitle: {
+    styleOverrides: {
+      root: {
+        "& .MuiIconButton-root": {
+          top: "10px",
+          right: "10px",
+          position: "absolute",
+          borderRadius: "50%",
+        },
+      },
+    },
+  },
   MuiLinearProgress: {
     styleOverrides: {
       root: ({ theme }) => ({


### PR DESCRIPTION
# Motivation
 Resolve MUI Dialog close button position.

# Before the fix
<img width="632" height="157" alt="image" src="https://github.com/user-attachments/assets/5e23f826-238e-4f61-ae1f-b568b76b4600" />

# After the fix
<img width="632" height="157" alt="image" src="https://github.com/user-attachments/assets/729ddf90-75a4-46b9-9a35-c5de352115ed" />
