### PR TITLE
fix(frontend): update inputs theme

### DIFF
--- a/packages/frontend/src/app-components/displays/Badge.tsx
+++ b/packages/frontend/src/app-components/displays/Badge.tsx
@@ -49,8 +49,8 @@ export const Badge = ({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        width: 24,
-        height: 24,
+        width: 22,
+        height: 22,
         borderRadius: 10,
         backgroundColor: background,
         color,
@@ -58,7 +58,7 @@ export const Badge = ({
         boxShadow: "0 0 4px #0001 inset",
       }}
     >
-      <TypeIcon size={14} />
+      <TypeIcon size={13} />
     </Box>
   );
 };

--- a/packages/frontend/src/app-components/inputs/FilterTextfield.tsx
+++ b/packages/frontend/src/app-components/inputs/FilterTextfield.tsx
@@ -6,7 +6,7 @@
 
 import { IconButton, InputAdornment, TextFieldProps } from "@mui/material";
 import debounce from "@mui/utils/debounce";
-import { Search as SearchIcon, X as ClearIcon } from "lucide-react";
+import { X as ClearIcon, Search as SearchIcon } from "lucide-react";
 import { FC, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useTranslate } from "@/hooks/useTranslate";
@@ -77,10 +77,10 @@ export const FilterTextfield: FC<FilterTextFieldProps> = ({
       slotProps={{
         input: {
           startAdornment: <Adornment Icon={SearchIcon} />,
-          endAdornment: clearable && (
+          endAdornment: defaultValue && clearable && (
             <InputAdornment position="end" onClick={handleClear}>
-              <IconButton size="small" sx={{ marginRight: -1 }}>
-                <ClearIcon size={16} />
+              <IconButton>
+                <ClearIcon />
               </IconButton>
             </InputAdornment>
           ),
@@ -88,7 +88,6 @@ export const FilterTextfield: FC<FilterTextFieldProps> = ({
       }}
       placeholder={t("placeholder.keywords")}
       {...props}
-      // value={inputValue}
       defaultValue={defaultValue}
       onChange={handleChange}
     />

--- a/packages/frontend/src/app-components/inputs/PasswordInput.tsx
+++ b/packages/frontend/src/app-components/inputs/PasswordInput.tsx
@@ -22,9 +22,11 @@ export const PasswordInput = forwardRef<any, PasswordInputProps>(
       setShowPassword(!showPassword);
     };
     const resolveInputSlotProps = (ownerState: any) => {
-      const resolved = (typeof slotProps?.input === "function"
-        ? slotProps.input(ownerState)
-        : slotProps?.input) as { endAdornment?: React.ReactNode } | undefined;
+      const resolved = (
+        typeof slotProps?.input === "function"
+          ? slotProps.input(ownerState)
+          : slotProps?.input
+      ) as { endAdornment?: React.ReactNode } | undefined;
 
       return {
         ...(resolved ?? {}),
@@ -32,8 +34,8 @@ export const PasswordInput = forwardRef<any, PasswordInputProps>(
           <>
             {resolved?.endAdornment}
             <InputAdornment position="end">
-              <IconButton onClick={handleTogglePasswordVisibility} edge="end">
-                {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+              <IconButton onClick={handleTogglePasswordVisibility}>
+                {showPassword ? <EyeOff /> : <Eye />}
               </IconButton>
             </InputAdornment>
           </>

--- a/packages/frontend/src/layout/theme/customizations/inputs.tsx
+++ b/packages/frontend/src/layout/theme/customizations/inputs.tsx
@@ -15,8 +15,7 @@ import { toggleButtonGroupClasses } from "@mui/material/ToggleButtonGroup";
 
 import { brand, gray } from "../themePrimitives";
 
-/* eslint-disable import/prefer-default-export */
-export const inputsCustomizations: Components<Theme> = {
+const buttonsCustomizations: Components<Theme> = {
   MuiButtonBase: {
     defaultProps: {
       disableTouchRipple: true,
@@ -316,6 +315,8 @@ export const inputsCustomizations: Components<Theme> = {
       }),
     },
   },
+};
+const checkboxCustomizations: Components<Theme> = {
   MuiCheckbox: {
     defaultProps: {
       disableRipple: true,
@@ -371,6 +372,31 @@ export const inputsCustomizations: Components<Theme> = {
       }),
     },
   },
+};
+
+export const inputsCustomizations: Components<Theme> = {
+  ...buttonsCustomizations,
+  ...checkboxCustomizations,
+  MuiAutocomplete: {
+    styleOverrides: {
+      root: {
+        "& .MuiAutocomplete-endAdornment": {
+          display: "flex",
+          gap: "6px",
+        },
+        "& .MuiAutocomplete-endAdornment button": {
+          width: "calc(15px + 9px)",
+          height: "calc(15px + 9px)",
+        },
+        "& .MuiAutocomplete-endAdornment button svg": {
+          minWidth: "15px",
+          minHeight: "15px",
+          maxWidth: "15px",
+          maxHeight: "15px",
+        },
+      },
+    },
+  },
   MuiInputBase: {
     styleOverrides: {
       root: {
@@ -390,7 +416,7 @@ export const inputsCustomizations: Components<Theme> = {
         padding: 0,
       },
       root: ({ theme }) => ({
-        padding: "8px 12px",
+        padding: "9px 12px",
         color: (theme.vars || theme).palette.text.primary,
         borderRadius: (theme.vars || theme).shape.borderRadius,
         borderColor: (theme.vars || theme).palette.divider,
@@ -411,7 +437,8 @@ export const inputsCustomizations: Components<Theme> = {
         variants: [
           {
             props: {
-              size: "small",
+              type: "text",
+              multiline: false,
             },
             style: {
               height: "2.25rem",
@@ -419,7 +446,8 @@ export const inputsCustomizations: Components<Theme> = {
           },
           {
             props: {
-              size: "medium",
+              type: "text",
+              multiline: false,
             },
             style: {
               height: "2.5rem",
@@ -433,6 +461,19 @@ export const inputsCustomizations: Components<Theme> = {
   MuiInputAdornment: {
     styleOverrides: {
       root: ({ theme }) => ({
+        "& button:last-child": {
+          marginRight: "-6px",
+        },
+        "& button": {
+          width: "calc(15px + 9px)",
+          height: "calc(15px + 9px)",
+        },
+        "& button svg": {
+          minWidth: "15px",
+          minHeight: "15px",
+          maxWidth: "15px",
+          maxHeight: "15px",
+        },
         color: (theme.vars || theme).palette.grey[500],
         ...theme.applyStyles("dark", {
           color: (theme.vars || theme).palette.grey[400],
@@ -447,5 +488,14 @@ export const inputsCustomizations: Components<Theme> = {
         marginBottom: 8,
       }),
     },
+  },
+  MuiCssBaseline: {
+    styleOverrides: `
+      input:-webkit-autofill,
+      input:-webkit-autofill:hover,
+      input:-webkit-autofill:focus,
+      input:-webkit-autofill:active {
+        -webkit-box-shadow: 0 0 0 30px #ffffff inset !important;
+      }`,
   },
 };


### PR DESCRIPTION
# Motivation
Update inputs theme

# Before the update
<img width="826" height="58" alt="image" src="https://github.com/user-attachments/assets/812b951d-a7d6-490c-bebe-a0190c3f2b6f" />
<img width="575" height="161" alt="image" src="https://github.com/user-attachments/assets/82f2e1fc-4033-4d0e-865f-03ad433b944c" />
<img width="865" height="232" alt="image" src="https://github.com/user-attachments/assets/3bb80ab8-0b60-428a-aae2-27d4b1dadee5" />
<img width="643" height="419" alt="image" src="https://github.com/user-attachments/assets/b4e2267f-2197-4696-80eb-617bc2d79736" />

# After the update
<img width="826" height="58" alt="image" src="https://github.com/user-attachments/assets/d0f66c7d-1e59-4b1e-8ca0-cbac60938215" />
<img width="575" height="161" alt="image" src="https://github.com/user-attachments/assets/7fa0b7f3-e532-4da6-a34d-92c06d7f63da" />
<img width="865" height="283" alt="image" src="https://github.com/user-attachments/assets/c36f4e56-2a79-484d-9e5c-67e6b89b1bf1" />
<img width="643" height="419" alt="image" src="https://github.com/user-attachments/assets/c1ac24f5-7be2-486e-9c4e-51d5b553ec12" />
