### PR TITLE
fix(frontend): make WorkflowBottomDrawer responsive

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/controls/RotateButton.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/controls/RotateButton.tsx
@@ -29,6 +29,7 @@ export const RotateButton = () => {
         borderRadius: 0,
         border: "1px solid #0001",
         padding: "2px 3px",
+        zIndex: 4,
       }}
       size="small"
       onClick={async () => {

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ReactFlowWrapper.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ReactFlowWrapper.tsx
@@ -23,6 +23,7 @@ import {
   EDGE_TYPES,
   NODE_TYPES,
 } from "../../types/workflow-node.types";
+import { RotateButton } from "../controls/RotateButton";
 
 export const ReactFlowWrapper = ({
   defaultEdges,
@@ -105,6 +106,7 @@ export const ReactFlowWrapper = ({
         fitViewOptions={{ duration: 200 }}
       />
       <Background size={2} />
+      <RotateButton />
     </ReactFlow>
   );
 };

--- a/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowBottomDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowBottomDrawer.tsx
@@ -341,7 +341,7 @@ export const WorkflowBottomDrawer = () => {
         variant="permanent"
         id={drawerId}
         sx={{
-          position: "absolute",
+          position: "relative",
           left: 0,
           right: 0,
           bottom: 0,
@@ -355,7 +355,6 @@ export const WorkflowBottomDrawer = () => {
           paper: {
             sx: {
               height: drawerHeight,
-              maxHeight: `calc(100% - ${headerOffset}px)`,
               borderTopLeftRadius: 0,
               borderTopRightRadius: 0,
               display: "flex",

--- a/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
@@ -27,7 +27,6 @@ import { IMemoryDefinition } from "@/types/memory-definition.types";
 import { WorkflowVersionAction } from "@/types/workfow-version.types";
 import type { IWorkflow } from "@/types/workfow.types";
 
-import { RotateButton } from "../components/controls/RotateButton";
 import { WorkflowFormDialog } from "../components/forms/WorkflowFormDialog";
 import { ActionFormDrawer } from "../components/main/ActionDrawer/ActionFormDrawer";
 import { ActionListDrawer } from "../components/main/ActionDrawer/ActionListDrawer";
@@ -334,7 +333,6 @@ export const Workflow = () => {
           }}
         />
         <WorkflowBottomDrawer />
-        <RotateButton />
       </StyledBox>
       <ActionFormDrawer />
       <WorkflowMenu

--- a/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
@@ -56,6 +56,8 @@ const StyledBox = styled(Box)(() => ({
   flex: 1,
   minWidth: 0,
   overflow: "hidden",
+  display: "flex",
+  flexDirection: "column",
 }));
 const WorkflowTitleOverlay = styled(Box)(() => ({
   position: "absolute",


### PR DESCRIPTION
# Motivation
Make WorkflowBottomDrawer responsive

# Before the fix
<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/198e68cb-f36a-4a71-96e2-addf640d2dff" />

# After the fix
<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/8b2c52b1-db48-42c0-ae36-7f1c6add82b9" />

[WorkflowBottomDrawer responsive.webm](https://github.com/user-attachments/assets/61907708-99bc-4383-9bff-407f13cb40cf)


