### PR TITLE
fix(frontend): remove Alert icon spacing

### DIFF
--- a/packages/frontend/src/layout/theme/customizations/feedback.tsx
+++ b/packages/frontend/src/layout/theme/customizations/feedback.tsx
@@ -35,6 +35,10 @@ export const feedbackCustomizations: Components<Theme> = {
           svg: {
             fill: theme.palette.grey[500],
           },
+          "& .MuiAlert-icon ": {
+            marginRight: 0,
+            padding: 0,
+          },
         },
       }),
     },


### PR DESCRIPTION
# Motivation
Remove Alert icon spacing

# Before the fix
<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/3f7e6bd2-de60-4589-82fa-d62e310d12b1" />

<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/84689ec3-d529-4c9b-9cae-2b1cf5154b59" />

# After the fix
<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/6d4fea6e-a775-490c-9e41-b338c1481817" />
<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/942aab21-92bb-482e-8303-43f6d6504d32" />
