### PR TITLE
fix(frontend): enhance datagrid action button styles

### DIFF
--- a/packages/frontend/src/app-components/tables/columns/getColumns.tsx
+++ b/packages/frontend/src/app-components/tables/columns/getColumns.tsx
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Stack, Tooltip } from "@mui/material";
+import { IconButtonOwnProps, Stack, Tooltip } from "@mui/material";
 import {
   GridActionsCellItem,
   GridColDef,
@@ -13,10 +13,8 @@ import {
   GridValidRowModel,
 } from "@mui/x-data-grid";
 import {
-  CheckCircle2,
   FileText,
-  List,
-  ListOrdered,
+  LucideProps,
   Pencil,
   RefreshCw,
   Shield,
@@ -24,92 +22,64 @@ import {
   Trash2,
   UserCog,
 } from "lucide-react";
+import { FunctionComponent } from "react";
 
 import { useHasPermission } from "@/hooks/useHasPermission";
 import { useTranslate } from "@/hooks/useTranslate";
 import { TTranslationKeys } from "@/i18n/i18n.types";
-import { theme } from "@/layout/theme";
 import { EntityType } from "@/services/types";
 import { PermissionAction } from "@/types/permission.types";
 
-export enum ActionColumnLabel {
+export enum ColumnActionType {
   Edit = "Edit",
   Delete = "Delete",
-  Values = "Values",
   Manage_Roles = "Manage_Roles",
   Permissions = "Permissions",
   Content = "Content",
-  Fields = "Fields",
   Manage_Labels = "Manage_Labels",
-  Toggle = "Toggle",
   Annotate = "Annotate",
 }
 
-const ACTION_COLUMN_LABEL_MAP: Record<ActionColumnLabel, TTranslationKeys> = {
-  [ActionColumnLabel.Edit]: "button.edit",
-  [ActionColumnLabel.Delete]: "button.delete",
-  [ActionColumnLabel.Values]: "button.values",
-  [ActionColumnLabel.Manage_Roles]: "button.manage_roles",
-  [ActionColumnLabel.Permissions]: "button.permissions",
-  [ActionColumnLabel.Content]: "button.content",
-  [ActionColumnLabel.Fields]: "button.fields",
-  [ActionColumnLabel.Manage_Labels]: "title.manage_labels",
-  [ActionColumnLabel.Toggle]: "button.toggle",
-  [ActionColumnLabel.Annotate]: "button.annotate",
+const COLUMN_ACTION_CONFIG_MAP: Record<
+  ColumnActionType,
+  {
+    label: TTranslationKeys;
+    icon: FunctionComponent<LucideProps>;
+    color?: IconButtonOwnProps["color"];
+  }
+> = {
+  [ColumnActionType.Edit]: {
+    label: "button.edit",
+    icon: Pencil,
+    color: "warning",
+  },
+  [ColumnActionType.Delete]: {
+    label: "button.delete",
+    icon: Trash2,
+    color: "error",
+  },
+  [ColumnActionType.Manage_Roles]: {
+    label: "button.manage_roles",
+    icon: UserCog,
+  },
+  [ColumnActionType.Permissions]: { label: "button.permissions", icon: Shield },
+  [ColumnActionType.Content]: { label: "button.content", icon: FileText },
+  [ColumnActionType.Manage_Labels]: {
+    label: "title.manage_labels",
+    icon: Tag,
+  },
+  [ColumnActionType.Annotate]: { label: "button.annotate", icon: RefreshCw },
 } as const;
 
 export interface ActionColumn<T extends GridValidRowModel> {
-  label: ActionColumnLabel;
-  action?: (row: T) => void;
+  action: ColumnActionType;
+  onClick?: (row: T) => void;
   requires?: PermissionAction[];
-  getState?: (row: T) => boolean;
   helperText?: string;
   isDisabled?: (row: T) => boolean;
 }
 
-const BUTTON_WIDTH = 60;
 const ACTION_ICON_SIZE = 18;
-
-export const getActionsWidth = (itemsNumber: number) =>
-  itemsNumber === 1 ? BUTTON_WIDTH + 60 : BUTTON_WIDTH * itemsNumber;
-
-function ActionIcon(label: ActionColumnLabel) {
-  switch (label) {
-    case ActionColumnLabel.Edit:
-      return <Pencil size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Delete:
-      return <Trash2 size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Values:
-      return <List size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Manage_Roles:
-      return <UserCog size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Permissions:
-      return <Shield size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Content:
-      return <FileText size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Fields:
-      return <ListOrdered size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Manage_Labels:
-      return <Tag size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Toggle:
-      return <CheckCircle2 size={ACTION_ICON_SIZE} />;
-    case ActionColumnLabel.Annotate:
-      return <RefreshCw size={ACTION_ICON_SIZE} />;
-    default:
-      return <></>;
-  }
-}
-
-function getColor(label: ActionColumnLabel) {
-  switch (label) {
-    case ActionColumnLabel.Edit:
-      return theme.palette.grey[900];
-    case ActionColumnLabel.Delete:
-      return theme.palette.error.main;
-    default:
-      return theme.palette.primary.main;
-  }
-}
 
 function StackComponent<T extends GridValidRowModel>({
   actions,
@@ -121,48 +91,35 @@ function StackComponent<T extends GridValidRowModel>({
   const { t } = useTranslate();
 
   return (
-    <Stack height="100%" alignItems="center" direction="row" spacing={0.5}>
+    <Stack>
       {actions.map(
-        ({
-          label,
-          action,
-          requires = [],
-          getState,
-          helperText,
-          isDisabled,
-        }) => (
-          <GridActionsCellItem
-            key={label}
-            className="actionButton"
-            icon={
-              <Tooltip
-                title={helperText || String(t(ACTION_COLUMN_LABEL_MAP[label]))}
-              >
-                {ActionIcon(label)}
-              </Tooltip>
-            }
-            label={helperText || t(ACTION_COLUMN_LABEL_MAP[label])}
-            showInMenu={false}
-            sx={{
-              color:
-                label === ActionColumnLabel.Toggle &&
-                getState &&
-                getState(params.row)
-                  ? getColor(label)
-                  : theme.palette.grey[600],
-              "&:hover": {
-                color: getColor(label),
-              },
-            }}
-            disabled={
-              (isDisabled && isDisabled(params.row)) ||
-              (params.row.builtin && requires.includes(PermissionAction.DELETE))
-            }
-            onClick={() => {
-              action && action(params.row);
-            }}
-          />
-        ),
+        ({ action, onClick, requires = [], helperText, isDisabled }) => {
+          const {
+            icon: Icon,
+            label: labelKey,
+            color = "primary",
+          } = COLUMN_ACTION_CONFIG_MAP[action];
+          const label = helperText || t(labelKey);
+
+          return (
+            <Tooltip key={action} title={label}>
+              <GridActionsCellItem
+                icon={<Icon size={ACTION_ICON_SIZE} />}
+                label={label}
+                showInMenu={false}
+                color={color}
+                disabled={
+                  (isDisabled && isDisabled(params.row)) ||
+                  (params.row.builtin &&
+                    requires.includes(PermissionAction.DELETE))
+                }
+                onClick={() => {
+                  onClick?.(params.row);
+                }}
+              />
+            </Tooltip>
+          );
+        },
       )}
     </Stack>
   );
@@ -173,12 +130,11 @@ export const getActionsColumn = <T extends GridValidRowModel>(
   headerName: string,
 ): GridColDef<T> => {
   return {
-    maxWidth: getActionsWidth(actions.length),
     field: "actions",
     headerName,
     sortable: false,
-    minWidth: getActionsWidth(actions.length),
-    align: "center",
+    align: "left",
+    headerAlign: "left",
     renderCell: (params) => (
       <StackComponent actions={actions} params={params} />
     ),

--- a/packages/frontend/src/components/content-types/index.tsx
+++ b/packages/frontend/src/components/content-types/index.tsx
@@ -9,7 +9,7 @@ import { AlignLeft } from "lucide-react";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
@@ -46,19 +46,19 @@ export const ContentTypes = () => {
     EntityType.CONTENT_TYPE,
     [
       {
-        label: ActionColumnLabel.Content,
-        action: (row) => router.push(`/content-types/content/${row.id}`),
+        action: ColumnActionType.Content,
+        onClick: (row) => router.push(`/content-types/content/${row.id}`),
       },
       {
-        label: ActionColumnLabel.Edit,
-        action: (row) => {
+        action: ColumnActionType.Edit,
+        onClick: (row) => {
           dialogs.open(ContentTypeFormDialog, { defaultValues: row });
         },
         requires: [PermissionAction.UPDATE],
       },
       {
-        label: ActionColumnLabel.Delete,
-        action: async ({ id }) => {
+        action: ColumnActionType.Delete,
+        onClick: async ({ id }) => {
           const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
 
           if (isConfirmed) {
@@ -73,7 +73,6 @@ export const ContentTypes = () => {
   const columns: GridColDef<IContentType>[] = [
     { flex: 1, field: "name", headerName: t("label.name") },
     {
-      maxWidth: 140,
       field: "createdAt",
       headerName: t("label.createdAt"),
       disableColumnMenu: true,
@@ -83,7 +82,6 @@ export const ContentTypes = () => {
         t("datetime.created_at", getDateTimeFormatter(params)),
     },
     {
-      maxWidth: 140,
       field: "updatedAt",
       headerName: t("label.updatedAt"),
       disableColumnMenu: true,

--- a/packages/frontend/src/components/contents/index.tsx
+++ b/packages/frontend/src/components/contents/index.tsx
@@ -12,7 +12,7 @@ import { Link as RouterLink } from "react-router-dom";
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import FileUploadButton from "@/app-components/inputs/FileInput";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
@@ -59,8 +59,8 @@ export const Contents = () => {
     EntityType.CONTENT,
     [
       {
-        label: ActionColumnLabel.Edit,
-        action: (row) => {
+        action: ColumnActionType.Edit,
+        onClick: (row) => {
           dialogs.open(ContentFormDialog, {
             defaultValues: row,
             presetValues: contentType,
@@ -69,8 +69,8 @@ export const Contents = () => {
         requires: [PermissionAction.UPDATE],
       },
       {
-        label: ActionColumnLabel.Delete,
-        action: async ({ id }) => {
+        action: ColumnActionType.Delete,
+        onClick: async ({ id }) => {
           const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
 
           if (isConfirmed) {

--- a/packages/frontend/src/components/labels/index.tsx
+++ b/packages/frontend/src/components/labels/index.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
@@ -45,8 +45,8 @@ export const Labels = () => {
     EntityType.LABEL,
     [
       {
-        label: ActionColumnLabel.Edit,
-        action: (row) => {
+        action: ColumnActionType.Edit,
+        onClick: (row) => {
           dialogs.open(LabelFormDialog, {
             defaultValues: row,
           });
@@ -54,8 +54,8 @@ export const Labels = () => {
         requires: [PermissionAction.UPDATE],
       },
       {
-        label: ActionColumnLabel.Delete,
-        action: async ({ id }) => {
+        action: ColumnActionType.Delete,
+        onClick: async ({ id }) => {
           const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
 
           if (isConfirmed) {

--- a/packages/frontend/src/components/languages/index.tsx
+++ b/packages/frontend/src/components/languages/index.tsx
@@ -10,7 +10,7 @@ import { Flag, Plus } from "lucide-react";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
@@ -67,15 +67,15 @@ export const Languages = () => {
     EntityType.LANGUAGE,
     [
       {
-        label: ActionColumnLabel.Edit,
-        action: (row) => {
+        action: ColumnActionType.Edit,
+        onClick: (row) => {
           dialogs.open(LanguageFormDialog, { defaultValues: row });
         },
         requires: [PermissionAction.UPDATE],
       },
       {
-        label: ActionColumnLabel.Delete,
-        action: async ({ id }) => {
+        action: ColumnActionType.Delete,
+        onClick: async ({ id }) => {
           const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
 
           if (isConfirmed) {

--- a/packages/frontend/src/components/memory-definitions/index.tsx
+++ b/packages/frontend/src/components/memory-definitions/index.tsx
@@ -9,7 +9,7 @@ import { MemoryStick, Plus } from "lucide-react";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
@@ -43,8 +43,8 @@ export const MemoryDefinitions = () => {
     EntityType.MEMORY_DEFINITION,
     [
       {
-        label: ActionColumnLabel.Edit,
-        action: (row) => {
+        action: ColumnActionType.Edit,
+        onClick: (row) => {
           dialogs.open(
             MemoryDefinitionFormDialog,
             { defaultValues: row },
@@ -54,8 +54,8 @@ export const MemoryDefinitions = () => {
         requires: [PermissionAction.UPDATE],
       },
       {
-        label: ActionColumnLabel.Delete,
-        action: async ({ id }) => {
+        action: ColumnActionType.Delete,
+        onClick: async ({ id }) => {
           const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
 
           if (isConfirmed) {

--- a/packages/frontend/src/components/roles/index.tsx
+++ b/packages/frontend/src/components/roles/index.tsx
@@ -9,7 +9,7 @@ import { Accessibility } from "lucide-react";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
@@ -41,8 +41,8 @@ export const Roles = () => {
     EntityType.ROLE,
     [
       {
-        label: ActionColumnLabel.Permissions,
-        action: (row) =>
+        action: ColumnActionType.Permissions,
+        onClick: (row) =>
           dialogs.open(
             PermissionBodyDialog,
             { defaultValues: row },
@@ -52,15 +52,15 @@ export const Roles = () => {
           ),
       },
       {
-        label: ActionColumnLabel.Edit,
-        action: (row) => {
+        action: ColumnActionType.Edit,
+        onClick: (row) => {
           dialogs.open(RoleFormDialog, { defaultValues: row });
         },
         requires: [PermissionAction.UPDATE],
       },
       {
-        label: ActionColumnLabel.Delete,
-        action: async ({ id }) => {
+        action: ColumnActionType.Delete,
+        onClick: async ({ id }) => {
           const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
 
           if (isConfirmed) {

--- a/packages/frontend/src/components/subscribers/index.tsx
+++ b/packages/frontend/src/components/subscribers/index.tsx
@@ -10,7 +10,7 @@ import { useMemo } from "react";
 
 import { ChipEntity } from "@/app-components/displays/ChipEntity";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { buildRenderPicture } from "@/app-components/tables/columns/renderPicture";
@@ -33,8 +33,8 @@ export const Subscribers = () => {
     EntityType.SUBSCRIBER,
     [
       {
-        label: ActionColumnLabel.Manage_Labels,
-        action: (row) => {
+        action: ColumnActionType.Manage_Labels,
+        onClick: (row) => {
           dialogs.open(SubscriberFormDialog, { defaultValues: row });
         },
         requires: [PermissionAction.UPDATE],

--- a/packages/frontend/src/components/translations/index.tsx
+++ b/packages/frontend/src/components/translations/index.tsx
@@ -10,7 +10,7 @@ import { Languages, RefreshCw } from "lucide-react";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
@@ -64,15 +64,15 @@ export const Translations = () => {
     EntityType.TRANSLATION,
     [
       {
-        label: ActionColumnLabel.Edit,
-        action: (row) => {
+        action: ColumnActionType.Edit,
+        onClick: (row) => {
           dialogs.open(TranslationFormDialog, { defaultValues: row });
         },
         requires: [PermissionAction.UPDATE],
       },
       {
-        label: ActionColumnLabel.Delete,
-        action: async ({ id }) => {
+        action: ColumnActionType.Delete,
+        onClick: async ({ id }) => {
           const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
 
           if (isConfirmed) {

--- a/packages/frontend/src/components/users/index.tsx
+++ b/packages/frontend/src/components/users/index.tsx
@@ -10,7 +10,7 @@ import { UserPlus, Users as UsersIcon } from "lucide-react";
 
 import { ChipEntity } from "@/app-components/displays/ChipEntity";
 import {
-  ActionColumnLabel,
+  ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { buildRenderPicture } from "@/app-components/tables/columns/renderPicture";
@@ -56,8 +56,8 @@ export const Users = () => {
     EntityType.USER,
     [
       {
-        label: ActionColumnLabel.Manage_Roles,
-        action: (row) => {
+        action: ColumnActionType.Manage_Roles,
+        onClick: (row) => {
           dialogs.open(EditUserFormDialog, {
             defaultValues: row,
             presetValues: roles,

--- a/packages/frontend/src/layout/theme/customizations/dataGrid.tsx
+++ b/packages/frontend/src/layout/theme/customizations/dataGrid.tsx
@@ -48,6 +48,41 @@ export const datagridCustomizations: Components<Theme> = {
             },
           },
         },
+        "& .MuiDataGrid-cell[data-field='actions']": {
+          alignContent: "center",
+          "& button": {
+            ":not(:hover)": {
+              color: theme.palette.common.black,
+            },
+            ":hover": {
+              stroke: "currenColor",
+              backgroundColor: gray[200],
+            },
+            ":active": {
+              backgroundColor: gray[200],
+            },
+            ...theme.applyStyles("dark", {
+              ":not(:hover)": {
+                color: theme.palette.common.white,
+              },
+              ":hover": {
+                backgroundColor: gray[700],
+              },
+            }),
+          },
+          "& .MuiIconButton-root": {
+            boxShadow: "none",
+            borderRadius: (theme.vars || theme).shape.borderRadius,
+            textTransform: "none",
+            letterSpacing: 0,
+            border: `1px solid ${gray[500]}`,
+          },
+          "& .MuiStack-root": {
+            flexDirection: "row",
+            display: "flex",
+            gap: theme.spacing(0.5),
+          },
+        },
       }),
       cell: ({ theme }) => ({
         borderTopColor: (theme.vars || theme).palette.divider,


### PR DESCRIPTION
# Motivation
Enhance DataGrid action button styles

# Updates
<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/e4808377-24b3-4a73-aaf6-0c2ce28c7135" />
<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/e7109c53-b932-4959-933d-a8406d5bb927" />


<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/fb9e3c67-f32b-476d-af6f-3ba65fd4ae4b" />
<img width="1280" height="686" alt="image" src="https://github.com/user-attachments/assets/3df4ffb3-b2c6-429f-a323-583fafa94d0e" />
