### PR TITLE
fix(frontend): visual editor button controllers dark mode

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/controls/RotateButton.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/controls/RotateButton.tsx
@@ -4,11 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
-import { IconButton } from "@mui/material";
-import { useReactFlow } from "@xyflow/react";
-import { RotateCw } from "lucide-react";
-
-import { AnimatedComponent } from "@/app-components/AnimatedComponent";
+import { Typography } from "@mui/material";
+import { ControlButton, useReactFlow } from "@xyflow/react";
 
 import { useWorkflow } from "../../hooks/useWorkflow";
 
@@ -18,20 +15,7 @@ export const RotateButton = () => {
     useWorkflow();
 
   return (
-    <IconButton
-      style={{
-        position: "absolute",
-        bottom: 119,
-        left: 14,
-        height: "26px",
-        width: "28px",
-        backgroundColor: "#fff",
-        borderRadius: 0,
-        border: "1px solid #0001",
-        padding: "2px 3px",
-        zIndex: 4,
-      }}
-      size="small"
+    <ControlButton
       onClick={async () => {
         if (selectedFlowId) {
           const toggledDirection =
@@ -58,13 +42,15 @@ export const RotateButton = () => {
         }
       }}
     >
-      <AnimatedComponent
-        component={RotateCw}
-        canRotate={direction === "vertical"}
-        from="-45"
-        to="45"
-        htmlColor="#000000de"
-      />
-    </IconButton>
+      <Typography
+        fontWeight={600}
+        sx={{
+          transition: "0.2s",
+          transform: `rotate(${direction === "horizontal" ? "50deg" : "140deg"})`,
+        }}
+      >
+        ↻
+      </Typography>
+    </ControlButton>
   );
 };

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ReactFlowWrapper.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ReactFlowWrapper.tsx
@@ -4,6 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
+import { useColorScheme } from "@mui/material";
 import {
   type Node,
   type Viewport,
@@ -35,6 +36,8 @@ export const ReactFlowWrapper = ({
   onDeleteNodes?: (ids: string[]) => void;
   onNodeDoubleClick?: (selectedNodeId: string) => void;
 } & PropsWithChildren) => {
+  const { mode } = useColorScheme();
+
   useOnViewportChange({
     onEnd: ({ x, y, zoom }) => {
       if (
@@ -95,6 +98,7 @@ export const ReactFlowWrapper = ({
       edgeTypes={EDGE_TYPES}
       onNodesChange={handleNodesChange}
       onlyRenderVisibleElements
+      colorMode={mode}
     >
       {children}
     </ReactFlow>

--- a/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
@@ -285,9 +285,11 @@ export const Workflow = () => {
             className="rf-controls-v4"
             onFitView={animateFocus}
             fitViewOptions={{ duration: 200 }}
-          />
+          >
+            <RotateButton />
+          </Controls>
+
           <Background size={2} />
-          <RotateButton />
           {isEmptyWorkflow && (
             <WorkflowEmptyState
               drawerId={actionsDrawerId}


### PR DESCRIPTION
# Motivation
Visual editor button controllers dark mode

# Before the fix
<img width="67" height="167" alt="image" src="https://github.com/user-attachments/assets/6c1c708b-0f0b-4258-9936-73548107f04f" />

# After the fix
<img width="67" height="167" alt="image" src="https://github.com/user-attachments/assets/89f6f949-8eb1-47f8-b2be-3583ef653b51" />
