### PR TITLE
fix(frontend): make add button dark mode compatible

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/PulseIconButton.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/PulseIconButton.tsx
@@ -6,7 +6,7 @@
 
 import type { IconButtonProps } from "@mui/material";
 import { IconButton } from "@mui/material";
-import { keyframes, styled } from "@mui/material/styles";
+import { keyframes, styled, useColorScheme } from "@mui/material/styles";
 
 const pulse = keyframes`
   0% {
@@ -35,6 +35,8 @@ const PulseIconButtonRoot = styled(IconButton, {
   shouldForwardProp: (prop) => prop !== "pulseSize",
 })<PulseIconButtonRootProps>(({ theme, pulseSize }) => {
   const ringInset = Math.max(4, Math.round(pulseSize * 0.14));
+  const { mode } = useColorScheme();
+  const isDarkMode = mode === "dark";
 
   return {
     position: "relative",
@@ -44,9 +46,11 @@ const PulseIconButtonRoot = styled(IconButton, {
     height: pulseSize,
     padding: 0,
     borderRadius: "50%",
-    border: `1px dashed ${theme.palette.divider}`,
-    backgroundColor: theme.palette.background.paper,
-    color: theme.palette.text.secondary,
+    border: `1px dashed ${isDarkMode ? theme.palette.grey[600] : theme.palette.grey[400]}`,
+    backgroundColor: isDarkMode
+      ? theme.palette.common.black
+      : theme.palette.common.white,
+    color: theme.typography.body1.color,
     boxShadow: theme.shadows[1],
     transition: ".2s",
     "&::after": {
@@ -61,7 +65,11 @@ const PulseIconButtonRoot = styled(IconButton, {
       zIndex: -1,
     },
     "&:hover": {
-      backgroundColor: `color-mix(in srgb, ${theme.palette.background.paper}, black 10%)`,
+      backgroundColor: `color-mix(in srgb, ${
+        isDarkMode ? theme.palette.common.black : theme.palette.common.white
+      }, ${
+        isDarkMode ? theme.palette.common.white : theme.palette.common.black
+      } 15%)`,
     },
     "@media (prefers-reduced-motion: reduce)": {
       "&::after": {


### PR DESCRIPTION
# Motivation
Make add button dark mode compatible

# Before the update
<img width="1918" height="997" alt="image" src="https://github.com/user-attachments/assets/0d1f7585-1747-47ae-ad9f-e22008db1833" />
<img width="1918" height="997" alt="image" src="https://github.com/user-attachments/assets/1fe1dc74-309a-47ea-9e6e-219ec6cb5448" />

# After the update
<img width="1918" height="997" alt="image" src="https://github.com/user-attachments/assets/1003f904-cb2f-40af-b3a3-6e60c3464eab" />
<img width="1918" height="997" alt="image" src="https://github.com/user-attachments/assets/eef25bea-c583-4c55-948c-07c36e0d9bfb" />
<img width="1918" height="997" alt="image" src="https://github.com/user-attachments/assets/9e910a90-3735-43e3-a578-e009da970617" />
<img width="1918" height="997" alt="image" src="https://github.com/user-attachments/assets/b59f0038-f252-4310-89f5-a1ea9c003fda" />
