### PR TITLE
fix(frontend): resolve import button size

### DIFF
--- a/packages/frontend/src/app-components/inputs/FileInput.tsx
+++ b/packages/frontend/src/app-components/inputs/FileInput.tsx
@@ -52,6 +52,7 @@ const FileUploadButton = forwardRef<HTMLLabelElement, FileUploadButtonProps>(
       <>
         <Button
           ref={ref}
+          size="small"
           htmlFor="importFile"
           variant="contained"
           component="label"


### PR DESCRIPTION
# Motivation
Resolve import button size

# Before the update 
<img width="413" height="179" alt="image" src="https://github.com/user-attachments/assets/d07342f1-89c7-4aea-931a-aa1c37ea8f38" />


# After the update
<img width="413" height="179" alt="image" src="https://github.com/user-attachments/assets/ac2700cd-518a-4e40-8998-10cd9f205390" />
