### PR TITLE
fix(frontend): adapt badges to dark mode

### DIFF
--- a/packages/frontend/src/app-components/displays/Badge.tsx
+++ b/packages/frontend/src/app-components/displays/Badge.tsx
@@ -4,14 +4,20 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Box, Typography } from "@mui/material";
-import { LucideIcon } from "lucide-react";
+import { Box, Tooltip, Typography } from "@mui/material";
+import { LoaderCircle, LucideIcon } from "lucide-react";
 
 export type BadgeWithTitleProps = {
   title?: string;
   icon?: LucideIcon;
   color?: string;
   background?: string;
+  width?: string;
+  height?: string;
+  selected?: boolean;
+  disableTooltip?: boolean;
+  padding?: string;
+  isLoading?: boolean;
 };
 
 export const BadgeWithTitle = ({ title, ...rest }: BadgeWithTitleProps) => {
@@ -28,30 +34,61 @@ export const BadgeWithTitle = ({ title, ...rest }: BadgeWithTitleProps) => {
 };
 
 export const Badge = ({
-  icon: TypeIcon,
+  icon: Icon,
   color,
-  background,
-}: Omit<BadgeWithTitleProps, "title">) => {
-  if (!TypeIcon) {
+  height = "24px",
+  width = "24px",
+  title,
+  selected,
+  disableTooltip,
+  padding = "2px",
+  isLoading,
+}: BadgeWithTitleProps) => {
+  if (!Icon) {
     return null;
   }
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        width: 22,
-        height: 22,
-        borderRadius: 10,
-        backgroundColor: background,
-        color,
-        flexShrink: 0,
-        boxShadow: "0 0 4px #0001 inset",
-      }}
+    <Tooltip
+      title={title}
+      arrow
+      disableHoverListener={!title || disableTooltip}
     >
-      <TypeIcon size={13} />
-    </Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color,
+          minWidth: width,
+          minHeight: height,
+          maxWidth: width,
+          maxHeight: height,
+          zIndex: 4,
+          border: (theme) =>
+            `2px solid ${selected ? theme.alpha(theme.vars.palette.primary.main, 0.8) : theme.alpha(theme.vars.palette.text.primary, 0.05)}`,
+          background: `color-mix(in srgb, transparent, ${color} ${selected ? "25%" : "10%"})`,
+          flexShrink: 0,
+          borderRadius: (theme) => (theme.shape.borderRadius as number) + 1,
+          transform: selected ? "scale(1.1)" : "scale(1)",
+          transition: "0.2s",
+          ...(isLoading && { animation: "rotate infinite 700ms linear" }),
+          "@keyframes rotate": {
+            from: {
+              transform: "rotate(0deg)",
+            },
+            to: {
+              transform: "rotate(360deg)",
+            },
+          },
+        }}
+      >
+        {isLoading ? (
+          <LoaderCircle />
+        ) : (
+          <Icon size="100%" style={{ padding }} />
+        )}
+      </Box>
+    </Tooltip>
   );
 };

--- a/packages/frontend/src/app-components/tables/GenericFilters.tsx
+++ b/packages/frontend/src/app-components/tables/GenericFilters.tsx
@@ -77,9 +77,15 @@ export const GenericFilters = ({ filters }: { filters?: Filter[] }) =>
       onChange,
       ...rest
     }) => {
-      if (rest.type === "enumFilter") {
-        const { defaultValue, ...defaultOptionRest } = defaultOption;
+      const {
+        defaultValue,
+        width,
+        height,
+        padding = "0px",
+        ...defaultOptionRest
+      } = defaultOption;
 
+      if (rest.type === "enumFilter") {
         return (
           <Grid key={field} flex={1} minWidth="180px">
             <TextField
@@ -92,14 +98,21 @@ export const GenericFilters = ({ filters }: { filters?: Filter[] }) =>
             >
               {defaultValue ? (
                 <MenuItem value={defaultValue}>
-                  <BadgeWithTitle {...defaultOptionRest} />
+                  <BadgeWithTitle
+                    {...defaultOptionRest}
+                    {...{ width, height, padding }}
+                  />
                 </MenuItem>
               ) : null}
               {typeInfo
                 ? Object.entries(typeInfo).map(
                     ([type, { key, ...infoRest }]) => (
                       <MenuItem key={key} value={type}>
-                        <BadgeWithTitle {...infoRest} title={type} />
+                        <BadgeWithTitle
+                          {...infoRest}
+                          title={type}
+                          {...{ width, height, padding }}
+                        />
                       </MenuItem>
                     ),
                   )
@@ -125,6 +138,7 @@ export const GenericFilters = ({ filters }: { filters?: Filter[] }) =>
                   <BadgeWithTitle
                     {...typeInfo?.[workflow.type]}
                     title={workflow.name}
+                    {...{ width, height, padding }}
                   />
                 </Box>
               )}
@@ -133,6 +147,7 @@ export const GenericFilters = ({ filters }: { filters?: Filter[] }) =>
                   <BadgeWithTitle
                     {...typeInfo?.[workflow.type]}
                     title={workflow.name}
+                    {...{ width, height, padding }}
                   />
                 </li>
               )}

--- a/packages/frontend/src/app-components/workflow/WorkflowBadgeWithTitle.tsx
+++ b/packages/frontend/src/app-components/workflow/WorkflowBadgeWithTitle.tsx
@@ -9,14 +9,17 @@ import { Box, Typography } from "@mui/material";
 import { WORKFLOW_TYPES } from "@/constants/workflow.constants";
 import type { IWorkflow } from "@/types/workfow.types";
 
+import { BadgeWithTitleProps } from "../displays/Badge";
+
 import { WorkflowTypeBadge } from "./WorkflowTypeBadge";
 
-export type WorkflowBadgeWithTitleProps = {
+export type WorkflowBadgeWithTitleProps = BadgeWithTitleProps & {
   workflow?: IWorkflow | null;
 };
 
 export const WorkflowBadgeWithTitle = ({
   workflow,
+  ...rest
 }: WorkflowBadgeWithTitleProps) => {
   if (!workflow) {
     return null;
@@ -31,7 +34,7 @@ export const WorkflowBadgeWithTitle = ({
   return (
     <Box gap={1} display="flex" alignItems="stretch">
       <Box display="flex" alignItems="center" justifyContent="center">
-        <WorkflowTypeBadge workflow={workflow} />
+        <WorkflowTypeBadge workflow={workflow} {...rest} />
       </Box>
       <Box display="flex" alignItems="center" justifyContent="center">
         <Typography

--- a/packages/frontend/src/app-components/workflow/WorkflowRunStatusBadge.tsx
+++ b/packages/frontend/src/app-components/workflow/WorkflowRunStatusBadge.tsx
@@ -29,5 +29,11 @@ export const WorkflowRunStatusBadge = ({
     WORKFLOW_STATUS[status] ?? WORKFLOW_STATUS[EWorkflowRunStatus.IDLE];
   const title = workflowRun?.status ?? status;
 
-  return <BadgeWithTitle {...badgeRest} title={title} />;
+  return (
+    <BadgeWithTitle
+      {...badgeRest}
+      title={title}
+      isLoading={workflowRun?.status === "running"}
+    />
+  );
 };

--- a/packages/frontend/src/app-components/workflow/WorkflowTypeBadge.tsx
+++ b/packages/frontend/src/app-components/workflow/WorkflowTypeBadge.tsx
@@ -4,23 +4,20 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Box, Tooltip } from "@mui/material";
-import { alpha, useTheme } from "@mui/material/styles";
-
 import { WORKFLOW_TYPES } from "@/constants/workflow.constants";
 import { useTranslate } from "@/hooks/useTranslate";
 import type { IWorkflow } from "@/types/workfow.types";
 
-type WorkflowTypeBadgeProps = {
+import { Badge, BadgeWithTitleProps } from "../displays/Badge";
+
+type WorkflowTypeBadgeProps = BadgeWithTitleProps & {
   workflow: IWorkflow;
-  selected?: boolean;
 };
 
 export const WorkflowTypeBadge = ({
   workflow,
-  selected = true,
+  ...rest
 }: WorkflowTypeBadgeProps) => {
-  const theme = useTheme();
   const { t } = useTranslate();
   const typeInfo = WORKFLOW_TYPES[workflow.type];
 
@@ -28,37 +25,8 @@ export const WorkflowTypeBadge = ({
     return null;
   }
 
-  const { icon: Icon, labelKey } = typeInfo;
+  const { icon: Icon, labelKey, color } = typeInfo;
   const label = t(labelKey);
-  const resolvedColor = selected
-    ? typeInfo.color
-    : theme.palette.text.secondary;
-  const resolvedBackground = selected
-    ? typeInfo.background
-    : alpha(resolvedColor, 0.12);
 
-  return (
-    <Tooltip title={label} arrow disableHoverListener={!label}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          width: 32,
-          height: 32,
-          borderRadius: (theme) => (theme.shape.borderRadius as number) + 1,
-          flexShrink: 0,
-          color: resolvedColor,
-          backgroundColor: resolvedBackground,
-          transition: "0.33s",
-          border: ".15rem solid transparent",
-          borderColor: selected
-            ? alpha(theme.palette.primary.main, 0.2)
-            : "transparent",
-        }}
-      >
-        <Icon size={18} />
-      </Box>
-    </Tooltip>
-  );
+  return <Badge title={label} icon={Icon} color={color} {...rest} />;
 };

--- a/packages/frontend/src/components/visual-editor/v4/components/forms/WorkflowForm.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/forms/WorkflowForm.tsx
@@ -274,13 +274,18 @@ export const WorkflowForm: FC<
                               icon={
                                 <WorkflowTypeBadge
                                   workflow={badgeWorkflow}
-                                  selected={false}
+                                  width="32px"
+                                  height="32px"
+                                  padding="4px"
                                 />
                               }
                               checkedIcon={
                                 <WorkflowTypeBadge
                                   workflow={badgeWorkflow}
                                   selected={isSelected}
+                                  width="32px"
+                                  height="32px"
+                                  padding="4px"
                                 />
                               }
                             />

--- a/packages/frontend/src/components/visual-editor/v4/components/main/FlowsDrawer/types.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/FlowsDrawer/types.ts
@@ -22,7 +22,6 @@ export type FlowTypeInfo = {
   labelKey: TTranslationKeys;
   icon: LucideIcon;
   color: string;
-  background: string;
 };
 
 export type FlowTypeMeta = {

--- a/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowTitleBar/WorkflowTitleBar.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowTitleBar/WorkflowTitleBar.tsx
@@ -93,7 +93,9 @@ export const WorkflowTitleBar = ({
         >
           <WorkflowTypeBadge
             workflow={workflow}
-            selected
+            width="32px"
+            height="32px"
+            padding="4px"
           />
           <Box
             sx={{

--- a/packages/frontend/src/components/workflow-runs/index.tsx
+++ b/packages/frontend/src/components/workflow-runs/index.tsx
@@ -140,7 +140,8 @@ export const WorkflowRuns = ({
         defaultOption: {
           icon: GalleryHorizontalEnd,
           title: `${t("label.all")} ${t("label.types")}`,
-          background: "#f8f8f8",
+          width: "18px",
+          height: "18px",
         },
         typeInfo: WORKFLOW_TYPES,
         onChange: setName,
@@ -154,8 +155,9 @@ export const WorkflowRuns = ({
         defaultOption: {
           icon: GalleryHorizontalEnd,
           title: `${t("label.all")} ${t("label.types")}`,
-          background: "#f8f8f8",
           defaultValue: defaultType,
+          width: "18px",
+          height: "18px",
         },
         typeInfo: WORKFLOW_TYPES,
         onChange: setType,
@@ -169,8 +171,9 @@ export const WorkflowRuns = ({
         defaultOption: {
           icon: GalleryHorizontalEnd,
           title: `${t("label.all")} ${t("label.status")}`,
-          background: "#f8f8f8",
           defaultValue: defaultWorkflowRunStatus,
+          width: "18px",
+          height: "18px",
         },
         typeInfo: WORKFLOW_STATUS,
         onChange: setWorkflowRunStatus,

--- a/packages/frontend/src/constants/workflow.constants.ts
+++ b/packages/frontend/src/constants/workflow.constants.ts
@@ -17,7 +17,7 @@ import {
   GitBranch,
   GripVertical,
   Hand,
-  MessageSquare,
+  MessagesSquare,
   Pause,
   Play,
   Repeat,
@@ -192,31 +192,26 @@ export const WORKFLOW_STATUS: Record<
     key: WorkflowType.conversational,
     icon: X,
     color: theme.palette.error.main,
-    background: "#f8f8f8",
   },
   [EWorkflowRunStatus.FINISHED]: {
     key: WorkflowType.conversational,
     icon: Check,
     color: theme.palette.success.main,
-    background: "#f8f8f8",
   },
   [EWorkflowRunStatus.IDLE]: {
     key: WorkflowType.conversational,
     icon: ChartNoAxesGantt,
     color: theme.palette.info.main,
-    background: "#f8f8f8",
   },
   [EWorkflowRunStatus.RUNNING]: {
     key: WorkflowType.conversational,
     icon: Play,
     color: theme.palette.success.main,
-    background: "#f8f8f8",
   },
   [EWorkflowRunStatus.SUSPENDED]: {
     key: WorkflowType.conversational,
     icon: Pause,
     color: theme.palette.warning.main,
-    background: "#f8f8f8",
   },
 };
 
@@ -225,30 +220,26 @@ type WorkflowTypeInfo = {
   labelKey: TTranslationKeys;
   icon: LucideIcon;
   color: string;
-  background: string;
 };
 
 export const WORKFLOW_TYPES: Record<WorkflowType, WorkflowTypeInfo> = {
   [WorkflowType.conversational]: {
     key: WorkflowType.conversational,
     labelKey: "label.conversational",
-    icon: MessageSquare,
-    color: "#1d4ed8",
-    background: "#e0ecff",
+    icon: MessagesSquare,
+    color: theme.palette.info.main,
   },
   [WorkflowType.scheduled]: {
     key: WorkflowType.scheduled,
     labelKey: "label.scheduled",
     icon: Clock,
-    color: "#b45309",
-    background: "#fef3c7",
+    color: theme.palette.warning.main,
   },
   [WorkflowType.manual]: {
     key: WorkflowType.manual,
     labelKey: "label.manual",
     icon: Hand,
-    color: "#047857",
-    background: "#d1fae5",
+    color: theme.palette.success.main,
   },
 };
 


### PR DESCRIPTION
# Motivation
Adapt badges to dark mode

# Updates
<video src="https://github.com/user-attachments/assets/b21a218d-a234-4dfc-9c84-d3f009d7637d" ></video>
<img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/146f2fc5-fc57-4e24-a338-237a46c86019" />
<img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/5fd268a5-bc94-4c52-8cef-78403cb4b5c4" />
<img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/0459fec6-b1f7-4f61-a43e-086c7fa849df" />
<img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/05bdd735-93c4-4150-bfb5-30c97e7c8c6e" />
<img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/e9a99ac7-f49c-41fe-a25f-f1af34eb4e0c" />
<img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/fa426854-d36b-4414-8a5d-150b3a03337b" />


