### PR TITLE
fix(frontend): update autocomplete chip height

### DIFF
--- a/packages/frontend/src/app-components/inputs/AutoCompleteEntityDistinctSelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteEntityDistinctSelect.tsx
@@ -127,6 +127,7 @@ const AutoCompleteEntityDistinctSelect = <
         </Box>
       )}
       multiple
+      data-multiple="true"
       {...rest}
     />
   );

--- a/packages/frontend/src/app-components/inputs/AutoCompleteEntitySelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteEntitySelect.tsx
@@ -134,6 +134,7 @@ const AutoCompleteEntitySelect = <
       options={options || []}
       onSearch={onSearch}
       loading={isFetching}
+      data-multiple={rest.multiple}
       {...rest}
     />
   );

--- a/packages/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/packages/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -74,7 +74,7 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
             />
           </ContentItem>
           <ContentItem>
-            <Grid container gap="20px">
+            <Grid container gap={2}>
               <Grid size="grow">
                 <Controller
                   name="labels"
@@ -104,9 +104,11 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                   control={control}
                 />
               </Grid>
-              <Grid size="auto" alignContent="center">
-                <Link href="/labels">
-                  <Button variant="contained">{t("button.manage")}</Button>
+              <Grid size="auto" alignContent="end">
+                <Link href="/subscribers/labels">
+                  <Button variant="contained" size="small">
+                    {t("button.manage")}
+                  </Button>
                 </Link>
               </Grid>
             </Grid>

--- a/packages/frontend/src/components/users/EditUserForm.tsx
+++ b/packages/frontend/src/components/users/EditUserForm.tsx
@@ -115,9 +115,11 @@ export const EditUserForm: FC<ComponentFormProps<IUser, IRole[]>> = ({
                   }}
                 />
               </Grid>
-              <Grid size="auto" alignContent="center">
+              <Grid size="auto" alignContent="end">
                 <Link href="/roles">
-                  <Button variant="contained">{t("button.manage")}</Button>
+                  <Button variant="contained" size="small">
+                    {t("button.manage")}
+                  </Button>
                 </Link>
               </Grid>
             </Grid>

--- a/packages/frontend/src/layout/theme/customizations/inputs.tsx
+++ b/packages/frontend/src/layout/theme/customizations/inputs.tsx
@@ -303,6 +303,11 @@ export const inputsCustomizations: Components<Theme> = {
           display: "flex",
           gap: "6px",
         },
+        "&[data-multiple='true']": {
+          "& .MuiAutocomplete-inputRoot": {
+            height: "100%",
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
# Motivation
Update autocomplete chip height

# Before the fix
<img width="1915" height="998" alt="image" src="https://github.com/user-attachments/assets/1cb6b59c-0aa8-484c-9f5a-8a3f7c115502" />
<img width="1915" height="998" alt="image" src="https://github.com/user-attachments/assets/c8e2e2ff-97ff-4a3d-a6e8-463d988fc53b" />
<img width="1915" height="998" alt="image" src="https://github.com/user-attachments/assets/15f0ff2d-1d94-4dcd-99fb-0e29cf281251" />
<img width="1915" height="998" alt="image" src="https://github.com/user-attachments/assets/eee2b014-0fd8-4e7b-a03a-edfa5772fb2b" />

# After applying the fixes
<img width="1915" height="998" alt="image" src="https://github.com/user-attachments/assets/6886f1bd-78c5-4538-81de-40a3bad5260e" />
<img width="1915" height="998" alt="image" src="https://github.com/user-attachments/assets/0e2fbe7a-7292-44ce-a144-cc3797065392" />
<img width="1915" height="998" alt="image" src="https://github.com/user-attachments/assets/93ac213b-b233-484b-9b4d-0cedd3f55928" />
<img width="1915" height="998" alt="image" src="https://github.com/user-attachments/assets/938dc43e-89dc-4145-8213-ab4728b5804d" />
