### PR TITLE
fix(frontend): resolve dashboard sidebar hover menu position

### DIFF
--- a/packages/frontend/src/app-components/menus/DashboardSidebar/DashboardSidebarPageItem.tsx
+++ b/packages/frontend/src/app-components/menus/DashboardSidebar/DashboardSidebarPageItem.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 
 import { useDashboardSidebar } from "./hooks/useDashboardSidebar";
-import { ICON_WIDTH, MINI_DRAWER_WIDTH } from "./measurements.constansts";
+import { ICON_WIDTH } from "./measurements.constansts";
 import { DashboardSidebarProvider } from "./providers/DashboardSidebarProvider";
 import { DashboardSidebarPageItemProps } from "./types/sidebar.types";
 
@@ -40,6 +40,10 @@ export const DashboardSidebarPageItem = ({
     useDashboardSidebar();
   const [isHovered, setIsHovered] = React.useState(false);
   const hasSub = !!nestedNavigation;
+  const submenuAnchorName = `--dashboard-sidebar-item-${React.useId().replaceAll(
+    ":",
+    "",
+  )}`;
   const isExternal = href?.startsWith("http");
   const LinkComp = isExternal ? "a" : Link;
   const handleClick = () => onPageItemClick?.(id, hasSub);
@@ -66,6 +70,7 @@ export const DashboardSidebarPageItem = ({
       <ListItem
         sx={{
           px: mini ? 0 : 1,
+          anchorName: mini ? submenuAnchorName : undefined,
         }}
         disablePadding
         onMouseEnter={() => hasSub && mini && setIsHovered(true)}
@@ -136,7 +141,14 @@ export const DashboardSidebarPageItem = ({
 
         {hasSub && mini && (
           <Grow in={isHovered}>
-            <Box sx={{ position: "fixed", left: MINI_DRAWER_WIDTH }}>
+            <Box
+              sx={{
+                position: "fixed",
+                positionAnchor: submenuAnchorName,
+                top: "anchor(top)",
+                left: "calc(anchor(right) + 8px)",
+              }}
+            >
               <Paper elevation={8}>
                 <DashboardSidebarProvider
                   {...{


### PR DESCRIPTION
# Motivation
Resolve dashboard sidebar hover menu position

<img width="206" height="502" alt="image" src="https://github.com/user-attachments/assets/7bc7f13d-a2b4-4932-bd0d-8669e3e7abee" />

<img width="206" height="502" alt="image" src="https://github.com/user-attachments/assets/df77bcb4-e274-4ca9-8455-4537885c6996" />
