### PR TITLE
fix(widget): resolve carousel chevron color

### DIFF
--- a/packages/widget/src/components/messages/CarouselMessage.scss
+++ b/packages/widget/src/components/messages/CarouselMessage.scss
@@ -57,7 +57,7 @@
     display: grid;
     place-items: center;
     background-color: var(--hb-color-surface-overlay);
-    color: var(--hb-color-text-inverse);
+    color: var(--hb-color-text-primary);
     border: none;
     padding: 0;
     cursor: pointer;


### PR DESCRIPTION
# Motivation
 Resolve carousel chevron color

# Updates
<img width="327" height="458" alt="image" src="https://github.com/user-attachments/assets/af89667a-9b8d-4705-aab2-42278c25d773" />
<img width="327" height="458" alt="image" src="https://github.com/user-attachments/assets/85f0496c-990c-49db-a8bb-05d54f9d80c0" />

<img width="327" height="458" alt="image" src="https://github.com/user-attachments/assets/4b47ab77-b393-48c8-a63f-71384a3151e6" />

<img width="327" height="458" alt="image" src="https://github.com/user-attachments/assets/fbd8a345-8da7-453c-87db-11ad134cf3ed" />
