### PR TITLE
feat: move subscriber + channel to ctx to input

### DIFF
--- a/packages/api/src/channel/lib/ConversationalEventWrapper.ts
+++ b/packages/api/src/channel/lib/ConversationalEventWrapper.ts
@@ -253,18 +253,15 @@ export default abstract class ConversationalEventWrapper<
 
   getContextData() {
     return {
-      messageId: this.getId(),
-      eventType: this.getEventType(),
-      messageType: this.getMessageType(),
+      channel: this.getChannelData(),
+      initiator: this.getInitiator(),
     };
   }
 
   buildInput(): Record<string, unknown> {
     const input: Record<string, unknown> = {
-      channel: this.getChannelData(),
       message_type: this.getMessageType(),
       event_type: this.getEventType(),
-      sender: this.getInitiator(),
       payload: this.getPayload(),
       message: this.getMessage(),
       text: this.getText(),

--- a/packages/api/src/extensions/channels/web/__test__/wrapper.spec.ts
+++ b/packages/api/src/extensions/channels/web/__test__/wrapper.spec.ts
@@ -124,5 +124,18 @@ describe(`Web event wrapper`, () => {
     expect(event.getPayload()).toEqual(expected.payload);
     expect(event.getMessage()).toEqual(expected.message);
     expect(event.getDeliveredMessages()).toEqual([]);
+    expect(event.buildInput()).not.toHaveProperty('channel');
+    expect(event.buildInput()).not.toHaveProperty('sender');
+    expect(event.getContextData()).toEqual(
+      expect.objectContaining({
+        channel: {
+          ...expected.channelData,
+          name: WEB_CHANNEL_NAME,
+        },
+      }),
+    );
+    expect(event.getContextData()).not.toHaveProperty('messageId');
+    expect(event.getContextData()).not.toHaveProperty('eventType');
+    expect(event.getContextData()).not.toHaveProperty('messageType');
   });
 });

--- a/packages/api/src/workflow/contexts/workflow-runtime.context.spec.ts
+++ b/packages/api/src/workflow/contexts/workflow-runtime.context.spec.ts
@@ -28,7 +28,10 @@ class TestEventWrapper extends TriggerEventWrapper {
   }
 
   getContextData(): Record<string, unknown> {
-    return {};
+    return {
+      channel: { name: 'web-channel' },
+      initiator: { id: 'owner-1' },
+    };
   }
 }
 
@@ -93,6 +96,12 @@ describe('WorkflowRuntimeContext', () => {
     expect(context.memoryStore).toBe(store);
     expect(context.state).toMatchObject({
       locale: 'en',
+      channel: {
+        name: 'web-channel',
+      },
+      initiator: {
+        id: 'owner-1',
+      },
       initiatorId: 'owner-1',
       workflowId: 'workflow-1',
       runId: 'run-1',

--- a/packages/api/src/workflow/contexts/workflow-runtime.context.ts
+++ b/packages/api/src/workflow/contexts/workflow-runtime.context.ts
@@ -107,8 +107,10 @@ export abstract class WorkflowRuntimeContext<
     memory: MemoryStore,
   ): Promise<this> {
     this.resetState();
-    await this.hydrate(run.context);
     this.event = event;
+    // Hydrate persisted state first, then merge transient event context.
+    await this.hydrate(run.context);
+    await this.hydrate(event.getContextData());
     this.initiatorId = run.triggeredBy.id;
     this.workflowId = run.workflow.id;
     this.workflowRunId = run.id;
@@ -118,7 +120,13 @@ export abstract class WorkflowRuntimeContext<
     return this;
   }
 
-  async hydrate(stored: WorkflowContextState): Promise<this> {
+  async hydrate(
+    stored?: Record<string, unknown> | WorkflowContextState | null,
+  ): Promise<this> {
+    if (!stored) {
+      return this;
+    }
+
     this.state = {
       ...this.state,
       ...stored,

--- a/packages/api/src/workflow/lib/trigger-event-wrapper.ts
+++ b/packages/api/src/workflow/lib/trigger-event-wrapper.ts
@@ -32,6 +32,9 @@ export abstract class TriggerEventWrapper<
 
   abstract getMetadata(): Record<string, unknown>;
 
+  /**
+   * Returns event-scoped data that should live on workflow context state.
+   */
   abstract getContextData(): Record<string, unknown>;
 
   abstract buildInput(): Record<string, unknown>;

--- a/packages/api/src/workflow/services/agentic.service.ts
+++ b/packages/api/src/workflow/services/agentic.service.ts
@@ -275,12 +275,16 @@ export class AgenticService {
     if (!workflow.definition) {
       throw new Error('Workflow definition is required to create a run');
     }
+    const initialContext = {
+      ...(workflow.definition.context ?? {}),
+      ...event.getContextData(),
+    };
     const run = await this.workflowRunService.create({
       workflow: workflow.id,
       workflowVersion: workflow.currentVersion?.id ?? null,
       triggeredBy: initiator.id,
       input: event.buildInput(),
-      context: workflow.definition.context ?? null,
+      context: Object.keys(initialContext).length > 0 ? initialContext : null,
       metadata: event.getMetadata(),
     });
     const populated = await this.workflowRunService.findOneAndPopulate(run.id);


### PR DESCRIPTION
# Motivation

Move the initiator object (subscriber/user) to the context state instead of the input.

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
