### PR TITLE
fix(frontend): resolve Drawer glitchs

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer.tsx
@@ -86,7 +86,7 @@ const ActionFormDrawerContent = ({
 }: ActionFormDrawerContentProps) => {
   const { t } = useTranslate();
 
-  if (!isOpen) return null;
+  if (!isOpen || !Object.keys(inputData).length) return null;
 
   if (!actionSchema) {
     return (

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer.tsx
@@ -168,11 +168,14 @@ export const ActionFormDrawer = () => {
     : t("visual_editor.actions_drawer.form.empty_state.no_action");
 
   useEffect(() => {
+    if (!open) {
+      return;
+    }
     setInputData((taskDefinition?.inputs as Record<string, unknown>) ?? {});
     setSettingsData(
       (taskDefinition?.settings as Record<string, unknown>) ?? {},
     );
-  }, [taskDefinition, actionName]);
+  }, [open, taskName, actionName]);
 
   const handleClose = () => {
     if (selectedFlowId) {


### PR DESCRIPTION
# Motivation
Resolve Drawer glitch's:
1) The edit form drawer forms are losing states when refreshing state with open drawer
- Update a Text Message step text field
- Click save
- Wait for the updates to be saved
- Open the drawer again
- Refresh the page

2) The form glitch if the edit is open and a save is triggered 
- Create a text message step
- Create a second one
- Open the first step and update the first value field
- Wait around 3 seconds  and see the values changes (glitch)
