### PR TITLE
fix(api): resolve DB parser stack overflow issue

### DIFF
--- a/packages/api/src/cms/entities/menu.entity.ts
+++ b/packages/api/src/cms/entities/menu.entity.ts
@@ -38,7 +38,6 @@ export { MenuType };
   )
 `,
 )
-@Check(`"parent_id" IS NULL OR "id" <> "parent_id"`)
 export class MenuOrmEntity extends BaseOrmEntity<MenuTransformerDto> {
   plainCls = Menu;
 
@@ -98,6 +97,12 @@ export class MenuOrmEntity extends BaseOrmEntity<MenuTransformerDto> {
   private async ensureValidParent(): Promise<void> {
     const parentId = this.parent?.id;
     if (parentId) {
+      if (this.id && parentId === this.id) {
+        throw new Error(
+          'Menu Validation Error: parent should not reference itself',
+        );
+      }
+
       // Ensure parent is nested
       const manager = MenuOrmEntity.getEntityManager();
       const parent = await manager.findOne(MenuOrmEntity, {

--- a/packages/api/src/cms/services/menu.service.spec.ts
+++ b/packages/api/src/cms/services/menu.service.spec.ts
@@ -162,6 +162,18 @@ describe('MenuService (TypeORM)', () => {
         menuService.updateOne(child.id, { parent: parentPostback.id }),
       ).rejects.toThrow();
     });
+
+    it('rejects assigning a menu as its own parent', async () => {
+      const parent = await menuService.create({
+        title: 'Self parent candidate',
+        type: MenuType.nested,
+      });
+      createdIds.add(parent.id);
+
+      await expect(
+        menuService.updateOne(parent.id, { parent: parent.id }),
+      ).rejects.toThrow(/parent should not reference itself/i);
+    });
   });
 
   describe('deleteOne', () => {


### PR DESCRIPTION
# Motivation
Resolve DB parser stack overflow issue

```SQL
Unable to connect to the database. Retrying (1)...
@hexabot-ai/api:dev: QueryFailedError: SQLITE_ERROR: parser stack overflow
@hexabot-ai/api:dev:     at handler (Hexabot/node_modules/typeorm/driver/src/driver/sqlite/SqliteQueryRunner.ts:133:29)
@hexabot-ai/api:dev:     at replacement (Hexabot/node_modules/sqlite3/lib/trace.js:25:27)
@hexabot-ai/api:dev:     at Statement.errBack (Hexabot/node_modules/sqlite3/lib/sqlite3.js:15:21)

```

# Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
