### PR TITLE
fix: avoid mutating input data on run resume

### DIFF
--- a/packages/api/src/workflow/services/agentic.service.spec.ts
+++ b/packages/api/src/workflow/services/agentic.service.spec.ts
@@ -314,7 +314,7 @@ describe('AgenticService (TypeORM)', () => {
       } as any;
       workflowContextFactoryMock.create.mockResolvedValue(runtimeContext);
       const runnerState: ExecutionState = {
-        input: { merged: true },
+        input: { original: true },
         output: { next: 'output' },
         iterationStack: [0],
         iteration: { item: 'loop', index: 0 },
@@ -366,7 +366,7 @@ describe('AgenticService (TypeORM)', () => {
       expect(fromDefinitionSpy).toHaveBeenCalledTimes(1);
       expect(workflowInstance.buildRunnerFromState).toHaveBeenCalledWith({
         state: {
-          input: { original: true, latest: 'payload' },
+          input: { original: true },
           output: { saved: true },
           iterationStack: [0],
           iteration: { item: 'loop', index: 0 },
@@ -399,6 +399,7 @@ describe('AgenticService (TypeORM)', () => {
         resumeResult.awaitResults,
       );
       expect(updatedRun.lastResumeData).toEqual(event.buildInput());
+      expect(updatedRun.input).toEqual({ original: true });
       expect(updatedRun.output).toEqual(runnerState.output);
       expect(updatedRun.context).toEqual(runtimeContext.state);
       expect(updatedRun.stepLog).toEqual(

--- a/packages/api/src/workflow/services/agentic.service.ts
+++ b/packages/api/src/workflow/services/agentic.service.ts
@@ -239,7 +239,7 @@ export class AgenticService {
 
     const latestInput = context.event.buildInput();
     const runner = await workflowInstance.buildRunnerFromState({
-      state: this.buildExecutionState(run, latestInput),
+      state: this.buildExecutionState(run),
       context,
       snapshot: run.snapshot ?? { status: run.status, actions: {} },
       suspension: run.suspendedStep
@@ -394,17 +394,9 @@ export class AgenticService {
   /**
    * Build the ExecutionState used to rebuild a runner.
    */
-  private buildExecutionState(
-    run: WorkflowRunFull,
-    latestInput?: Record<string, unknown>,
-  ): ExecutionState {
-    const baseInput = run.input ?? {};
-    const mergedInput =
-      latestInput && Object.keys(latestInput).length > 0
-        ? { ...baseInput, ...latestInput }
-        : baseInput;
+  private buildExecutionState(run: WorkflowRunFull): ExecutionState {
     const state: ExecutionState = {
-      input: mergedInput,
+      input: run.input ?? {},
       output: run.output ?? {},
       iterationStack: [],
     };


### PR DESCRIPTION
# Motivation

Avoid mutating the input data on workflow run resume.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
