### PR TITLE
fix(api): resolve DTO's reset issue

### DIFF
--- a/packages/api/src/chat/dto/subscriber.dto.ts
+++ b/packages/api/src/chat/dto/subscriber.dto.ts
@@ -128,7 +128,7 @@ export class SubscriberCreateDto extends UserProfileCreateDto {
   @IsOptional()
   @IsString()
   @IsUUIDv4({ message: 'AssignedTo must be a valid UUID' })
-  assignedTo: string | null = null;
+  assignedTo: string | null;
 
   @ApiPropertyOptional({
     description: 'Subscriber assigned at',
@@ -171,7 +171,7 @@ export class SubscriberCreateDto extends UserProfileCreateDto {
   @IsOptional()
   @IsString()
   @IsUUIDv4({ message: 'Avatar Attachment ID must be a valid UUID' })
-  avatar: string | null = null;
+  avatar: string | null;
 }
 
 export class SubscriberUpdateDto extends PartialType(SubscriberCreateDto) {}

--- a/packages/api/src/user/dto/user.dto.ts
+++ b/packages/api/src/user/dto/user.dto.ts
@@ -150,7 +150,7 @@ export class UserCreateDto extends UserProfileCreateDto {
   @IsOptional()
   @IsString()
   @IsUUIDv4({ message: 'Avatar must be a valid UUID' })
-  avatar: string | null = null;
+  avatar: string | null;
 
   @ApiPropertyOptional({
     description: 'User state',


### PR DESCRIPTION
# Motivation
Resolve DTO's reset issue

# How to reproduce:
1) Avatar
- Open the profile page
- Update the profile avatar
- Open the label page
- Create a label
- Open the subscriber page
- Update the subscriber labels
- Refresh the page  
- See that the Subscriber avatar is reset 

2) assignedTo
- Open the inbox
- Assign a conversation to a subscriber
- Open the subscriber page
- Update the labels of the same subscriber
- Open the inbox page
- See that the Subscriber AssignTo is reset 

# Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
