### PR TITLE
Feat/unified defs

### DIFF
--- a/packages/agentic/AGENTS.md
+++ b/packages/agentic/AGENTS.md
@@ -19,10 +19,11 @@ Use this file as the predictable entrypoint for AI coding agents working on the 
 - Run the suspend/resume quickstart: `pnpm dlx ts-node packages/agentic/examples/suspend-resume/workflow.ts`
 
 ## DSL essentials (YAML or JS object)
-- Workflow parts: optional `inputs.schema`, `context`, `defaults.settings`, `tasks`, `flow`, `outputs`. Long-term state should be stored on the workflow context.
-- Expressions: any string starting with `=` is JSONata; everything else is literal. Scopes: `$input`, `$context`, `$output`, `$iteration` (`item`, `index`), `$accumulator`, `$result` (only inside `tasks.*.outputs`).
-- Flow primitives: `do` (single task), `parallel` (`strategy: wait_all|wait_any`), `conditional` (first truthy branch wins; optional `else`), `loop` (`for_each`, optional `until`, `accumulate`, `max_concurrency` hint).
-- Tasks: names must be `snake_case`; each declares `action`, optional `inputs`/`outputs` maps, and `settings` that merge over `defaults.settings`.
+- Workflow parts: optional `inputs.schema`, `context`, `defaults.settings`, required `defs`, `flow`, `outputs`. Long-term state should be stored on the workflow context.
+- Expressions: any string starting with `=` is JSONata; everything else is literal. Scopes: `$input`, `$context`, `$output`, `$iteration` (`item`, `index`), `$accumulator`, `$result` (only inside `defs.<task>.outputs` for `kind: task` defs).
+- Flow primitives: `do` (single task def reference), `parallel` (`strategy: wait_all|wait_any`), `conditional` (first truthy branch wins; optional `else`), `loop` (`for_each`, optional `until`, `accumulate`, `max_concurrency` hint).
+- Defs: `defs.<name>` is the only root registry. `kind: task` defs execute actions (`action`, optional `inputs`/`outputs`/`settings`/`bindings`), non-task defs require `settings` and may also declare nested `bindings`.
+- Bindings: any def may declare `bindings`; validation is recursive and enforces cardinality, kind matching, duplicates, cycles, and allowlists from `action.supportedBindings` or `kind.supportedBindings`.
 - Outputs: required map evaluated after the flow; values are expressions that usually reference `$output.<task>.*`.
 
 ## Runtime architecture (TS)
@@ -31,7 +32,7 @@ Use this file as the predictable entrypoint for AI coding agents working on the 
 - Step ids: generated from the flow path (e.g., `0.branch.1:conditional`); loop iterations append `[i.j]` suffixes.
 - Snapshots: every start/resume returns `{ status, snapshot }` with `WorkflowSnapshot.actions` capturing per-step status (`pending|running|suspended|completed|failed|skipped`).
 - Events: runners can emit to any `emit`/`on`-compatible emitter (`WorkflowEventEmitter` is the built-in helper) with `hook:workflow:start|finish|failure|suspended` and `hook:step:start|success|error|suspended|skipped`.
-- Evaluation order: task inputs are evaluated before marking a step as running; outputs are mapped via `evaluateMapping` (falls back to raw result when no outputs map is provided). Final workflow outputs are evaluated only after the flow completes.
+- Evaluation order: task-def inputs are evaluated before marking a step as running; outputs are mapped via `evaluateMapping` (falls back to raw result when no outputs map is provided). Final workflow outputs are evaluated only after the flow completes.
 - Parallel semantics: executed sequentially for determinism; `wait_any` short-circuits after the first completed child, `wait_all` waits for all.
 - Loop semantics: iterates over evaluated `for_each.in` (arrays only), threads `$iteration` and accumulator; `until` is checked after each iteration; accumulated values are exposed under `$output.<loop_name>.<accumulator_alias>` when `name` is set.
 
@@ -39,11 +40,14 @@ Use this file as the predictable entrypoint for AI coding agents working on the 
 - Create actions with `defineAction` (or extend `AbstractAction`): provide `name` (snake_case), optional `description`, `inputSchema`, `outputSchema`, optional `settingSchema`, and an async `execute`.
 - `AbstractAction.run` handles `parseInput`, merges/parses settings (defaults live in `SettingsSchema`, including `timeout_ms` and retry policy), wraps `execute` with timeout/retries, and validates the output.
 - Suspension: inside `execute`, `await context.workflow.suspend(options)`; the runner marks the step as `suspended` and returns `{ status: 'suspended', step, reason?, data? }`. On resume, the suspended action continues from the `await` with the provided data.
-- Settings merge: `mergeSettings` deep-merges `defaults.settings` with task-level overrides; undefined values do not clobber defaults.
+- Settings merge: `mergeSettings` deep-merges `defaults.settings` with task-def overrides; undefined values do not clobber defaults.
 
 ## Conventions and gotchas
 - Expressions must start with `=`; validation will parse JSONata and fail early on syntax errors.
 - Task/action names are enforced as `snake_case` by `assertSnakeCaseName`.
+- Root `tasks` is invalid; use `defs` only.
+- Non-task defs must include `settings` (empty object is valid).
+- If compile-time `actions` are provided, any def declaring `action` must resolve to a known action.
 - `max_concurrency` in loops is accepted in the DSL but not yet enforced by the in-process runner (treat it as a hint for now).
 - `timeout_ms: 0` disables timeouts. Default retries come from `DEFAULT_RETRY_SETTINGS` (3 attempts, exponential backoff starting at 25ms, capped at 10s, no jitter).
 - Outputs mapping is optional; when omitted the entire raw action result is stored under `$output.<task>`.
@@ -52,7 +56,7 @@ Use this file as the predictable entrypoint for AI coding agents working on the 
 ## When extending the package
 - Add or adjust DSL shape in `packages/agentic/src/dsl.types.ts` and update `packages/agentic/DSL.md` plus the example workflow if behavior changes.
 - Extend runtime behavior in `packages/agentic/src/workflow-*.ts`; keep tests in `packages/agentic/src/__tests__` in sync.
-- For new actions in the example, update `packages/agentic/example/actions/*` and `example/workflow.yml` so the runnable demo continues to work.
+- For new actions in the example, update `packages/agentic/examples/full/actions/*` and `packages/agentic/examples/full/workflow.yml` so the runnable demo continues to work.
 - Prefer small, well-named helper functions; keep the public surface re-exported via `packages/agentic/src/index.ts`.
 
 ## Quick reference: examples

--- a/packages/agentic/README.md
+++ b/packages/agentic/README.md
@@ -23,24 +23,31 @@ The package ships both ESM (`import`) and CommonJS (`require`) entrypoints plus 
 
 ## DSL essentials
 
-A workflow is a single YAML (or object) that declares inputs, context, defaults, tasks, control-flow, and outputs. The full annotated reference lives in `./DSL.md` and `example/workflow.yml`. The important pieces:
+A workflow is a single YAML (or object) that declares inputs, context, defaults, definitions, control-flow, and outputs. The full annotated reference lives in `./DSL.md` and `examples/full/workflow.yml`. The important pieces:
 
 - `inputs.schema`: JSON-schema-like fields validated at runtime.
 - `context`: read-only values injected by the host (including any long-term state) and exposed to expressions.
 - `defaults.settings`: inherited by every task (timeouts, retries, and action-specific settings).
-- `defs`: reusable typed entities that tasks can mount through bindings.
-- `tasks`: catalog of actions to call; names must be `snake_case`. Each task declares `inputs` and `settings`.
-- `tasks.<task>.bindings`: optional kind-based refs that mount parsed defs into action runtime args (`<kind>: [<defName>...]` for `multiple: true`, `<kind>: <defName>` for `multiple: false`).
+- `defs`: required root registry for all definitions.
+- `defs.<name>` with `kind: task`: executable task defs with `action` and optional `inputs`, `settings`, `bindings`, `description`.
+- `defs.<name>` with `kind != task`: binding defs; `settings` is required (use `{}` when empty), with optional `action`, `bindings`, `description`.
+- `flow[].do`: must reference a `defs.<name>` entry where `kind: task`.
+- `defs.<name>.bindings`: optional kind-based refs on any def (`<kind>: [<defName>...]` for `multiple: true`, `<kind>: <defName>` for `multiple: false`).
 - `flow`: ordered list of steps combining `do`, `parallel`, `conditional`, `loop`.
 - `outputs`: expressions evaluated after the flow finishes.
 
 Task results are stored automatically under `$output.<task>` for downstream expressions.
 
-When workflows use `defs` or task `bindings`, pass `bindingKinds` (a map of binding kind names to `{ schema, multiple }`) to `Workflow.fromYaml` / `Workflow.fromDefinition`. The engine validates kind names, def payloads, and task binding refs before compilation.
+When workflows use defs with bindings, pass `bindingKinds` to `Workflow.fromYaml` / `Workflow.fromDefinition`. Each kind descriptor supports `{ schema, multiple, supportedBindings?, actionPolicy? }`.
+
+Binding validation is recursive and enforces cardinality, reference existence, kind matching, duplicate references, cycle detection, and allowlists:
+- if a def has `action`, allowlist comes from `actions[action].supportedBindings`.
+- otherwise allowlist comes from `bindingKinds[def.kind].supportedBindings`.
+- when `actions` are provided at compile time, defs declaring `action` must resolve.
 
 At runtime, mounted bindings follow kind cardinality:
-- `multiple: true` kinds mount as `{ [defName]: parsedPayload }`.
-- `multiple: false` kinds mount as the direct `parsedPayload`.
+- `multiple: true` kinds mount as `{ [defName]: { settings, action?, bindings? } }`.
+- `multiple: false` kinds mount as `{ settings, action?, bindings? }`.
 
 Any string starting with `=` is parsed as JSONata; everything else is literal. Expressions receive `{ input, context, output, iteration, accumulator }` as scope; `$context` resolves to your workflow context state.
 
@@ -61,11 +68,11 @@ class AppContext extends BaseWorkflowContext<{ user_id: string }> {
 
 const bindingKinds = {
   tools: {
-    schema: z.object({
-      action: z.string(),
-      settings: z.record(z.string(), z.unknown()).optional(),
-    }),
+    // For non-task kinds, schema validates the "settings" payload.
+    schema: z.record(z.string(), z.unknown()),
     multiple: true,
+    actionPolicy: 'required' as const,
+    supportedBindings: ['tools'] as const,
   },
 };
 type AppBindings = InferWorkflowBindings<typeof bindingKinds>;
@@ -77,7 +84,7 @@ export const call_api = defineAction<
   Settings,
   AppBindings
 >({
-  name: 'call_api', // must match task.action
+  name: 'call_api', // must match defs.<task>.action
   description: 'Fetches data from an API',
   inputSchema: z.object({ id: z.string() }),
   outputSchema: z.object({ body: z.string() }),
@@ -101,7 +108,7 @@ import { Workflow, WorkflowEventEmitter, BaseWorkflowContext } from '@hexabot-ai
 import fs from 'node:fs';
 
 const yamlSource = fs.readFileSync('workflow.yml', 'utf8');
-const actions = { call_api }; // keys are task.action names
+const actions = { call_api }; // keys are action names referenced by defs.*.action
 
 class AppContext extends BaseWorkflowContext<{ user_id: string; thread_id: string }> {}
 
@@ -132,7 +139,7 @@ if (startResult.status === 'finished') {
 You can also skip YAML and use `Workflow.fromDefinition` with a typed object that matches `WorkflowDefinition`.
 Attach an event emitter to your workflow context (via the constructor or by setting `context.eventEmitter`); it accepts any object with `emit` and `on` methods. `WorkflowEventEmitter` is a small, dependency-free helper with typed payloads (`WorkflowEventEmitterLike` describes the shape).
 
-If your YAML declares `defs` / `tasks.*.bindings`, pass the same `bindingKinds` registry:
+If your YAML declares `defs.*.bindings`, pass the same `bindingKinds` registry:
 
 ```ts
 const workflow = Workflow.fromYaml(yamlSource, {
@@ -148,8 +155,9 @@ inputs:
   schema:
     user_id:
       type: string
-tasks:
+defs:
   greet_user:
+    kind: task
     action: call_api
     inputs:
       id: "=$input.user_id"
@@ -173,7 +181,7 @@ const workflow = Workflow.fromYaml(yamlSource, {
 });
 ```
 
-These helpers are registered on every expression and can be referenced from YAML, e.g. `text: "=$i18n('Bye bye')"` inside a task input.
+These helpers are registered on every expression and can be referenced from YAML, e.g. `text: "=$i18n('Bye bye')"` inside `defs.<task>.inputs`.
 
 ## Suspension and human-in-the-loop
 

--- a/packages/agentic/examples/defs-bindings-agent/bindings.ts
+++ b/packages/agentic/examples/defs-bindings-agent/bindings.ts
@@ -10,11 +10,10 @@ import type { InferWorkflowBindings } from '../../src';
 
 export const bindingKinds = {
   tools: {
-    schema: z.strictObject({
-      action: z.string(),
-      settings: z.record(z.string(), z.unknown()).optional(),
-    }),
+    schema: z.record(z.string(), z.unknown()),
     multiple: true,
+    actionPolicy: 'required' as const,
+    supportedBindings: ['tools'],
   },
 };
 

--- a/packages/agentic/examples/defs-bindings-agent/workflow.yml
+++ b/packages/agentic/examples/defs-bindings-agent/workflow.yml
@@ -7,9 +7,8 @@ defs:
     settings:
       multiplier: 2
       bias: 1
-
-tasks:
   my_agent:
+    kind: task
     action: ai_agent
     inputs:
       prompt: "Caculate the score for x=10"

--- a/packages/agentic/examples/full/workflow.yml
+++ b/packages/agentic/examples/full/workflow.yml
@@ -50,8 +50,9 @@ defaults:
       multiplier: 1.5
 
 # Task catalog: each task has a unique name, description, action, inputs, settings.
-tasks:
+defs:
   understand_request:
+    kind: task
     description: "LLM categorizes the incoming query, extracts a short summary, and lists missing must-have fields."
     action: call_llm
     inputs:
@@ -76,6 +77,7 @@ tasks:
         multiplier: 1.2
 
   fetch_user_profile:
+    kind: task
     description: "Look up CRM profile and recent cases for the authenticated user."
     action: get_user_profile
     inputs:
@@ -84,6 +86,7 @@ tasks:
 
   # Three distinct actions will run in parallel; their outputs will later be merged.
   search_recent_news:
+    kind: task
     description: "Web search for fresh information about the user's company or topic."
     action: search_web
     inputs:
@@ -93,6 +96,7 @@ tasks:
       timeout_ms: 7000
 
   retrieve_memory_thread:
+    kind: task
     description: "Recall summarized prior conversation for continuity."
     action: query_memory
     inputs:
@@ -102,6 +106,7 @@ tasks:
       timeout_ms: 3000
 
   fetch_calendar_events:
+    kind: task
     description: "Pull the user's upcoming meetings for scheduling-aware replies."
     action: get_calendar_events
     inputs:
@@ -112,6 +117,7 @@ tasks:
 
   # Human-in-the-loop primitive: ask the user a clarifying question and pause the run until they respond.
   ask_for_missing_detail:
+    kind: task
     description: >
       Send a clarifying question to the end user when the request lacks required fields.
       The engine MUST pause the workflow here and resume once a reply is received or a timeout occurs.
@@ -126,6 +132,7 @@ tasks:
       timeout_ms: 86400000                 # 24h; engines may choose a default if omitted
 
   synthesize_research:
+    kind: task
     description: "LLM that combines all signals (including any user clarification) into a concise brief."
     action: call_llm
     inputs:
@@ -141,6 +148,7 @@ tasks:
       temperature: 0.35
 
   route_by_intent:
+    kind: task
     description: "Decide which downstream path to take using a branching table."
     action: decision_router
     inputs:
@@ -162,6 +170,7 @@ tasks:
       default_next: send_generic_summary
 
   draft_support_reply:
+    kind: task
     description: "Generate troubleshooting steps tailored to the user."
     action: call_llm
     inputs:
@@ -175,6 +184,7 @@ tasks:
       temperature: 0.3
 
   craft_sales_pitch:
+    kind: task
     description: "Write a sales email using retrieved company insights."
     action: call_llm
     inputs:
@@ -188,6 +198,7 @@ tasks:
       temperature: 0.55
 
   escalate_to_human:
+    kind: task
     description: "Open or update a human-agent ticket with full context."
     action: create_ticket
     inputs:
@@ -197,6 +208,7 @@ tasks:
       clarification: "=$exists($output.ask_for_missing_detail.text) ? $output.ask_for_missing_detail.text : ''"
 
   send_generic_summary:
+    kind: task
     description: "Fallback response when no specialized branch applies."
     action: call_llm
     inputs:
@@ -207,6 +219,7 @@ tasks:
       model: gpt-4o-mini
 
   send_email_response:
+    kind: task
     description: "Deliver the chosen response via email."
     action: send_email
     inputs:
@@ -226,6 +239,7 @@ tasks:
 
   # Loop-specific tasks used by the for-each demo in the flow below.
   draft_stakeholder_update:
+    kind: task
     description: "LLM crafts a short FYI note for each stakeholder iterated in the loop."
     action: call_llm
     inputs:
@@ -238,6 +252,7 @@ tasks:
       temperature: 0.35
 
   send_stakeholder_update:
+    kind: task
     description: "Deliver FYI notes to stakeholders and capture acknowledgement."
     action: send_email
     inputs:

--- a/packages/agentic/examples/suspend-resume/workflow.yml
+++ b/packages/agentic/examples/suspend-resume/workflow.yml
@@ -5,14 +5,16 @@ inputs:
       type: string
       description: "Prompt shown to the user when the workflow suspends."
 
-tasks:
+defs:
   wait_for_confirmation:
+    kind: task
     description: "Sends a prompt and suspends until the reply is provided via resume."
     action: wait_for_user
     inputs:
       prompt: "=$input.question"
 
   format_acknowledgement:
+    kind: task
     description: "Formats a message using the reply captured after resuming the run."
     action: format_reply
     inputs:

--- a/packages/agentic/src/__tests__/parser.test.ts
+++ b/packages/agentic/src/__tests__/parser.test.ts
@@ -9,8 +9,8 @@ import { WorkflowDefinitionSchema } from '../dsl.types';
 describe('WorkflowDefinitionSchema', () => {
   it('parses a minimal valid workflow', () => {
     const minimal = {
-      tasks: {
-        noop: { action: 'call' },
+      defs: {
+        noop: { kind: 'task', action: 'call' },
       },
       flow: [{ do: 'noop' }],
       outputs: { result: '=$output.noop' },
@@ -21,8 +21,8 @@ describe('WorkflowDefinitionSchema', () => {
 
   it('rejects workflows with invalid JSONata expressions', () => {
     const invalid = {
-      tasks: {
-        noop: { action: 'call' },
+      defs: {
+        noop: { kind: 'task', action: 'call' },
       },
       flow: [{ do: 'noop' }],
       outputs: { result: '=$sum([1,2' }, // missing closing bracket makes JSONata invalid
@@ -35,8 +35,8 @@ describe('WorkflowDefinitionSchema', () => {
 
   it('rejects task output mappings', () => {
     const invalid = {
-      tasks: {
-        noop: { action: 'call', outputs: { value: '=1' } },
+      defs: {
+        noop: { kind: 'task', action: 'call', outputs: { value: '=1' } },
       },
       flow: [{ do: 'noop' }],
       outputs: { result: '=$output.noop' },
@@ -55,9 +55,8 @@ describe('WorkflowDefinitionSchema', () => {
           action: 'calculate_score',
           settings: { multiplier: 2 },
         },
-      },
-      tasks: {
         agent_step: {
+          kind: 'task',
           action: 'ai_agent',
           bindings: {
             tools: ['calculate'],
@@ -77,10 +76,10 @@ describe('WorkflowDefinitionSchema', () => {
         calculate: {
           kind: 'tools',
           action: 'calculate_score',
+          settings: {},
         },
-      },
-      tasks: {
         agent_step: {
+          kind: 'task',
           action: 'ai_agent',
           bindings: {
             tools: 42,

--- a/packages/agentic/src/__tests__/test-helpers.ts
+++ b/packages/agentic/src/__tests__/test-helpers.ts
@@ -1,0 +1,36 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type {
+  DefDefinition,
+  TaskDefinition,
+  WorkflowDefinition,
+} from '../dsl.types';
+
+export const createTaskDef = (
+  definition: Omit<TaskDefinition, 'kind'>,
+): TaskDefinition => ({
+  kind: 'task',
+  ...definition,
+});
+
+export const createTaskDefs = (
+  tasks: Record<string, Omit<TaskDefinition, 'kind'>>,
+): WorkflowDefinition['defs'] =>
+  Object.fromEntries(
+    Object.entries(tasks).map(([taskName, taskDefinition]) => [
+      taskName,
+      createTaskDef(taskDefinition),
+    ]),
+  );
+
+export const mergeTaskDefs = (
+  tasks: Record<string, Omit<TaskDefinition, 'kind'>>,
+  defs: Record<string, DefDefinition> = {},
+): WorkflowDefinition['defs'] => ({
+  ...defs,
+  ...createTaskDefs(tasks),
+});

--- a/packages/agentic/src/__tests__/validation.test.ts
+++ b/packages/agentic/src/__tests__/validation.test.ts
@@ -12,6 +12,8 @@ import { z } from 'zod';
 
 import { validateWorkflow } from '../dsl.types';
 
+import { mergeTaskDefs } from './test-helpers';
+
 const fixturePath = path.join(
   __dirname,
   '..',
@@ -23,11 +25,9 @@ const fixturePath = path.join(
 const fixtureYaml = fs.readFileSync(fixturePath, 'utf8');
 const bindingKinds = {
   tools: {
-    schema: z.strictObject({
-      action: z.string(),
-      settings: z.record(z.string(), z.unknown()).optional(),
-    }),
+    schema: z.record(z.string(), z.unknown()),
     multiple: true,
+    actionPolicy: 'required' as const,
   },
   toolset: {
     schema: z.strictObject({
@@ -51,7 +51,7 @@ describe('validateWorkflow', () => {
     expect(result.success).toBe(true);
 
     if (result.success) {
-      expect(Object.keys(result.data.tasks)).toContain('understand_request');
+      expect(Object.keys(result.data.defs)).toContain('understand_request');
       expect(result.data.flow.length).toBeGreaterThan(0);
       expect(result.data.outputs).toHaveProperty('delivered');
     }
@@ -130,21 +130,23 @@ describe('validateWorkflow', () => {
 
   it('accepts defs and task bindings when all refs and kinds are valid', () => {
     const workflow = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 'calculate_score',
-          settings: { multiplier: 2 },
-        },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            tools: ['calculate'],
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              tools: ['calculate'],
+            },
           },
         },
-      },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: { multiplier: 2 },
+          },
+        },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -155,21 +157,25 @@ describe('validateWorkflow', () => {
 
   it('accepts single-ref task bindings for kinds with multiple=false', () => {
     const workflow = {
-      defs: {
-        chat_model: {
-          kind: 'model',
-          provider: 'openai',
-          model: 'gpt-4o-mini',
-        },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            model: 'chat_model',
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              model: 'chat_model',
+            },
           },
         },
-      },
+        {
+          chat_model: {
+            kind: 'model',
+            settings: {
+              provider: 'openai',
+              model: 'gpt-4o-mini',
+            },
+          },
+        },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -180,21 +186,25 @@ describe('validateWorkflow', () => {
 
   it('fails when single-ref binding kinds are provided as arrays', () => {
     const workflow = {
-      defs: {
-        chat_model: {
-          kind: 'model',
-          provider: 'openai',
-          model: 'gpt-4o-mini',
-        },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            model: ['chat_model'],
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              model: ['chat_model'],
+            },
           },
         },
-      },
+        {
+          chat_model: {
+            kind: 'model',
+            settings: {
+              provider: 'openai',
+              model: 'gpt-4o-mini',
+            },
+          },
+        },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -214,20 +224,23 @@ describe('validateWorkflow', () => {
 
   it('fails when multi-ref binding kinds are provided as strings', () => {
     const workflow = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 'calculate_score',
-        },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            tools: 'calculate',
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              tools: 'calculate',
+            },
           },
         },
-      },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {},
+          },
+        },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -247,15 +260,17 @@ describe('validateWorkflow', () => {
 
   it('fails when task bindings reference unknown defs', () => {
     const workflow = {
-      defs: {},
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            tools: ['missing_tool'],
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              tools: ['missing_tool'],
+            },
           },
         },
-      },
+        {},
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -271,20 +286,22 @@ describe('validateWorkflow', () => {
 
   it('fails when a task binding references a def with a different kind', () => {
     const workflow = {
-      defs: {
-        calculator_pack: {
-          kind: 'toolset',
-          name: 'calc',
-        },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            tools: ['calculator_pack'],
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              tools: ['calculator_pack'],
+            },
           },
         },
-      },
+        {
+          calculator_pack: {
+            kind: 'toolset',
+            settings: { name: 'calc' },
+          },
+        },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -300,17 +317,21 @@ describe('validateWorkflow', () => {
 
   it('fails when defs declare undeclared kinds', () => {
     const workflow = {
-      defs: {
-        remote_server: {
-          kind: 'mcp_server',
-          endpoint: 'http://localhost:3000',
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+          },
         },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
+        {
+          remote_server: {
+            kind: 'mcp_server',
+            settings: {
+              endpoint: 'http://localhost:3000',
+            },
+          },
         },
-      },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -326,20 +347,23 @@ describe('validateWorkflow', () => {
 
   it('fails when task bindings use undeclared kinds', () => {
     const workflow = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 'calculate_score',
-        },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            mcp_server: ['calculate'],
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              mcp_server: ['calculate'],
+            },
           },
         },
-      },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {},
+          },
+        },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -349,7 +373,7 @@ describe('validateWorkflow', () => {
     if (!result.success) {
       expect(
         result.errors.some((error) =>
-          error.includes('tasks.agent_step.bindings.mcp_server'),
+          error.includes('defs.agent_step.bindings.mcp_server'),
         ),
       ).toBe(true);
     }
@@ -357,20 +381,23 @@ describe('validateWorkflow', () => {
 
   it('fails when defs or bindings are present without bindingKinds', () => {
     const workflow = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 'calculate_score',
-        },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            tools: ['calculate'],
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              tools: ['calculate'],
+            },
           },
         },
-      },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {},
+          },
+        },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };
@@ -386,20 +413,23 @@ describe('validateWorkflow', () => {
 
   it('fails when task bindings include duplicate refs', () => {
     const workflow = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 'calculate_score',
-        },
-      },
-      tasks: {
-        agent_step: {
-          action: 'understand_request_action',
-          bindings: {
-            tools: ['calculate', 'calculate'],
+      defs: mergeTaskDefs(
+        {
+          agent_step: {
+            action: 'understand_request_action',
+            bindings: {
+              tools: ['calculate', 'calculate'],
+            },
           },
         },
-      },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {},
+          },
+        },
+      ),
       flow: [{ do: 'agent_step' }],
       outputs: { result: '=$output.agent_step' },
     };

--- a/packages/agentic/src/__tests__/workflow-compiler.test.ts
+++ b/packages/agentic/src/__tests__/workflow-compiler.test.ts
@@ -13,6 +13,8 @@ import type { Settings, WorkflowDefinition } from '../dsl.types';
 import { compileWorkflow } from '../workflow-compiler';
 import { StepType, type EventEmitterLike } from '../workflow-event-emitter';
 
+import { createTaskDefs, mergeTaskDefs } from './test-helpers';
+
 class TestContext extends BaseWorkflowContext {
   public eventEmitter: EventEmitterLike = { emit: jest.fn(), on: jest.fn() };
 }
@@ -66,7 +68,7 @@ describe('compileWorkflow', () => {
           retries: baseRetries,
         },
       },
-      tasks: {
+      defs: createTaskDefs({
         worker_task: {
           action: 'worker_action',
           description: 'does work',
@@ -83,7 +85,7 @@ describe('compileWorkflow', () => {
             },
           },
         },
-      },
+      }),
       flow: [
         { do: 'worker_task' },
         {
@@ -184,12 +186,12 @@ describe('compileWorkflow', () => {
 
   it('throws when an action implementation is missing', () => {
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         missing: {
           action: 'unknown_action',
           inputs: { value: 1 },
         },
-      },
+      }),
       flow: [{ do: 'missing' }],
       outputs: { out: '=$output.missing.value' },
     };
@@ -201,7 +203,7 @@ describe('compileWorkflow', () => {
           Action<unknown, unknown, TestContext, Settings>
         >,
       }),
-    ).toThrow(/No action implementations provided/);
+    ).toThrow(/No action implementation provided for "unknown_action"/);
   });
 
   it('mounts task bindings from defs using parsed binding payloads', () => {
@@ -211,40 +213,40 @@ describe('compileWorkflow', () => {
     const bindingKinds: BindingKindSchemas = {
       tools: {
         schema: z.strictObject({
-          action: z.string(),
-          settings: z.strictObject({
-            multiplier: z.number(),
-            bias: z.number(),
-          }),
+          multiplier: z.number(),
+          bias: z.number(),
         }),
         multiple: true,
+        actionPolicy: 'required',
       },
     };
     const definition: WorkflowDefinition = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          description: 'Compute a score',
-          action: 'calculate_score',
-          settings: {
-            multiplier: 2,
-            bias: 1,
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              tools: ['calculate'],
+            },
           },
         },
-      },
-      tasks: {
-        worker_task: {
-          action: 'worker_action',
-          bindings: {
-            tools: ['calculate'],
+        {
+          calculate: {
+            kind: 'tools',
+            description: 'Compute a score',
+            action: 'calculate_score',
+            settings: {
+              multiplier: 2,
+              bias: 1,
+            },
           },
         },
-      },
+      ),
       flow: [{ do: 'worker_task' }],
       outputs: { out: '=$output.worker_task' },
     };
     const compiled = compileWorkflow(definition, {
-      actions: { worker_action: action },
+      actions: { worker_action: action, calculate_score: action },
       bindingKinds,
     });
 
@@ -255,6 +257,91 @@ describe('compileWorkflow', () => {
           settings: {
             multiplier: 2,
             bias: 1,
+          },
+        },
+      },
+    });
+  });
+
+  it('mounts nested bindings recursively', () => {
+    const { action } = createAction({
+      supportedBindings: ['tools', 'model'],
+    });
+    const bindingKinds: BindingKindSchemas = {
+      tools: {
+        schema: z.strictObject({
+          multiplier: z.number(),
+        }),
+        multiple: true,
+        actionPolicy: 'required',
+        supportedBindings: ['model'],
+      },
+      model: {
+        schema: z.strictObject({
+          provider: z.string(),
+          model: z.string(),
+        }),
+        multiple: false,
+      },
+    };
+    const definition: WorkflowDefinition = {
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              tools: ['calculate'],
+            },
+          },
+        },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {
+              multiplier: 2,
+            },
+            bindings: {
+              model: 'chat_model',
+            },
+          },
+          chat_model: {
+            kind: 'model',
+            settings: {
+              provider: 'openai',
+              model: 'gpt-4o-mini',
+            },
+          },
+        },
+      ),
+      flow: [{ do: 'worker_task' }],
+      outputs: { out: '=$output.worker_task' },
+    };
+    const compiled = compileWorkflow(definition, {
+      actions: {
+        worker_action: action,
+        calculate_score: {
+          ...action,
+          supportedBindings: ['model'],
+        },
+      },
+      bindingKinds,
+    });
+
+    expect(compiled.tasks.worker_task.bindings).toEqual({
+      tools: {
+        calculate: {
+          action: 'calculate_score',
+          settings: {
+            multiplier: 2,
+          },
+          bindings: {
+            model: {
+              settings: {
+                provider: 'openai',
+                model: 'gpt-4o-mini',
+              },
+            },
           },
         },
       },
@@ -275,21 +362,25 @@ describe('compileWorkflow', () => {
       },
     };
     const definition: WorkflowDefinition = {
-      defs: {
-        openai_chatgpt: {
-          kind: 'model',
-          provider: 'openai',
-          model: 'gpt-4o-mini',
-        },
-      },
-      tasks: {
-        worker_task: {
-          action: 'worker_action',
-          bindings: {
-            model: 'openai_chatgpt',
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              model: 'openai_chatgpt',
+            },
           },
         },
-      },
+        {
+          openai_chatgpt: {
+            kind: 'model',
+            settings: {
+              provider: 'openai',
+              model: 'gpt-4o-mini',
+            },
+          },
+        },
+      ),
       flow: [{ do: 'worker_task' }],
       outputs: { out: '=$output.worker_task' },
     };
@@ -300,8 +391,10 @@ describe('compileWorkflow', () => {
 
     expect(compiled.tasks.worker_task.bindings).toEqual({
       model: {
-        provider: 'openai',
-        model: 'gpt-4o-mini',
+        settings: {
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+        },
       },
     });
   });
@@ -320,21 +413,25 @@ describe('compileWorkflow', () => {
       },
     };
     const definition: WorkflowDefinition = {
-      defs: {
-        openai_chatgpt: {
-          kind: 'model',
-          provider: 'openai',
-          model: 'gpt-4o-mini',
-        },
-      },
-      tasks: {
-        worker_task: {
-          action: 'worker_action',
-          bindings: {
-            model: ['openai_chatgpt'],
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              model: ['openai_chatgpt'],
+            },
           },
         },
-      },
+        {
+          openai_chatgpt: {
+            kind: 'model',
+            settings: {
+              provider: 'openai',
+              model: 'gpt-4o-mini',
+            },
+          },
+        },
+      ),
       flow: [{ do: 'worker_task' }],
       outputs: { out: '=$output.worker_task' },
     };
@@ -354,33 +451,37 @@ describe('compileWorkflow', () => {
     const bindingKinds: BindingKindSchemas = {
       tools: {
         schema: z.strictObject({
-          action: z.string(),
+          multiplier: z.number().optional(),
         }),
         multiple: true,
+        actionPolicy: 'required',
       },
     };
     const definition: WorkflowDefinition = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 'calculate_score',
-        },
-      },
-      tasks: {
-        worker_task: {
-          action: 'worker_action',
-          bindings: {
-            tools: 'calculate',
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              tools: 'calculate',
+            },
           },
         },
-      },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {},
+          },
+        },
+      ),
       flow: [{ do: 'worker_task' }],
       outputs: { out: '=$output.worker_task' },
     };
 
     expect(() =>
       compileWorkflow(definition, {
-        actions: { worker_action: action },
+        actions: { worker_action: action, calculate_score: action },
         bindingKinds,
       }),
     ).toThrow(/Expected an array of def references/);
@@ -391,33 +492,37 @@ describe('compileWorkflow', () => {
     const bindingKinds: BindingKindSchemas = {
       tools: {
         schema: z.strictObject({
-          action: z.string(),
+          multiplier: z.number().optional(),
         }),
         multiple: true,
+        actionPolicy: 'required',
       },
     };
     const definition: WorkflowDefinition = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 'calculate_score',
-        },
-      },
-      tasks: {
-        worker_task: {
-          action: 'worker_action',
-          bindings: {
-            tools: ['calculate'],
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              tools: ['calculate'],
+            },
           },
         },
-      },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {},
+          },
+        },
+      ),
       flow: [{ do: 'worker_task' }],
       outputs: { out: '=$output.worker_task' },
     };
 
     expect(() =>
       compileWorkflow(definition, {
-        actions: { worker_action: action },
+        actions: { worker_action: action, calculate_score: action },
         bindingKinds,
       }),
     ).toThrow(/does not support binding kind "tools"/);
@@ -426,12 +531,12 @@ describe('compileWorkflow', () => {
   it('allows actions with no supported bindings when tasks do not mount bindings', () => {
     const { action } = createAction();
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         worker_task: {
           action: 'worker_action',
           inputs: { value: 1 },
         },
-      },
+      }),
       flow: [{ do: 'worker_task' }],
       outputs: { out: '=$output.worker_task' },
     };
@@ -442,31 +547,115 @@ describe('compileWorkflow', () => {
     expect(compiled.tasks.worker_task.bindings).toEqual({});
   });
 
-  it('throws when a def payload fails binding schema validation', () => {
-    const { action } = createAction();
+  it('throws when a def settings payload fails binding schema validation', () => {
+    const { action } = createAction({
+      supportedBindings: ['tools'],
+    });
     const bindingKinds: BindingKindSchemas = {
       tools: {
         schema: z.strictObject({
-          action: z.string(),
+          multiplier: z.number(),
         }),
         multiple: true,
+        actionPolicy: 'required',
       },
     };
     const definition: WorkflowDefinition = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 42,
-        } as any,
-      },
-      tasks: {
-        worker_task: {
-          action: 'worker_action',
-          bindings: {
-            tools: ['calculate'],
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              tools: ['calculate'],
+            },
           },
         },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {
+              multiplier: 'invalid',
+            } as any,
+          },
+        },
+      ),
+      flow: [{ do: 'worker_task' }],
+      outputs: { out: '=$output.worker_task' },
+    };
+
+    expect(() =>
+      compileWorkflow(definition, {
+        actions: { worker_action: action, calculate_score: action },
+        bindingKinds,
+      }),
+    ).toThrow(/defs\.calculate\.settings/);
+  });
+
+  it('throws when defs or bindings are provided without bindingKinds', () => {
+    const { action } = createAction({
+      supportedBindings: ['tools'],
+    });
+    const definition: WorkflowDefinition = {
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              tools: ['calculate'],
+            },
+          },
+        },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {},
+          },
+        },
+      ),
+      flow: [{ do: 'worker_task' }],
+      outputs: { out: '=$output.worker_task' },
+    };
+
+    expect(() =>
+      compileWorkflow(definition, {
+        actions: { worker_action: action, calculate_score: action },
+      }),
+    ).toThrow(/bindingKinds/);
+  });
+
+  it('throws when non-task defs with action do not resolve', () => {
+    const { action } = createAction({
+      supportedBindings: ['tools'],
+    });
+    const bindingKinds: BindingKindSchemas = {
+      tools: {
+        schema: z.strictObject({
+          multiplier: z.number().optional(),
+        }),
+        multiple: true,
+        actionPolicy: 'required',
       },
+    };
+    const definition: WorkflowDefinition = {
+      defs: mergeTaskDefs(
+        {
+          worker_task: {
+            action: 'worker_action',
+            bindings: {
+              tools: ['calculate'],
+            },
+          },
+        },
+        {
+          calculate: {
+            kind: 'tools',
+            action: 'calculate_score',
+            settings: {},
+          },
+        },
+      ),
       flow: [{ do: 'worker_task' }],
       outputs: { out: '=$output.worker_task' },
     };
@@ -476,34 +665,6 @@ describe('compileWorkflow', () => {
         actions: { worker_action: action },
         bindingKinds,
       }),
-    ).toThrow(/defs\.calculate\.action/);
-  });
-
-  it('throws when defs or task bindings are provided without bindingKinds', () => {
-    const { action } = createAction();
-    const definition: WorkflowDefinition = {
-      defs: {
-        calculate: {
-          kind: 'tools',
-          action: 'calculate_score',
-        },
-      },
-      tasks: {
-        worker_task: {
-          action: 'worker_action',
-          bindings: {
-            tools: ['calculate'],
-          },
-        },
-      },
-      flow: [{ do: 'worker_task' }],
-      outputs: { out: '=$output.worker_task' },
-    };
-
-    expect(() =>
-      compileWorkflow(definition, {
-        actions: { worker_action: action },
-      }),
-    ).toThrow(/bindingKinds/);
+    ).toThrow(/No action implementation provided for "calculate_score"/);
   });
 });

--- a/packages/agentic/src/__tests__/workflow-definition-path.test.ts
+++ b/packages/agentic/src/__tests__/workflow-definition-path.test.ts
@@ -7,15 +7,17 @@
 import type { FlowStep, WorkflowDefinition } from '../dsl.types';
 import { Workflow, type FlowStepPath } from '../workflow';
 
+import { createTaskDefs } from './test-helpers';
+
 const createDefinition = (): WorkflowDefinition => ({
-  tasks: {
+  defs: createTaskDefs({
     task_one: { action: 'noop' },
     task_two: { action: 'noop' },
     task_three: { action: 'noop' },
     task_four: { action: 'noop' },
     task_five: { action: 'noop' },
     task_six: { action: 'noop' },
-  },
+  }),
   flow: [
     { do: 'task_one' },
     { parallel: { steps: [{ do: 'task_two' }, { do: 'task_three' }] } },
@@ -71,12 +73,12 @@ describe('workflow definition path helpers', () => {
       const definition = createDefinition();
       const updated = Workflow.setValueAtPath(
         definition,
-        ['tasks', 'task_one', 'action'],
+        ['defs', 'task_one', 'action'],
         'updated_action',
       );
 
       expect(updated).not.toBe(definition);
-      expect(updated.tasks.task_one.action).toBe('updated_action');
+      expect(updated.defs.task_one.action).toBe('updated_action');
       expect(updated.flow).toBe(definition.flow);
     });
 
@@ -112,8 +114,14 @@ describe('workflow definition path helpers', () => {
 
       expect(nextDefinition.flow).toHaveLength(2);
       expect(nextDefinition.flow[1]).toEqual(definition.flow[2]);
-      expect(nextDefinition.tasks.task_two).toEqual({ action: 'noop' });
-      expect(nextDefinition.tasks.task_three).toEqual({ action: 'noop' });
+      expect(nextDefinition.defs.task_two).toEqual({
+        kind: 'task',
+        action: 'noop',
+      });
+      expect(nextDefinition.defs.task_three).toEqual({
+        kind: 'task',
+        action: 'noop',
+      });
       expect(definition.flow).toHaveLength(3);
     });
 
@@ -133,8 +141,11 @@ describe('workflow definition path helpers', () => {
 
       expect(steps).toHaveLength(1);
       expect(steps[0]).toEqual({ do: 'task_three' });
-      expect(nextDefinition.tasks.task_two).toBeUndefined();
-      expect(nextDefinition.tasks.task_three).toEqual({ action: 'noop' });
+      expect(nextDefinition.defs.task_two).toBeUndefined();
+      expect(nextDefinition.defs.task_three).toEqual({
+        kind: 'task',
+        action: 'noop',
+      });
     });
 
     it('removes an unreferenced task definition when deleting a task step', () => {
@@ -144,7 +155,7 @@ describe('workflow definition path helpers', () => {
       expect(updated).not.toBeNull();
       const nextDefinition = updated as WorkflowDefinition;
 
-      expect(nextDefinition.tasks.task_one).toBeUndefined();
+      expect(nextDefinition.defs.task_one).toBeUndefined();
       expect(nextDefinition.flow).toEqual(definition.flow.slice(1));
     });
 
@@ -162,7 +173,10 @@ describe('workflow definition path helpers', () => {
       expect(updated).not.toBeNull();
       const nextDefinition = updated as WorkflowDefinition;
 
-      expect(nextDefinition.tasks.task_one).toEqual({ action: 'noop' });
+      expect(nextDefinition.defs.task_one).toEqual({
+        kind: 'task',
+        action: 'noop',
+      });
       expect(nextDefinition.flow).toEqual([
         ...definition.flow.slice(1),
         { do: 'task_one' },
@@ -175,7 +189,7 @@ describe('workflow definition path helpers', () => {
       expect(Workflow.removeStepAtPath(definition, [])).toBeNull();
       expect(Workflow.removeStepAtPath(definition, ['flow', '1'])).toBeNull();
       expect(
-        Workflow.removeStepAtPath(definition, ['tasks', 'task_one', 0]),
+        Workflow.removeStepAtPath(definition, ['defs', 'task_one', 0]),
       ).toBeNull();
       expect(Workflow.removeStepAtPath(definition, ['flow', 99])).toBeNull();
     });
@@ -242,7 +256,7 @@ describe('workflow definition path helpers', () => {
         Workflow.insertStepAtPath(definition, ['flow', '1'], step),
       ).toBeNull();
       expect(
-        Workflow.insertStepAtPath(definition, ['tasks', 'task_one', 0], step),
+        Workflow.insertStepAtPath(definition, ['defs', 'task_one', 0], step),
       ).toBeNull();
     });
   });
@@ -252,9 +266,10 @@ describe('workflow definition path helpers', () => {
       const baseDefinition = createDefinition();
       const definition: WorkflowDefinition = {
         ...baseDefinition,
-        tasks: {
-          ...baseDefinition.tasks,
+        defs: {
+          ...baseDefinition.defs,
           task_two: {
+            kind: 'task',
             action: 'noop',
             inputs: {
               from_dot: '=$output.task_one.value',
@@ -301,8 +316,11 @@ describe('workflow definition path helpers', () => {
         'renamed_task',
       );
 
-      expect(nextDefinition.tasks.task_one).toBeUndefined();
-      expect(nextDefinition.tasks.renamed_task).toEqual({ action: 'noop' });
+      expect(nextDefinition.defs.task_one).toBeUndefined();
+      expect(nextDefinition.defs.renamed_task).toEqual({
+        kind: 'task',
+        action: 'noop',
+      });
       expect(nextDefinition.flow).toEqual([
         { do: 'renamed_task' },
         {
@@ -327,7 +345,9 @@ describe('workflow definition path helpers', () => {
           },
         },
       ]);
-      expect(nextDefinition.tasks.task_two.inputs).toEqual({
+      expect(
+        (nextDefinition.defs.task_two as { inputs?: unknown }).inputs,
+      ).toEqual({
         from_dot: '=$output.renamed_task.value',
         from_single: "=$output['renamed_task']",
         from_double: '=$output["renamed_task"]',

--- a/packages/agentic/src/__tests__/workflow-runner.test.ts
+++ b/packages/agentic/src/__tests__/workflow-runner.test.ts
@@ -19,6 +19,8 @@ import {
 import { WorkflowRunner } from '../workflow-runner';
 import type { ExecutionState } from '../workflow-types';
 
+import { createTaskDefs } from './test-helpers';
+
 class MemoryEmitter implements WorkflowEventEmitterLike<{}> {
   private listeners: Partial<{
     [K in keyof WorkflowEventMap]: Array<
@@ -114,7 +116,7 @@ describe('WorkflowRunner', () => {
           retries: defaultRetries,
         },
       },
-      tasks: {
+      defs: createTaskDefs({
         inherit_task: {
           action: 'inspect_settings_action',
           inputs: { label: '="inherit"' },
@@ -137,7 +139,7 @@ describe('WorkflowRunner', () => {
             },
           },
         },
-      },
+      }),
       flow: [
         { do: 'inherit_task' },
         { do: 'override_timeout_task' },
@@ -217,7 +219,7 @@ describe('WorkflowRunner', () => {
     });
     const definition: WorkflowDefinition = {
       defaults: { settings: { timeout_ms: 0, retries: baseRetries } },
-      tasks: {
+      defs: createTaskDefs({
         first_task: {
           action: 'first_action',
         },
@@ -234,7 +236,7 @@ describe('WorkflowRunner', () => {
           action: 'echo_action',
           inputs: { message: '=$iteration.item' },
         },
-      },
+      }),
       flow: [
         {
           parallel: {
@@ -364,7 +366,7 @@ describe('WorkflowRunner', () => {
     });
     const definition: WorkflowDefinition = {
       defaults: { settings: { timeout_ms: 0, retries: baseRetries } },
-      tasks: {
+      defs: createTaskDefs({
         first_task: {
           action: 'first_action',
         },
@@ -375,7 +377,7 @@ describe('WorkflowRunner', () => {
           action: 'echo_action',
           inputs: { message: '=$iteration.item' },
         },
-      },
+      }),
       flow: [
         {
           parallel: {
@@ -472,12 +474,12 @@ describe('WorkflowRunner', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         wait_step: {
           action: 'suspend_action',
           inputs: { prompt: '="Ping"' },
         },
-      },
+      }),
       flow: [{ do: 'wait_step' }],
       outputs: { reply: '=$output.wait_step.reply' },
     };
@@ -521,9 +523,9 @@ describe('WorkflowRunner', () => {
       execute: async () => ({ ok: true }),
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         ping_step: { action: 'ping_action' },
-      },
+      }),
       flow: [{ do: 'ping_step' }],
       outputs: { ok: '=$output.ping_step.ok' },
     };
@@ -599,12 +601,12 @@ describe('WorkflowRunner', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         emit_step: {
           action: 'emit_action',
           inputs: { note: '=$input.note' },
         },
-      },
+      }),
       flow: [{ do: 'emit_step' }],
       outputs: { note: '=$output.emit_step.note' },
       inputs: {
@@ -643,12 +645,12 @@ describe('WorkflowRunner', () => {
       },
     );
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         fail_step: {
           action: 'failing_action',
           inputs: { value: 1 },
         },
-      },
+      }),
       flow: [{ do: 'fail_step' }],
       outputs: { value: '=$output.fail_step.value' },
     };
@@ -708,7 +710,7 @@ describe('WorkflowRunner', () => {
       execute: followExecute,
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         wait_step: {
           action: 'resume_suspend_action',
           inputs: { prompt: '="Ping?"' },
@@ -717,7 +719,7 @@ describe('WorkflowRunner', () => {
           action: 'follow_action',
           inputs: { message: '=$output.wait_step.reply' },
         },
-      },
+      }),
       flow: [{ do: 'wait_step' }, { do: 'follow_step' }],
       outputs: {
         reply: '=$output.wait_step.reply',
@@ -774,9 +776,9 @@ describe('WorkflowRunner', () => {
       execute: async ({ input }) => `echo:${input.value}`,
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         raw_step: { action: 'raw_action', inputs: { value: '="hello"' } },
-      },
+      }),
       flow: [{ do: 'raw_step' }],
       outputs: { final: '=$output.raw_step' },
     };
@@ -814,9 +816,9 @@ describe('WorkflowRunner', () => {
       execute: async () => ({ ok: true }),
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         only_step: { action: 'noop_action', inputs: {} },
-      },
+      }),
       flow: [{ do: 'only_step' }],
       outputs: { ok: '=$output.only_step.ok' },
     };
@@ -859,12 +861,12 @@ describe('WorkflowRunner', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         wait_step: {
           action: 'loop_suspend_action',
           inputs: { prompt: '="Ping"' },
         },
-      },
+      }),
       flow: [
         {
           loop: {
@@ -957,12 +959,12 @@ describe('WorkflowRunner', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         wait_step: {
           action: 'multi_suspend_action',
           inputs: {},
         },
-      },
+      }),
       flow: [{ do: 'wait_step' }],
       outputs: {
         firstReply: '=$output.wait_step.firstReply',
@@ -1052,12 +1054,12 @@ describe('WorkflowRunner', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         wait_step: {
           action: 'single_suspend_action',
           inputs: {},
         },
-      },
+      }),
       flow: [{ do: 'wait_step' }],
       outputs: { reply: '=$output.wait_step.reply' },
     };
@@ -1124,12 +1126,12 @@ describe('WorkflowRunner', () => {
       execute: async ({ input }) => ({ delivered: input.text }),
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         send_goodbye: {
           action: 'send_action',
           inputs: { text: "=$i18n('Bye bye')" },
         },
-      },
+      }),
       flow: [{ do: 'send_goodbye' }],
       outputs: { message: '=$output.send_goodbye.delivered' },
     };
@@ -1167,12 +1169,12 @@ describe('WorkflowRunner', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         count_step: {
           action: 'count_action',
           inputs: { amount: '=$input.amount' },
         },
-      },
+      }),
       flow: [{ do: 'count_step' }],
       outputs: { total: '=$output.count_step.total' },
       inputs: {
@@ -1236,9 +1238,9 @@ describe('WorkflowRunner', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         mutate_step: { action: 'mutate_action' },
-      },
+      }),
       flow: [{ do: 'mutate_step' }],
       outputs: { ok: '=$output.mutate_step.ok' },
     };

--- a/packages/agentic/src/__tests__/workflow.test.ts
+++ b/packages/agentic/src/__tests__/workflow.test.ts
@@ -12,6 +12,8 @@ import { Settings, WorkflowDefinition, validateWorkflow } from '../dsl.types';
 import { Workflow, WorkflowEventEmitter } from '../workflow';
 import { EventEmitterLike } from '../workflow-event-emitter';
 
+import { createTaskDefs } from './test-helpers';
+
 class TestContext extends BaseWorkflowContext {
   public eventEmitter: EventEmitterLike = { emit: jest.fn(), on: jest.fn() };
 
@@ -55,7 +57,7 @@ describe('Workflow execution', () => {
           },
         },
       },
-      tasks: {
+      defs: createTaskDefs({
         greet_user: {
           action: 'greet_action',
           inputs: {
@@ -73,7 +75,7 @@ describe('Workflow execution', () => {
             },
           },
         },
-      },
+      }),
       flow: [{ do: 'greet_user' }],
       outputs: {
         final: "='Hello ' & $output.greet_user.name",
@@ -116,12 +118,12 @@ describe('Workflow execution', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         ask_user: {
           action: 'await_reply',
           inputs: { prompt: '="Ping"' },
         },
-      },
+      }),
       flow: [{ do: 'ask_user' }],
       outputs: { reply: '=$output.ask_user.reply' },
     };
@@ -164,12 +166,12 @@ describe('Workflow execution', () => {
       execute: async ({ input }) => ({ doubled: input.value * 2 }),
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         double_step: {
           action: 'double_value',
           inputs: { value: '=$input.value' },
         },
-      },
+      }),
       flow: [{ do: 'double_step' }],
       outputs: { result: '=$output.double_step.doubled' },
       inputs: {
@@ -213,7 +215,7 @@ describe('Workflow execution', () => {
 
   it('throws on invalid YAML input', () => {
     expect(() =>
-      Workflow.fromYaml('tasks: {}', {
+      Workflow.fromYaml('defs: {}', {
         actions: {} as Record<string, never>,
       }),
     ).toThrow(/Workflow validation failed/);
@@ -221,12 +223,12 @@ describe('Workflow execution', () => {
 
   it('stringifies a workflow definition to YAML', () => {
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         greet_user: {
           action: 'greet_action',
           inputs: { name: '=$input.name' },
         },
-      },
+      }),
       flow: [{ do: 'greet_user' }],
       outputs: { result: '=$output.greet_user.name' },
     };
@@ -251,12 +253,12 @@ describe('Workflow execution', () => {
       },
     );
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         failing_task: {
           action: 'failing_action',
           inputs: {},
         },
-      },
+      }),
       flow: [{ do: 'failing_task' }],
       outputs: { result: '=$output.failing_task' },
     };
@@ -293,12 +295,12 @@ describe('Workflow execution', () => {
       },
     });
     const definition: WorkflowDefinition = {
-      tasks: {
+      defs: createTaskDefs({
         pause_step: {
           action: 'suspending_action',
           inputs: {},
         },
-      },
+      }),
       flow: [{ do: 'pause_step' }],
       outputs: { reply: '=$output.pause_step.reply' },
     };

--- a/packages/agentic/src/action/__tests__/action.test.ts
+++ b/packages/agentic/src/action/__tests__/action.test.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import type {
   BindingKindSchemas,
   InferWorkflowBindings,
+  MountedBindingPayload,
 } from '../../bindings/base-binding';
 import { BaseWorkflowContext } from '../../context';
 import { Settings, SettingsSchema } from '../../dsl.types';
@@ -42,11 +43,9 @@ const OutputSchema = z.object({ result: z.number() });
 const NoSettingsSchema = z.any();
 const _bindingKindSchemas = {
   tools: {
-    schema: z.strictObject({
-      action: z.string(),
-      settings: z.record(z.string(), z.unknown()).optional(),
-    }),
+    schema: z.record(z.string(), z.unknown()),
     multiple: true,
+    actionPolicy: 'required',
   },
   model: {
     schema: z.strictObject({
@@ -281,6 +280,7 @@ describe('workflow step primitives', () => {
         tools: {
           calculate: {
             action: 'calculate_score',
+            settings: {},
           },
         },
       } as any),
@@ -300,6 +300,7 @@ describe('workflow step primitives', () => {
           tools: {
             calculate: {
               action: 'calculate_score',
+              settings: {},
             },
           },
         },
@@ -368,13 +369,13 @@ describe('workflow step primitives', () => {
     expectType<
       Equal<
         NonNullable<TestBindings['tools']>,
-        Record<string, z.infer<typeof _bindingKindSchemas.tools.schema>>
+        Record<string, MountedBindingPayload<typeof _bindingKindSchemas.tools>>
       >
     >();
     expectType<
       Equal<
         NonNullable<TestBindings['model']>,
-        z.infer<typeof _bindingKindSchemas.model.schema>
+        MountedBindingPayload<typeof _bindingKindSchemas.model>
       >
     >();
 

--- a/packages/agentic/src/bindings/base-binding.ts
+++ b/packages/agentic/src/bindings/base-binding.ts
@@ -6,7 +6,15 @@
 
 import { z, type ZodIssue } from 'zod';
 
+const TASK_KIND = 'task';
+
 export type BindingKindSchema = z.ZodTypeAny;
+
+export type BindingActionPolicy = 'forbidden' | 'optional' | 'required';
+
+export type BindingValidationActionMetadata = {
+  supportedBindings?: readonly string[];
+};
 
 export type BindingKindDescriptor<
   TSchema extends z.ZodTypeAny = BindingKindSchema,
@@ -14,19 +22,29 @@ export type BindingKindDescriptor<
 > = {
   schema: TSchema;
   multiple: TMultiple;
+  supportedBindings?: readonly string[];
+  actionPolicy?: BindingActionPolicy;
 };
 
 export type BindingKindSchemas = Record<string, BindingKindDescriptor>;
 
+export type MountedBindingPayload<
+  TBindingKind extends BindingKindDescriptor = BindingKindDescriptor,
+> = {
+  settings: z.infer<TBindingKind['schema']>;
+  action?: string;
+  bindings?: Record<string, unknown>;
+};
+
 export type InferMountedBindingValue<
   TBindingKind extends BindingKindDescriptor = BindingKindDescriptor,
 > = TBindingKind['multiple'] extends true
-  ? Record<string, z.infer<TBindingKind['schema']>>
+  ? Record<string, MountedBindingPayload<TBindingKind>>
   : TBindingKind['multiple'] extends false
-    ? z.infer<TBindingKind['schema']>
+    ? MountedBindingPayload<TBindingKind>
     :
-        | z.infer<TBindingKind['schema']>
-        | Record<string, z.infer<TBindingKind['schema']>>;
+        | MountedBindingPayload<TBindingKind>
+        | Record<string, MountedBindingPayload<TBindingKind>>;
 
 export type InferWorkflowBindings<
   TBindingKinds extends BindingKindSchemas = BindingKindSchemas,
@@ -36,45 +54,64 @@ export type InferWorkflowBindings<
   >;
 }>;
 
-export type DefLike = {
-  kind: string;
-  description?: string;
-  [key: string]: unknown;
-};
+export type CompiledTaskBindings = Record<string, unknown>;
 
 export type TaskBindingReferences = Record<string, string | string[]>;
 
-export type BindingAwareTaskLike = {
+export type DefLike = {
+  kind: string;
+  description?: string;
+  action?: string;
+  settings?: unknown;
   bindings?: TaskBindingReferences;
+  [key: string]: unknown;
 };
 
 export type BindingAwareWorkflowLike = {
-  defs?: Record<string, DefLike>;
-  tasks: Record<string, BindingAwareTaskLike>;
+  defs: Record<string, DefLike>;
 };
 
 export type ResolvedBindingDef = {
   kind: string;
-  payload: unknown;
+  payload: MountedBindingPayload;
 };
 
 export type ResolvedBindingDefs = Record<string, ResolvedBindingDef>;
 
-export type CompiledTaskBindings = Record<string, unknown>;
+export type ValidateAndResolveBindingsOptions = {
+  bindingKinds?: BindingKindSchemas;
+  actions?: Record<string, BindingValidationActionMetadata>;
+};
 
 type BindingValidationResult = {
   errors: string[];
   resolvedDefs: ResolvedBindingDefs;
 };
 
-const hasBindingsConfigured = (workflow: BindingAwareWorkflowLike): boolean => {
-  if (workflow.defs && Object.keys(workflow.defs).length > 0) {
-    return true;
+const resolveValidationOptions = (
+  options?: BindingKindSchemas | ValidateAndResolveBindingsOptions,
+): ValidateAndResolveBindingsOptions => {
+  if (!options) {
+    return {};
   }
 
-  return Object.values(workflow.tasks).some(
-    (task) => task.bindings && Object.keys(task.bindings).length > 0,
+  if ('bindingKinds' in options || 'actions' in options) {
+    return options as ValidateAndResolveBindingsOptions;
+  }
+
+  return { bindingKinds: options as BindingKindSchemas };
+};
+const hasBindingsConfigured = (workflow: BindingAwareWorkflowLike): boolean => {
+  const defs = workflow.defs ?? {};
+  const hasNonTaskDefs = Object.values(defs).some(
+    (definition) => definition.kind !== TASK_KIND,
   );
+  const hasNestedBindings = Object.values(defs).some(
+    (definition) =>
+      definition.bindings && Object.keys(definition.bindings).length > 0,
+  );
+
+  return hasNonTaskDefs || hasNestedBindings;
 };
 const formatZodIssues = (issues: ZodIssue[], prefix: string): string[] =>
   issues.map((issue) => {
@@ -82,11 +119,6 @@ const formatZodIssues = (issues: ZodIssue[], prefix: string): string[] =>
 
     return `${prefix}.${path}: ${issue.message}`;
   });
-const stripDefMeta = (definition: DefLike): unknown => {
-  const { kind: _kind, description: _description, ...payload } = definition;
-
-  return payload;
-};
 const collectDuplicateReferences = (refs: string[]): string[] => {
   const seen = new Set<string>();
   const duplicates = new Set<string>();
@@ -104,25 +136,136 @@ const collectDuplicateReferences = (refs: string[]): string[] => {
 };
 const toBindingRefs = (refs: string | string[]): string[] =>
   Array.isArray(refs) ? refs : [refs];
+const collectBindingRefs = (
+  bindings?: TaskBindingReferences,
+): Array<{ kind: string; ref: string }> => {
+  if (!bindings) {
+    return [];
+  }
+
+  const refs: Array<{ kind: string; ref: string }> = [];
+  for (const [bindingKind, bindingRefs] of Object.entries(bindings)) {
+    for (const ref of toBindingRefs(bindingRefs)) {
+      refs.push({ kind: bindingKind, ref });
+    }
+  }
+
+  return refs;
+};
+const detectBindingCycles = (defs: Record<string, DefLike>): string[] => {
+  const errors: string[] = [];
+  const reportedCycles = new Set<string>();
+  const states = new Map<string, 'visiting' | 'visited'>();
+  const stack: string[] = [];
+  const defNames = Object.keys(defs);
+  const visit = (defName: string) => {
+    const state = states.get(defName);
+    if (state === 'visited') {
+      return;
+    }
+
+    if (state === 'visiting') {
+      const cycleStart = stack.indexOf(defName);
+      if (cycleStart === -1) {
+        return;
+      }
+
+      const cyclePath = [...stack.slice(cycleStart), defName];
+      const cycleKey = cyclePath.join('->');
+
+      if (!reportedCycles.has(cycleKey)) {
+        reportedCycles.add(cycleKey);
+        errors.push(
+          `defs.${defName}.bindings: Circular binding reference detected (${cyclePath.join(' -> ')}).`,
+        );
+      }
+
+      return;
+    }
+
+    states.set(defName, 'visiting');
+    stack.push(defName);
+
+    const definition = defs[defName];
+    for (const { ref } of collectBindingRefs(definition?.bindings)) {
+      if (!Object.prototype.hasOwnProperty.call(defs, ref)) {
+        continue;
+      }
+
+      visit(ref);
+    }
+
+    stack.pop();
+    states.set(defName, 'visited');
+  };
+
+  for (const defName of defNames) {
+    visit(defName);
+  }
+
+  return errors;
+};
+const resolveSupportedBindingKinds = (
+  definition: DefLike,
+  defName: string,
+  kinds: BindingKindSchemas,
+  actions: Record<string, BindingValidationActionMetadata> | undefined,
+  errors: string[],
+): readonly string[] | null => {
+  if (definition.action) {
+    if (!actions) {
+      return null;
+    }
+
+    const action = actions[definition.action];
+    if (!action) {
+      errors.push(
+        `defs.${defName}.action: No action implementation provided for "${definition.action}".`,
+      );
+
+      return [];
+    }
+
+    return action.supportedBindings ?? [];
+  }
+
+  if (definition.kind === TASK_KIND) {
+    return [];
+  }
+
+  return kinds[definition.kind]?.supportedBindings ?? [];
+};
 
 export const validateAndResolveBindings = (
   workflow: BindingAwareWorkflowLike,
-  bindingKinds?: BindingKindSchemas,
+  options?: BindingKindSchemas | ValidateAndResolveBindingsOptions,
 ): BindingValidationResult => {
   const errors: string[] = [];
   const resolvedDefs: ResolvedBindingDefs = {};
   const defs = workflow.defs ?? {};
-  const kinds = bindingKinds ?? {};
+  const resolvedOptions = resolveValidationOptions(options);
+  const kinds = resolvedOptions.bindingKinds ?? {};
+  const actions = resolvedOptions.actions;
   const kindNames = Object.keys(kinds);
   const hasBindingUsage = hasBindingsConfigured(workflow);
+  const parsedSettingsByDefName = new Map<string, unknown>();
 
   if (hasBindingUsage && kindNames.length === 0) {
     errors.push(
-      'Workflows that declare defs or task bindings require a non-empty "bindingKinds" registry.',
+      'Workflows that declare non-task defs or nested bindings require a non-empty "bindingKinds" registry.',
     );
   }
 
   for (const [defName, defDefinition] of Object.entries(defs)) {
+    if (defDefinition.kind === TASK_KIND) {
+      if (defDefinition.action && actions && !actions[defDefinition.action]) {
+        errors.push(
+          `defs.${defName}.action: No action implementation provided for "${defDefinition.action}".`,
+        );
+      }
+      continue;
+    }
+
     const kindDefinition = kinds[defDefinition.kind];
 
     if (!kindDefinition) {
@@ -132,36 +275,61 @@ export const validateAndResolveBindings = (
       continue;
     }
 
+    const actionPolicy = kindDefinition.actionPolicy ?? 'optional';
+    if (actionPolicy === 'required' && !defDefinition.action) {
+      errors.push(
+        `defs.${defName}.action: Binding kind "${defDefinition.kind}" requires an action.`,
+      );
+    }
+    if (actionPolicy === 'forbidden' && defDefinition.action) {
+      errors.push(
+        `defs.${defName}.action: Binding kind "${defDefinition.kind}" does not allow action declarations.`,
+      );
+    }
+    if (defDefinition.action && actions && !actions[defDefinition.action]) {
+      errors.push(
+        `defs.${defName}.action: No action implementation provided for "${defDefinition.action}".`,
+      );
+    }
+
     const { schema } = kindDefinition;
-    const payload = stripDefMeta(defDefinition);
-    const parsedPayload = schema.safeParse(payload);
+    const parsedPayload = schema.safeParse(defDefinition.settings);
 
     if (!parsedPayload.success) {
       errors.push(
-        ...formatZodIssues(parsedPayload.error.issues, `defs.${defName}`),
+        ...formatZodIssues(
+          parsedPayload.error.issues,
+          `defs.${defName}.settings`,
+        ),
       );
       continue;
     }
 
-    resolvedDefs[defName] = {
-      kind: defDefinition.kind,
-      payload: parsedPayload.data,
-    };
+    parsedSettingsByDefName.set(defName, parsedPayload.data);
   }
 
-  for (const [taskName, taskDefinition] of Object.entries(workflow.tasks)) {
-    const taskBindings = taskDefinition.bindings;
+  for (const [defName, defDefinition] of Object.entries(defs)) {
+    const defBindings = defDefinition.bindings;
 
-    if (!taskBindings) {
+    if (!defBindings) {
       continue;
     }
 
-    for (const [bindingKind, bindingRefs] of Object.entries(taskBindings)) {
+    const supportedKinds = resolveSupportedBindingKinds(
+      defDefinition,
+      defName,
+      kinds,
+      actions,
+      errors,
+    );
+    const shouldValidateSupportedKinds = Array.isArray(supportedKinds);
+
+    for (const [bindingKind, bindingRefs] of Object.entries(defBindings)) {
       const kindDefinition = kinds[bindingKind];
 
       if (!kindDefinition) {
         errors.push(
-          `tasks.${taskName}.bindings.${bindingKind}: Unknown binding kind "${bindingKind}".`,
+          `defs.${defName}.bindings.${bindingKind}: Unknown binding kind "${bindingKind}".`,
         );
         continue;
       }
@@ -169,22 +337,34 @@ export const validateAndResolveBindings = (
       const { multiple } = kindDefinition;
       if (multiple && !Array.isArray(bindingRefs)) {
         errors.push(
-          `tasks.${taskName}.bindings.${bindingKind}: Expected an array of def references for binding kind "${bindingKind}".`,
+          `defs.${defName}.bindings.${bindingKind}: Expected an array of def references for binding kind "${bindingKind}".`,
         );
         continue;
       }
       if (!multiple && typeof bindingRefs !== 'string') {
         errors.push(
-          `tasks.${taskName}.bindings.${bindingKind}: Expected a single def reference string for binding kind "${bindingKind}".`,
+          `defs.${defName}.bindings.${bindingKind}: Expected a single def reference string for binding kind "${bindingKind}".`,
         );
         continue;
+      }
+
+      if (
+        shouldValidateSupportedKinds &&
+        supportedKinds &&
+        !supportedKinds.includes(bindingKind)
+      ) {
+        const supportedKindsLabel =
+          supportedKinds.length > 0 ? supportedKinds.join(', ') : '<none>';
+        errors.push(
+          `defs.${defName}.bindings.${bindingKind}: "${defDefinition.action ?? defDefinition.kind}" does not support binding kind "${bindingKind}". Supported binding kinds: ${supportedKindsLabel}.`,
+        );
       }
 
       const refs = toBindingRefs(bindingRefs);
       const duplicateRefs = collectDuplicateReferences(refs);
       if (duplicateRefs.length > 0) {
         errors.push(
-          `tasks.${taskName}.bindings.${bindingKind}: Duplicate def reference(s): ${duplicateRefs.join(', ')}`,
+          `defs.${defName}.bindings.${bindingKind}: Duplicate def reference(s): ${duplicateRefs.join(', ')}`,
         );
       }
 
@@ -193,18 +373,75 @@ export const validateAndResolveBindings = (
 
         if (!definition) {
           errors.push(
-            `tasks.${taskName}.bindings.${bindingKind}: Unknown def reference "${ref}".`,
+            `defs.${defName}.bindings.${bindingKind}: Unknown def reference "${ref}".`,
           );
           continue;
         }
 
         if (definition.kind !== bindingKind) {
           errors.push(
-            `tasks.${taskName}.bindings.${bindingKind}: Def "${ref}" has kind "${definition.kind}" and cannot be mounted as "${bindingKind}".`,
+            `defs.${defName}.bindings.${bindingKind}: Def "${ref}" has kind "${definition.kind}" and cannot be mounted as "${bindingKind}".`,
           );
         }
       }
     }
+  }
+
+  errors.push(...detectBindingCycles(defs));
+
+  const inProgress = new Set<string>();
+  const mountResolvedDef = (
+    defName: string,
+  ): MountedBindingPayload | undefined => {
+    const existing = resolvedDefs[defName];
+    if (existing) {
+      return existing.payload;
+    }
+
+    const definition = defs[defName];
+    if (!definition || definition.kind === TASK_KIND) {
+      return undefined;
+    }
+
+    const parsedSettings = parsedSettingsByDefName.get(defName);
+    if (parsedSettings === undefined) {
+      return undefined;
+    }
+
+    if (inProgress.has(defName)) {
+      return undefined;
+    }
+
+    inProgress.add(defName);
+    const nestedBindings = mountTaskBindings(
+      definition.bindings,
+      resolvedDefs,
+      kinds,
+      mountResolvedDef,
+    );
+    const payload: MountedBindingPayload = {
+      settings: parsedSettings,
+      ...(definition.action ? { action: definition.action } : {}),
+      ...(Object.keys(nestedBindings).length > 0
+        ? { bindings: nestedBindings }
+        : {}),
+    };
+
+    resolvedDefs[defName] = {
+      kind: definition.kind,
+      payload,
+    };
+    inProgress.delete(defName);
+
+    return payload;
+  };
+
+  for (const [defName, definition] of Object.entries(defs)) {
+    if (definition.kind === TASK_KIND) {
+      continue;
+    }
+
+    mountResolvedDef(defName);
   }
 
   return { errors, resolvedDefs };
@@ -214,6 +451,7 @@ export const mountTaskBindings = (
   taskBindings: TaskBindingReferences | undefined,
   resolvedDefs: ResolvedBindingDefs,
   bindingKinds?: BindingKindSchemas,
+  resolveDef?: (defName: string) => MountedBindingPayload | undefined,
 ): CompiledTaskBindings => {
   if (!taskBindings) {
     return {};
@@ -234,26 +472,28 @@ export const mountTaskBindings = (
         continue;
       }
 
-      const resolvedDef = resolvedDefs[ref];
+      const resolvedDefPayload =
+        resolvedDefs[ref]?.payload ?? resolveDef?.(ref) ?? undefined;
 
-      if (!resolvedDef) {
+      if (!resolvedDefPayload) {
         continue;
       }
 
-      mounted[bindingKind] = resolvedDef.payload;
+      mounted[bindingKind] = resolvedDefPayload;
       continue;
     }
 
     const mountedKindDefs: Record<string, unknown> = {};
 
     for (const ref of refs) {
-      const resolvedDef = resolvedDefs[ref];
+      const resolvedDefPayload =
+        resolvedDefs[ref]?.payload ?? resolveDef?.(ref) ?? undefined;
 
-      if (!resolvedDef) {
+      if (!resolvedDefPayload) {
         continue;
       }
 
-      mountedKindDefs[ref] = resolvedDef.payload;
+      mountedKindDefs[ref] = resolvedDefPayload;
     }
 
     if (Object.keys(mountedKindDefs).length > 0) {

--- a/packages/agentic/src/bindings/base-binding.ts
+++ b/packages/agentic/src/bindings/base-binding.ts
@@ -54,7 +54,7 @@ export type InferWorkflowBindings<
   >;
 }>;
 
-export type CompiledTaskBindings = Record<string, unknown>;
+export type CompiledTaskBindings = InferWorkflowBindings;
 
 export type TaskBindingReferences = Record<string, string | string[]>;
 
@@ -483,7 +483,7 @@ export const mountTaskBindings = (
       continue;
     }
 
-    const mountedKindDefs: Record<string, unknown> = {};
+    const mountedKindDefs: Record<string, MountedBindingPayload> = {};
 
     for (const ref of refs) {
       const resolvedDefPayload =

--- a/packages/agentic/src/dsl.types.ts
+++ b/packages/agentic/src/dsl.types.ts
@@ -197,7 +197,10 @@ export const SettingsSchema = BaseSettingsSchema.catchall(JsonValueSchema);
 const TaskBindingReferenceSchema = z.union([z.string(), z.array(z.string())]);
 const TaskBindingsSchema = z.record(z.string(), TaskBindingReferenceSchema);
 
+export const TASK_KIND = 'task' as const;
+
 export const TaskDefinitionSchema = z.strictObject({
+  kind: z.literal(TASK_KIND),
   description: z.string().optional(),
   action: z.string(),
   inputs: z.record(z.string(), JsonValueSchema).optional(),
@@ -205,12 +208,23 @@ export const TaskDefinitionSchema = z.strictObject({
   settings: SettingsSchema.optional(),
 });
 
-const DefDefinitionSchema = z
-  .object({
-    kind: z.string(),
-    description: z.string().optional(),
-  })
-  .catchall(z.unknown());
+const NonTaskDefinitionSchema = z.strictObject({
+  kind: z
+    .string()
+    .refine(
+      (kind) => kind !== TASK_KIND,
+      `kind "${TASK_KIND}" must follow the task definition shape.`,
+    ),
+  description: z.string().optional(),
+  action: z.string().optional(),
+  settings: z.record(z.string(), z.unknown()),
+  bindings: TaskBindingsSchema.optional(),
+});
+
+export const DefDefinitionSchema = z.union([
+  TaskDefinitionSchema,
+  NonTaskDefinitionSchema,
+]);
 const ConditionalWhenSchema: z.ZodType<ConditionalBranch> = z.lazy(() =>
   z.strictObject({
     condition: ExpressionStringSchema,
@@ -290,8 +304,7 @@ export const WorkflowDefinitionSchema = z.strictObject({
   inputs: InputsSchema.optional(),
   context: z.record(z.string(), JsonValueSchema).optional(),
   defaults: DefaultsSchema.optional(),
-  defs: z.record(z.string(), DefDefinitionSchema).optional(),
-  tasks: z.record(z.string(), TaskDefinitionSchema),
+  defs: z.record(z.string(), DefDefinitionSchema),
   flow: z.array(FlowStepSchema),
   outputs: z.record(z.string(), ExpressionStringSchema),
 });
@@ -304,16 +317,21 @@ export type TaskDefinition = z.infer<typeof TaskDefinitionSchema>;
 
 export type DefDefinition = z.infer<typeof DefDefinitionSchema>;
 
-export type TaskDefinitions = z.infer<typeof WorkflowDefinitionSchema>['tasks'];
-
 export type DefDefinitions = z.infer<typeof WorkflowDefinitionSchema>['defs'];
+
+export type TaskDefinitions = Record<string, TaskDefinition>;
 
 export type WorkflowMetadata = z.infer<typeof WorkflowMetadataSchema>;
 
 export type WorkflowDefinition = z.infer<typeof WorkflowDefinitionSchema>;
 
+export type WorkflowValidationActionMetadata = {
+  supportedBindings?: readonly string[];
+};
+
 export type ValidateWorkflowOptions = {
   bindingKinds?: BindingKindSchemas;
+  actions?: Record<string, WorkflowValidationActionMetadata>;
 };
 
 export type WorkflowValidationResult =
@@ -352,6 +370,20 @@ const collectTaskReferences = (steps: FlowStep[]): string[] => {
 
   return refs;
 };
+
+export const isTaskDefinition = (
+  definition: DefDefinition,
+): definition is TaskDefinition => definition.kind === TASK_KIND;
+
+export const extractTaskDefinitions = (defs: DefDefinitions): TaskDefinitions =>
+  Object.entries(defs).reduce<TaskDefinitions>((tasks, [defName, def]) => {
+    if (isTaskDefinition(def)) {
+      tasks[defName] = def;
+    }
+
+    return tasks;
+  }, {});
+
 const formatZodErrors = (issues: z.ZodIssue[]): string[] =>
   issues.map((issue) => {
     const path = issue.path.join('.') || '<root>';
@@ -386,9 +418,10 @@ export function validateWorkflow(
   }
 
   const errors: string[] = [];
+  const taskDefinitions = extractTaskDefinitions(parsed.data.defs);
   const referencedTasks = new Set(collectTaskReferences(parsed.data.flow));
   const missingTasks = Array.from(referencedTasks).filter(
-    (task) => !Object.prototype.hasOwnProperty.call(parsed.data.tasks, task),
+    (task) => !Object.prototype.hasOwnProperty.call(taskDefinitions, task),
   );
 
   if (missingTasks.length > 0) {
@@ -397,10 +430,10 @@ export function validateWorkflow(
     );
   }
 
-  const bindingValidation = validateAndResolveBindings(
-    parsed.data,
-    options?.bindingKinds,
-  );
+  const bindingValidation = validateAndResolveBindings(parsed.data, {
+    bindingKinds: options?.bindingKinds,
+    actions: options?.actions,
+  });
 
   if (bindingValidation.errors.length > 0) {
     errors.push(...bindingValidation.errors);

--- a/packages/agentic/src/step-executors/task-executor.test.ts
+++ b/packages/agentic/src/step-executors/task-executor.test.ts
@@ -57,7 +57,9 @@ const createTask = (runImpl: jest.Mock): CompiledTask => ({
   action: createAction(runImpl),
   inputs: { payload: { kind: 'literal', value: 123 } },
   settings: {} as any,
-  bindings: { tools: { calculate: { action: 'calculate_score' } } },
+  bindings: {
+    tools: { calculate: { action: 'calculate_score', settings: {} } },
+  },
 });
 const createCompiled = (task: CompiledTask): CompiledWorkflow =>
   ({

--- a/packages/agentic/src/step-executors/task-executor.ts
+++ b/packages/agentic/src/step-executors/task-executor.ts
@@ -65,7 +65,7 @@ export async function executeTaskStep(
 
   try {
     const actionPromise = Promise.resolve().then(() =>
-      task.action.run(inputs, env.context, task.settings, task.bindings as any),
+      task.action.run(inputs, env.context, task.settings, task.bindings),
     );
     const outcome = await waitForTaskProgress(env, stepInfo.id, actionPromise);
 

--- a/packages/agentic/src/step-executors/task-executor.ts
+++ b/packages/agentic/src/step-executors/task-executor.ts
@@ -65,7 +65,7 @@ export async function executeTaskStep(
 
   try {
     const actionPromise = Promise.resolve().then(() =>
-      task.action.run(inputs, env.context, task.settings, task.bindings),
+      task.action.run(inputs, env.context, task.settings, task.bindings as any),
     );
     const outcome = await waitForTaskProgress(env, stepInfo.id, actionPromise);
 

--- a/packages/agentic/src/utils/workflow-definition.ts
+++ b/packages/agentic/src/utils/workflow-definition.ts
@@ -4,7 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { FlowStep, WorkflowDefinition } from '../dsl.types';
+import {
+  TASK_KIND,
+  type FlowStep,
+  type WorkflowDefinition,
+} from '../dsl.types';
 
 const escapeRegExp = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -139,22 +143,25 @@ export const safeRenameTaskInDefinition = (
     return definition;
   }
 
-  if (
-    !Object.prototype.hasOwnProperty.call(definition.tasks, currentTaskName)
-  ) {
+  if (!Object.prototype.hasOwnProperty.call(definition.defs, currentTaskName)) {
     return definition;
   }
 
-  const renamedTasks = Object.entries(definition.tasks).reduce<
-    WorkflowDefinition['tasks']
-  >((acc, [taskName, task]) => {
-    acc[taskName === currentTaskName ? nextTaskName : taskName] = task;
+  const currentDefinition = definition.defs[currentTaskName];
+  if (!currentDefinition || currentDefinition.kind !== TASK_KIND) {
+    return definition;
+  }
+
+  const renamedDefs = Object.entries(definition.defs).reduce<
+    WorkflowDefinition['defs']
+  >((acc, [defName, def]) => {
+    acc[defName === currentTaskName ? nextTaskName : defName] = def;
 
     return acc;
   }, {});
   const definitionWithRenamedFlow: WorkflowDefinition = {
     ...definition,
-    tasks: renamedTasks,
+    defs: renamedDefs,
     flow: renameTaskInFlow(definition.flow, currentTaskName, nextTaskName),
   };
 

--- a/packages/agentic/src/workflow-compiler.ts
+++ b/packages/agentic/src/workflow-compiler.ts
@@ -19,6 +19,7 @@ import type {
   TaskDefinition,
   WorkflowDefinition,
 } from './dsl.types';
+import { extractTaskDefinitions as extractTaskDefinitionsFromDefs } from './dsl.types';
 import { assertSnakeCaseName } from './utils/naming';
 import { StepType } from './workflow-event-emitter';
 import type {
@@ -152,10 +153,11 @@ const compileTasks = (
 ): Record<string, CompiledTask> => {
   const compiled: Record<string, CompiledTask> = {};
   const defaultSettings = definition.defaults?.settings;
-  const bindingValidation = validateAndResolveBindings(
-    definition,
-    options.bindingKinds,
-  );
+  const taskDefinitions = extractTaskDefinitionsFromDefs(definition.defs);
+  const bindingValidation = validateAndResolveBindings(definition, {
+    bindingKinds: options.bindingKinds,
+    actions: options.actions,
+  });
 
   if (bindingValidation.errors.length > 0) {
     throw new Error(
@@ -163,41 +165,9 @@ const compileTasks = (
     );
   }
 
-  assertActionsBound(definition.tasks, options.actions);
+  assertActionsBound(taskDefinitions, options.actions);
 
-  const unsupportedBindingErrors: string[] = [];
-
-  for (const [taskName, task] of Object.entries(definition.tasks)) {
-    const taskBindingKinds = Object.keys(task.bindings ?? {});
-    if (taskBindingKinds.length === 0) {
-      continue;
-    }
-
-    const action = options.actions[task.action];
-    const supportedBindingKinds = action.supportedBindings ?? [];
-
-    for (const bindingKind of taskBindingKinds) {
-      if (supportedBindingKinds.includes(bindingKind)) {
-        continue;
-      }
-
-      const supportedKindsLabel =
-        supportedBindingKinds.length > 0
-          ? supportedBindingKinds.join(', ')
-          : '<none>';
-      unsupportedBindingErrors.push(
-        `tasks.${taskName}.bindings.${bindingKind}: Action "${task.action}" does not support binding kind "${bindingKind}". Supported binding kinds: ${supportedKindsLabel}.`,
-      );
-    }
-  }
-
-  if (unsupportedBindingErrors.length > 0) {
-    throw new Error(
-      `Workflow bindings validation failed: ${unsupportedBindingErrors.join('; ')}`,
-    );
-  }
-
-  for (const [taskName, task] of Object.entries(definition.tasks)) {
+  for (const [taskName, task] of Object.entries(taskDefinitions)) {
     assertSnakeCaseName(taskName, 'action');
 
     const action = options.actions[task.action];

--- a/packages/agentic/src/workflow.ts
+++ b/packages/agentic/src/workflow.ts
@@ -8,6 +8,7 @@ import { stringify as stringifyYaml } from 'yaml';
 
 import type { BaseWorkflowContext, WorkflowSnapshot } from './context';
 import {
+  TASK_KIND,
   WorkflowDefinition,
   WorkflowDefinitionSchema,
   validateWorkflow,
@@ -114,6 +115,7 @@ export class Workflow {
   ): Workflow {
     const validation = validateWorkflow(definition, {
       bindingKinds: options.bindingKinds,
+      actions: options.actions,
     });
     if (!validation.success) {
       throw new Error(
@@ -133,6 +135,7 @@ export class Workflow {
   static fromYaml(yaml: string, options: WorkflowCompileOptions): Workflow {
     const validation = validateWorkflow(yaml, {
       bindingKinds: options.bindingKinds,
+      actions: options.actions,
     });
     if (!validation.success) {
       throw new Error(
@@ -255,10 +258,14 @@ export class Workflow {
     if (
       !removedTaskName ||
       !Object.prototype.hasOwnProperty.call(
-        nextDefinition.tasks,
+        nextDefinition.defs,
         removedTaskName,
       )
     ) {
+      return nextDefinition;
+    }
+
+    if (nextDefinition.defs[removedTaskName]?.kind !== TASK_KIND) {
       return nextDefinition;
     }
 
@@ -266,12 +273,12 @@ export class Workflow {
       return nextDefinition;
     }
 
-    const { [removedTaskName]: _removedTask, ...remainingTasks } =
-      nextDefinition.tasks;
+    const { [removedTaskName]: _removedTask, ...remainingDefs } =
+      nextDefinition.defs;
 
     return {
       ...nextDefinition,
-      tasks: remainingTasks,
+      defs: remainingDefs,
     };
   }
 

--- a/packages/api/src/bindings/base-binding-kind.ts
+++ b/packages/api/src/bindings/base-binding-kind.ts
@@ -31,6 +31,10 @@ export abstract class BaseBindingKindProvider<
 
   public readonly icon: string;
 
+  public readonly supportedBindings: readonly string[];
+
+  public readonly actionPolicy: 'forbidden' | 'optional' | 'required';
+
   private readonly runtimeBindingsService: RuntimeBindingsService;
 
   protected constructor(
@@ -43,6 +47,8 @@ export abstract class BaseBindingKindProvider<
     this.multiple = metadata.multiple;
     this.color = metadata.color ?? BaseBindingKindProvider.DEFAULT_COLOR;
     this.icon = metadata.icon ?? BaseBindingKindProvider.DEFAULT_ICON;
+    this.supportedBindings = metadata.supportedBindings ?? [];
+    this.actionPolicy = metadata.actionPolicy ?? 'forbidden';
   }
 
   onModuleInit() {
@@ -52,6 +58,8 @@ export abstract class BaseBindingKindProvider<
       multiple: this.multiple,
       color: this.color,
       icon: this.icon,
+      supportedBindings: this.supportedBindings,
+      actionPolicy: this.actionPolicy,
     });
   }
 }

--- a/packages/api/src/bindings/runtime-bindings.service.spec.ts
+++ b/packages/api/src/bindings/runtime-bindings.service.spec.ts
@@ -58,6 +58,8 @@ describe('RuntimeBindingsService', () => {
       multiple: true,
       color: '#f59e0b',
       icon: 'Wrench',
+      supportedBindings: ['tools', 'model', 'memory'],
+      actionPolicy: 'required',
     });
     service.register({
       kind: 'model',
@@ -65,6 +67,8 @@ describe('RuntimeBindingsService', () => {
       multiple: false,
       color: '#ad46fc',
       icon: 'Brain',
+      supportedBindings: [],
+      actionPolicy: 'forbidden',
     });
     service.register({
       kind: 'memory',
@@ -72,6 +76,8 @@ describe('RuntimeBindingsService', () => {
       multiple: true,
       color: '#0ea5e9',
       icon: 'Database',
+      supportedBindings: [],
+      actionPolicy: 'forbidden',
     });
     const definitions = service.getAllSchemaDefinitions();
 
@@ -87,6 +93,16 @@ describe('RuntimeBindingsService', () => {
     expect(definitions.model.icon).toBe('Brain');
     expect(definitions.memory.color).toBe('#0ea5e9');
     expect(definitions.memory.icon).toBe('Database');
+    expect(definitions.tools.supportedBindings).toEqual([
+      'tools',
+      'model',
+      'memory',
+    ]);
+    expect(definitions.model.supportedBindings).toEqual([]);
+    expect(definitions.memory.supportedBindings).toEqual([]);
+    expect(definitions.tools.actionPolicy).toBe('required');
+    expect(definitions.model.actionPolicy).toBe('forbidden');
+    expect(definitions.memory.actionPolicy).toBe('forbidden');
     expect(definitions.tools.schema.$schema).toBe(
       'http://json-schema.org/draft-07/schema#',
     );
@@ -97,7 +113,10 @@ describe('RuntimeBindingsService', () => {
       'http://json-schema.org/draft-07/schema#',
     );
     const toolsDefinition = definitions.tools.schema as
-      | { properties?: Record<string, { type?: string }> }
+      | {
+          properties?: Record<string, { type?: string }>;
+          additionalProperties?: unknown;
+        }
       | undefined;
     const modelDefinition = definitions.model.schema as
       | { properties?: Record<string, { type?: string }> }
@@ -106,7 +125,8 @@ describe('RuntimeBindingsService', () => {
       | { properties?: Record<string, { type?: string }> }
       | undefined;
 
-    expect(toolsDefinition?.properties?.action?.type).toBe('string');
+    expect(toolsDefinition?.properties?.action).toBeUndefined();
+    expect(toolsDefinition?.additionalProperties).toBeDefined();
     expect(modelDefinition?.properties?.provider?.type).toBe('string');
     expect(modelDefinition?.properties?.model_id?.type).toBe('string');
     expect(memoryDefinition?.properties?.definition_id?.type).toBe('string');
@@ -158,5 +178,7 @@ describe('RuntimeBindingsService', () => {
 
     expect(definitions[customKind]).toBeDefined();
     expect(definitions[customKind]?.multiple).toBe(false);
+    expect(definitions[customKind]?.supportedBindings).toEqual([]);
+    expect(definitions[customKind]?.actionPolicy).toBe('forbidden');
   });
 });

--- a/packages/api/src/bindings/runtime-bindings.service.ts
+++ b/packages/api/src/bindings/runtime-bindings.service.ts
@@ -26,6 +26,8 @@ export class RuntimeBindingsService {
     multiple,
     color,
     icon,
+    supportedBindings,
+    actionPolicy,
   }: RegisterRuntimeBindingKindParams): void {
     if (RuntimeBindingsService.registry.has(kind)) {
       throw new Error(
@@ -38,6 +40,8 @@ export class RuntimeBindingsService {
       multiple,
       color,
       icon,
+      supportedBindings,
+      actionPolicy,
     });
   }
 
@@ -92,6 +96,8 @@ export class RuntimeBindingsService {
           multiple: bindingDefinition.multiple,
           color: bindingDefinition.color,
           icon: bindingDefinition.icon,
+          supportedBindings: bindingDefinition.supportedBindings ?? [],
+          actionPolicy: bindingDefinition.actionPolicy ?? 'optional',
         },
       ]),
     );

--- a/packages/api/src/extensions/actions/ai/agent.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/agent.action.spec.ts
@@ -74,12 +74,14 @@ describe('AiAgentAction', () => {
     }> = {},
   ): any => ({
     model: {
-      provider: 'openai',
-      model_id: 'gpt-4o-mini',
-      api_key: 'test-key',
-      base_url: 'https://api.openai.com',
-      organization: 'org-1',
-      ...overrides,
+      settings: {
+        provider: 'openai',
+        model_id: 'gpt-4o-mini',
+        api_key: 'test-key',
+        base_url: 'https://api.openai.com',
+        organization: 'org-1',
+        ...overrides,
+      },
     },
   });
 
@@ -333,7 +335,9 @@ describe('AiAgentAction', () => {
         ...createModelBindings(),
         memory: {
           selected_profile: {
-            definition_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            settings: {
+              definition_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            },
           },
         },
       } as any,
@@ -439,7 +443,9 @@ describe('AiAgentAction', () => {
         context: createContext(),
         bindings: {
           model: {
-            provider: 'openai',
+            settings: {
+              provider: 'openai',
+            },
           },
         } as any,
       }),

--- a/packages/api/src/extensions/actions/ai/agent.action.ts
+++ b/packages/api/src/extensions/actions/ai/agent.action.ts
@@ -50,10 +50,10 @@ export class AiAgentAction extends AiBaseAction<
   }: ExecArgs<AiAgentInput, WorkflowRuntimeContext, AiAgentSettings>) {
     const logger = context.services.logger;
     const modelBinding = bindings.model;
-    const providerName = modelBinding?.provider ?? 'openai';
+    const providerName = modelBinding?.settings?.provider ?? 'openai';
     const modelId = this.resolveModelId(modelBinding);
     const credentials = await context.services.credentials.findOneValue(
-      modelBinding?.api_key,
+      modelBinding?.settings?.api_key,
     );
     const providerOptions = this.buildProviderInitOptions(
       providerName,

--- a/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
@@ -176,11 +176,13 @@ describe('AiBaseAction', () => {
       const options = action.buildProviderInitOptionsPublic(
         'custom',
         {
-          api_key: 'key',
-          base_url: 'https://example.com',
-          organization: 'org',
-          provider: 'openai',
-          model_id: 'gpt-4o-mini',
+          settings: {
+            api_key: 'key',
+            base_url: 'https://example.com',
+            organization: 'org',
+            provider: 'openai',
+            model_id: 'gpt-4o-mini',
+          },
         } as RuntimeBindings['model'],
         'key',
       );
@@ -200,7 +202,7 @@ describe('AiBaseAction', () => {
           'key',
         ),
       ).toThrow(
-        'No API key provided for provider "openai". Set bindings.model.<def>.api_key.',
+        'No API key provided for provider "openai". Set bindings.model.<def>.settings.api_key.',
       );
     });
   });
@@ -416,7 +418,9 @@ describe('AiBaseAction', () => {
     it('returns the model when provided', () => {
       expect(
         action.resolveModelIdPublic({
-          model_id: 'gpt-4o',
+          settings: {
+            model_id: 'gpt-4o',
+          },
         } as RuntimeBindings['model']),
       ).toBe('gpt-4o');
     });

--- a/packages/api/src/extensions/actions/ai/ai-base.action.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.ts
@@ -101,13 +101,14 @@ export abstract class AiBaseAction<
     credentials: string,
   ): ProviderInitOptions {
     const providerId = this.getProviderId(provider);
-    const apiKey = modelBinding?.api_key;
-    const baseURL = modelBinding?.base_url;
-    const organization = modelBinding?.organization;
+    const modelSettings = modelBinding?.settings;
+    const apiKey = modelSettings?.api_key;
+    const baseURL = modelSettings?.base_url;
+    const organization = modelSettings?.organization;
 
     if (!apiKey && this.shouldRequireApiKey(providerId)) {
       throw new Error(
-        `No API key provided for provider "${provider}". Set bindings.model.<def>.api_key.`,
+        `No API key provided for provider "${provider}". Set bindings.model.<def>.settings.api_key.`,
       );
     }
 
@@ -325,24 +326,30 @@ export abstract class AiBaseAction<
   protected isModelBindingConfig(
     value: unknown,
   ): value is RuntimeBindings['model'] {
-    const knownKeys: Array<keyof NonNullable<RuntimeBindings['model']>> = [
+    const knownKeys = [
       'provider',
       'model_id',
       'api_key',
       'base_url',
       'organization',
-    ];
+    ] as const;
+
+    if (!this.isPlainObject(value) || !this.isPlainObject(value.settings)) {
+      return false;
+    }
+
+    const settings = value.settings;
 
     return (
-      this.isPlainObject(value) &&
-      knownKeys.some((key) => key in value) &&
-      (value.model === undefined || typeof value.model === 'string') &&
-      (value.provider === undefined || typeof value.provider === 'string')
+      knownKeys.some((key) => key in settings) &&
+      (settings.model_id === undefined ||
+        typeof settings.model_id === 'string') &&
+      (settings.provider === undefined || typeof settings.provider === 'string')
     );
   }
 
   protected resolveModelId(modelBinding: RuntimeBindings['model']) {
-    const modelId = modelBinding?.model_id;
+    const modelId = modelBinding?.settings?.model_id;
 
     if (!modelId) {
       throw new Error(`A model is required to run ${this.name}.`);
@@ -491,10 +498,14 @@ export abstract class AiBaseAction<
 
     const selectedSlugs = new Set<string>();
     for (const [defName, binding] of Object.entries(memoryBindings)) {
-      const slug = idToSlug.get(binding.definition_id);
+      const definitionId = binding.settings?.definition_id;
+      const slug =
+        typeof definitionId === 'string'
+          ? idToSlug.get(definitionId)
+          : undefined;
       if (!slug) {
         throw new Error(
-          `Unable to resolve memory definition "${binding.definition_id}" from bindings.memory.${defName}.definition_id.`,
+          `Unable to resolve memory definition "${String(definitionId)}" from bindings.memory.${defName}.settings.definition_id.`,
         );
       }
 
@@ -643,7 +654,13 @@ export abstract class AiBaseAction<
       if (normalizedToolName.length === 0) {
         continue;
       }
-      const actionName = toolDefinition.action.trim() as ActionName;
+      const actionNameRaw = toolDefinition.action;
+      if (typeof actionNameRaw !== 'string' || actionNameRaw.trim() === '') {
+        throw new Error(
+          `Invalid tool action in bindings.tools.${normalizedToolName}.action`,
+        );
+      }
+      const actionName = actionNameRaw.trim() as ActionName;
       const action = actionService.get(actionName);
 
       tools[normalizedToolName] = {
@@ -651,7 +668,7 @@ export abstract class AiBaseAction<
         inputSchema: action.inputSchema,
         outputSchema: action.outputSchema,
         execute: async (input) =>
-          action.run(input, context, toolDefinition.settings),
+          action.run(input, context, toolDefinition.settings as any),
       };
     }
 

--- a/packages/api/src/extensions/actions/ai/generate-object.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/generate-object.action.spec.ts
@@ -75,12 +75,14 @@ describe('AiGenerateObjectAction', () => {
     }> = {},
   ): any => ({
     model: {
-      provider: 'openai',
-      model_id: 'gpt-4o-mini',
-      api_key: 'test-key',
-      base_url: 'https://api.openai.com',
-      organization: 'org-1',
-      ...overrides,
+      settings: {
+        provider: 'openai',
+        model_id: 'gpt-4o-mini',
+        api_key: 'test-key',
+        base_url: 'https://api.openai.com',
+        organization: 'org-1',
+        ...overrides,
+      },
     },
   });
 
@@ -268,7 +270,7 @@ describe('AiGenerateObjectAction', () => {
         context: createContext(),
         bindings: {
           model: {
-            openai_chatgpt: {
+            settings: {
               provider: 'openai',
             },
           },

--- a/packages/api/src/extensions/actions/ai/generate-object.base.action.ts
+++ b/packages/api/src/extensions/actions/ai/generate-object.base.action.ts
@@ -38,10 +38,10 @@ export abstract class AiGenerateObjectBaseAction<
   }: ExecArgs<I, C, AiGenerateObjectSettings>) {
     const logger = context.services.logger;
     const modelBinding = bindings.model;
-    const providerName = modelBinding?.provider ?? 'openai';
+    const providerName = modelBinding?.settings?.provider ?? 'openai';
     const modelId = this.resolveModelId(modelBinding);
     const credentials = await context.services.credentials.findOneValue(
-      modelBinding?.api_key,
+      modelBinding?.settings?.api_key,
     );
     const providerOptions = this.buildProviderInitOptions(
       providerName,

--- a/packages/api/src/extensions/actions/ai/generate-reply.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/generate-reply.action.spec.ts
@@ -70,10 +70,12 @@ describe('AiGenerateReplyAction', () => {
     }> = {},
   ): any => ({
     model: {
-      provider: 'openai',
-      model_id: 'gpt-4o-mini',
-      api_key: 'test-key',
-      ...overrides,
+      settings: {
+        provider: 'openai',
+        model_id: 'gpt-4o-mini',
+        api_key: 'test-key',
+        ...overrides,
+      },
     },
   });
 
@@ -166,7 +168,7 @@ describe('AiGenerateReplyAction', () => {
         context: createContext(),
         bindings: {
           model: {
-            openai_chatgpt: {
+            settings: {
               provider: 'openai',
             },
           },

--- a/packages/api/src/extensions/actions/ai/generate-text.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/generate-text.action.spec.ts
@@ -77,12 +77,14 @@ describe('AiGenerateTextAction', () => {
     }> = {},
   ): any => ({
     model: {
-      provider: 'openai',
-      model_id: 'gpt-4o-mini',
-      api_key: 'test-key',
-      base_url: 'https://api.openai.com',
-      organization: 'org-1',
-      ...overrides,
+      settings: {
+        provider: 'openai',
+        model_id: 'gpt-4o-mini',
+        api_key: 'test-key',
+        base_url: 'https://api.openai.com',
+        organization: 'org-1',
+        ...overrides,
+      },
     },
   });
 
@@ -292,7 +294,9 @@ describe('AiGenerateTextAction', () => {
         ...createModelBindings(),
         memory: {
           selected_profile: {
-            definition_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            settings: {
+              definition_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            },
           },
         },
       } as any,
@@ -463,7 +467,7 @@ describe('AiGenerateTextAction', () => {
         context: createContext(),
         bindings: {
           model: {
-            openai_chatgpt: {
+            settings: {
               provider: 'openai',
             },
           },

--- a/packages/api/src/extensions/actions/ai/generate-text.base.action.ts
+++ b/packages/api/src/extensions/actions/ai/generate-text.base.action.ts
@@ -34,10 +34,10 @@ export abstract class AiGenerateTextBaseAction<
   }: ExecArgs<I, C, AiGenerateTextSettings>) {
     const logger = context.services.logger;
     const modelBinding = bindings.model;
-    const providerName = modelBinding?.provider ?? 'openai';
+    const providerName = modelBinding?.settings?.provider ?? 'openai';
     const modelId = this.resolveModelId(modelBinding);
     const credentials = await context.services.credentials.findOneValue(
-      modelBinding?.api_key,
+      modelBinding?.settings?.api_key,
     );
     const providerOptions = this.buildProviderInitOptions(
       providerName,

--- a/packages/api/src/extensions/actions/ai/infer-object.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/infer-object.action.spec.ts
@@ -74,10 +74,12 @@ describe('AiInferObjectAction', () => {
     }> = {},
   ): any => ({
     model: {
-      provider: 'openai',
-      model_id: 'gpt-4o-mini',
-      api_key: 'test-key',
-      ...overrides,
+      settings: {
+        provider: 'openai',
+        model_id: 'gpt-4o-mini',
+        api_key: 'test-key',
+        ...overrides,
+      },
     },
   });
 
@@ -199,7 +201,7 @@ describe('AiInferObjectAction', () => {
         context: createContext(),
         bindings: {
           model: {
-            openai_chatgpt: {
+            settings: {
               provider: 'openai',
             },
           },

--- a/packages/api/src/extensions/actions/ai/tools.binding.ts
+++ b/packages/api/src/extensions/actions/ai/tools.binding.ts
@@ -9,10 +9,7 @@ import z from 'zod';
 
 import { createBindingKind } from '@/bindings/create-binding-kind';
 
-export const aiToolBindingSchema = z.strictObject({
-  action: z.string().min(1),
-  settings: z.record(z.string(), z.unknown()).optional(),
-});
+export const aiToolBindingSchema = z.record(z.string(), z.unknown());
 
 declare global {
   interface RuntimeBindingKindRegistry {
@@ -24,6 +21,8 @@ export const ToolsBindingKind = createBindingKind({
   kind: 'tools',
   schema: aiToolBindingSchema,
   multiple: true,
+  actionPolicy: 'required',
+  supportedBindings: ['tools', 'model', 'memory'],
   color: '#f59e0b',
   icon: 'Wrench',
 });

--- a/packages/api/src/i18n/services/translation.service.spec.ts
+++ b/packages/api/src/i18n/services/translation.service.spec.ts
@@ -27,8 +27,9 @@ describe('TranslationService', () => {
       description: 'Workflow description',
       definition: {
         workflow: { description: 'Internal workflow description' },
-        tasks: {
+        defs: {
           send_text: {
+            kind: 'task',
             action: 'send_text_message',
             description: '=$t("Task description to ignore")',
             inputs: {
@@ -50,8 +51,9 @@ describe('TranslationService', () => {
       name: 'secondary',
       version: '0.1.0',
       definition: {
-        tasks: {
+        defs: {
           ask_choice: {
+            kind: 'task',
             action: 'send_quick_replies',
             settings: {
               prompt: '=$t("Settings prompt")',

--- a/packages/api/src/i18n/services/translation.service.ts
+++ b/packages/api/src/i18n/services/translation.service.ts
@@ -5,10 +5,12 @@
  */
 
 import type {
+  DefDefinitions,
   JsonValue,
   TaskDefinition,
   TaskDefinitions,
 } from '@hexabot-ai/agentic';
+import { extractTaskDefinitions as extractTaskDefinitionsFromDefs } from '@hexabot-ai/agentic';
 import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import jsonata from 'jsonata';
@@ -53,14 +55,15 @@ export class TranslationService extends BaseOrmService<
     const allStrings: string[] = [];
 
     for (const workflow of workflows) {
-      if (!workflow.definition?.tasks) {
+      if (!workflow.definition?.defs) {
         continue;
       }
 
       try {
-        allStrings.push(
-          ...this.collectTaskTranslationStrings(workflow.definition.tasks),
+        const taskDefinitions = this.extractTaskDefinitions(
+          workflow.definition.defs,
         );
+        allStrings.push(...this.collectTaskTranslationStrings(taskDefinitions));
       } catch (err) {
         this.logger.warn(
           `Unable to collect workflow translations from ${workflow.id}`,
@@ -113,6 +116,10 @@ export class TranslationService extends BaseOrmService<
     return Object.values(tasks).flatMap((task) =>
       this.collectTaskDefinitionTranslations(task),
     );
+  }
+
+  private extractTaskDefinitions(defs: DefDefinitions): TaskDefinitions {
+    return extractTaskDefinitionsFromDefs(defs);
   }
 
   /**

--- a/packages/api/src/utils/test/fixtures/memory-record.ts
+++ b/packages/api/src/utils/test/fixtures/memory-record.ts
@@ -41,8 +41,9 @@ export const memoryRecordFixtureIds = {
 } as const;
 
 const memoryWorkflowDefinition: WorkflowDefinition = {
-  tasks: {
+  defs: {
     noop: {
+      kind: 'task',
       action: 'noop_task',
     },
   },

--- a/packages/api/src/utils/test/fixtures/workflow-run.ts
+++ b/packages/api/src/utils/test/fixtures/workflow-run.ts
@@ -44,8 +44,9 @@ export const workflowRunFixtureIds = {
 } as const;
 
 const workflowRunWorkflowDefinition: WorkflowDefinition = {
-  tasks: {
+  defs: {
     noop: {
+      kind: 'task',
       action: 'noop_task',
     },
   },

--- a/packages/api/src/utils/test/fixtures/workflow.ts
+++ b/packages/api/src/utils/test/fixtures/workflow.ts
@@ -32,14 +32,16 @@ type WorkflowFixture = WorkflowCreateDto & { definitionYml: string };
  * It sends an initial text and follows up with a quick reply prompt.
  */
 export const messagingWorkflowDefinition: WorkflowDefinition = {
-  tasks: {
+  defs: {
     send_greeting: {
+      kind: 'task',
       action: 'send_text_message',
       inputs: {
         text: '="Welcome to Hexabot! Let us know how to help."',
       },
     },
     prompt_next_step: {
+      kind: 'task',
       action: 'send_quick_replies',
       description: 'Offer quick replies to continue the conversation.',
       inputs: {
@@ -69,8 +71,9 @@ export const messagingWorkflowDefinition: WorkflowDefinition = {
  * Scheduled workflow definition used to validate cron-based execution.
  */
 export const scheduledWorkflowDefinition: WorkflowDefinition = {
-  tasks: {
+  defs: {
     send_update: {
+      kind: 'task',
       // Dummy action used only for scheduled workflow testing.
       action: 'noop_task',
       inputs: {

--- a/packages/api/src/workflow/contexts/workflow-context-factory.ts
+++ b/packages/api/src/workflow/contexts/workflow-context-factory.ts
@@ -40,7 +40,11 @@ export class WorkflowContextFactory {
 
     const ids = Object.values(definition.defs)
       .filter((def) => def?.kind === 'memory')
-      .map((def) => (def as { definition_id?: unknown }).definition_id)
+      .map(
+        (def) =>
+          (def as { settings?: { definition_id?: unknown } }).settings
+            ?.definition_id,
+      )
       .filter((value): value is string => typeof value === 'string' && !!value);
 
     return Array.from(new Set(ids));

--- a/packages/api/src/workflow/controllers/workflow-version.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow-version.controller.spec.ts
@@ -41,8 +41,9 @@ describe('WorkflowVersionController (TypeORM)', () => {
       type: WorkflowType.conversational,
       schedule: null,
       definitionYml: WorkflowHelper.stringifyDefinition({
-        tasks: {
+        defs: {
           send_greeting: {
+            kind: 'task',
             action: 'send_text_message',
             inputs: { text: '="Hi"' },
           },
@@ -109,8 +110,9 @@ describe('WorkflowVersionController (TypeORM)', () => {
         action: WorkflowVersionAction.update,
         workflow: created.id,
         definitionYml: WorkflowHelper.stringifyDefinition({
-          tasks: {
+          defs: {
             send_greeting: {
+              kind: 'task',
               action: 'send_text_message',
               inputs: { text: '="Hello world"' },
             },

--- a/packages/api/src/workflow/controllers/workflow.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow.controller.spec.ts
@@ -152,6 +152,8 @@ describe('WorkflowController (TypeORM)', () => {
       multiple: true,
       color: '#f59e0b',
       icon: 'Wrench',
+      supportedBindings: ['tools', 'model', 'memory'],
+      actionPolicy: 'required',
     });
     runtimeBindingsService.register({
       kind: 'model',
@@ -159,6 +161,8 @@ describe('WorkflowController (TypeORM)', () => {
       multiple: false,
       color: '#ad46fc',
       icon: 'Brain',
+      supportedBindings: [],
+      actionPolicy: 'forbidden',
     });
     runtimeBindingsService.register({
       kind: 'memory',
@@ -166,6 +170,8 @@ describe('WorkflowController (TypeORM)', () => {
       multiple: true,
       color: '#0ea5e9',
       icon: 'Database',
+      supportedBindings: [],
+      actionPolicy: 'forbidden',
     });
     runtimeBindingsService.register({
       kind: 'weather',
@@ -281,6 +287,18 @@ describe('WorkflowController (TypeORM)', () => {
       expect(bindings.memory.icon).toBe('Database');
       expect(bindings.weather.color).toBe('#22c55e');
       expect(bindings.weather.icon).toBe('CloudSun');
+      expect(bindings.tools.supportedBindings).toEqual([
+        'tools',
+        'model',
+        'memory',
+      ]);
+      expect(bindings.model.supportedBindings).toEqual([]);
+      expect(bindings.memory.supportedBindings).toEqual([]);
+      expect(bindings.weather.supportedBindings).toEqual([]);
+      expect(bindings.tools.actionPolicy).toBe('required');
+      expect(bindings.model.actionPolicy).toBe('forbidden');
+      expect(bindings.memory.actionPolicy).toBe('forbidden');
+      expect(bindings.weather.actionPolicy).toBe('optional');
       expect(bindings.tools.schema.$schema).toBe(
         'http://json-schema.org/draft-07/schema#',
       );
@@ -291,7 +309,10 @@ describe('WorkflowController (TypeORM)', () => {
         'http://json-schema.org/draft-07/schema#',
       );
       const toolsDefinition = bindings.tools.schema as
-        | { properties?: Record<string, { type?: string }> }
+        | {
+            properties?: Record<string, { type?: string }>;
+            additionalProperties?: unknown;
+          }
         | undefined;
       const modelDefinition = bindings.model.schema as
         | { properties?: Record<string, { type?: string }> }
@@ -303,7 +324,8 @@ describe('WorkflowController (TypeORM)', () => {
         | { properties?: Record<string, { type?: string }> }
         | undefined;
 
-      expect(toolsDefinition?.properties?.action?.type).toBe('string');
+      expect(toolsDefinition?.properties?.action).toBeUndefined();
+      expect(toolsDefinition?.additionalProperties).toBeDefined();
       expect(modelDefinition?.properties?.provider?.type).toBe('string');
       expect(modelDefinition?.properties?.model_id?.type).toBe('string');
       expect(memoryDefinition?.properties?.definition_id?.type).toBe('string');

--- a/packages/api/src/workflow/defaults/default-workflow.ts
+++ b/packages/api/src/workflow/defaults/default-workflow.ts
@@ -13,8 +13,9 @@ import { stringify } from 'yaml';
  * until the next incoming message resumes the run.
  */
 export const defaultWorkflowDefinition: WorkflowDefinition = {
-  tasks: {
+  defs: {
     send_default_reply: {
+      kind: 'task',
       action: 'send_text_message',
       description: 'Send a basic acknowledgment using messaging actions.',
       inputs: {

--- a/packages/api/src/workflow/entities/workflow.entity.ts
+++ b/packages/api/src/workflow/entities/workflow.entity.ts
@@ -61,7 +61,7 @@ export class WorkflowOrmEntity extends BaseOrmEntity<WorkflowTransformerDto> {
           retries: { ...DEFAULT_RETRY_SETTINGS },
         },
       },
-      tasks: {},
+      defs: {},
       flow: [],
       outputs: {},
     });

--- a/packages/api/src/workflow/services/workflow-run.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-run.service.spec.ts
@@ -45,8 +45,8 @@ describe('WorkflowRunService (TypeORM)', () => {
   let creatorId: string;
 
   const buildWorkflowDefinition = (): WorkflowDefinition => ({
-    tasks: {
-      greet: { action: 'greet' },
+    defs: {
+      greet: { kind: 'task', action: 'greet' },
     },
     flow: [{ do: 'greet' }],
     outputs: { result: '=1' },

--- a/packages/api/src/workflow/services/workflow-version.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-version.service.spec.ts
@@ -108,7 +108,7 @@ describe('WorkflowVersionService (TypeORM)', () => {
             retries: { ...DEFAULT_RETRY_SETTINGS },
           },
         },
-        tasks: {},
+        defs: {},
         flow: [],
         outputs: {},
       });

--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -50,8 +50,8 @@ describe('WorkflowService (TypeORM)', () => {
         description: 'Test workflow definition',
       },
       definition: {
-        tasks: {
-          greet: { action: 'greet' },
+        defs: {
+          greet: { kind: 'task', action: 'greet' },
         },
         flow: [{ do: 'greet' }],
         outputs: { result: '=1' },

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/JsonSchemaForm.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/JsonSchemaForm.tsx
@@ -9,6 +9,7 @@ import { Form } from "@rjsf/mui";
 import { getDefaultFormState, type RJSFSchema, type UiSchema } from "@rjsf/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { isRecord } from "@/utils/object";
 import validator from "@/utils/rjsf-zod-validator";
 
 import { FORM_FIELDS } from "./fields";
@@ -20,9 +21,6 @@ const FORM_UI_SCHEMA = {
     norender: true,
   },
 } as const;
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-};
 const withSchemaDefaults = (
   schema: RJSFSchema,
   formData: Record<string, unknown>,

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/templates/ActionObjectFieldTemplate.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/templates/ActionObjectFieldTemplate.tsx
@@ -31,6 +31,7 @@ import {
 import { MouseEvent, useMemo, useState } from "react";
 
 import { useTranslate } from "@/hooks/useTranslate";
+import { isRecord } from "@/utils/object";
 
 import { getDescription, LabelWithTooltip } from "../widgets/shared";
 
@@ -41,9 +42,6 @@ type ActionFieldUiOptions = {
   [key: string]: unknown;
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-};
 const getObjectSchemaPropertyTitle = (
   schema: RJSFSchema,
   propertyName: string,

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/templates/action-field-template.utils.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/templates/action-field-template.utils.ts
@@ -4,6 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
+import { isRecord } from "@/utils/object";
+
 type ActionButtonType = "web_url" | "postback";
 type ShowWhenCondition = {
   field: string;
@@ -29,9 +31,6 @@ const hasButtonType = (buttons: unknown, buttonType: ActionButtonType) => {
         (button as { type?: string }).type === buttonType,
     )
   );
-};
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 };
 const getValueByPath = (
   source: Record<string, unknown> | undefined,

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
@@ -116,7 +116,8 @@ export const useActionFormDrawerController = ({
   onClose,
 }: UseActionFormDrawerControllerParams): UseActionFormDrawerControllerResult => {
   const { t } = useTranslate();
-  const { definition, updateDefinitionState, isSaving } = useWorkflow();
+  const { definition, updateDefinitionState, isSaving, taskDefinitions } =
+    useWorkflow();
   const { actionsByName } = useWorkflowActionsCatalog();
   const selectedActionNode = useSelectedActionNode();
   const selectedNodeId = selectedActionNode?.id;
@@ -125,7 +126,7 @@ export const useActionFormDrawerController = ({
   const taskName = target?.initialTaskName ?? selectedActionNode?.taskName;
   const actionSchema = target?.action ?? (actionName ? actionsByName.get(actionName) : undefined);
   const taskDefinition =
-    !isCreateMode && taskName ? definition?.tasks?.[taskName] : undefined;
+    !isCreateMode && taskName ? taskDefinitions[taskName] : undefined;
   const [inputData, setInputData] = useState<Record<string, unknown>>({});
   const [actionSettingsData, setActionSettingsData] = useState<
     Record<string, unknown>
@@ -182,7 +183,7 @@ export const useActionFormDrawerController = ({
     actionName,
     taskName,
     taskDescription: target?.initialTaskDescription ?? taskDefinition?.description,
-    tasks: definition?.tasks,
+    tasks: taskDefinitions,
   });
   const handleSaveClose = useStepDrawerClose(() => {
     onClose?.("save");
@@ -323,11 +324,12 @@ export const useActionFormDrawerController = ({
     const hasSettingValues = Object.keys(nextSettingsData).length > 0;
 
     if (isCreateMode && target) {
-      if (Object.prototype.hasOwnProperty.call(definition.tasks, nextTaskName)) {
+      if (Object.prototype.hasOwnProperty.call(taskDefinitions, nextTaskName)) {
         return;
       }
 
       const nextTask: TaskDefinition = {
+        kind: "task",
         action: actionSchema.name,
         ...(normalizedDescription ? { description: normalizedDescription } : {}),
         ...(hasInputValues
@@ -340,8 +342,8 @@ export const useActionFormDrawerController = ({
       const nextStep: FlowStep = { do: nextTaskName };
       const definitionWithTask: WorkflowDefinition = {
         ...definition,
-        tasks: {
-          ...(definition.tasks ?? {}),
+        defs: {
+          ...(definition.defs ?? {}),
           [nextTaskName]: nextTask,
         },
         outputs:
@@ -369,12 +371,12 @@ export const useActionFormDrawerController = ({
 
     if (
       nextTaskName !== taskName &&
-      Object.prototype.hasOwnProperty.call(definition.tasks, nextTaskName)
+      Object.prototype.hasOwnProperty.call(taskDefinitions, nextTaskName)
     ) {
       return;
     }
 
-    const currentTask = definition.tasks?.[taskName];
+    const currentTask = taskName ? taskDefinitions[taskName] : undefined;
 
     if (!currentTask) {
       return;
@@ -395,14 +397,18 @@ export const useActionFormDrawerController = ({
     };
     let nextDefinition: WorkflowDefinition = {
       ...definition,
-      tasks: {
-        ...(definition.tasks ?? {}),
+      defs: {
+        ...(definition.defs ?? {}),
         [taskName]: nextTask,
       },
     };
 
     if (!normalizedDescription) {
-      delete nextDefinition.tasks[taskName].description;
+      const nextTaskDefinition = nextDefinition.defs[taskName];
+
+      if (nextTaskDefinition?.kind === "task") {
+        delete nextTaskDefinition.description;
+      }
     }
 
     if (nextTaskName !== taskName) {
@@ -428,7 +434,7 @@ export const useActionFormDrawerController = ({
     (isCreateMode
       ? !target ||
         !normalizedTaskName ||
-        Object.prototype.hasOwnProperty.call(definition.tasks, normalizedTaskName)
+        Object.prototype.hasOwnProperty.call(taskDefinitions, normalizedTaskName)
       : !selectedActionNode || !taskDefinition);
 
   return {

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useTaskIdentityController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useTaskIdentityController.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { WorkflowDefinition } from "@hexabot-ai/agentic";
+import type { TaskDefinition } from "@hexabot-ai/agentic";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useTranslate } from "@/hooks/useTranslate";
@@ -16,7 +16,7 @@ type UseTaskIdentityControllerParams = {
   actionName?: string;
   taskName?: string;
   taskDescription?: string;
-  tasks?: WorkflowDefinition["tasks"];
+  tasks?: Record<string, TaskDefinition>;
 };
 
 export const useTaskIdentityController = ({

--- a/packages/frontend/src/components/visual-editor/v4/components/main/BindingDrawer/BindingSelectionDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/BindingDrawer/BindingSelectionDrawer.tsx
@@ -106,10 +106,37 @@ const asRecord = (value: unknown): Record<string, unknown> | undefined => {
 
   return value as Record<string, unknown>;
 };
-const toBindingFormData = (definition: Record<string, unknown>) => {
-  const { kind: _kind, description: _description, ...rest } = definition;
+const getSchemaPropertyNames = (schema?: JSONSchema): string[] => {
+  const schemaRecord = asRecord(schema);
+  const schemaProperties = asRecord(schemaRecord?.properties);
 
-  return rest;
+  if (!schemaProperties) {
+    return [];
+  }
+
+  return Object.keys(schemaProperties);
+};
+const pickSchemaFields = (
+  value: Record<string, unknown>,
+  schema?: JSONSchema,
+): Record<string, unknown> => {
+  const schemaPropertyNames = getSchemaPropertyNames(schema);
+
+  if (!schemaPropertyNames.length) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => schemaPropertyNames.includes(key)),
+  );
+};
+const toBindingFormData = (
+  definition: Record<string, unknown>,
+  schema?: JSONSchema,
+) => {
+  const settings = asRecord(definition.settings);
+
+  return pickSchemaFields(settings ?? {}, schema);
 };
 const BindingSelectionDrawerContent = ({
   isOpen,
@@ -489,7 +516,9 @@ export const BindingSelectionDrawer = ({
       setBindingName(editingBindingName);
       setBindingDescription(existingDescription);
       setBindingData(
-        existingDefinition ? toBindingFormData(existingDefinition) : {},
+        existingDefinition
+          ? toBindingFormData(existingDefinition, bindingSchema)
+          : {},
       );
       setMode("create");
       setHasVisibleErrors(false);
@@ -510,6 +539,7 @@ export const BindingSelectionDrawer = ({
   }, [
     availableBindings.length,
     bindingKind,
+    bindingSchema,
     defaultBindingData,
     defs,
     editingBindingName,

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ToolDrawer/ToolFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ToolDrawer/ToolFormDrawer.tsx
@@ -47,7 +47,7 @@ type ToolFormDrawerContentProps = {
 
 type ToolFormDrawerCreateTarget = {
   mode: "create";
-  taskName: string;
+  ownerDefName: string;
   bindingKind: typeof TOOL_BINDING_KIND;
   actionName: string;
   initialBindingName: string;
@@ -57,7 +57,7 @@ type ToolFormDrawerCreateTarget = {
 
 type ToolFormDrawerEditTarget = {
   mode: "edit";
-  taskName: string;
+  ownerDefName: string;
   bindingKind: typeof TOOL_BINDING_KIND;
   bindingName: string;
 };
@@ -195,13 +195,13 @@ export const ToolFormDrawer = ({ target, onClose }: ToolFormDrawerProps) => {
   const actionSchema = actionName ? actionsByName.get(actionName) : undefined;
   const panelKeyBase = target
     ? target.mode === "create"
-      ? `tool-create-${target.taskName}-${target.initialBindingName}`
-      : `tool-edit-${target.taskName}-${target.bindingName}`
+      ? `tool-create-${target.ownerDefName}-${target.initialBindingName}`
+      : `tool-edit-${target.ownerDefName}-${target.bindingName}`
     : "tool";
   const targetKey = target
     ? target.mode === "create"
-      ? `create:${target.taskName}:${target.initialBindingName}:${target.actionName}`
-      : `edit:${target.taskName}:${target.bindingName}`
+      ? `create:${target.ownerDefName}:${target.initialBindingName}:${target.actionName}`
+      : `edit:${target.ownerDefName}:${target.bindingName}`
     : "";
   const hasSettingsSchema = useMemo(
     () =>
@@ -278,7 +278,7 @@ export const ToolFormDrawer = ({ target, onClose }: ToolFormDrawerProps) => {
     const nextDefinition =
       target.mode === "create"
         ? createToolBindingDefinitionMutation(definition, {
-            taskName: target.taskName,
+            ownerDefName: target.ownerDefName,
             bindingKind: target.bindingKind,
             bindingName: normalizedToolName,
             actionName: resolvedTarget.actionName,
@@ -286,7 +286,7 @@ export const ToolFormDrawer = ({ target, onClose }: ToolFormDrawerProps) => {
             settings: actionSettingsData,
           })
         : updateToolBindingDefinitionMutation(definition, {
-            taskName: target.taskName,
+            ownerDefName: target.ownerDefName,
             bindingKind: target.bindingKind,
             currentBindingName: target.bindingName,
             nextBindingName: normalizedToolName,

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/completion.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/completion.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type { Monaco } from "@monaco-editor/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { registerYamlCompletionProvider } from "./completion";
+import { YAML_LANGUAGE_ID } from "./constants";
+
+type CompletionProvider = Parameters<
+  Monaco["languages"]["registerCompletionItemProvider"]
+>[1];
+
+const createMonacoMock = () => {
+  let provider: CompletionProvider | undefined;
+
+  const monaco = {
+    languages: {
+      CompletionItemKind: {
+        Snippet: 1,
+        Reference: 2,
+        Function: 3,
+      },
+      CompletionItemInsertTextRule: {
+        InsertAsSnippet: 4,
+      },
+      registerCompletionItemProvider: vi.fn((languageId, completionProvider) => {
+        if (languageId === YAML_LANGUAGE_ID) {
+          provider = completionProvider;
+        }
+
+        return { dispose: vi.fn() };
+      }),
+    },
+  } as unknown as Monaco;
+
+  return {
+    monaco,
+    getProvider: () => provider,
+  };
+};
+
+describe("yaml completion", () => {
+  it("suggests task ids from provider state for flow do references", () => {
+    const { monaco, getProvider } = createMonacoMock();
+
+    registerYamlCompletionProvider(monaco, undefined, () => ["task_alpha"]);
+
+    const provider = getProvider();
+
+    if (!provider) {
+      throw new Error("Expected YAML completion provider to be registered");
+    }
+
+    const doLine = "  - do: ";
+    const suggestions = provider.provideCompletionItems(
+      {
+        getLineContent: () => doLine,
+        getWordUntilPosition: () => ({
+          word: "",
+          startColumn: doLine.length + 1,
+          endColumn: doLine.length + 1,
+        }),
+      } as never,
+      {
+        lineNumber: 9,
+        column: doLine.length + 1,
+      } as never,
+      { triggerCharacter: ":" } as never,
+      {} as never,
+    ).suggestions;
+
+    expect(suggestions.map((suggestion) => suggestion.label)).toContain(
+      "task_alpha",
+    );
+  });
+});

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/completion.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/completion.ts
@@ -6,7 +6,6 @@
 
 import type { Monaco } from "@monaco-editor/react";
 import type { IDisposable, IPosition, editor } from "monaco-editor";
-import { parse as parseYaml } from "yaml";
 
 import type { IAction } from "@/types/action.types";
 
@@ -29,42 +28,24 @@ const isCommentOrBlank = (line: string) => {
 
   return trimmed.length === 0 || trimmed.startsWith("#");
 };
-const isInTasksBlock = (model: editor.ITextModel, position: IPosition) => {
+const isInDefsBlock = (model: editor.ITextModel, position: IPosition) => {
   for (let lineNumber = position.lineNumber; lineNumber >= 1; lineNumber -= 1) {
     const line = model.getLineContent(lineNumber);
 
     if (isCommentOrBlank(line)) continue;
 
     if (countIndent(line) === 0) {
-      return /^tasks:\s*(#.*)?$/.test(line.trim());
+      return /^defs:\s*(#.*)?$/.test(line.trim());
     }
   }
 
   return false;
 };
-const extractTaskIds = (value: string) => {
-  try {
-    const parsed = parseYaml(value);
-
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return [];
-    }
-
-    const tasks = (parsed as { tasks?: unknown }).tasks;
-
-    if (!tasks || typeof tasks !== "object" || Array.isArray(tasks)) {
-      return [];
-    }
-
-    return Object.keys(tasks as Record<string, unknown>).sort();
-  } catch {
-    return [];
-  }
-};
 const buildTaskCompletionItems = (
   monacoInstance: Monaco,
   model: editor.ITextModel,
   position: IPosition,
+  taskIds?: string[],
 ) => {
   const linePrefix = model
     .getLineContent(position.lineNumber)
@@ -74,9 +55,7 @@ const buildTaskCompletionItems = (
     return [];
   }
 
-  const taskIds = extractTaskIds(model.getValue());
-
-  if (taskIds.length === 0) {
+  if (!taskIds?.length) {
     return [];
   }
 
@@ -118,7 +97,7 @@ const buildActionCompletionItems = (
     return [];
   }
 
-  if (!isInTasksBlock(model, position)) {
+  if (!isInDefsBlock(model, position)) {
     return [];
   }
 
@@ -155,6 +134,7 @@ const buildActionCompletionItems = (
 export const registerYamlCompletionProvider = (
   monacoInstance: Monaco,
   getActions?: () => IAction[] | undefined,
+  getTaskIds?: () => string[] | undefined,
 ): IDisposable => {
   const suggestions = buildYamlCompletionItems(monacoInstance);
 
@@ -167,6 +147,7 @@ export const registerYamlCompletionProvider = (
           monacoInstance,
           model,
           position,
+          getTaskIds?.(),
         );
         const actionSuggestions = buildActionCompletionItems(
           monacoInstance,

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/useYamlEditorController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/useYamlEditorController.ts
@@ -25,7 +25,7 @@ import { useDebouncedEffect } from "./useDebouncedEffect";
 import { applyWorkflowValidationMarkers } from "./validation/validation";
 
 export function useYamlEditorController({ errorLine, errorMessage }: Pick<YamlEditorProps, "errorLine" | "errorMessage">) {
-  const { yaml, updateDefinitionState, workflow } = useWorkflow();
+  const { yaml, updateDefinitionState, workflow, taskIds } = useWorkflow();
   const {
     data: actions = [],
     isLoading: actionsLoading,
@@ -96,15 +96,17 @@ export function useYamlEditorController({ errorLine, errorMessage }: Pick<YamlEd
     if (!monaco) return;
 
     completionDisposableRef.current?.dispose();
-    completionDisposableRef.current = registerYamlCompletionProvider(monaco, () => availableActions);
+    completionDisposableRef.current = registerYamlCompletionProvider(
+      monaco,
+      () => availableActions,
+      () => taskIds,
+    );
 
     return () => {
       completionDisposableRef.current?.dispose();
       completionDisposableRef.current = null;
     };
-    // we only want to re-run when `availableActions` changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [availableActions]);
+  }, [availableActions, taskIds]);
 
   useEffect(() => {
     return () => {

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/validation/validation.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/validation/validation.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type { Monaco } from "@monaco-editor/react";
+import type { editor } from "monaco-editor";
+import { describe, expect, it, vi } from "vitest";
+
+import type { IAction } from "@/types/action.types";
+
+import { YAML_WORKFLOW_VALIDATION_OWNER } from "../constants";
+
+import { applyWorkflowValidationMarkers } from "./validation";
+
+const makeAction = (name: string): IAction =>
+  ({
+    name,
+    inputSchema: {},
+    settingSchema: {},
+    outputSchema: {},
+  }) as IAction;
+
+describe("yaml validation markers", () => {
+  it("targets unknown action markers under defs.<task>.action paths", () => {
+    const setModelMarkers = vi.fn();
+    const model = {} as editor.ITextModel;
+    const editorInstance = {
+      getModel: () => model,
+    } as editor.IStandaloneCodeEditor;
+    const monacoInstance = {
+      MarkerSeverity: {
+        Error: 8,
+      },
+      editor: {
+        setModelMarkers,
+      },
+    } as unknown as Monaco;
+    const yaml = [
+      "defs:",
+      "  task_alpha:",
+      "    kind: task",
+      "    action: missing_action",
+      "flow:",
+      "  - do: task_alpha",
+      "outputs:",
+      "  result: \"=$output.task_alpha\"",
+    ].join("\n");
+
+    applyWorkflowValidationMarkers({
+      editorInstance,
+      monacoInstance,
+      yaml,
+      actions: [makeAction("known_action")],
+    });
+
+    expect(setModelMarkers).toHaveBeenCalledTimes(1);
+    const [targetModel, owner, markers] = setModelMarkers.mock.calls[0] as [
+      editor.ITextModel,
+      string,
+      editor.IMarkerData[],
+    ];
+
+    expect(targetModel).toBe(model);
+    expect(owner).toBe(YAML_WORKFLOW_VALIDATION_OWNER);
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.message).toContain('Unknown action: "missing_action"');
+    expect(markers[0]?.startLineNumber).toBe(4);
+    expect((markers[0]?.endLineNumber ?? 0) >= 4).toBe(true);
+  });
+});

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/validation/validation.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/validation/validation.ts
@@ -4,7 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import { BaseSettingsSchema, WorkflowDefinitionSchema } from "@hexabot-ai/agentic";
+import {
+  BaseSettingsSchema,
+  WorkflowDefinitionSchema,
+  extractTaskDefinitions,
+} from "@hexabot-ai/agentic";
 import type { Monaco } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
 import { LineCounter, parseDocument } from "yaml";
@@ -109,7 +113,8 @@ export const applyWorkflowValidationMarkers = ({
     return;
   }
 
-  const knownTasks = new Set(Object.keys(parsed.data.tasks));
+  const taskDefinitions = extractTaskDefinitions(parsed.data.defs);
+  const knownTasks = new Set(Object.keys(taskDefinitions));
   const references = collectTaskReferences(parsed.data.flow, ["flow"]);
   const actionsByName =
     actions?.reduce<Record<string, IAction>>((acc, action) => {
@@ -131,10 +136,10 @@ export const applyWorkflowValidationMarkers = ({
 
   if (actionsByName) {
     // Validate task inputs/settings/outputs against action schemas.
-    Object.entries(parsed.data.tasks).forEach(([taskName, task]) => {
+    Object.entries(taskDefinitions).forEach(([taskName, task]) => {
       const actionName = task.action;
       const actionDefinition = actionsByName[actionName];
-      const taskPath: ReferencePath = ["tasks", taskName];
+      const taskPath: ReferencePath = ["defs", taskName];
 
       if (!actionDefinition) {
         markers.push({

--- a/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowDefinitionState.ts
+++ b/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowDefinitionState.ts
@@ -149,6 +149,20 @@ export const useWorkflowDefinitionState = ({
       ),
     [actionsByName],
   );
+  const actionValidationMetadata = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(compileActionsByName).map(
+          ([actionName, actionDefinition]) => [
+            actionName,
+            {
+              supportedBindings: actionDefinition.supportedBindings ?? [],
+            },
+          ],
+        ),
+      ),
+    [compileActionsByName],
+  );
   const definitionSignatureRef = useRef("");
   const {
     definition,
@@ -199,6 +213,7 @@ export const useWorkflowDefinitionState = ({
 
       const validation = validateWorkflow(nextDefinitionYml, {
         bindingKinds,
+        actions: actionValidationMetadata,
       });
 
       if (!validation.success) {
@@ -210,7 +225,7 @@ export const useWorkflowDefinitionState = ({
         definitionYml: nextDefinitionYml,
       });
     }, 4000),
-    [bindingKinds, workflow?.id, commitVersion],
+    [actionValidationMetadata, bindingKinds, workflow?.id, commitVersion],
     (memoizedFn) => {
       memoizedFn.clear();
     },

--- a/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
@@ -75,10 +75,10 @@ import {
 } from "../utils/binding-name.utils";
 import { getSchemaDefaults } from "../utils/schema-defaults.utils";
 import {
-  mountTaskBindingRef,
-  setTaskBindingRefs,
+  mountDefBindingRef,
+  setDefBindingRefs,
   toBindingRefs,
-  unmountTaskBindingRef,
+  unmountDefBindingRef,
 } from "../utils/task-bindings.utils";
 import {
   TOOL_BINDING_KIND,
@@ -136,6 +136,7 @@ export const Workflow = () => {
     updateWorkflow,
     updateWorkflowURL,
     definition,
+    taskDefinitions,
     flow,
     isDefinitionDirty,
     isSaving: isDefinitionSaving,
@@ -220,7 +221,7 @@ export const Workflow = () => {
 
     return getDisabledBindingRefs({
       definition,
-      taskName: pendingBindingAdd.taskName,
+      ownerDefName: pendingBindingAdd.ownerDefName,
       bindingKind: pendingBindingAdd.bindingKind,
       bindingsByName,
     });
@@ -287,7 +288,7 @@ export const Workflow = () => {
 
         setToolDrawerTarget({
           mode: "create",
-          taskName: pendingToolBindingAdd.taskName,
+          ownerDefName: pendingToolBindingAdd.ownerDefName,
           bindingKind: TOOL_BINDING_KIND,
           actionName: action.name,
           initialBindingName: nextToolName,
@@ -306,7 +307,8 @@ export const Workflow = () => {
       const baseDefinition = definition ?? createBaseDefinition();
       const nextTaskName = createTaskName(
         action.name,
-        baseDefinition.tasks ?? {},
+        baseDefinition.defs ?? {},
+        taskDefinitions,
       );
 
       setPendingActionCreateTarget({
@@ -325,7 +327,13 @@ export const Workflow = () => {
       setPendingBindingAdd(null);
       setEditingBindingTarget(null);
     },
-    [definition, pendingInsertPath, pendingToolBindingAdd, setGraphSelection],
+    [
+      definition,
+      pendingInsertPath,
+      pendingToolBindingAdd,
+      setGraphSelection,
+      taskDefinitions,
+    ],
   );
 
   useEffect(() => {
@@ -479,11 +487,11 @@ export const Workflow = () => {
   }, [definition, dialogs, handleSaveWorkflowSettings, isDefinitionSaving]);
   const handleAddBinding = useCallback(
     ({
-      taskName,
+      ownerDefName,
       bindingKind,
       ...payload
     }: WorkflowBindingAddPayload) => {
-      if (!definition || !definition.tasks[taskName]) {
+      if (!definition || !definition.defs[ownerDefName]) {
         return;
       }
 
@@ -493,7 +501,7 @@ export const Workflow = () => {
         setEditingBindingTarget(null);
         setPendingToolBindingAdd({
           ...payload,
-          taskName,
+          ownerDefName,
           bindingKind,
         });
         setActionsDrawerOpen(true);
@@ -516,7 +524,7 @@ export const Workflow = () => {
       setEditingBindingTarget(null);
       setPendingBindingAdd({
         ...payload,
-        taskName,
+        ownerDefName,
         bindingKind,
       });
     },
@@ -528,10 +536,10 @@ export const Workflow = () => {
         return;
       }
 
-      const { taskName, bindingKind } = pendingBindingAdd;
-      const taskDefinition = definition.tasks[taskName];
+      const { ownerDefName, bindingKind } = pendingBindingAdd;
+      const ownerDefinition = definition.defs[ownerDefName];
 
-      if (!taskDefinition) {
+      if (!ownerDefinition) {
         return;
       }
 
@@ -542,14 +550,14 @@ export const Workflow = () => {
       }
 
       const multiple = bindingDefinition.multiple ?? true;
-      const nextTaskDefinition = mountTaskBindingRef(
-        taskDefinition,
+      const nextOwnerDefinition = mountDefBindingRef(
+        ownerDefinition,
         bindingKind,
         bindingName,
         multiple,
       );
 
-      if (nextTaskDefinition === taskDefinition) {
+      if (nextOwnerDefinition === ownerDefinition) {
         setPendingBindingAdd(null);
 
         return;
@@ -557,9 +565,9 @@ export const Workflow = () => {
 
       const nextDefinition = {
         ...definition,
-        tasks: {
-          ...definition.tasks,
-          [taskName]: nextTaskDefinition,
+        defs: {
+          ...definition.defs,
+          [ownerDefName]: nextOwnerDefinition,
         },
       };
 
@@ -583,10 +591,10 @@ export const Workflow = () => {
         return;
       }
 
-      const { taskName, bindingKind } = pendingBindingAdd;
-      const taskDefinition = definition.tasks[taskName];
+      const { ownerDefName, bindingKind } = pendingBindingAdd;
+      const ownerDefinition = definition.defs[ownerDefName];
 
-      if (!taskDefinition) {
+      if (!ownerDefinition) {
         return;
       }
 
@@ -597,14 +605,14 @@ export const Workflow = () => {
       }
 
       const multiple = bindingDefinition.multiple ?? true;
-      const nextTaskDefinition = mountTaskBindingRef(
-        taskDefinition,
+      const nextOwnerDefinition = mountDefBindingRef(
+        ownerDefinition,
         bindingKind,
         bindingName,
         multiple,
       );
 
-      if (nextTaskDefinition === taskDefinition) {
+      if (nextOwnerDefinition === ownerDefinition) {
         setPendingBindingAdd(null);
 
         return;
@@ -614,17 +622,14 @@ export const Workflow = () => {
         ...definition,
         defs: {
           ...(definition.defs ?? {}),
+          [ownerDefName]: nextOwnerDefinition,
           [bindingName]: {
-            ...bindingDefinitionPayload,
             kind: bindingKind,
+            settings: bindingDefinitionPayload,
             ...(normalizedDescription
               ? { description: normalizedDescription }
               : {}),
-          } as { [key: string]: unknown; kind: string },
-        },
-        tasks: {
-          ...definition.tasks,
-          [taskName]: nextTaskDefinition,
+          },
         },
       };
 
@@ -667,28 +672,35 @@ export const Workflow = () => {
         delete nextDefs[currentBindingName];
       }
 
-      nextDefs[nextBindingName] = {
-        ...bindingDefinitionPayload,
+      const updatedDefinition = {
+        ...currentDef,
         kind: bindingKind,
+        settings: bindingDefinitionPayload,
         ...(normalizedDescription
           ? { description: normalizedDescription }
           : {}),
-      } as { [key: string]: unknown; kind: string };
+      };
+
+      if (!normalizedDescription) {
+        delete updatedDefinition.description;
+      }
+
+      nextDefs[nextBindingName] = updatedDefinition;
 
       const bindingDefinition = bindingsByName.get(bindingKind);
-      const multiple = bindingDefinition?.multiple ?? false;
-      const nextTasks =
+      const multiple = bindingDefinition?.multiple ?? true;
+      const nextDefsWithRenamedRefs =
         currentBindingName !== nextBindingName
           ? (Object.fromEntries(
-              Object.entries(definition.tasks).map(
-                ([taskName, taskDefinition]) => {
+              Object.entries(nextDefs).map(
+                ([defName, defDefinition]) => {
                   const refs = toBindingRefs(
-                    taskDefinition.bindings?.[bindingKind],
+                    defDefinition.bindings?.[bindingKind],
                     multiple,
                   );
 
                   if (!refs.includes(currentBindingName)) {
-                    return [taskName, taskDefinition];
+                    return [defName, defDefinition];
                   }
 
                   const replacedRefs = refs.map((refName) =>
@@ -697,9 +709,9 @@ export const Workflow = () => {
                   const dedupedRefs = Array.from(new Set(replacedRefs));
 
                   return [
-                    taskName,
-                    setTaskBindingRefs(
-                      taskDefinition,
+                    defName,
+                    setDefBindingRefs(
+                      defDefinition,
                       bindingKind,
                       dedupedRefs,
                       multiple,
@@ -707,13 +719,12 @@ export const Workflow = () => {
                   ];
                 },
               ),
-            ) as typeof definition.tasks)
-          : definition.tasks;
+            ) as typeof definition.defs)
+          : nextDefs;
 
       updateDefinitionState({
         ...definition,
-        defs: nextDefs,
-        tasks: nextTasks,
+        defs: nextDefsWithRenamedRefs,
       });
       setEditingBindingTarget(null);
       setPendingBindingAdd(null);
@@ -744,17 +755,20 @@ export const Workflow = () => {
           : undefined;
       const bindingKind = nodeData?.bindingKind;
       const bindingName = nodeData?.bindingName;
-      const taskName = nodeData?.taskName;
+      const ownerDefName = nodeData?.ownerDefName;
 
       if (node.type === ENodeType.BINDING_MULTI) {
         if (bindingKind === TOOL_BINDING_KIND) {
-          if (typeof bindingName !== "string" || typeof taskName !== "string") {
+          if (
+            typeof bindingName !== "string" ||
+            typeof ownerDefName !== "string"
+          ) {
             return;
           }
 
           setToolDrawerTarget({
             mode: "edit",
-            taskName,
+            ownerDefName,
             bindingKind: TOOL_BINDING_KIND,
             bindingName,
           });
@@ -768,7 +782,10 @@ export const Workflow = () => {
         return;
       }
 
-      if (!isNonToolBindingKind(bindingKind, bindingsByName)) {
+      const resolvedBindingKind =
+        definition?.defs?.[bindingName]?.kind ?? bindingKind;
+
+      if (!isNonToolBindingKind(resolvedBindingKind, bindingsByName)) {
         return;
       }
 
@@ -776,23 +793,23 @@ export const Workflow = () => {
       setPendingToolBindingAdd(null);
       setToolDrawerTarget(null);
       setEditingBindingTarget({
-        bindingKind,
+        bindingKind: resolvedBindingKind,
         bindingName,
       });
     },
-    [bindingsByName],
+    [bindingsByName, definition?.defs],
   );
   const handleRemoveBinding = useCallback(
     ({
-      taskName,
+      ownerDefName,
       bindingKind,
       bindingName,
     }: WorkflowBindingRemovePayload) => {
-      if (!definition || !definition.tasks[taskName]) {
+      if (!definition || !definition.defs[ownerDefName]) {
         return;
       }
 
-      const taskDefinition = definition.tasks[taskName];
+      const ownerDefinition = definition.defs[ownerDefName];
       const bindingDefinition = bindingsByName.get(bindingKind);
 
       if (!bindingDefinition) {
@@ -801,7 +818,7 @@ export const Workflow = () => {
 
       const multiple = bindingDefinition.multiple ?? true;
       const currentRefs = toBindingRefs(
-        taskDefinition.bindings?.[bindingKind],
+        ownerDefinition.bindings?.[bindingKind],
         multiple,
       );
 
@@ -809,17 +826,17 @@ export const Workflow = () => {
         return;
       }
 
-      const nextTaskDefinition = unmountTaskBindingRef(
-        taskDefinition,
+      const nextOwnerDefinition = unmountDefBindingRef(
+        ownerDefinition,
         bindingKind,
         bindingName,
         multiple,
       );
       const nextDefinition = {
         ...definition,
-        tasks: {
-          ...definition.tasks,
-          [taskName]: nextTaskDefinition,
+        defs: {
+          ...definition.defs,
+          [ownerDefName]: nextOwnerDefinition,
         },
       };
 

--- a/packages/frontend/src/components/visual-editor/v4/providers/WorkflowJsonataGlobalsSchemaProvider.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/providers/WorkflowJsonataGlobalsSchemaProvider.tsx
@@ -22,7 +22,7 @@ import {
 export const WorkflowJsonataGlobalsSchemaProvider = ({
   children,
 }: PropsWithChildren) => {
-  const { definition, workflow } = useWorkflow();
+  const { definition, taskDefinitions, workflow } = useWorkflow();
   const { actionsByName } = useWorkflowActionsCatalog();
   const getMemoryDefinitionFromCache = useGetFromCache(
     EntityType.MEMORY_DEFINITION,
@@ -45,11 +45,18 @@ export const WorkflowJsonataGlobalsSchemaProvider = ({
     () =>
       buildJsonataGlobalsSchema({
         definition,
+        taskDefinitions,
         actionsByName,
         memoryDefinitions,
         inputSchema: workflow?.inputSchema,
       }),
-    [actionsByName, definition, memoryDefinitions, workflow?.inputSchema],
+    [
+      actionsByName,
+      definition,
+      memoryDefinitions,
+      taskDefinitions,
+      workflow?.inputSchema,
+    ],
   );
 
   return (

--- a/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
@@ -7,7 +7,9 @@
 import {
   WorkflowDefinition,
   Workflow as WorkflowHelper,
+  extractTaskDefinitions,
   type FlowStep,
+  type TaskDefinition,
 } from "@hexabot-ai/agentic";
 import {
   isSameWorkflowSelection,
@@ -33,12 +35,11 @@ import { getSchemaDefaults } from "../utils/schema-defaults.utils";
 import {
   createBaseDefinition,
   createTaskName,
+  extractTaskIdsFromYaml,
 } from "../utils/workflow-definition.utils";
 
-type TaskInputs = NonNullable<WorkflowDefinition["tasks"][string]["inputs"]>;
-type TaskSettings = NonNullable<
-  WorkflowDefinition["tasks"][string]["settings"]
->;
+type TaskInputs = NonNullable<TaskDefinition["inputs"]>;
+type TaskSettings = NonNullable<TaskDefinition["settings"]>;
 const EMPTY_GRAPH_SELECTION: WorkflowSelectionSnapshot = {
   nodeIds: [],
   nodes: [],
@@ -84,25 +85,36 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
   } = useWorkflowDefinitionState({
     workflow,
   });
+  const taskDefinitions = useMemo(
+    () => extractTaskDefinitions(definition?.defs ?? {}),
+    [definition?.defs],
+  );
+  const taskIds = useMemo(
+    () => extractTaskIdsFromYaml(yaml),
+    [yaml],
+  );
   const addActionStep = (action: IAction, insertPath?: FlowStepPath | null) => {
     const baseDefinition = definition ?? createBaseDefinition();
     const nextTaskName = createTaskName(
       action.name,
-      baseDefinition.tasks ?? {},
+      baseDefinition.defs ?? {},
+      taskDefinitions,
     );
     const taskDescription = action.description?.trim();
     const inputDefaults = getSchemaDefaults<TaskInputs>(action.inputSchema);
     const settingDefaults = getSchemaDefaults<TaskSettings>(
       action.settingSchema,
     )!;
-    const nextTasks = {
-      ...baseDefinition.tasks,
-      [nextTaskName]: {
-        action: action.name,
-        ...(taskDescription ? { description: taskDescription } : {}),
-        ...(inputDefaults !== undefined ? { inputs: inputDefaults } : {}),
-        ...(settingDefaults !== undefined ? { settings: settingDefaults } : {}),
-      },
+    const nextTaskDefinition: TaskDefinition = {
+      kind: "task",
+      action: action.name,
+      ...(taskDescription ? { description: taskDescription } : {}),
+      ...(inputDefaults !== undefined ? { inputs: inputDefaults } : {}),
+      ...(settingDefaults !== undefined ? { settings: settingDefaults } : {}),
+    };
+    const nextDefs = {
+      ...baseDefinition.defs,
+      [nextTaskName]: nextTaskDefinition,
     };
     const nextOutputs =
       baseDefinition.outputs && Object.keys(baseDefinition.outputs).length > 0
@@ -111,7 +123,7 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
     const nextStep: FlowStep = { do: nextTaskName };
     const definitionWithTask: WorkflowDefinition = {
       ...baseDefinition,
-      tasks: nextTasks,
+      defs: nextDefs,
       outputs: nextOutputs,
     };
     const insertedDefinition = insertPath
@@ -320,6 +332,8 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
         removeStepAtPath,
         definition,
         flow,
+        taskDefinitions,
+        taskIds,
       }}
     >
       {children}

--- a/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
+++ b/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
@@ -6,6 +6,7 @@
 
 import type {
   CompiledStep,
+  TaskDefinition,
   WorkflowDefinition,
   WorkflowEventMap,
 } from "@hexabot-ai/agentic";
@@ -64,6 +65,8 @@ export interface IWorkflowContext {
   removeStepAtPath: (stepPath: FlowStepPath, nodeId?: string) => void;
   definition?: WorkflowDefinition;
   flow?: CompiledStep[];
+  taskDefinitions: Record<string, TaskDefinition>;
+  taskIds: string[];
 }
 
 export interface WorkflowContextProps {

--- a/packages/frontend/src/components/visual-editor/v4/utils/jsonata-globals-schema.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/jsonata-globals-schema.utils.ts
@@ -4,7 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { WorkflowDefinition } from "@hexabot-ai/agentic";
+import {
+  extractTaskDefinitions,
+  type TaskDefinition,
+  type WorkflowDefinition,
+} from "@hexabot-ai/agentic";
 
 import type {
   GlobalsSchema,
@@ -12,20 +16,20 @@ import type {
 } from "@/app-components/inputs/JsonataFormulaField";
 import type { IAction } from "@/types/action.types";
 import type { IMemoryDefinition } from "@/types/memory-definition.types";
+import { isRecord } from "@/utils/object";
 
-type WorkflowTaskDefinition = NonNullable<WorkflowDefinition["tasks"]>[string];
+type WorkflowTaskDefinition = TaskDefinition;
 
 const MEMORY_BINDING_KIND = "memory";
 
 type BuildJsonataGlobalsSchemaArgs = {
   definition?: WorkflowDefinition;
+  taskDefinitions?: Record<string, WorkflowTaskDefinition>;
   actionsByName: ReadonlyMap<string, IAction>;
   memoryDefinitions?: IMemoryDefinition[];
   inputSchema?: unknown;
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  Boolean(value) && typeof value === "object" && !Array.isArray(value);
 const createOpenObjectSchema = (): JsonSchemaLike => ({
   type: "object",
   properties: {},
@@ -49,7 +53,10 @@ export const extractMemoryDefinitionIdsFromWorkflowDefinition = (
         return acc;
       }
 
-      const definitionId = defDefinition.definition_id;
+      const definitionSettings = isRecord(defDefinition.settings)
+        ? defDefinition.settings
+        : undefined;
+      const definitionId = definitionSettings?.definition_id;
 
       if (typeof definitionId !== "string" || !definitionId.trim()) {
         return acc;
@@ -124,11 +131,14 @@ const getContextSchema = (
 
 export const buildJsonataGlobalsSchema = ({
   definition,
+  taskDefinitions,
   actionsByName,
   memoryDefinitions,
   inputSchema,
 }: BuildJsonataGlobalsSchemaArgs): GlobalsSchema => {
-  const outputProperties = Object.entries(definition?.tasks ?? {}).reduce<
+  const resolvedTaskDefinitions =
+    taskDefinitions ?? extractTaskDefinitions(definition?.defs ?? {});
+  const outputProperties = Object.entries(resolvedTaskDefinitions).reduce<
     Record<string, JsonSchemaLike>
   >((acc, [taskName, taskDefinition]) => {
     acc[taskName] = getTaskOutputSchema({

--- a/packages/frontend/src/components/visual-editor/v4/utils/schema-defaults.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/schema-defaults.utils.ts
@@ -9,6 +9,7 @@ import { getDefaultFormState, RJSFSchema, UiSchema } from "@rjsf/utils";
 import { JSONSchema7 } from "json-schema";
 import { JSONSchema } from "monaco-yaml";
 
+import { isRecord } from "@/utils/object";
 import validator from "@/utils/rjsf-zod-validator";
 
 export const getSchemaDefaults = <T extends Record<string, JsonValue>>(
@@ -65,10 +66,6 @@ const normalizeDefaults = (
 };
 
 type SchemaProperties = Record<string, unknown>;
-
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-};
 
 export const getSchemaProperties = <T extends SchemaProperties>(
   schema?: RJSFSchema,

--- a/packages/frontend/src/components/visual-editor/v4/utils/task-bindings.utils.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/task-bindings.utils.test.ts
@@ -4,19 +4,30 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { TaskDefinition } from "@hexabot-ai/agentic";
+import type { DefDefinition, TaskDefinition } from "@hexabot-ai/agentic";
 import { describe, expect, it } from "vitest";
 
 import {
+  mountDefBindingRef,
   mountTaskBindingRef,
   toBindingRefs,
+  unmountDefBindingRef,
   unmountTaskBindingRef,
 } from "./task-bindings.utils";
 
 const createTaskDefinition = (
   bindings?: Record<string, string | string[]>,
 ): TaskDefinition => ({
+  kind: "task",
   action: "ai_generate_reply",
+  ...(bindings ? { bindings } : {}),
+});
+const createNonTaskDefinition = (
+  bindings?: Record<string, string | string[]>,
+): DefDefinition => ({
+  kind: "tools",
+  action: "search_web",
+  settings: {},
   ...(bindings ? { bindings } : {}),
 });
 
@@ -63,5 +74,14 @@ describe("task-bindings.utils", () => {
     const nextTask = mountTaskBindingRef(task, "model", "anthropic_claude", false);
 
     expect(nextTask.bindings?.model).toBe("anthropic_claude");
+  });
+
+  it("mounts and unmounts refs on non-task owner defs", () => {
+    const ownerDef = createNonTaskDefinition({ memory: ["profile"] });
+    const mounted = mountDefBindingRef(ownerDef, "memory", "session", true);
+    const unmounted = unmountDefBindingRef(mounted, "memory", "profile", true);
+
+    expect(mounted.bindings?.memory).toEqual(["profile", "session"]);
+    expect(unmounted.bindings?.memory).toEqual(["session"]);
   });
 });

--- a/packages/frontend/src/components/visual-editor/v4/utils/task-bindings.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/task-bindings.utils.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { TaskDefinition } from "@hexabot-ai/agentic";
+import type { DefDefinition } from "@hexabot-ai/agentic";
 
 export const toBindingRefs = (value: unknown, multiple: boolean): string[] => {
   if (multiple) {
@@ -33,14 +33,14 @@ export const toBindingRefs = (value: unknown, multiple: boolean): string[] => {
     .filter(Boolean);
 };
 
-const withTaskBindingRefs = (
-  taskDefinition: TaskDefinition,
+const withDefBindingRefs = <TDefDefinition extends DefDefinition>(
+  defDefinition: TDefDefinition,
   bindingKind: string,
   refs: string[],
   multiple: boolean,
-): TaskDefinition => {
+): TDefDefinition => {
   const nextBindings: Record<string, string | string[]> = {
-    ...(taskDefinition.bindings ?? {}),
+    ...(defDefinition.bindings ?? {}),
   };
 
   if (refs.length > 0) {
@@ -50,39 +50,40 @@ const withTaskBindingRefs = (
   }
 
   if (Object.keys(nextBindings).length === 0) {
-    const { bindings: _bindings, ...taskWithoutBindings } = taskDefinition;
+    const { bindings: _bindings, ...defWithoutBindings } = defDefinition;
 
-    return taskWithoutBindings;
+    return defWithoutBindings as TDefDefinition;
   }
 
   return {
-    ...taskDefinition,
+    ...defDefinition,
     bindings: nextBindings,
-  };
+  } as TDefDefinition;
 };
 
-export const setTaskBindingRefs = (
-  taskDefinition: TaskDefinition,
+export const setDefBindingRefs = <TDefDefinition extends DefDefinition>(
+  defDefinition: TDefDefinition,
   bindingKind: string,
   refs: string[],
   multiple: boolean,
-): TaskDefinition => withTaskBindingRefs(taskDefinition, bindingKind, refs, multiple);
+): TDefDefinition =>
+  withDefBindingRefs(defDefinition, bindingKind, refs, multiple);
 
-export const mountTaskBindingRef = (
-  taskDefinition: TaskDefinition,
+export const mountDefBindingRef = <TDefDefinition extends DefDefinition>(
+  defDefinition: TDefDefinition,
   bindingKind: string,
   bindingRef: string,
   multiple: boolean,
-): TaskDefinition => {
-  const currentRefs = toBindingRefs(taskDefinition.bindings?.[bindingKind], multiple);
+): TDefDefinition => {
+  const currentRefs = toBindingRefs(defDefinition.bindings?.[bindingKind], multiple);
 
   if (multiple) {
     if (currentRefs.includes(bindingRef)) {
-      return taskDefinition;
+      return defDefinition;
     }
 
-    return setTaskBindingRefs(
-      taskDefinition,
+    return setDefBindingRefs(
+      defDefinition,
       bindingKind,
       [...currentRefs, bindingRef],
       true,
@@ -90,25 +91,30 @@ export const mountTaskBindingRef = (
   }
 
   if (currentRefs.length === 1 && currentRefs[0] === bindingRef) {
-    return taskDefinition;
+    return defDefinition;
   }
 
-  return setTaskBindingRefs(taskDefinition, bindingKind, [bindingRef], false);
+  return setDefBindingRefs(defDefinition, bindingKind, [bindingRef], false);
 };
 
-export const unmountTaskBindingRef = (
-  taskDefinition: TaskDefinition,
+export const unmountDefBindingRef = <TDefDefinition extends DefDefinition>(
+  defDefinition: TDefDefinition,
   bindingKind: string,
   bindingRef: string,
   multiple: boolean,
-): TaskDefinition => {
-  const currentRefs = toBindingRefs(taskDefinition.bindings?.[bindingKind], multiple);
+): TDefDefinition => {
+  const currentRefs = toBindingRefs(defDefinition.bindings?.[bindingKind], multiple);
 
   if (!currentRefs.includes(bindingRef)) {
-    return taskDefinition;
+    return defDefinition;
   }
 
   const nextRefs = currentRefs.filter((refName) => refName !== bindingRef);
 
-  return setTaskBindingRefs(taskDefinition, bindingKind, nextRefs, multiple);
+  return setDefBindingRefs(defDefinition, bindingKind, nextRefs, multiple);
 };
+
+// Deprecated aliases kept to avoid broad call-site churn.
+export const setTaskBindingRefs = setDefBindingRefs;
+export const mountTaskBindingRef = mountDefBindingRef;
+export const unmountTaskBindingRef = unmountDefBindingRef;

--- a/packages/frontend/src/components/visual-editor/v4/utils/tool-bindings.utils.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/tool-bindings.utils.test.ts
@@ -18,22 +18,40 @@ import {
 
 const createDefinition = (): WorkflowDefinition => ({
   defs: {
+    profile_memory: {
+      kind: "memory",
+      settings: {
+        provider: "redis",
+      },
+    },
     search: {
       kind: "tools",
       action: "search_web",
       description: "Search",
       settings: { timeout: 10 },
+      bindings: {
+        memory: ["profile_memory"],
+      },
     },
-  },
-  tasks: {
     ai_generate_reply: {
+      kind: "task",
       action: "ai_generate_reply",
       bindings: {
         tools: ["search"],
       },
     },
     summarize: {
+      kind: "task",
       action: "ai_summarize",
+      bindings: {
+        tools: ["search"],
+      },
+    },
+    tool_router: {
+      kind: "tool_router",
+      settings: {
+        strategy: "round_robin",
+      },
       bindings: {
         tools: ["search"],
       },
@@ -49,7 +67,7 @@ describe("tool-bindings.utils", () => {
   it("creates a tool def and mounts it on the target task bindings", () => {
     const definition = createDefinition();
     const nextDefinition = createToolBindingDefinitionMutation(definition, {
-      taskName: "ai_generate_reply",
+      ownerDefName: "ai_generate_reply",
       bindingKind: "tools",
       bindingName: "calculate",
       actionName: "calculate_score",
@@ -63,7 +81,7 @@ describe("tool-bindings.utils", () => {
       description: "Calculator",
       settings: { multiplier: 2, bias: 1 },
     });
-    expect(nextDefinition.tasks.ai_generate_reply.bindings?.tools).toEqual([
+    expect(nextDefinition.defs.ai_generate_reply.bindings?.tools).toEqual([
       "search",
       "calculate",
     ]);
@@ -89,7 +107,7 @@ describe("tool-bindings.utils", () => {
   it("updates an existing tool settings and description", () => {
     const definition = createDefinition();
     const nextDefinition = updateToolBindingDefinitionMutation(definition, {
-      taskName: "ai_generate_reply",
+      ownerDefName: "ai_generate_reply",
       bindingKind: "tools",
       currentBindingName: "search",
       nextBindingName: "search",
@@ -103,13 +121,16 @@ describe("tool-bindings.utils", () => {
       action: "search_web",
       description: "Web Search",
       settings: { timeout: 25 },
+      bindings: {
+        memory: ["profile_memory"],
+      },
     });
   });
 
-  it("renames tool defs and updates mounted refs across all tasks", () => {
+  it("renames tool defs and updates mounted refs across all defs", () => {
     const definition = createDefinition();
     const nextDefinition = updateToolBindingDefinitionMutation(definition, {
-      taskName: "ai_generate_reply",
+      ownerDefName: "ai_generate_reply",
       bindingKind: "tools",
       currentBindingName: "search",
       nextBindingName: "search_tool",
@@ -124,17 +145,23 @@ describe("tool-bindings.utils", () => {
       action: "search_web",
       description: "Search tool",
       settings: { timeout: 50 },
+      bindings: {
+        memory: ["profile_memory"],
+      },
     });
-    expect(nextDefinition.tasks.ai_generate_reply.bindings?.tools).toEqual([
+    expect(nextDefinition.defs.ai_generate_reply.bindings?.tools).toEqual([
       "search_tool",
     ]);
-    expect(nextDefinition.tasks.summarize.bindings?.tools).toEqual(["search_tool"]);
+    expect(nextDefinition.defs.summarize.bindings?.tools).toEqual(["search_tool"]);
+    expect(nextDefinition.defs.tool_router.bindings?.tools).toEqual([
+      "search_tool",
+    ]);
   });
 
   it("strips empty optional fields on create and update", () => {
     const definition = createDefinition();
     const withNewTool = createToolBindingDefinitionMutation(definition, {
-      taskName: "ai_generate_reply",
+      ownerDefName: "ai_generate_reply",
       bindingKind: "tools",
       bindingName: "translate",
       actionName: "translate_text",
@@ -145,10 +172,11 @@ describe("tool-bindings.utils", () => {
     expect(withNewTool.defs?.translate).toEqual({
       kind: "tools",
       action: "translate_text",
+      settings: {},
     });
 
     const updated = updateToolBindingDefinitionMutation(withNewTool, {
-      taskName: "ai_generate_reply",
+      ownerDefName: "ai_generate_reply",
       bindingKind: "tools",
       currentBindingName: "search",
       nextBindingName: "search",
@@ -160,6 +188,10 @@ describe("tool-bindings.utils", () => {
     expect(updated.defs?.search).toEqual({
       kind: "tools",
       action: "search_web",
+      settings: {},
+      bindings: {
+        memory: ["profile_memory"],
+      },
     });
   });
 });

--- a/packages/frontend/src/components/visual-editor/v4/utils/tool-bindings.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/tool-bindings.utils.ts
@@ -5,13 +5,14 @@
  */
 
 import {
+  type DefDefinition,
   JsonValue,
   type WorkflowDefinition,
 } from "@hexabot-ai/agentic";
 
 import {
-  mountTaskBindingRef,
-  setTaskBindingRefs,
+  mountDefBindingRef,
+  setDefBindingRefs,
   toBindingRefs,
 } from "./task-bindings.utils";
 
@@ -25,9 +26,9 @@ const sanitizeToolDescription = (value?: string): string | undefined => {
 };
 const sanitizeToolSettings = (
   value?: Record<string, unknown>,
-): Record<string, JsonValue> | undefined => {
+): Record<string, JsonValue> => {
   if (!value || Object.keys(value).length === 0) {
-    return undefined;
+    return {};
   }
 
   return value as Record<string, JsonValue>;
@@ -48,12 +49,12 @@ const createToolDefinition = ({
     kind: TOOL_BINDING_KIND,
     action: actionName,
     ...(normalizedDescription ? { description: normalizedDescription } : {}),
-    ...(normalizedSettings ? { settings: normalizedSettings } : {}),
+    settings: normalizedSettings,
   };
 };
 
 export type CreateToolBindingDefinitionMutationArgs = {
-  taskName: string;
+  ownerDefName: string;
   bindingKind: string;
   bindingName: string;
   actionName: string;
@@ -64,7 +65,7 @@ export type CreateToolBindingDefinitionMutationArgs = {
 export const createToolBindingDefinitionMutation = (
   definition: WorkflowDefinition,
   {
-    taskName,
+    ownerDefName,
     bindingKind,
     bindingName,
     actionName,
@@ -72,9 +73,9 @@ export const createToolBindingDefinitionMutation = (
     settings,
   }: CreateToolBindingDefinitionMutationArgs,
 ): WorkflowDefinition => {
-  const taskDefinition = definition.tasks[taskName];
+  const ownerDefinition = definition.defs[ownerDefName];
 
-  if (!taskDefinition) {
+  if (!ownerDefinition) {
     return definition;
   }
 
@@ -84,14 +85,14 @@ export const createToolBindingDefinitionMutation = (
     return definition;
   }
 
-  const nextTaskDefinition = mountTaskBindingRef(
-    taskDefinition,
+  const nextOwnerDefinition = mountDefBindingRef(
+    ownerDefinition,
     bindingKind,
     bindingName,
     true,
   );
 
-  if (nextTaskDefinition === taskDefinition) {
+  if (nextOwnerDefinition === ownerDefinition) {
     return definition;
   }
 
@@ -100,16 +101,13 @@ export const createToolBindingDefinitionMutation = (
     defs: {
       ...currentDefs,
       [bindingName]: createToolDefinition({ actionName, description, settings }),
-    },
-    tasks: {
-      ...definition.tasks,
-      [taskName]: nextTaskDefinition,
+      [ownerDefName]: nextOwnerDefinition,
     },
   };
 };
 
 export type UpdateToolBindingDefinitionMutationArgs = {
-  taskName: string;
+  ownerDefName: string;
   bindingKind: string;
   currentBindingName: string;
   nextBindingName: string;
@@ -149,18 +147,24 @@ export const updateToolBindingDefinitionMutation = (
     delete nextDefs[currentBindingName];
   }
 
-  nextDefs[nextBindingName] = createToolDefinition({
+  const nextToolDefinition = createToolDefinition({
     actionName,
     description,
     settings,
-  });
+  }) as DefDefinition;
+  const currentBindings = currentDef.bindings;
 
-  const nextTasks = Object.fromEntries(
-    Object.entries(definition.tasks).map(([taskName, taskDefinition]) => {
-      const refs = toBindingRefs(taskDefinition.bindings?.[bindingKind], true);
+  nextDefs[nextBindingName] = {
+    ...nextToolDefinition,
+    ...(currentBindings ? { bindings: currentBindings } : {}),
+  };
+
+  const nextDefsWithRenamedRefs = Object.fromEntries(
+    Object.entries(nextDefs).map(([defName, defDefinition]) => {
+      const refs = toBindingRefs(defDefinition.bindings?.[bindingKind], true);
 
       if (!refs.includes(currentBindingName)) {
-        return [taskName, taskDefinition];
+        return [defName, defDefinition];
       }
 
       const replacedRefs = refs.map((ref) =>
@@ -169,15 +173,14 @@ export const updateToolBindingDefinitionMutation = (
       const dedupedRefs = Array.from(new Set(replacedRefs));
 
       return [
-        taskName,
-        setTaskBindingRefs(taskDefinition, bindingKind, dedupedRefs, true),
+        defName,
+        setDefBindingRefs(defDefinition, bindingKind, dedupedRefs, true),
       ];
     }),
-  ) as WorkflowDefinition["tasks"];
+  ) as WorkflowDefinition["defs"];
 
   return {
     ...definition,
-    defs: nextDefs,
-    tasks: nextTasks,
+    defs: nextDefsWithRenamedRefs,
   };
 };

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-binding-routing.utils.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-binding-routing.utils.test.ts
@@ -24,20 +24,32 @@ const createDefinition = (): WorkflowDefinition => ({
   defs: {
     openai_chatgpt: {
       kind: "model",
-      provider: "openai",
+      settings: {
+        provider: "openai",
+      },
     },
     profile: {
       kind: "memory",
-      provider: "redis",
+      settings: {
+        provider: "redis",
+      },
     },
-  },
-  tasks: {
     agent: {
+      kind: "task",
       action: "agent_action",
       bindings: {
         model: "openai_chatgpt",
         memory: ["profile"],
         tools: ["search"],
+      },
+    },
+    memory_router: {
+      kind: "memory_router",
+      settings: {
+        strategy: "all",
+      },
+      bindings: {
+        memory: ["profile"],
       },
     },
   },
@@ -64,7 +76,7 @@ describe("workflow-binding-routing.utils", () => {
     expect(
       getDisabledBindingRefs({
         definition,
-        taskName: "agent",
+        ownerDefName: "agent",
         bindingKind: "memory",
         bindingsByName,
       }),
@@ -78,11 +90,25 @@ describe("workflow-binding-routing.utils", () => {
     expect(
       getDisabledBindingRefs({
         definition,
-        taskName: "agent",
+        ownerDefName: "agent",
         bindingKind: "model",
         bindingsByName,
       }),
     ).toEqual([]);
+  });
+
+  it("supports disabled refs lookup for non-task owner defs", () => {
+    const definition = createDefinition();
+    const bindingsByName = createBindingsByName();
+
+    expect(
+      getDisabledBindingRefs({
+        definition,
+        ownerDefName: "memory_router",
+        bindingKind: "memory",
+        bindingsByName,
+      }),
+    ).toEqual(["profile"]);
   });
 
   it("returns an empty list for tools and unknown tasks", () => {
@@ -92,7 +118,7 @@ describe("workflow-binding-routing.utils", () => {
     expect(
       getDisabledBindingRefs({
         definition,
-        taskName: "agent",
+        ownerDefName: "agent",
         bindingKind: "tools",
         bindingsByName,
       }),
@@ -100,7 +126,7 @@ describe("workflow-binding-routing.utils", () => {
     expect(
       getDisabledBindingRefs({
         definition,
-        taskName: "unknown",
+        ownerDefName: "unknown",
         bindingKind: "memory",
         bindingsByName,
       }),

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-binding-routing.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-binding-routing.utils.ts
@@ -20,14 +20,14 @@ export const isNonToolBindingKind = (
 
 type GetDisabledBindingRefsArgs = {
   definition: WorkflowDefinition;
-  taskName: string;
+  ownerDefName: string;
   bindingKind: string;
   bindingsByName: ReadonlyMap<string, WorkflowBindingDefinition>;
 };
 
 export const getDisabledBindingRefs = ({
   definition,
-  taskName,
+  ownerDefName,
   bindingKind,
   bindingsByName,
 }: GetDisabledBindingRefsArgs): string[] => {
@@ -47,11 +47,11 @@ export const getDisabledBindingRefs = ({
     return [];
   }
 
-  const taskDefinition = definition.tasks[taskName];
+  const ownerDefinition = definition.defs[ownerDefName];
 
-  if (!taskDefinition) {
+  if (!ownerDefinition) {
     return [];
   }
 
-  return toBindingRefs(taskDefinition.bindings?.[bindingKind], true);
+  return toBindingRefs(ownerDefinition.bindings?.[bindingKind], true);
 };

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-definition.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-definition.utils.ts
@@ -9,12 +9,17 @@ import {
   DEFAULT_RETRY_SETTINGS,
   DEFAULT_TIMEOUT_MS,
   type CompiledStep,
+  type TaskDefinition,
   type WorkflowCompileOptions,
   type WorkflowDefinition,
+  extractTaskDefinitions,
   isSnakeCaseName,
   validateWorkflow,
   toSnakeCase,
 } from "@hexabot-ai/agentic";
+import { parse as parseYaml } from "yaml";
+
+import { isRecord } from "@/utils/object";
 
 /**
  * Build a minimal workflow definition with defaults and optional metadata.
@@ -26,7 +31,7 @@ export const createBaseDefinition = (): WorkflowDefinition => ({
       retries: { ...DEFAULT_RETRY_SETTINGS },
     },
   },
-  tasks: {},
+  defs: {},
   flow: [],
   outputs: {},
 });
@@ -55,8 +60,10 @@ export const normalizeTaskName = (value: string): string => {
  */
 export const createTaskName = (
   actionName: string,
-  tasks: WorkflowDefinition["tasks"],
+  defs: WorkflowDefinition["defs"],
+  taskDefinitions?: Record<string, TaskDefinition>,
 ) => {
+  const tasks = taskDefinitions ?? extractTaskDefinitions(defs ?? {});
   const baseName = normalizeTaskName(actionName) || "new_task";
   const normalizedBase = isSnakeCaseName(baseName) ? baseName : "new_task";
   let candidate = normalizedBase;
@@ -69,13 +76,37 @@ export const createTaskName = (
 
   return candidate;
 };
+export const extractTaskIdsFromYaml = (yaml: string): string[] => {
+  try {
+    const parsed = parseYaml(yaml);
+
+    if (!isRecord(parsed) || !isRecord(parsed.defs)) {
+      return [];
+    }
+
+    return Object.keys(
+      extractTaskDefinitions(parsed.defs as WorkflowDefinition["defs"]),
+    ).sort();
+  } catch {
+    return [];
+  }
+};
 
 export const getDefinition = (
   yaml: string,
   options: WorkflowCompileOptions,
 ): { definition: WorkflowDefinition; flow: CompiledStep[] } => {
+  const actionValidationMetadata = Object.fromEntries(
+    Object.entries(options.actions).map(([actionName, actionDefinition]) => [
+      actionName,
+      {
+        supportedBindings: actionDefinition.supportedBindings ?? [],
+      },
+    ]),
+  );
   const validation = validateWorkflow(yaml, {
     bindingKinds: options.bindingKinds,
+    actions: actionValidationMetadata,
   });
 
   if (!validation.success) {

--- a/packages/frontend/src/contexts/workflow-bindings.context.tsx
+++ b/packages/frontend/src/contexts/workflow-bindings.context.tsx
@@ -22,6 +22,8 @@ export type WorkflowBindingDefinition = {
   multiple: boolean;
   color?: string;
   icon?: string;
+  supportedBindings?: string[];
+  actionPolicy?: "forbidden" | "optional" | "required";
 };
 
 type WorkflowBindingsCatalog = Record<string, WorkflowBindingDefinition>;
@@ -70,6 +72,8 @@ export const WorkflowBindingsProvider = ({ children }: PropsWithChildren) => {
               >[0],
             ),
             multiple: bindingDefinition.multiple ?? true,
+            supportedBindings: bindingDefinition.supportedBindings ?? [],
+            actionPolicy: bindingDefinition.actionPolicy ?? "optional",
           },
         ]),
       ),

--- a/packages/frontend/src/utils/object.ts
+++ b/packages/frontend/src/utils/object.ts
@@ -4,9 +4,9 @@
  * Full terms: see LICENSE.md.
  */
 
-function isObject(item: any): item is Record<string, any> {
-  return item && typeof item === "object" && !Array.isArray(item);
-}
+export const isRecord = (item: unknown): item is Record<string, unknown> => {
+  return item !== null && typeof item === "object" && !Array.isArray(item);
+};
 
 export function merge<
   T extends Record<string, any>,
@@ -14,7 +14,7 @@ export function merge<
 >(target: T, source: U): T & U {
   const output: Record<string, any> = { ...target };
 
-  if (isObject(target) && isObject(source)) {
+  if (isRecord(target) && isRecord(source)) {
     Object.keys(source).forEach((key) => {
       if (Array.isArray(source[key])) {
         if (Array.isArray(target[key])) {
@@ -23,7 +23,7 @@ export function merge<
         } else {
           output[key] = source[key];
         }
-      } else if (isObject(source[key])) {
+      } else if (isRecord(source[key])) {
         if (!(key in target)) {
           output[key] = source[key];
         } else {

--- a/packages/frontend/src/utils/rjsf-zod-validator.ts
+++ b/packages/frontend/src/utils/rjsf-zod-validator.ts
@@ -15,6 +15,8 @@ import {
 } from "@rjsf/utils";
 import { z } from "zod";
 
+import { isRecord } from "@/utils/object";
+
 type ErrorPathSegment = number | string | symbol;
 type ErrorPath = ErrorPathSegment[];
 type JsonRecord = Record<string, unknown>;
@@ -31,9 +33,6 @@ type ZodSchemaLike = {
 
 let schemaCache = new WeakMap<object, ZodSchemaLike>();
 
-const isRecord = (value: unknown): value is JsonRecord => {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-};
 const mergeSchemaWithRootRefs = (
   schema: RJSFSchema,
   rootSchema: RJSFSchema,

--- a/packages/graph/src/workflow/components/WorkflowGraph.tsx
+++ b/packages/graph/src/workflow/components/WorkflowGraph.tsx
@@ -152,7 +152,6 @@ const WorkflowGraphCanvas = forwardRef<WorkflowGraphHandle, WorkflowGraphProps>(
     const lastViewportRef = useRef<Viewport>({ x: 0, y: 0, zoom: 1 });
     const { graphData, isEmptyWorkflow } = useWorkflowGraphLayout({
       compiledFlow: model.compiledFlow,
-      tasks: model.definition?.tasks,
       defs: model.definition?.defs,
       layoutDirection: model.layoutDirection,
       actionCatalog: model.actionCatalog,

--- a/packages/graph/src/workflow/components/workflow-nodes/BindingPlaceholder/index.tsx
+++ b/packages/graph/src/workflow/components/workflow-nodes/BindingPlaceholder/index.tsx
@@ -24,10 +24,10 @@ export const BindingPlaceholder: FC<
   const { translate, onAddBinding } = useWorkflowGraphHost();
   const stepId = data?.stepId;
   const stepPath = data?.stepPath;
-  const taskName = data?.taskName;
+  const ownerDefName = data?.ownerDefName;
   const bindingKind = data?.bindingKind;
   const canAddBinding = Boolean(
-    onAddBinding && stepId && stepPath && taskName && bindingKind,
+    onAddBinding && stepId && stepPath && ownerDefName && bindingKind,
   );
   const addLabel = translate("button.add");
   const handleAddBinding = useCallback(
@@ -35,7 +35,7 @@ export const BindingPlaceholder: FC<
       event.preventDefault();
       event.stopPropagation();
 
-      if (!canAddBinding || !onAddBinding || !taskName || !bindingKind) {
+      if (!canAddBinding || !onAddBinding || !ownerDefName || !bindingKind) {
         return;
       }
 
@@ -43,7 +43,7 @@ export const BindingPlaceholder: FC<
         nodeId: id,
         stepId,
         stepPath,
-        taskName,
+        ownerDefName,
         bindingKind,
       });
     },
@@ -52,9 +52,9 @@ export const BindingPlaceholder: FC<
       canAddBinding,
       id,
       onAddBinding,
+      ownerDefName,
       stepId,
       stepPath,
-      taskName,
     ],
   );
 

--- a/packages/graph/src/workflow/components/workflow-nodes/GenericNodeDeleteButton.tsx
+++ b/packages/graph/src/workflow/components/workflow-nodes/GenericNodeDeleteButton.tsx
@@ -18,7 +18,16 @@ const STEP_REMOVABLE_NODE_TYPES = new Set<StepRemovableNodeType>([
 
 export const GenericNodeDeleteButton = () => {
   const { translate, onRemoveStep, onRemoveBinding } = useWorkflowGraphHost();
-  const { id, type, stepId, stepPath, taskName, bindingKind, bindingName } =
+  const {
+    id,
+    type,
+    stepId,
+    stepPath,
+    ownerDefName,
+    ownerBindingKind,
+    bindingKind,
+    bindingName,
+  } =
     useWorkflowNode();
   const isStepRemovable =
     !!stepPath &&
@@ -28,8 +37,8 @@ export const GenericNodeDeleteButton = () => {
     onRemoveBinding &&
     stepPath &&
     stepId &&
-    taskName &&
-    bindingKind &&
+    ownerDefName &&
+    (ownerBindingKind || bindingKind) &&
     bindingName
   );
   const handleDelete = useCallback(
@@ -38,12 +47,18 @@ export const GenericNodeDeleteButton = () => {
       event.stopPropagation();
 
       if (isBindingRemovable) {
+        const resolvedBindingKind = ownerBindingKind ?? bindingKind;
+
+        if (!stepPath || !stepId || !ownerDefName || !bindingName || !resolvedBindingKind) {
+          return;
+        }
+
         onRemoveBinding?.({
           nodeId: id,
           stepId,
           stepPath,
-          taskName,
-          bindingKind,
+          ownerDefName,
+          bindingKind: resolvedBindingKind,
           bindingName,
         });
 
@@ -64,9 +79,10 @@ export const GenericNodeDeleteButton = () => {
       isStepRemovable,
       onRemoveBinding,
       onRemoveStep,
+      ownerBindingKind,
+      ownerDefName,
       stepId,
       stepPath,
-      taskName,
     ],
   );
 

--- a/packages/graph/src/workflow/hooks/useWorkflowGraphLayout.ts
+++ b/packages/graph/src/workflow/hooks/useWorkflowGraphLayout.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { CompiledStep, DefDefinitions, TaskDefinitions } from "@hexabot-ai/agentic";
+import type { CompiledStep, DefDefinitions } from "@hexabot-ai/agentic";
 import type { ResizeControlDirection } from "@xyflow/system";
 import { useEffect, useRef, useState } from "react";
 
@@ -21,7 +21,6 @@ import {
 
 type UseWorkflowGraphLayoutProps = {
   compiledFlow?: CompiledStep[];
-  tasks?: TaskDefinitions;
   defs?: DefDefinitions;
   layoutDirection?: ResizeControlDirection;
   actionCatalog: ReadonlyMap<string, WorkflowAction>;
@@ -30,7 +29,6 @@ type UseWorkflowGraphLayoutProps = {
 
 export const useWorkflowGraphLayout = ({
   compiledFlow,
-  tasks,
   defs,
   layoutDirection,
   actionCatalog,
@@ -61,7 +59,6 @@ export const useWorkflowGraphLayout = ({
         const layoutedGraph = await buildNodesAndEdges({
           config,
           flow: compiledFlow,
-          tasks,
           defs,
           actionCatalog,
           bindingCatalog,
@@ -91,7 +88,6 @@ export const useWorkflowGraphLayout = ({
     compiledFlow,
     defs,
     layoutDirection,
-    tasks,
   ]);
 
   return {

--- a/packages/graph/src/workflow/types/workflow-node.types.ts
+++ b/packages/graph/src/workflow/types/workflow-node.types.ts
@@ -8,7 +8,6 @@ import type {
   CompiledStep,
   DefDefinitions,
   StepType,
-  TaskDefinitions,
 } from "@hexabot-ai/agentic";
 import type { Edge, Node, NodeProps } from "@xyflow/react";
 import type {
@@ -68,6 +67,8 @@ export type WorkflowBindingDefinition = {
   multiple: boolean;
   color?: string;
   icon?: string;
+  supportedBindings?: readonly string[];
+  actionPolicy?: "forbidden" | "optional" | "required";
 };
 export type WorkflowBindingCatalog = ReadonlyMap<
   string,
@@ -90,6 +91,8 @@ export type WorkflowNodeTheme = {
 export type CommonNodeDadaTypes = NodeDataTitle & {
   stepId?: string;
   taskName?: string;
+  ownerDefName?: string;
+  ownerBindingKind?: string;
   bindingKind?: string;
   bindingName?: string;
   description?: string;
@@ -120,14 +123,14 @@ export type BranchPlaceholderData = CommonNodeData<ENodeType.BRANCH_PLACEHOLDER>
   onOpenInsertMenu?: OnOpenInsertMenu;
 };
 export type BindingPlaceholderData = CommonNodeData<ENodeType.BINDING_PLACEHOLDER> & {
-  taskName?: string;
+  ownerDefName?: string;
   bindingKind?: string;
 };
 
 export type WorkflowBindingBasePayload = {
   stepId?: string;
   stepPath?: FlowStepPath;
-  taskName: string;
+  ownerDefName: string;
   bindingKind: string;
   nodeId?: string;
 };
@@ -193,7 +196,9 @@ export type BindingOutPort =
 export type WorkflowPort = ELinkType | ConditionalOperatorOutPort | BindingOutPort;
 
 type WorkflowPortPrefix<P extends string> = P extends ENodeType.TASK
-  ? "task" | "bindingOut"
+  | ENodeType.BINDING_MULTI
+  | ENodeType.BINDING_SINGLE
+  ? P | "bindingOut"
   : P;
 
 export type Port<P extends string> = Extract<
@@ -261,7 +266,6 @@ export interface INodeConfig {
 export interface IBuildNodesAndEdgesProps {
   config: INodeConfig;
   flow?: CompiledStep[];
-  tasks?: TaskDefinitions;
   defs?: DefDefinitions;
   actionCatalog: ReadonlyMap<string, WorkflowAction>;
   bindingCatalog: WorkflowBindingCatalog;

--- a/packages/graph/src/workflow/utils/graph-builder/id-factory.ts
+++ b/packages/graph/src/workflow/utils/graph-builder/id-factory.ts
@@ -41,20 +41,23 @@ export const createPlaceholderNodeId = (
 
 export const createAttachmentNodeId = (
   stepId: string,
+  ownerDefName: string,
   name: string,
   index: number,
   namespace?: string,
 ): string => {
   const namespacePart = namespace ? `${normalizeName(namespace)}:` : "";
+  const ownerPart = toToken(ownerDefName);
 
-  return `attachment:${toToken(stepId)}:binding:${namespacePart}${index}:${normalizeName(name)}`;
+  return `attachment:${toToken(stepId)}:binding:${ownerPart}:${namespacePart}${index}:${normalizeName(name)}`;
 };
 
 export const createBindingPlaceholderNodeId = (
   stepId: string,
+  ownerDefName: string,
   kind: string,
 ): string => {
-  return `attachment:${toToken(stepId)}:binding-placeholder:${normalizeName(kind)}`;
+  return `attachment:${toToken(stepId)}:binding-placeholder:${toToken(ownerDefName)}:${normalizeName(kind)}`;
 };
 
 export const createEdgeId = ({

--- a/packages/graph/src/workflow/utils/graph-builder/traverse.ts
+++ b/packages/graph/src/workflow/utils/graph-builder/traverse.ts
@@ -6,12 +6,12 @@
 
 import {
   StepType,
+  isTaskDefinition,
   type CompiledConditionalStep,
   type CompiledLoopStep,
   type CompiledParallelStep,
   type CompiledStep,
   type DefDefinitions,
-  type TaskDefinitions,
 } from "@hexabot-ai/agentic";
 
 import {
@@ -68,7 +68,6 @@ type TraversalExit = {
 
 type GraphBuilderContext = {
   config: INodeConfig;
-  tasks?: TaskDefinitions;
   defs?: DefDefinitions;
   actionCatalog: ReadonlyMap<string, WorkflowAction>;
   bindingCatalog: WorkflowBindingCatalog;
@@ -124,14 +123,19 @@ const buildBindingOutPort = (
   total: number,
 ): BindingOutPort =>
   `${ELinkType.BINDING_OUT}-${index}-${total}-${encodeURIComponent(bindingKind)}`;
-const buildBindingPorts = (
+const buildBindingPorts = <
+  TNodeType extends
+    | ENodeType.TASK
+    | ENodeType.BINDING_MULTI
+    | ENodeType.BINDING_SINGLE,
+>(
   bindingKinds: string[],
-): WorkflowNodePort<ENodeType.TASK>[] => {
+): WorkflowNodePort<TNodeType>[] => {
   return bindingKinds.map((bindingKind, index) => {
     return {
       id: buildBindingOutPort(bindingKind, index, bindingKinds.length),
       label: getBindingPortLabel(bindingKind),
-    };
+    } as WorkflowNodePort<TNodeType>;
   });
 };
 const toBindingRefs = (
@@ -165,16 +169,14 @@ const toBindingRefs = (
     .filter((entry): entry is string => typeof entry === "string")
     .filter(Boolean);
 };
-const resolveEffectiveBindingKinds = (
-  taskAction: string,
-  actionCatalog: ReadonlyMap<string, WorkflowAction>,
+const resolveCatalogBindingKinds = (
+  candidateKinds: readonly string[],
   bindingCatalog: WorkflowBindingCatalog,
-) => {
-  const supportedKinds = actionCatalog.get(taskAction)?.supportedBindings ?? [];
+): string[] => {
   const availableKinds = new Set(bindingCatalog.keys());
   const resolvedKinds: string[] = [];
 
-  supportedKinds.forEach((bindingKind) => {
+  candidateKinds.forEach((bindingKind) => {
     if (
       typeof bindingKind !== "string" ||
       !bindingKind ||
@@ -189,32 +191,56 @@ const resolveEffectiveBindingKinds = (
 
   return resolvedKinds;
 };
-const getTaskMeta = (
-  taskName: string,
-  tasks: TaskDefinitions | undefined,
+const resolveActionSupportedBindingKinds = (
+  actionName: string,
   actionCatalog: ReadonlyMap<string, WorkflowAction>,
   bindingCatalog: WorkflowBindingCatalog,
-) => {
-  const taskDefinition = tasks?.[taskName];
-  const actionName =
-    typeof taskDefinition?.action === "string" ? taskDefinition.action : "";
-  const bindingKinds = resolveEffectiveBindingKinds(
-    actionName,
-    actionCatalog,
+): string[] => {
+  if (!actionName) {
+    return [];
+  }
+
+  const supportedKinds = actionCatalog.get(actionName)?.supportedBindings ?? [];
+
+  return resolveCatalogBindingKinds(supportedKinds, bindingCatalog);
+};
+const resolveEffectiveBindingKindsForDef = (
+  defDefinition: DefDefinitions[string],
+  actionCatalog: ReadonlyMap<string, WorkflowAction>,
+  bindingCatalog: WorkflowBindingCatalog,
+): string[] => {
+  if (isTaskDefinition(defDefinition)) {
+    return resolveActionSupportedBindingKinds(
+      defDefinition.action,
+      actionCatalog,
+      bindingCatalog,
+    );
+  }
+
+  const bindingKindDefinition = bindingCatalog.get(defDefinition.kind);
+
+  if (!bindingKindDefinition) {
+    return [];
+  }
+
+  const actionPolicy = bindingKindDefinition.actionPolicy ?? "optional";
+
+  if (actionPolicy === "required") {
+    if (typeof defDefinition.action !== "string" || !defDefinition.action) {
+      return [];
+    }
+
+    return resolveActionSupportedBindingKinds(
+      defDefinition.action,
+      actionCatalog,
+      bindingCatalog,
+    );
+  }
+
+  return resolveCatalogBindingKinds(
+    bindingKindDefinition.supportedBindings ?? [],
     bindingCatalog,
   );
-  const bindings = taskDefinition?.bindings as Record<string, unknown> | undefined;
-
-  return {
-    actionName,
-    bindingKinds,
-    mountedBindings: Object.fromEntries(
-      bindingKinds.map((bindingKind) => [
-        bindingKind,
-        toBindingRefs(bindings?.[bindingKind], bindingCatalog.get(bindingKind)),
-      ]),
-    ) as Record<string, string[]>,
-  };
 };
 const buildConditionalOperatorOutPort = (
   branchIndex: number,
@@ -457,30 +483,53 @@ const getBindingNodeDescription = ({
 
   return typeof def?.description === "string" ? def.description.trim() : undefined;
 };
-const addTaskAttachments = (
+const addDefAttachments = (
   state: TraverseState,
   {
     stepId,
     stepPath,
+    ownerDefName,
     taskName,
     parentNodeId,
     level,
-    bindingKinds,
-    mountedBindings,
+    visitedOwnerDefs,
   }: {
     stepId: string;
     stepPath: FlowStepPath;
+    ownerDefName: string;
     taskName: string;
     parentNodeId: string;
     level: number;
-    bindingKinds: string[];
-    mountedBindings: Record<string, string[]>;
+    visitedOwnerDefs: Set<string>;
   },
 ) => {
+  if (visitedOwnerDefs.has(ownerDefName)) {
+    return;
+  }
+
+  const ownerDefinition = state.defs?.[ownerDefName];
+
+  if (!ownerDefinition) {
+    return;
+  }
+
+  const bindingKinds = resolveEffectiveBindingKindsForDef(
+    ownerDefinition,
+    state.actionCatalog,
+    state.bindingCatalog,
+  );
+  const nextVisitedOwnerDefs = new Set(visitedOwnerDefs);
+
+  nextVisitedOwnerDefs.add(ownerDefName);
+
   bindingKinds.forEach((bindingKind, bindingIndex) => {
     const bindingDefinition = state.bindingCatalog.get(bindingKind);
+
+    if (!bindingDefinition) {
+      return;
+    }
+
     const isMultiple = bindingDefinition?.multiple ?? true;
-    const bindingNodeTheme = getBindingNodeTheme(bindingDefinition);
     const bindingPlaceholderTheme = bindingDefinition?.color
       ? { borderColor: bindingDefinition.color }
       : {};
@@ -489,18 +538,44 @@ const addTaskAttachments = (
       bindingIndex,
       bindingKinds.length,
     );
-    const mountedRefs = mountedBindings[bindingKind] ?? [];
-    const placeholderNodeId = createBindingPlaceholderNodeId(stepId, bindingKind);
+    const mountedRefs = toBindingRefs(
+      ownerDefinition.bindings?.[bindingKind],
+      bindingDefinition,
+    );
+    const placeholderNodeId = createBindingPlaceholderNodeId(
+      stepId,
+      ownerDefName,
+      bindingKind,
+    );
 
     mountedRefs.forEach((bindingName, bindingRefIndex) => {
+      const mountedDefinition = state.defs?.[bindingName];
+      const mountedBindingKind =
+        typeof mountedDefinition?.kind === "string"
+          ? mountedDefinition.kind
+          : bindingKind;
+      const mountedBindingDefinition =
+        state.bindingCatalog.get(mountedBindingKind) ?? bindingDefinition;
+      const nestedBindingKinds = mountedDefinition
+        ? resolveEffectiveBindingKindsForDef(
+            mountedDefinition,
+            state.actionCatalog,
+            state.bindingCatalog,
+          )
+        : [];
       const bindingNodeType = resolveBindingNodeType(isMultiple);
       const bindingNodeId = createAttachmentNodeId(
         stepId,
+        ownerDefName,
         bindingName,
         bindingRefIndex,
         bindingKind,
       );
       const bindingNodeBaseData = state.config.nodes[bindingNodeType];
+      const ports = [
+        ...bindingNodeBaseData.ports,
+        ...buildBindingPorts<typeof bindingNodeType>(nestedBindingKinds),
+      ] as typeof bindingNodeBaseData.ports;
 
       addSemanticNode(state, {
         id: bindingNodeId,
@@ -520,12 +595,15 @@ const addTaskAttachments = (
           stepId,
           stepPath,
           taskName,
-          bindingKind,
+          ownerDefName,
+          ownerBindingKind: bindingKind,
+          bindingKind: mountedBindingKind,
           bindingName,
           level,
+          ports,
           theme: {
             ...bindingNodeBaseData.theme,
-            ...bindingNodeTheme,
+            ...getBindingNodeTheme(mountedBindingDefinition),
           },
         },
       });
@@ -534,6 +612,16 @@ const addTaskAttachments = (
         source: parentNodeId,
         target: bindingNodeId,
         sourceHandle,
+      });
+
+      addDefAttachments(state, {
+        stepId,
+        stepPath,
+        ownerDefName: bindingName,
+        taskName,
+        parentNodeId: bindingNodeId,
+        level,
+        visitedOwnerDefs: nextVisitedOwnerDefs,
       });
     });
 
@@ -556,6 +644,7 @@ const addTaskAttachments = (
           stepId,
           stepPath,
           taskName,
+          ownerDefName,
           bindingKind,
           level,
           theme: {
@@ -755,20 +844,25 @@ const walkStep = ({
   const entryInsertPath = disableEntryInsertPath ? undefined : stepPath;
 
   if (step.type === StepType.Task) {
-    const taskMeta = getTaskMeta(
-      step.taskName,
-      state.tasks,
-      state.actionCatalog,
-      state.bindingCatalog,
-    );
+    const taskDefinition = state.defs?.[step.taskName];
     const actionName =
-      taskMeta.actionName || getTaskAction(step.taskName, state.tasks) || "";
+      taskDefinition && isTaskDefinition(taskDefinition)
+        ? taskDefinition.action
+        : (getTaskAction(step.taskName, state.defs) ?? "");
+    const bindingKinds =
+      taskDefinition && isTaskDefinition(taskDefinition)
+        ? resolveEffectiveBindingKindsForDef(
+            taskDefinition,
+            state.actionCatalog,
+            state.bindingCatalog,
+          )
+        : [];
     const taskNodeId = createStepNodeId(step.id, "task");
     const groupName = getGroupName(groupPath);
     const taskBaseData = state.config.nodes[ENodeType.TASK];
     const ports: WorkflowNodePort<ENodeType.TASK>[] = [
       ...taskBaseData.ports,
-      ...buildBindingPorts(taskMeta.bindingKinds),
+      ...buildBindingPorts<ENodeType.TASK>(bindingKinds),
     ];
 
     addSemanticNode(state, {
@@ -782,7 +876,7 @@ const walkStep = ({
       data: {
         ...taskBaseData,
         title: step.taskName,
-        description: getTaskDescription(step.taskName, state.tasks),
+        description: getTaskDescription(step.taskName, state.defs),
         actionName,
         stepId: step.id,
         level,
@@ -792,14 +886,14 @@ const walkStep = ({
       },
     });
 
-    addTaskAttachments(state, {
+    addDefAttachments(state, {
       stepId: step.id,
       stepPath,
+      ownerDefName: step.taskName,
       taskName: step.taskName,
       parentNodeId: taskNodeId,
       level,
-      bindingKinds: taskMeta.bindingKinds,
-      mountedBindings: taskMeta.mountedBindings,
+      visitedOwnerDefs: new Set(),
     });
 
     connectIncoming(state, {
@@ -972,7 +1066,6 @@ const walkSteps = ({
 export const traverseWorkflow = ({
   flow,
   config,
-  tasks,
   defs,
   actionCatalog,
   bindingCatalog,
@@ -987,7 +1080,6 @@ export const traverseWorkflow = ({
   const groups = new Map<string, GroupMeta>();
   const state: TraverseState = {
     config,
-    tasks,
     defs,
     actionCatalog,
     bindingCatalog,

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -5,12 +5,13 @@
  */
 
 import {
+  type DefDefinitions,
   StepType,
   type CompiledConditionalStep,
   type CompiledLoopStep,
   type CompiledParallelStep,
   type CompiledStep,
-  type TaskDefinitions,
+  type TaskDefinition,
 } from "@hexabot-ai/agentic";
 import { describe, expect, it } from "vitest";
 
@@ -37,7 +38,21 @@ const taskStep = (id: string, taskName: string): CompiledStep => {
     taskName,
   };
 };
-const baseTasks = (taskNames: string[]): TaskDefinitions => {
+
+type TestTaskDefinitions = Record<string, Omit<TaskDefinition, "kind">>;
+
+const withTaskKind = (tasks: TestTaskDefinitions): DefDefinitions => {
+  return Object.fromEntries(
+    Object.entries(tasks).map(([taskName, taskDefinition]) => [
+      taskName,
+      {
+        kind: "task",
+        ...taskDefinition,
+      },
+    ]),
+  );
+};
+const baseTasks = (taskNames: string[]): TestTaskDefinitions => {
   return taskNames.reduce((acc, taskName) => {
     acc[taskName] = {
       action: `action_${taskName}`,
@@ -45,7 +60,7 @@ const baseTasks = (taskNames: string[]): TaskDefinitions => {
     };
 
     return acc;
-  }, {} as TaskDefinitions);
+  }, {} as TestTaskDefinitions);
 };
 const createActionCatalog = (
   bindingsByAction: Record<string, readonly string[]>,
@@ -68,6 +83,8 @@ const createBindingCatalog = (
         multiple?: boolean;
         color?: string;
         icon?: string;
+        supportedBindings?: readonly string[];
+        actionPolicy?: "forbidden" | "optional" | "required";
       }
   >,
 ): ReadonlyMap<string, WorkflowBindingDefinition> => {
@@ -90,6 +107,8 @@ const createBindingCatalog = (
           multiple: bindingKind.multiple ?? true,
           color: bindingKind.color,
           icon: bindingKind.icon,
+          supportedBindings: bindingKind.supportedBindings,
+          actionPolicy: bindingKind.actionPolicy,
         },
       ];
     }),
@@ -98,18 +117,23 @@ const createBindingCatalog = (
 const buildGraph = async ({
   flow,
   tasks,
+  defs = {},
   actionCatalog = new Map(),
   bindingCatalog = new Map(),
 }: {
   flow: CompiledStep[];
-  tasks: TaskDefinitions;
+  tasks: TestTaskDefinitions;
+  defs?: DefDefinitions;
   actionCatalog?: ReadonlyMap<string, WorkflowAction>;
   bindingCatalog?: ReadonlyMap<string, WorkflowBindingDefinition>;
 }) => {
   const graph = await buildNodesAndEdges({
     config: getWorkflowDefaultConfig("horizontal"),
     flow,
-    tasks,
+    defs: {
+      ...defs,
+      ...withTaskKind(tasks),
+    },
     actionCatalog,
     bindingCatalog,
   });
@@ -133,11 +157,27 @@ const getNodePorts = (
 
   return ports.map((port) => (typeof port === "string" ? port : port.id));
 };
+const getNodeTitle = (node: { data?: unknown }): string | undefined => {
+  const data =
+    node.data && typeof node.data === "object"
+      ? (node.data as Record<string, unknown>)
+      : undefined;
+
+  return typeof data?.title === "string" ? data.title : undefined;
+};
+const getNodeOwnerDefName = (node: { data?: unknown }): string | undefined => {
+  const data =
+    node.data && typeof node.data === "object"
+      ? (node.data as Record<string, unknown>)
+      : undefined;
+
+  return typeof data?.ownerDefName === "string" ? data.ownerDefName : undefined;
+};
 
 describe("buildNodesAndEdges", () => {
   it("always renders action steps as task nodes", async () => {
     const flow: CompiledStep[] = [taskStep("0:worker", "worker")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       worker: {
         action: "worker_action",
         settings: {},
@@ -158,7 +198,7 @@ describe("buildNodesAndEdges", () => {
 
   it("projects node card style variables from node metrics", async () => {
     const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       agent: {
         action: "agent_action",
         bindings: {
@@ -197,7 +237,7 @@ describe("buildNodesAndEdges", () => {
 
   it("uses workflow def description for mounted binding nodes", async () => {
     const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       agent: {
         action: "agent_action",
         bindings: {
@@ -209,11 +249,12 @@ describe("buildNodesAndEdges", () => {
     const graph = await buildNodesAndEdges({
       config: getWorkflowDefaultConfig("horizontal"),
       flow,
-      tasks,
       defs: {
+        ...withTaskKind(tasks),
         main_model: {
           kind: "model",
           description: "Primary model used by this task",
+          settings: {},
         },
       },
       actionCatalog: createActionCatalog({
@@ -232,7 +273,7 @@ describe("buildNodesAndEdges", () => {
 
   it("falls back to legacy dimensions when nodeMetrics is omitted", async () => {
     const flow: CompiledStep[] = [taskStep("0:worker", "worker")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       worker: {
         action: "worker_action",
         settings: {},
@@ -246,7 +287,7 @@ describe("buildNodesAndEdges", () => {
     const graph = await buildNodesAndEdges({
       config: legacyConfig,
       flow,
-      tasks,
+      defs: withTaskKind(tasks),
       actionCatalog: createActionCatalog({
         worker_action: [],
       }),
@@ -268,7 +309,7 @@ describe("buildNodesAndEdges", () => {
       taskStep("0:first_agent", "first_agent"),
       taskStep("1:second_agent", "second_agent"),
     ];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       first_agent: {
         action: "agent_action_a",
         bindings: {
@@ -307,7 +348,7 @@ describe("buildNodesAndEdges", () => {
 
   it("renders mounted tool bindings from task.bindings.tools", async () => {
     const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       agent: {
         action: "agent_action",
         bindings: {
@@ -348,7 +389,7 @@ describe("buildNodesAndEdges", () => {
 
   it("renders mounted memory bindings through generic multi-binding pipeline", async () => {
     const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       agent: {
         action: "agent_action",
         bindings: {
@@ -402,9 +443,280 @@ describe("buildNodesAndEdges", () => {
     ).toBe(true);
   });
 
+  it("renders nested binding attachments from mounted binding defs", async () => {
+    const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
+    const tasks: TestTaskDefinitions = {
+      agent: {
+        action: "agent_action",
+        bindings: {
+          tools: ["search_tool"],
+        },
+        settings: {},
+      },
+    };
+    const graph = await buildGraph({
+      flow,
+      tasks,
+      defs: {
+        search_tool: {
+          kind: "tools",
+          action: "search_action",
+          settings: {},
+          bindings: {
+            memory: ["profile_memory"],
+          },
+        },
+        profile_memory: {
+          kind: "memory",
+          settings: {},
+        },
+      },
+      actionCatalog: createActionCatalog({
+        agent_action: ["tools"],
+        search_action: ["memory"],
+      }),
+      bindingCatalog: createBindingCatalog([
+        {
+          kind: "tools",
+          multiple: true,
+          actionPolicy: "required",
+          supportedBindings: ["model"],
+        },
+        { kind: "memory", multiple: true },
+        { kind: "model", multiple: false },
+      ]),
+    });
+    const toolNode = graph.nodes.find((node) => getNodeTitle(node) === "search_tool");
+    const nestedMemoryNode = graph.nodes.find(
+      (node) => getNodeTitle(node) === "profile_memory",
+    );
+
+    expect(toolNode).toBeDefined();
+    expect(nestedMemoryNode).toBeDefined();
+    expect(
+      graph.edges.some(
+        (edge) =>
+          edge.source === toolNode?.id &&
+          edge.sourceHandle === "bindingOut-0-1-memory" &&
+          edge.target === nestedMemoryNode?.id,
+      ),
+    ).toBe(true);
+  });
+
+  it("positions nested binding placeholders below their owner binding node", async () => {
+    const flow: CompiledStep[] = [taskStep("0:ai_generate_reply", "ai_generate_reply")];
+    const tasks: TestTaskDefinitions = {
+      ai_generate_reply: {
+        action: "ai_generate_reply_action",
+        bindings: {
+          tools: ["ai_generate_reply_2"],
+        },
+        settings: {},
+      },
+    };
+    const graph = await buildGraph({
+      flow,
+      tasks,
+      defs: {
+        ai_generate_reply_2: {
+          kind: "tools",
+          action: "ai_generate_reply_action",
+          settings: {},
+          bindings: {
+            model: "model",
+          },
+        },
+        model: {
+          kind: "model",
+          settings: {},
+        },
+      },
+      actionCatalog: createActionCatalog({
+        ai_generate_reply_action: ["tools", "model"],
+      }),
+      bindingCatalog: createBindingCatalog([
+        {
+          kind: "tools",
+          multiple: true,
+          actionPolicy: "required",
+        },
+        { kind: "model", multiple: false },
+      ]),
+    });
+    const ownerBindingNode = graph.nodes.find(
+      (node) => getNodeTitle(node) === "ai_generate_reply_2",
+    );
+    const nestedPlaceholderNodes = graph.nodes.filter(
+      (node) =>
+        node.type === ENodeType.BINDING_PLACEHOLDER &&
+        getNodeOwnerDefName(node) === "ai_generate_reply_2",
+    );
+
+    expect(ownerBindingNode).toBeDefined();
+    expect(nestedPlaceholderNodes.length).toBeGreaterThan(0);
+
+    if (!ownerBindingNode) {
+      return;
+    }
+
+    nestedPlaceholderNodes.forEach((placeholderNode) => {
+      expect(placeholderNode.position.y).toBeGreaterThan(
+        ownerBindingNode.position.y + 100,
+      );
+    });
+  });
+
+  it("resolves required action-policy nested bindings from action allowlists", async () => {
+    const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
+    const tasks: TestTaskDefinitions = {
+      agent: {
+        action: "agent_action",
+        bindings: {
+          tools: ["search_tool"],
+        },
+        settings: {},
+      },
+    };
+    const graph = await buildGraph({
+      flow,
+      tasks,
+      defs: {
+        search_tool: {
+          kind: "tools",
+          action: "search_action",
+          settings: {},
+        },
+      },
+      actionCatalog: createActionCatalog({
+        agent_action: ["tools"],
+        search_action: ["memory"],
+      }),
+      bindingCatalog: createBindingCatalog([
+        {
+          kind: "tools",
+          multiple: true,
+          actionPolicy: "required",
+          supportedBindings: ["model"],
+        },
+        { kind: "memory", multiple: true },
+        { kind: "model", multiple: false },
+      ]),
+    });
+    const toolNode = graph.nodes.find((node) => getNodeTitle(node) === "search_tool");
+    const nestedPlaceholder = graph.nodes.find(
+      (node) =>
+        node.type === ENodeType.BINDING_PLACEHOLDER &&
+        getNodeOwnerDefName(node) === "search_tool" &&
+        getNodeTitle(node) === "memory",
+    );
+
+    expect(toolNode).toBeDefined();
+    expect(getNodePorts(toolNode).includes("bindingOut-0-1-memory")).toBe(true);
+    expect(getNodePorts(toolNode).includes("bindingOut-0-1-model")).toBe(false);
+    expect(nestedPlaceholder).toBeDefined();
+  });
+
+  it("resolves optional action-policy nested bindings from kind allowlists", async () => {
+    const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
+    const tasks: TestTaskDefinitions = {
+      agent: {
+        action: "agent_action",
+        bindings: {
+          tools: ["search_tool"],
+        },
+        settings: {},
+      },
+    };
+    const graph = await buildGraph({
+      flow,
+      tasks,
+      defs: {
+        search_tool: {
+          kind: "tools",
+          action: "search_action",
+          settings: {},
+        },
+      },
+      actionCatalog: createActionCatalog({
+        agent_action: ["tools"],
+        search_action: ["memory"],
+      }),
+      bindingCatalog: createBindingCatalog([
+        {
+          kind: "tools",
+          multiple: true,
+          actionPolicy: "optional",
+          supportedBindings: ["model"],
+        },
+        { kind: "memory", multiple: true },
+        { kind: "model", multiple: false },
+      ]),
+    });
+    const toolNode = graph.nodes.find((node) => getNodeTitle(node) === "search_tool");
+    const nestedPlaceholder = graph.nodes.find(
+      (node) =>
+        node.type === ENodeType.BINDING_PLACEHOLDER &&
+        getNodeOwnerDefName(node) === "search_tool" &&
+        getNodeTitle(node) === "model",
+    );
+
+    expect(toolNode).toBeDefined();
+    expect(getNodePorts(toolNode).includes("bindingOut-0-1-model")).toBe(true);
+    expect(getNodePorts(toolNode).includes("bindingOut-0-1-memory")).toBe(false);
+    expect(nestedPlaceholder).toBeDefined();
+  });
+
+  it("does not expose nested bindings when required action is missing or unresolved", async () => {
+    const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
+    const tasks: TestTaskDefinitions = {
+      agent: {
+        action: "agent_action",
+        bindings: {
+          tools: ["search_tool"],
+        },
+        settings: {},
+      },
+    };
+    const graph = await buildGraph({
+      flow,
+      tasks,
+      defs: {
+        search_tool: {
+          kind: "tools",
+          action: "missing_action",
+          settings: {},
+        },
+      },
+      actionCatalog: createActionCatalog({
+        agent_action: ["tools"],
+      }),
+      bindingCatalog: createBindingCatalog([
+        {
+          kind: "tools",
+          multiple: true,
+          actionPolicy: "required",
+          supportedBindings: ["memory"],
+        },
+        { kind: "memory", multiple: true },
+      ]),
+    });
+    const toolNode = graph.nodes.find((node) => getNodeTitle(node) === "search_tool");
+    const nestedPlaceholders = graph.nodes.filter(
+      (node) =>
+        node.type === ENodeType.BINDING_PLACEHOLDER &&
+        getNodeOwnerDefName(node) === "search_tool",
+    );
+
+    expect(toolNode).toBeDefined();
+    expect(
+      getNodePorts(toolNode).some((port) => port.startsWith("bindingOut-")),
+    ).toBe(false);
+    expect(nestedPlaceholders).toHaveLength(0);
+  });
+
   it("applies binding color and icon metadata to mounted and placeholder nodes", async () => {
     const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       agent: {
         action: "agent_action",
         bindings: {
@@ -450,7 +762,7 @@ describe("buildNodesAndEdges", () => {
 
   it("renders mounted single-ref model bindings from string task bindings", async () => {
     const flow: CompiledStep[] = [taskStep("0:worker", "worker")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       worker: {
         action: "worker_action",
         bindings: {
@@ -487,7 +799,7 @@ describe("buildNodesAndEdges", () => {
 
   it("renders model binding placeholder when model-capable action has no mounted model", async () => {
     const flow: CompiledStep[] = [taskStep("0:worker", "worker")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       worker: {
         action: "worker_action",
         settings: {},
@@ -521,7 +833,7 @@ describe("buildNodesAndEdges", () => {
 
   it("does not mount legacy settings.provider/model without task model binding", async () => {
     const flow: CompiledStep[] = [taskStep("0:worker", "worker")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       worker: {
         action: "worker_action",
         settings: {
@@ -549,7 +861,7 @@ describe("buildNodesAndEdges", () => {
 
   it("renders single-binding nodes for custom binding kinds when multiple=false", async () => {
     const flow: CompiledStep[] = [taskStep("0:worker", "worker")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       worker: {
         action: "worker_action",
         bindings: {
@@ -590,7 +902,7 @@ describe("buildNodesAndEdges", () => {
 
   it("renders binding placeholders for tasks with supported bindings", async () => {
     const flow: CompiledStep[] = [taskStep("0:worker", "worker")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       worker: {
         action: "worker_action",
         settings: {},
@@ -624,7 +936,7 @@ describe("buildNodesAndEdges", () => {
 
   it("filters unsupported binding kinds that are missing from the binding catalog", async () => {
     const flow: CompiledStep[] = [taskStep("0:worker", "worker")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       worker: {
         action: "worker_action",
         bindings: {
@@ -658,7 +970,7 @@ describe("buildNodesAndEdges", () => {
 
   it("does not mount legacy settings.tools without task bindings", async () => {
     const flow: CompiledStep[] = [taskStep("0:agent", "agent")];
-    const tasks: TaskDefinitions = {
+    const tasks: TestTaskDefinitions = {
       agent: {
         action: "agent_action",
         settings: {
@@ -992,7 +1304,7 @@ describe("buildNodesAndEdges", () => {
     const graph = await buildNodesAndEdges({
       config: getWorkflowDefaultConfig("horizontal"),
       flow: [],
-      tasks: {},
+      defs: {},
       actionCatalog: new Map(),
       bindingCatalog: new Map(),
     });

--- a/packages/graph/src/workflow/utils/workflow-node.utils.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.ts
@@ -274,16 +274,21 @@ const addExtraNodes = (
 ) => {
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
   const isHorizontal = isHorizontalDirection(ctx);
-  const adjacencyMap = edges.reduce((acc, { source, target }) => {
+  const adjacencyMap = new Map<string, GraphNode[]>();
+  const incomingAttachmentCounts = new Map<string, number>();
+
+  edges.forEach(({ source, target }) => {
     const sourceNode = nodesById.get(source);
     const targetNode = nodesById.get(target);
 
     if (sourceNode && targetNode) {
-      acc.set(source, [...(acc.get(source) || []), targetNode]);
+      adjacencyMap.set(source, [...(adjacencyMap.get(source) ?? []), targetNode]);
+      incomingAttachmentCounts.set(
+        target,
+        (incomingAttachmentCounts.get(target) ?? 0) + 1,
+      );
     }
-
-    return acc;
-  }, new Map<string, GraphNode[]>());
+  });
 
   if (adjacencyMap.size === 0) {
     return nodes;
@@ -293,14 +298,43 @@ const addExtraNodes = (
     string,
     Pick<GraphNode, "position" | "targetPosition" | "sourcePosition">
   >();
+  const resolvedPositions = new Map(nodes.map((node) => [node.id, node.position]));
+  const remainingIncoming = new Map(incomingAttachmentCounts);
+  const sourceIds = [...adjacencyMap.keys()];
+  const queue = sourceIds.filter(
+    (sourceId) => (remainingIncoming.get(sourceId) ?? 0) === 0,
+  );
+  const queued = new Set(queue);
+  const processed = new Set<string>();
 
-  adjacencyMap.forEach((targets, sourceId) => {
-    const sourceNode = nodesById.get(sourceId);
+  if (!queue.length) {
+    sourceIds.forEach((sourceId) => {
+      queue.push(sourceId);
+      queued.add(sourceId);
+    });
+  }
 
-    if (!sourceNode) {
+  const enqueueSource = (sourceId: string) => {
+    if (
+      !adjacencyMap.has(sourceId) ||
+      queued.has(sourceId) ||
+      processed.has(sourceId)
+    ) {
       return;
     }
 
+    queue.push(sourceId);
+    queued.add(sourceId);
+  };
+  const positionTargets = (sourceId: string) => {
+    const targets = adjacencyMap.get(sourceId);
+    const sourceNode = nodesById.get(sourceId);
+
+    if (!sourceNode || !targets?.length) {
+      return;
+    }
+
+    const sourcePosition = resolvedPositions.get(sourceId) ?? sourceNode.position;
     const sourceDimensions = getWorkflowNodeDimensions(sourceNode.type, ctx.config);
     const targetsWithDimensions = targets.map((target) => ({
       node: target,
@@ -315,25 +349,63 @@ const addExtraNodes = (
       EXTRA_NODE_GAP * (targets.length - 1);
 
     let cursor = isHorizontal
-      ? sourceNode.position.x + (sourceDimensions.width - totalBreadth) / 2
-      : sourceNode.position.y + (sourceDimensions.height - totalBreadth) / 2;
+      ? sourcePosition.x + (sourceDimensions.width - totalBreadth) / 2
+      : sourcePosition.y + (sourceDimensions.height - totalBreadth) / 2;
 
     targetsWithDimensions.forEach(({ node, dimensions }) => {
+      const position = isHorizontal
+        ? {
+            x: cursor,
+            y: sourcePosition.y + sourceDimensions.height + EXTRA_NODE_OFFSET,
+          }
+        : {
+            x: sourcePosition.x - EXTRA_NODE_OFFSET - dimensions.width,
+            y: cursor,
+          };
+
       overrides.set(node.id, {
-        position: isHorizontal
-          ? {
-              x: cursor,
-              y: sourceNode.position.y + sourceDimensions.height + EXTRA_NODE_OFFSET,
-            }
-          : {
-              x: sourceNode.position.x - EXTRA_NODE_OFFSET - dimensions.width,
-              y: cursor,
-            },
+        position,
         targetPosition: isHorizontal ? Position.Top : Position.Right,
         sourcePosition: isHorizontal ? Position.Bottom : Position.Left,
       });
+      resolvedPositions.set(node.id, position);
       cursor += (isHorizontal ? dimensions.width : dimensions.height) + EXTRA_NODE_GAP;
+
+      const nextRemainingIncoming = (remainingIncoming.get(node.id) ?? 0) - 1;
+
+      remainingIncoming.set(node.id, nextRemainingIncoming);
+
+      if (nextRemainingIncoming <= 0) {
+        enqueueSource(node.id);
+      }
     });
+  };
+
+  // Nested attachment targets must read their parent's overridden coordinates.
+  while (queue.length) {
+    const sourceId = queue.shift();
+
+    if (!sourceId) {
+      continue;
+    }
+
+    queued.delete(sourceId);
+
+    if (processed.has(sourceId)) {
+      continue;
+    }
+
+    processed.add(sourceId);
+    positionTargets(sourceId);
+  }
+
+  sourceIds.forEach((sourceId) => {
+    if (processed.has(sourceId)) {
+      return;
+    }
+
+    positionTargets(sourceId);
+    processed.add(sourceId);
   });
 
   return nodes.map((node) => ({
@@ -390,7 +462,6 @@ const getGroupNodes = (
 export const buildNodesAndEdges = async ({
   config,
   flow,
-  tasks,
   defs,
   actionCatalog,
   bindingCatalog,
@@ -404,7 +475,6 @@ export const buildNodesAndEdges = async ({
   const traversal = traverseWorkflow({
     flow,
     config,
-    tasks,
     defs,
     actionCatalog,
     bindingCatalog,

--- a/packages/graph/src/workflow/utils/workflow-task.utils.ts
+++ b/packages/graph/src/workflow/utils/workflow-task.utils.ts
@@ -4,15 +4,32 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { TaskDefinitions } from "@hexabot-ai/agentic";
+import {
+  isTaskDefinition,
+  type DefDefinitions,
+  type TaskDefinition,
+} from "@hexabot-ai/agentic";
+
+const getTaskDefinition = (
+  taskName: string,
+  defs?: DefDefinitions,
+): TaskDefinition | undefined => {
+  const definition = defs?.[taskName];
+
+  if (!definition || !isTaskDefinition(definition)) {
+    return undefined;
+  }
+
+  return definition;
+};
 
 export const getTaskDescription = (
   taskName: string,
-  tasks?: TaskDefinitions,
+  defs?: DefDefinitions,
 ): string => {
-  return tasks?.[taskName]?.description ?? "No description provided.";
+  return getTaskDefinition(taskName, defs)?.description ?? "No description provided.";
 };
 
-export const getTaskAction = (taskName: string, tasks?: TaskDefinitions) => {
-  return tasks?.[taskName]?.action;
+export const getTaskAction = (taskName: string, defs?: DefDefinitions) => {
+  return getTaskDefinition(taskName, defs)?.action;
 };


### PR DESCRIPTION
# Motivation

Defs-Only Workflow Model with Kind-Driven Nested Bindings :

- Replaced the split defs + tasks model with a single root defs registry.
- Added built-in task kind in agentic; external kinds remain registry-driven.
- Enabled nested bindings on any kind using kind/action allowlists.

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
