### PR TITLE
fix: update workflow retrieval and save logic in WorkflowVersionOrmEn…

### DIFF
--- a/packages/api/src/workflow/entities/workflow-version.entity.ts
+++ b/packages/api/src/workflow/entities/workflow-version.entity.ts
@@ -126,10 +126,18 @@ export class WorkflowVersionOrmEntity extends BaseOrmEntity<WorkflowVersionTrans
     }
 
     const manager = WorkflowVersionOrmEntity.getEntityManager();
-    const workflow = manager.create(WorkflowOrmEntity, {
-      id: workflowId,
-      currentVersion: { id: this.id },
+    const workflowRepository = manager.getRepository(WorkflowOrmEntity);
+    const workflow = await workflowRepository.findOne({
+      where: { id: workflowId },
     });
-    await manager.save(WorkflowOrmEntity, workflow);
+
+    if (!workflow) {
+      return;
+    }
+
+    workflow.currentVersion = manager.create(WorkflowVersionOrmEntity, {
+      id: this.id,
+    });
+    await workflowRepository.save(workflow);
   }
 }


### PR DESCRIPTION
# Motivation

On version save, backend updated Workflow.currentVersion by saving a partial workflow entity.
The resulting entity update event could carry incomplete fields, which then polluted frontend cache state.

Root-cause fix: Updated backend version hook to load and save a full workflow entity before setting currentVersion

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
