### PR TITLE
fix(frontend): enabled credential add button for MCP dialog

### DIFF
--- a/packages/frontend/src/components/mcp-servers/McpServerForm.tsx
+++ b/packages/frontend/src/components/mcp-servers/McpServerForm.tsx
@@ -252,6 +252,7 @@ export const McpServerForm: FC<ComponentFormProps<IMcpServer>> = ({
                         onChange={(_event, selected) =>
                           onChange(selected?.id || null)
                         }
+                        enableEntityAddButton
                         {...restField}
                       />
                     );


### PR DESCRIPTION
# Motivation
Enabled credential add button for MCP dialog

<img width="681" height="572" alt="image" src="https://github.com/user-attachments/assets/9410888b-5a1e-4340-87ca-0fd7ef70fa67" />
<img width="681" height="572" alt="image" src="https://github.com/user-attachments/assets/357283ff-ce86-40ac-b6c9-8fbb40db3e78" />
