### PR TITLE
fix(api): adapt await replay action color for dark mode

### DIFF
--- a/packages/api/src/extensions/actions/messaging/await-reply.action.ts
+++ b/packages/api/src/extensions/actions/messaging/await-reply.action.ts
@@ -37,7 +37,7 @@ export class AwaitReplyAction extends BaseAction<
         workflowTypes: [WorkflowType.conversational],
         outputSchema: awaitReplyResumeSchema,
         icon: 'Hourglass',
-        color: '#040606',
+        color: '#5C6B6B',
         group: 'messaging',
       },
       actionService,


### PR DESCRIPTION
# Motivation
Adapt await replay action color for dark mode

<img width="1291" height="196" alt="image" src="https://github.com/user-attachments/assets/956b1391-b02a-4392-8894-067de593db35" />


<img width="1291" height="196" alt="image" src="https://github.com/user-attachments/assets/ea6f997a-e73b-44e0-8db8-04aad9453b70" />

