### PR TITLE
fix(graph): unit tests

### DIFF
--- a/packages/graph/vitest.config.mjs
+++ b/packages/graph/vitest.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
         },
     },
     test: {
-        environment: "jsdom",
+        environment: "node",
         include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     },
 });

--- a/packages/graph/vitest.config.mts
+++ b/packages/graph/vitest.config.mts
@@ -15,7 +15,7 @@ export default defineConfig({
     },
   },
   test: {
-    environment: "jsdom",
+    environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 });


### PR DESCRIPTION
# Motivation

Root cause confirmed: @hexabot-ai/graph was running Vitest in jsdom mode, which resolves jsdom@28 -> html-encoding-sniffer@6 -> @exodus/bytes (ESM). On local node v20.18.1, that chain fails with ERR_REQUIRE_ESM during worker startup.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
