### PR TITLE
fix(frontend): vite sass warn

### DIFF
--- a/packages/frontend/vite.config.mts
+++ b/packages/frontend/vite.config.mts
@@ -13,6 +13,16 @@ const monorepoRoot = path.resolve(__dirname, "../..");
 
 export default defineConfig({
   plugins: [react()],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: "modern-compiler",
+      },
+      sass: {
+        api: "modern-compiler",
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
# Motivation

@hexabot-ai/frontend uses vite@5.4.20, and in that version Sass preprocessing defaults to legacy mode (api ?? "legacy"), which triggers Dart Sass legacy-js-api deprecations.

I updated Vite config to force the modern Sass API for both scss and sass

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
