### PR TITLE
fix(frontend): add scrollbar dark mode support

### DIFF
--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/StepTraceFilters.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/StepTraceFilters.tsx
@@ -32,7 +32,7 @@ export const StepTraceFilters = ({
   const { t } = useTranslate();
 
   return (
-    <Box display="flex" gap={1} alignItems="center">
+    <Box display="flex" gap={1} alignItems="center" p={1} pb={0}>
       <ToggleButtonGroup
         exclusive
         size="small"

--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/StepTraceList.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/StepTraceList.tsx
@@ -24,7 +24,7 @@ export const StepTraceList = ({
   const steps = Object.values(stepLog ?? {});
 
   return (
-    <Grid gap={1} display="flex" flexDirection="column" overflow="auto">
+    <Grid px={1} gap={1} display="flex" flexDirection="column" overflow="auto">
       {steps.length === 0 ? (
         <StepTraceEmpty hasTrace={Boolean(stepLog)} />
       ) : (

--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/StepTracePanel.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/StepTracePanel.tsx
@@ -34,17 +34,15 @@ export const StepTracePanel = ({
       <Paper
         variant="outlined"
         sx={{
-          p: 1,
           display: "flex",
           flexDirection: "column",
-          gap: 2,
+          gap: 1,
           flex: 1,
           minHeight: 0,
           overflow: "hidden",
           height: "100%",
         }}
       >
-        {/* <StepTraceHeader /> */}
         <StepTraceFilters
           includeSkipped={includeSkipped}
           onIncludeSkippedChange={setIncludeSkipped}

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -9,21 +9,43 @@ a {
   text-decoration: none;
 }
 
-/* custom scrollbar */
 ::-webkit-scrollbar {
-  width: 5px;
+  width: 8px;
 }
-
 ::-webkit-scrollbar-track {
-  background: #f5f6fa;
+  background: rgb(245, 245, 245);
+  border-radius: 8px;
 }
-
+::-webkit-scrollbar-track:hover {
+  background: rgb(238, 238, 238);
+}
 ::-webkit-scrollbar-thumb {
-  background: #888;
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background-clip: content-box;
+}
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(0, 0, 0, 0.4);
+}
+::-webkit-scrollbar-thumb:active {
+  background-color: rgba(0, 0, 0, 0.6);
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: #555;
+[data-mui-color-scheme="dark"] ::-webkit-scrollbar-track {
+  background: rgb(30, 30, 30);
+}
+[data-mui-color-scheme="dark"] ::-webkit-scrollbar-track:hover {
+  background: rgb(50, 50, 50);
+}
+[data-mui-color-scheme="dark"] ::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+[data-mui-color-scheme="dark"] ::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(255, 255, 255, 0.4);
+}
+[data-mui-color-scheme="dark"] ::-webkit-scrollbar-thumb:active {
+  background-color: rgba(255, 255, 255, 0.6);
 }
 
 input::-ms-reveal,


### PR DESCRIPTION
# Motivation
This PR adds dark mode support for the scrollbar so it looks better when the app is in dark theme. 
It updates the scrollbar colors to match dark mode and improves the overall visual experience without changing any functionality.

# Screenshots

## Before the update
### Light Mode
1) default
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/485fb048-2bef-4845-b572-4897d30c1424" />
2) hover
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/bfa701b6-d64c-434b-b00a-2d85309f7bde" />
3) active: N/A

### Dark Mode
1) default
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/7d3e29b4-4931-4b02-b62f-6e18744070d0" />
2) hover
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/854d26c6-85ee-4526-bfbc-ddfec3f54b0b" />
3) active: N/A

## After the update
### Light Mode
1) default
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/d0886c05-1db8-4921-8a0a-1cd52c89d870" />
2) hover
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/92872164-4630-47ad-a2c0-7ec31f963cae" />
3) active
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/5af9d56c-90ab-454c-ba3c-1b385bd819ce" />

### Dark Mode
1) default
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/51327852-652e-4a45-8e5a-f40cdd0e33e5" />
2) hover
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/fc903243-523b-469f-a3cc-c8fae9dfca8b" />
3) active
> <img width="1441" height="646" alt="image" src="https://github.com/user-attachments/assets/992bb486-83b2-40ba-a677-5dabdc6ff19e" />