### PR TITLE
refactor(frontend): implements useDeleteEntity hook

### DIFF
--- a/packages/frontend/src/app-components/dialogs/dialog.constants.ts
+++ b/packages/frontend/src/app-components/dialogs/dialog.constants.ts
@@ -11,6 +11,7 @@ import { ContentFormDialog } from "@/components/contents/ContentFormDialog";
 import { CredentialFormDialog } from "@/components/credentials/CredentialFormDialog";
 import { LabelFormDialog } from "@/components/labels/LabelFormDialog";
 import { LanguageFormDialog } from "@/components/languages/LanguageFormDialog";
+import { McpServerFormDialog } from "@/components/mcp-servers/McpServerFormDialog";
 import { MemoryDefinitionFormDialog } from "@/components/memory-definitions/MemoryDefinitionFormDialog";
 import { RoleFormDialog } from "@/components/roles/RoleFormDialog";
 import { TranslationFormDialog } from "@/components/translations/TranslationFormDialog";
@@ -56,6 +57,10 @@ export const BASE_ADD_DIALOG_MAP = {
   },
   [EntityType.TRANSLATION]: {
     dialog: TranslationFormDialog,
+    presetValues: undefined,
+  },
+  [EntityType.MCP_SERVER]: {
+    dialog: McpServerFormDialog,
     presetValues: undefined,
   },
 } as const satisfies {

--- a/packages/frontend/src/components/content-types/index.tsx
+++ b/packages/frontend/src/components/content-types/index.tsx
@@ -7,16 +7,14 @@
 import { GridColDef } from "@mui/x-data-grid";
 import { AlignLeft } from "lucide-react";
 
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
-import { useDelete } from "@/hooks/crud/useDelete";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useAppRouter } from "@/hooks/useAppRouter";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { IContentType } from "@/types/content-type.types";
@@ -27,21 +25,9 @@ import { ContentTypeFormDialog } from "./ContentTypeFormDialog";
 
 export const ContentTypes = () => {
   const { t } = useTranslate();
-  const { toast } = useToast();
   const router = useAppRouter();
   const dialogs = useDialogs();
-  const options = {
-    onError: (error: Error) => {
-      toast.error(error);
-    },
-    onSuccess: () => {
-      toast.success(t("message.item_delete_success"));
-    },
-  };
-  const { mutate: deleteContentType } = useDelete(
-    EntityType.CONTENT_TYPE,
-    options,
-  );
+  const { confirmToDeleteEntity } = useDeleteEntity(EntityType.CONTENT_TYPE);
   const actionColumns = useActionColumns<IContentType>(
     EntityType.CONTENT_TYPE,
     [
@@ -58,13 +44,7 @@ export const ContentTypes = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteContentType(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
       },
     ],

--- a/packages/frontend/src/components/contents/index.tsx
+++ b/packages/frontend/src/components/contents/index.tsx
@@ -9,7 +9,6 @@ import { GridColDef } from "@mui/x-data-grid";
 import { AlignLeft } from "lucide-react";
 
 import { BackButton } from "@/app-components/buttons/BackButton";
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import FileUploadButton from "@/app-components/inputs/FileInput";
 import {
   ColumnActionType,
@@ -17,7 +16,7 @@ import {
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { isSameEntity } from "@/hooks/crud/helpers";
-import { useDelete } from "@/hooks/crud/useDelete";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useGet, useGetFromCache } from "@/hooks/crud/useGet";
 import { useImport } from "@/hooks/crud/useImport";
 import { useTanstackQueryClient } from "@/hooks/crud/useTanstack";
@@ -49,11 +48,7 @@ export const Contents = () => {
       toast.success(t("message.success_save"));
     },
   });
-  const { mutate: deleteContent } = useDelete(EntityType.CONTENT, {
-    onSuccess: () => {
-      toast.success(t("message.item_delete_success"));
-    },
-  });
+  const { confirmToDeleteEntity } = useDeleteEntity(EntityType.CONTENT);
   const getEntityFromCache = useGetFromCache(EntityType.CONTENT_TYPE);
   const actionColumns = useActionColumns<IContent>(
     EntityType.CONTENT,
@@ -70,13 +65,7 @@ export const Contents = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteContent(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
       },
     ],

--- a/packages/frontend/src/components/credentials/index.tsx
+++ b/packages/frontend/src/components/credentials/index.tsx
@@ -7,16 +7,14 @@
 import { GridColDef } from "@mui/x-data-grid";
 import { KeyRound, Plus } from "lucide-react";
 
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { ChipEntity } from "@/app-components/displays/ChipEntity";
 import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
-import { useDelete } from "@/hooks/crud/useDelete";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { ICredential } from "@/types/credential.types";
@@ -27,16 +25,8 @@ import { CredentialFormDialog } from "./CredentialFormDialog";
 
 export const Credentials = () => {
   const { t } = useTranslate();
-  const { toast } = useToast();
   const dialogs = useDialogs();
-  const { mutate: deleteCredential } = useDelete(EntityType.CREDENTIAL, {
-    onError: () => {
-      toast.error(t("message.internal_server_error"));
-    },
-    onSuccess() {
-      toast.success(t("message.item_delete_success"));
-    },
-  });
+  const { confirmToDeleteEntity } = useDeleteEntity(EntityType.CREDENTIAL);
   const actionColumns = useActionColumns<ICredential>(
     EntityType.CREDENTIAL,
     [
@@ -49,13 +39,7 @@ export const Credentials = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteCredential(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
       },
     ],

--- a/packages/frontend/src/components/labels/index.tsx
+++ b/packages/frontend/src/components/labels/index.tsx
@@ -8,17 +8,14 @@ import { GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import { Tags } from "lucide-react";
 import { useState } from "react";
 
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
-import { useDelete } from "@/hooks/crud/useDelete";
-import { useDeleteMany } from "@/hooks/crud/useDeleteMany";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useGetFromCache } from "@/hooks/crud/useGet";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { ILabel } from "@/types/label.types";
@@ -29,18 +26,8 @@ import { LabelFormDialog } from "./LabelFormDialog";
 
 export const Labels = () => {
   const { t } = useTranslate();
-  const { toast } = useToast();
   const dialogs = useDialogs();
-  const options = {
-    onError: () => {
-      toast.error(t("message.internal_server_error"));
-    },
-    onSuccess() {
-      toast.success(t("message.item_delete_success"));
-    },
-  };
-  const { mutate: deleteLabel } = useDelete(EntityType.LABEL, options);
-  const { mutate: deleteLabels } = useDeleteMany(EntityType.LABEL, options);
+  const { confirmToDeleteEntity } = useDeleteEntity(EntityType.LABEL);
   const actionColumns = useActionColumns<ILabel>(
     EntityType.LABEL,
     [
@@ -55,13 +42,7 @@ export const Labels = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteLabel(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
       },
     ],
@@ -148,16 +129,8 @@ export const Labels = () => {
         },
         {
           permissionAction: PermissionAction.DELETE,
-          onClick: async () => {
-            const isConfirmed = await dialogs.confirm(ConfirmDialogBody, {
-              mode: "selection",
-              count: selectedLabels.length,
-            });
-
-            if (isConfirmed) {
-              deleteLabels(selectedLabels);
-            }
-          },
+          onClick: () =>
+            confirmToDeleteEntity({ ids: selectedLabels, mode: "selection" }),
           disabled: !selectedLabels.length,
         },
       ]}

--- a/packages/frontend/src/components/languages/index.tsx
+++ b/packages/frontend/src/components/languages/index.tsx
@@ -8,14 +8,13 @@ import { Switch } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 import { Flag, Plus } from "lucide-react";
 
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { isSameEntity } from "@/hooks/crud/helpers";
-import { useDelete } from "@/hooks/crud/useDelete";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useTanstackQueryClient } from "@/hooks/crud/useTanstack";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { useDialogs } from "@/hooks/useDialogs";
@@ -42,14 +41,7 @@ export const Languages = () => {
       toast.success(t("message.success_save"));
     },
   });
-  const { mutate: deleteLanguage } = useDelete(EntityType.LANGUAGE, {
-    onError: () => {
-      toast.error(t("message.internal_server_error"));
-    },
-    onSuccess() {
-      toast.success(t("message.item_delete_success"));
-    },
-  });
+  const { confirmToDeleteEntity } = useDeleteEntity(EntityType.LANGUAGE);
   const queryClient = useTanstackQueryClient();
   const toggleDefault = (row: ILanguage) => {
     if (!row.isDefault) {
@@ -86,13 +78,7 @@ export const Languages = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteLanguage(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
         isDisabled: (row) => row.isDefault,
       },

--- a/packages/frontend/src/components/mcp-servers/index.tsx
+++ b/packages/frontend/src/components/mcp-servers/index.tsx
@@ -9,14 +9,13 @@ import { GridColDef } from "@mui/x-data-grid";
 import { Plug, Plus } from "lucide-react";
 import { useState } from "react";
 
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import { ChipEntity } from "@/app-components/displays/ChipEntity";
 import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
-import { useDelete } from "@/hooks/crud/useDelete";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useFind } from "@/hooks/crud/useFind";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { useApiClientMutation } from "@/hooks/useApiClient";
@@ -67,14 +66,7 @@ export const McpServers = () => {
       toast.success(t("message.success_save"));
     },
   });
-  const { mutate: deleteMcpServer } = useDelete(EntityType.MCP_SERVER, {
-    onError: (error: Error) => {
-      toast.error(error);
-    },
-    onSuccess() {
-      toast.success(t("message.item_delete_success"));
-    },
-  });
+  const { confirmToDeleteEntity } = useDeleteEntity(EntityType.MCP_SERVER);
   const { mutateAsync: testMcpServer } = useApiClientMutation("testMcpServer");
   const {
     data: tools = [],
@@ -193,13 +185,7 @@ export const McpServers = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteMcpServer(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
       },
     ],

--- a/packages/frontend/src/components/memory-definitions/index.tsx
+++ b/packages/frontend/src/components/memory-definitions/index.tsx
@@ -7,15 +7,13 @@
 import { GridColDef } from "@mui/x-data-grid";
 import { MemoryStick, Plus } from "lucide-react";
 
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
-import { useDelete } from "@/hooks/crud/useDelete";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { IMemoryDefinition } from "@/types/memory-definition.types";
@@ -26,18 +24,9 @@ import { MemoryDefinitionFormDialog } from "./MemoryDefinitionFormDialog";
 
 export const MemoryDefinitions = () => {
   const { t } = useTranslate();
-  const { toast } = useToast();
   const dialogs = useDialogs();
-  const { mutate: deleteMemoryDefinition } = useDelete(
+  const { confirmToDeleteEntity } = useDeleteEntity(
     EntityType.MEMORY_DEFINITION,
-    {
-      onError: () => {
-        toast.error(t("message.internal_server_error"));
-      },
-      onSuccess() {
-        toast.success(t("message.item_delete_success"));
-      },
-    },
   );
   const actionColumns = useActionColumns<IMemoryDefinition>(
     EntityType.MEMORY_DEFINITION,
@@ -55,13 +44,7 @@ export const MemoryDefinitions = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteMemoryDefinition(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
       },
     ],

--- a/packages/frontend/src/components/roles/index.tsx
+++ b/packages/frontend/src/components/roles/index.tsx
@@ -7,15 +7,13 @@
 import { GridColDef } from "@mui/x-data-grid";
 import { Accessibility } from "lucide-react";
 
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
-import { useDelete } from "@/hooks/crud/useDelete";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useDialogs } from "@/hooks/useDialogs";
-import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { PermissionAction } from "@/types/permission.types";
@@ -27,16 +25,8 @@ import { RoleFormDialog } from "./RoleFormDialog";
 
 export const Roles = () => {
   const { t } = useTranslate();
-  const { toast } = useToast();
   const dialogs = useDialogs();
-  const { mutate: deleteRole } = useDelete(EntityType.ROLE, {
-    onError: (error) => {
-      toast.error(error);
-    },
-    onSuccess() {
-      toast.success(t("message.item_delete_success"));
-    },
-  });
+  const { confirmToDeleteEntity } = useDeleteEntity(EntityType.ROLE);
   const actionColumns = useActionColumns<IRole>(
     EntityType.ROLE,
     [
@@ -60,13 +50,7 @@ export const Roles = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteRole(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
       },
     ],

--- a/packages/frontend/src/components/translations/index.tsx
+++ b/packages/frontend/src/components/translations/index.tsx
@@ -8,13 +8,12 @@ import { Chip, Stack } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 import { Languages, RefreshCw } from "lucide-react";
 
-import { ConfirmDialogBody } from "@/app-components/dialogs";
 import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
-import { useDelete } from "@/hooks/crud/useDelete";
+import { useDeleteEntity } from "@/hooks/crud/useDelete";
 import { useFind } from "@/hooks/crud/useFind";
 import { useApiClientMutation } from "@/hooks/useApiClient";
 import { useDialogs } from "@/hooks/useDialogs";
@@ -38,14 +37,7 @@ export const Translations = () => {
       hasCount: false,
     },
   );
-  const { mutate: deleteTranslation } = useDelete(EntityType.TRANSLATION, {
-    onError: (error) => {
-      toast.error(error);
-    },
-    onSuccess() {
-      toast.success(t("message.item_delete_success"));
-    },
-  });
+  const { confirmToDeleteEntity } = useDeleteEntity(EntityType.TRANSLATION);
   const { mutateAsync: checkRefreshTranslations, isPending } =
     useApiClientMutation("refreshTranslations", {
       onError: () => {
@@ -67,13 +59,7 @@ export const Translations = () => {
       },
       {
         action: ColumnActionType.Delete,
-        onClick: async ({ id }) => {
-          const isConfirmed = await dialogs.confirm(ConfirmDialogBody);
-
-          if (isConfirmed) {
-            deleteTranslation(id);
-          }
-        },
+        onClick: ({ id }) => confirmToDeleteEntity({ ids: [id] }),
         requires: [PermissionAction.DELETE],
       },
     ],

--- a/packages/frontend/src/hooks/crud/useDelete.ts
+++ b/packages/frontend/src/hooks/crud/useDelete.ts
@@ -4,11 +4,17 @@
  * Full terms: see LICENSE.md.
  */
 
+import { BASE_ADD_DIALOG_MAP } from "@/app-components/dialogs/dialog.constants";
 import { QueryType, TMutationOptions } from "@/services/types";
 import { THook } from "@/types/base.types";
+import { type ConfirmOptions } from "@/types/common/dialogs.types";
 
 import { useEntityApiClient } from "../useApiClient";
+import { useEntityDialogs } from "../useEntityDialogs";
+import { useToast } from "../useToast";
+import { useTranslate } from "../useTranslate";
 
+import { useDeleteMany } from "./useDeleteMany";
 import { useTanstackMutation, useTanstackQueryClient } from "./useTanstack";
 
 export const useDelete = <
@@ -43,4 +49,43 @@ export const useDeleteFromCache = <TE extends THook["entity"]>(entity: TE) => {
       },
     });
   };
+};
+
+export const useDeleteEntity = <TE extends keyof typeof BASE_ADD_DIALOG_MAP>(
+  entity: TE,
+) => {
+  const { t } = useTranslate();
+  const { toast } = useToast();
+  const options = {
+    onError: () => {
+      toast.error(t("message.internal_server_error"));
+    },
+    onSuccess() {
+      toast.success(t("message.item_delete_success"));
+    },
+  };
+  const { mutate: deleteEntity } = useDelete(entity, options);
+  const { mutate: deleteEntities } = useDeleteMany(entity, options);
+  const entityDialogs = useEntityDialogs(entity);
+  const confirmToDeleteEntity = async (
+    confirmOptions: ConfirmOptions & { ids?: string[] } = { mode: "click" },
+  ) => {
+    const { ids = [], mode = "click", ...options } = confirmOptions;
+
+    if (!ids.length) {
+      return;
+    }
+    const isConfirmed = await entityDialogs.confirmDelete({
+      ...options,
+      mode,
+      count: ids.length,
+    });
+
+    if (!isConfirmed) {
+      return;
+    }
+    mode === "selection" ? deleteEntities(ids) : deleteEntity(ids[0]);
+  };
+
+  return { confirmToDeleteEntity };
 };


### PR DESCRIPTION
# Motivation
Refactor deletion logic to use the new useDeleteEntity hook instead of the previous useDelete setup. 
This simplifies the code by removing manual options for success and error handling (like toast messages) and centralizes the delete behavior in a reusable hook. 
