### PR TITLE
fix: patch Vite to pre-bundle it up front

### DIFF
--- a/packages/frontend/vite.config.mts
+++ b/packages/frontend/vite.config.mts
@@ -13,6 +13,10 @@ const monorepoRoot = path.resolve(__dirname, "../..");
 
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    // Avoid one-time dev-server reload when YAML editor first mounts its worker.
+    include: ["monaco-yaml", "monaco-yaml/yaml.worker.js"],
+  },
   css: {
     preprocessorOptions: {
       scss: {


### PR DESCRIPTION
# Motivation

YML editor refresh is caused by Vite dev optimizer.  Why it appears “sometimes”:

monaco-yaml/yaml.worker.js is imported only through the YAML editor worker path, mounted from YamlEditor.tsx.

When that dep is first discovered (or cache was invalidated), Vite re-optimizes and force-reloads once.

I patched Vite to pre-bundle it up front.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
