### PR TITLE
feat(api): name-only cutover

### DIFF
--- a/packages/api/AGENTS.md
+++ b/packages/api/AGENTS.md
@@ -54,6 +54,7 @@ Use this file as the entrypoint for AI coding agents working on the Hexabot API.
 - Dynamic providers are resolved during bootstrap via `nestjs-dynamic-providers` before app creation.
 - Extension cleanup runs on application bootstrap in `packages/api/src/extension/extension.module.ts`.
 - Use extension settings instead of hardcoded behavior when adding new channel/action/helper behavior.
+- Channel/helper runtime setting group keys and settings hook namespaces must match the extension `name` (kebab-case).
 
 ## Coding conventions and gotchas
 - All new TS files must include the license header; ESLint `header/header` enforces it.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -42,6 +42,9 @@ The API is divided into several key modules, each responsible for specific funct
 
 - Built-in extensions live in `packages/api/src/extensions` (channels, actions, helpers).
 - Additional extensions are discovered from `hexabot-channel-*`, `hexabot-action-*`, and `hexabot-helper-*` packages, plus compiled extensions in `dist/extensions`.
+- Channel/helper runtime setting group keys and settings hook namespaces are now the extension `name` (kebab-case).
+- Third-party channel/helper extensions must define settings groups and i18n namespaces with the same kebab-case extension `name`.
+
 
 ## Installation
 

--- a/packages/api/src/actions/base-action.ts
+++ b/packages/api/src/actions/base-action.ts
@@ -9,7 +9,6 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { z, type ZodType } from 'zod';
 
 import { RuntimeBindings } from '@/bindings/runtime-bindings';
-import { HyphenToUnderscore } from '@/utils/types/extension';
 import { ConversationalWorkflowContext } from '@/workflow/contexts/conversational-workflow.context';
 import { WorkflowType } from '@/workflow/types';
 
@@ -68,10 +67,6 @@ export abstract class BaseAction<
 
   getName(): ActionName {
     return this.name as ActionName;
-  }
-
-  getNamespace<N extends ActionName = ActionName>() {
-    return this.getName().replaceAll('-', '_') as HyphenToUnderscore<N>;
   }
 
   async onModuleInit() {

--- a/packages/api/src/attachment/repositories/attachment.repository.spec.ts
+++ b/packages/api/src/attachment/repositories/attachment.repository.spec.ts
@@ -117,7 +117,7 @@ describe('AttachmentRepository (TypeORM)', () => {
         createdByRef: AttachmentCreatedByRef.User,
         createdBy: CREATOR_UUID,
         channel: {
-          'web-channel': { id: 'channel-id' },
+          web: { id: 'channel-id' },
         },
         ...overrides,
       };

--- a/packages/api/src/channel/channel.middleware.spec.ts
+++ b/packages/api/src/channel/channel.middleware.spec.ts
@@ -26,9 +26,7 @@ describe('ChannelMiddleware', () => {
 
     await middleware.use(req, {} as Response, next);
 
-    expect(channelService.getChannelHandler).toHaveBeenCalledWith(
-      'facebook-channel',
-    );
+    expect(channelService.getChannelHandler).toHaveBeenCalledWith('facebook');
     expect(channel.middleware).toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
   });
@@ -50,9 +48,7 @@ describe('ChannelMiddleware', () => {
 
     await middleware.use(req, {} as Response, next);
 
-    expect(channelService.getChannelHandler).toHaveBeenCalledWith(
-      'facebook-channel',
-    );
+    expect(channelService.getChannelHandler).toHaveBeenCalledWith('facebook');
     expect(channel.middleware).toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
   });

--- a/packages/api/src/channel/channel.middleware.ts
+++ b/packages/api/src/channel/channel.middleware.ts
@@ -38,9 +38,7 @@ export class ChannelMiddleware implements NestMiddleware {
       const channelName = this.resolveChannelName(req);
 
       if (channelName) {
-        const channel = this.channelService.getChannelHandler(
-          `${channelName}-channel`,
-        );
+        const channel = this.channelService.getChannelHandler(channelName);
         if (channel) {
           return await channel.middleware(req, res, next);
         }

--- a/packages/api/src/channel/channel.service.spec.ts
+++ b/packages/api/src/channel/channel.service.spec.ts
@@ -57,7 +57,7 @@ describe('ChannelService', () => {
     jest.clearAllMocks();
   });
 
-  it('forwards websocket web-channel requests without workflow id', async () => {
+  it('forwards websocket web requests without workflow id', async () => {
     const req = {
       method: 'GET',
       query: {},
@@ -70,7 +70,7 @@ describe('ChannelService', () => {
     expect(webChannelHandler.handle).toHaveBeenCalledWith(req, res, undefined);
   });
 
-  it('validates and forwards workflow id for websocket web-channel requests', async () => {
+  it('validates and forwards workflow id for websocket web requests', async () => {
     const workflowId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
     const req = {
       method: 'POST',
@@ -85,7 +85,7 @@ describe('ChannelService', () => {
     expect(webChannelHandler.handle).toHaveBeenCalledWith(req, res, workflowId);
   });
 
-  it('throws 404 for websocket web-channel requests with unknown workflow id', async () => {
+  it('throws 404 for websocket web requests with unknown workflow id', async () => {
     const workflowId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
     const req = {
       method: 'POST',
@@ -102,7 +102,7 @@ describe('ChannelService', () => {
     expect(webChannelHandler.handle).not.toHaveBeenCalled();
   });
 
-  it('validates and forwards workflow id for websocket console-channel requests', async () => {
+  it('validates and forwards workflow id for websocket console requests', async () => {
     const workflowId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
     const req = {
       method: 'POST',

--- a/packages/api/src/channel/channel.service.ts
+++ b/packages/api/src/channel/channel.service.ts
@@ -105,7 +105,7 @@ export class ChannelService {
     res: Response,
     workflowId?: string,
   ): Promise<void> {
-    const handler = this.getChannelHandler(`${channel}-channel`);
+    const handler = this.getChannelHandler(channel);
     handler.handle(req, res, workflowId);
   }
 

--- a/packages/api/src/channel/lib/Handler.ts
+++ b/packages/api/src/channel/lib/Handler.ts
@@ -25,7 +25,6 @@ import { StdOutgoingEnvelope } from '@/chat/types/message';
 import { I18nService } from '@/i18n';
 import { SettingService } from '@/setting/services/setting.service';
 import { Extension } from '@/utils/generics/extension';
-import { HyphenToUnderscore } from '@/utils/types/extension';
 import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
 
@@ -81,11 +80,11 @@ export default abstract class ChannelHandler<
    * Returns the channel's settings
    * @returns Channel's settings
    */
-  async getSettings<S extends string = HyphenToUnderscore<N>>() {
+  async getSettings<S extends string = N>() {
     const settings = await this.settingService.getSettings();
 
     // @ts-expect-error workaround typing
-    return settings[this.getNamespace() as keyof Settings] as Settings[S];
+    return settings[this.getName() as keyof Settings] as Settings[S];
   }
 
   /**

--- a/packages/api/src/channel/lib/__test__/subscriber.mock.ts
+++ b/packages/api/src/channel/lib/__test__/subscriber.mock.ts
@@ -23,7 +23,7 @@ export const subscriberInstance: Subscriber = {
   lastvisit: new Date(),
   retainedFrom: new Date(),
   channel: {
-    name: 'web-channel',
+    name: 'web',
   },
   labels: [],
   avatar: null,

--- a/packages/api/src/channel/services/channel-attachment.service.spec.ts
+++ b/packages/api/src/channel/services/channel-attachment.service.spec.ts
@@ -55,7 +55,7 @@ describe('ChannelAttachmentService', () => {
     jwtService.sign.mockReturnValue('signed-token');
     attachmentService.findOne.mockResolvedValue(resource as any);
 
-    const url = await service.getPublicUrl('web-channel', { id: resource.id });
+    const url = await service.getPublicUrl('web', { id: resource.id });
 
     expect(attachmentService.findOne).toHaveBeenCalledWith(resource.id);
     expect(jwtService.sign).toHaveBeenCalledWith(
@@ -74,7 +74,7 @@ describe('ChannelAttachmentService', () => {
   });
 
   it('returns external URLs as-is', async () => {
-    const url = await service.getPublicUrl('web-channel', {
+    const url = await service.getPublicUrl('web', {
       url: 'https://example.com/file.png',
     });
 
@@ -83,7 +83,7 @@ describe('ChannelAttachmentService', () => {
   });
 
   it('returns the not-found URL for attachments without an ID', async () => {
-    const url = await service.getPublicUrl('web-channel', { id: null });
+    const url = await service.getPublicUrl('web', { id: null });
 
     expect(url).toBe(buildURL(config.apiBaseUrl, '/webhook/web/not-found'));
     expect(logger.warn).toHaveBeenCalledWith(
@@ -94,7 +94,7 @@ describe('ChannelAttachmentService', () => {
   it('returns the not-found URL when an internal attachment cannot be resolved', async () => {
     attachmentService.findOne.mockResolvedValue(null);
 
-    const url = await service.getPublicUrl('web-channel', {
+    const url = await service.getPublicUrl('web', {
       id: 'missing-attachment',
     });
 

--- a/packages/api/src/channel/services/channel-attachment.service.ts
+++ b/packages/api/src/channel/services/channel-attachment.service.ts
@@ -70,11 +70,10 @@ export class ChannelAttachmentService {
       }
 
       const token = this.jwtService.sign({ ...resource }, this.jwtSignOptions);
-      const channelRoute = this.getChannelRouteName(channelName);
 
       return buildURL(
         config.apiBaseUrl,
-        `/webhook/${channelRoute}/download/${resource.name}?t=${encodeURIComponent(token)}`,
+        `/webhook/${channelName}/download/${resource.name}?t=${encodeURIComponent(token)}`,
       );
     }
 
@@ -129,16 +128,7 @@ export class ChannelAttachmentService {
     }
   }
 
-  private getChannelRouteName(channelName: string): string {
-    const [name] = channelName.split('-');
-
-    return name;
-  }
-
   private buildNotFoundUrl(channelName: string): string {
-    return buildURL(
-      config.apiBaseUrl,
-      `/webhook/${this.getChannelRouteName(channelName)}/not-found`,
-    );
+    return buildURL(config.apiBaseUrl, `/webhook/${channelName}/not-found`);
   }
 }

--- a/packages/api/src/channel/services/channel-download.service.spec.ts
+++ b/packages/api/src/channel/services/channel-download.service.spec.ts
@@ -55,9 +55,7 @@ describe('ChannelDownloadService', () => {
 
     const result = await service.download('web', token, req);
 
-    expect(channelService.getChannelHandler).toHaveBeenCalledWith(
-      'web-channel',
-    );
+    expect(channelService.getChannelHandler).toHaveBeenCalledWith('web');
     expect(channelAttachmentService.download).toHaveBeenCalledWith(
       token,
       req,

--- a/packages/api/src/channel/services/channel-download.service.ts
+++ b/packages/api/src/channel/services/channel-download.service.ts
@@ -19,7 +19,7 @@ export class ChannelDownloadService {
   ) {}
 
   async download(channel: string, token: string, req: Request) {
-    const handler = this.channelService.getChannelHandler(`${channel}-channel`);
+    const handler = this.channelService.getChannelHandler(channel);
 
     return await this.channelAttachmentService.download(
       token,

--- a/packages/api/src/channel/types.ts
+++ b/packages/api/src/channel/types.ts
@@ -6,7 +6,7 @@
 
 import { AnySetting, ExtensionSetting } from '@/setting/types';
 
-export type ChannelName = `${string}-channel`;
+export type ChannelName = string;
 
 export type ChannelSetting<N extends string = string> = ExtensionSetting<
   {

--- a/packages/api/src/channel/types.ts
+++ b/packages/api/src/channel/types.ts
@@ -5,13 +5,12 @@
  */
 
 import { AnySetting, ExtensionSetting } from '@/setting/types';
-import { HyphenToUnderscore } from '@/utils/types/extension';
 
 export type ChannelName = `${string}-channel`;
 
 export type ChannelSetting<N extends string = string> = ExtensionSetting<
   {
-    group: HyphenToUnderscore<N>;
+    group: N;
   },
   AnySetting,
   'id' | 'createdAt' | 'updatedAt' | 'group'

--- a/packages/api/src/chat/repositories/subscriber.repository.spec.ts
+++ b/packages/api/src/chat/repositories/subscriber.repository.spec.ts
@@ -95,7 +95,7 @@ describe('SubscriberRepository (TypeORM)', () => {
       language: 'en',
       country: 'FR',
       timezone: 0,
-      channel: { name: 'web-channel' },
+      channel: { name: 'web' },
       lastvisit: new Date(),
       retainedFrom: new Date(),
       labels: existingLabels.slice(0, 2).map(

--- a/packages/api/src/chat/types/channel.ts
+++ b/packages/api/src/chat/types/channel.ts
@@ -9,8 +9,8 @@ import { z } from 'zod';
 import { ChannelName } from '@/channel/types';
 
 // @todo : rename
-export type SubscriberChannelData<C extends ChannelName = 'unknown-channel'> =
-  C extends 'unknown-channel'
+export type SubscriberChannelData<C extends ChannelName = 'unknown'> =
+  C extends 'unknown'
     ? { name: ChannelName }
     : {
         name: C;
@@ -22,7 +22,7 @@ export type SubscriberChannelData<C extends ChannelName = 'unknown-channel'> =
       };
 
 export const channelDataSchema = z.looseObject({
-  name: z.string().regex(/-channel$/) as z.ZodType<ChannelName>,
+  name: z.string().min(1) as z.ZodType<ChannelName>,
 });
 
 export type Channel = z.infer<typeof channelDataSchema>;

--- a/packages/api/src/extension/cleanup.service.spec.ts
+++ b/packages/api/src/extension/cleanup.service.spec.ts
@@ -85,22 +85,30 @@ describe('CleanupService', () => {
   });
 
   describe('delete', () => {
-    it('should delete all the unregistered settings with a group suffix `-channel` or/and `-helper`', async () => {
-      const registeredGroups = [
-        ...cleanupService.getChannelGroups(),
-        ...cleanupService.getHelperGroups(),
-      ];
-      expect(registeredGroups).toContain('local-storage-helper');
+    it('should delete unregistered extension settings using subgroup markers and purge legacy suffixed groups', async () => {
+      const registeredChannels = cleanupService.getChannelGroups();
+      const registeredHelpers = cleanupService.getHelperGroups();
+      const legacySuffixPattern = /-(channel|helper)$/;
+
+      expect(registeredHelpers).toContain('local-storage');
 
       await cleanupService.pruneExtensionSettings();
       const cleanSettings = await settingService.findAll();
-      const filteredSettings = initialSettings.filter(
-        ({ group }) =>
-          !/-(channel|helper)$/.test(group) !==
-          registeredGroups.includes(
-            group as `${string}-channel` | `${string}-helper`,
-          ),
-      );
+      const filteredSettings = initialSettings.filter(({ group, subgroup }) => {
+        if (legacySuffixPattern.test(group)) {
+          return false;
+        }
+
+        if (subgroup === 'channel') {
+          return registeredChannels.includes(group as string);
+        }
+
+        if (subgroup === 'helper') {
+          return registeredHelpers.includes(group as string);
+        }
+
+        return true;
+      });
 
       expect(sortSettings(cleanSettings)).toEqualPayload(
         sortSettings(filteredSettings),

--- a/packages/api/src/extension/cleanup.service.spec.ts
+++ b/packages/api/src/extension/cleanup.service.spec.ts
@@ -85,20 +85,20 @@ describe('CleanupService', () => {
   });
 
   describe('delete', () => {
-    it('should delete all the unregistered settings with a group suffix `_channel` or/and `_helper`', async () => {
-      const registeredNamespaces = [
-        ...cleanupService.getChannelNamespaces(),
-        ...cleanupService.getHelperNamespaces(),
+    it('should delete all the unregistered settings with a group suffix `-channel` or/and `-helper`', async () => {
+      const registeredGroups = [
+        ...cleanupService.getChannelGroups(),
+        ...cleanupService.getHelperGroups(),
       ];
-      expect(registeredNamespaces).toContain('local_storage_helper');
+      expect(registeredGroups).toContain('local-storage-helper');
 
       await cleanupService.pruneExtensionSettings();
       const cleanSettings = await settingService.findAll();
       const filteredSettings = initialSettings.filter(
         ({ group }) =>
-          !/_(channel|helper)$/.test(group) !==
-          registeredNamespaces.includes(
-            group as `${string}_channel` | `${string}_helper`,
+          !/-(channel|helper)$/.test(group) !==
+          registeredGroups.includes(
+            group as `${string}-channel` | `${string}-helper`,
           ),
       );
 

--- a/packages/api/src/extension/cleanup.service.ts
+++ b/packages/api/src/extension/cleanup.service.ts
@@ -13,7 +13,7 @@ import { HelperService } from '@/helper/helper.service';
 import { LoggerService } from '@/logger/logger.service';
 import { SettingService } from '@/setting/services/setting.service';
 
-import { TCriteria, TExtractExtension, TExtractNamespace } from './types';
+import { TCriteria, TExtractGroup } from './types';
 
 @Injectable()
 export class CleanupService {
@@ -29,15 +29,15 @@ export class CleanupService {
    *
    * @param criteria - An array of criteria objects containing:
    *                   - suffix: Regex pattern to match setting groups
-   *                   - namespaces: Array of namespaces to exclude from deletion
+   *                   - groups: Array of groups to exclude from deletion
    * @returns A promise that resolves to the result of the deletion operation.
    */
-  private async deleteManyBySuffixAndNamespaces(
+  private async deleteManyBySuffixAndGroups(
     criteria: TCriteria[],
   ): Promise<DeleteResult> {
     const groupsToDelete = new Set<string>();
 
-    for (const { suffix, namespaces } of criteria) {
+    for (const { suffix, groups } of criteria) {
       const matchingSettings = await this.settingService.find({
         where: { group: Like(`%${suffix}`) },
       });
@@ -46,10 +46,10 @@ export class CleanupService {
         continue;
       }
 
-      const namespacesSet = new Set<string>(namespaces);
+      const groupsSet = new Set<string>(groups);
 
       matchingSettings.forEach(({ group }) => {
-        if (!namespacesSet.has(group)) {
+        if (!groupsSet.has(group)) {
           groupsToDelete.add(group);
         }
       });
@@ -65,25 +65,25 @@ export class CleanupService {
   }
 
   /**
-   * Retrieves a list of channel Namespaces.
+   * Retrieves a list of channel setting groups.
    *
-   * @returns An array of channel Namespaces.
+   * @returns An array of channel groups.
    */
-  public getChannelNamespaces(): TExtractNamespace<'channel'>[] {
+  public getChannelGroups(): TExtractGroup<'channel'>[] {
     return this.channelService
       .getAll()
-      .map((channel) => channel.getNamespace<TExtractExtension<'channel'>>());
+      .map((channel) => channel.getName() as TExtractGroup<'channel'>);
   }
 
   /**
-   * Retrieves a list of helper Namespaces.
+   * Retrieves a list of helper setting groups.
    *
-   * @returns An array of helper Namespaces.
+   * @returns An array of helper groups.
    */
-  public getHelperNamespaces(): TExtractNamespace<'helper'>[] {
+  public getHelperGroups(): TExtractGroup<'helper'>[] {
     return this.helperService
       .getAll()
-      .map((helper) => helper.getNamespace<TExtractExtension<'helper'>>());
+      .map((helper) => helper.getName() as TExtractGroup<'helper'>);
   }
 
   /**
@@ -91,11 +91,11 @@ export class CleanupService {
    *
    */
   public async pruneExtensionSettings(): Promise<void> {
-    const channels = this.getChannelNamespaces();
-    const helpers = this.getHelperNamespaces();
-    const { deletedCount } = await this.deleteManyBySuffixAndNamespaces([
-      { suffix: '_channel', namespaces: channels },
-      { suffix: '_helper', namespaces: helpers },
+    const channels = this.getChannelGroups();
+    const helpers = this.getHelperGroups();
+    const { deletedCount } = await this.deleteManyBySuffixAndGroups([
+      { suffix: '-channel', groups: channels },
+      { suffix: '-helper', groups: helpers },
     ]);
 
     if (deletedCount > 0) {

--- a/packages/api/src/extension/cleanup.service.ts
+++ b/packages/api/src/extension/cleanup.service.ts
@@ -5,7 +5,7 @@
  */
 
 import { Injectable } from '@nestjs/common';
-import { In, Like } from 'typeorm';
+import { In } from 'typeorm';
 import { DeleteResult } from 'typeorm/driver/mongodb/typings';
 
 import { ChannelService } from '@/channel/channel.service';
@@ -28,18 +28,18 @@ export class CleanupService {
    * Deletes unused settings with the specified criteria.
    *
    * @param criteria - An array of criteria objects containing:
-   *                   - suffix: Regex pattern to match setting groups
+   *                   - extensionType: Extension type marker stored in setting subgroup
    *                   - groups: Array of groups to exclude from deletion
    * @returns A promise that resolves to the result of the deletion operation.
    */
-  private async deleteManyBySuffixAndGroups(
+  private async deleteManyBySubgroupAndGroups(
     criteria: TCriteria[],
   ): Promise<DeleteResult> {
     const groupsToDelete = new Set<string>();
 
-    for (const { suffix, groups } of criteria) {
+    for (const { extensionType, groups } of criteria) {
       const matchingSettings = await this.settingService.find({
-        where: { group: Like(`%${suffix}`) },
+        where: { subgroup: extensionType },
       });
 
       if (!matchingSettings.length) {
@@ -93,9 +93,9 @@ export class CleanupService {
   public async pruneExtensionSettings(): Promise<void> {
     const channels = this.getChannelGroups();
     const helpers = this.getHelperGroups();
-    const { deletedCount } = await this.deleteManyBySuffixAndGroups([
-      { suffix: '-channel', groups: channels },
-      { suffix: '-helper', groups: helpers },
+    const { deletedCount } = await this.deleteManyBySubgroupAndGroups([
+      { extensionType: 'channel', groups: channels },
+      { extensionType: 'helper', groups: helpers },
     ]);
 
     if (deletedCount > 0) {

--- a/packages/api/src/extension/types.ts
+++ b/packages/api/src/extension/types.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { ExtensionName, HyphenToUnderscore } from '@/utils/types/extension';
+import { ExtensionName } from '@/utils/types/extension';
 
 export type TExtensionName = Extract<ExtensionName, `${string}-${string}`>;
 
@@ -12,19 +12,14 @@ export type TExtension = TExtensionName extends `${string}-${infer S}`
   ? `${S}`
   : never;
 
-export type TNamespace = HyphenToUnderscore<TExtensionName>;
+export type TExtensionGroup = TExtensionName;
 
-export type TExtractNamespace<
-  T extends TExtension = TExtension,
-  M extends TExtensionName = TExtensionName,
-> = M extends `${string}${T}` ? HyphenToUnderscore<M> : never;
-
-export type TExtractExtension<
+export type TExtractGroup<
   T extends TExtension = TExtension,
   M extends TExtensionName = TExtensionName,
 > = M extends `${string}${T}` ? M : never;
 
 export type TCriteria = {
-  suffix: `_${TExtension}`;
-  namespaces: TNamespace[];
+  suffix: `-${TExtension}`;
+  groups: TExtensionGroup[];
 };

--- a/packages/api/src/extension/types.ts
+++ b/packages/api/src/extension/types.ts
@@ -4,22 +4,16 @@
  * Full terms: see LICENSE.md.
  */
 
-import { ExtensionName } from '@/utils/types/extension';
+import { ChannelName } from '@/channel/types';
+import { HelperName } from '@/helper/types';
 
-export type TExtensionName = Extract<ExtensionName, `${string}-${string}`>;
+export type TExtension = 'channel' | 'helper';
 
-export type TExtension = TExtensionName extends `${string}-${infer S}`
-  ? `${S}`
-  : never;
+export type TExtractGroup<T extends TExtension> = T extends 'channel'
+  ? ChannelName
+  : HelperName;
 
-export type TExtensionGroup = TExtensionName;
-
-export type TExtractGroup<
-  T extends TExtension = TExtension,
-  M extends TExtensionName = TExtensionName,
-> = M extends `${string}${T}` ? M : never;
-
-export type TCriteria = {
-  suffix: `-${TExtension}`;
-  groups: TExtensionGroup[];
+export type TCriteria<T extends TExtension = TExtension> = {
+  extensionType: T;
+  groups: TExtractGroup<T>[];
 };

--- a/packages/api/src/extensions/channels/console/console-channel.settings.ts
+++ b/packages/api/src/extensions/channels/console/console-channel.settings.ts
@@ -11,7 +11,7 @@ import { config } from '@/config';
 import { createSettingGroup } from '@/setting/create-setting-group';
 import { buildSettingSeedsFromSchema } from '@/setting/runtime-settings.seed';
 
-export const CONSOLE_CHANNEL_NAME = 'console-channel' as const;
+export const CONSOLE_CHANNEL_NAME = 'console' as const;
 
 const CONSOLE_ALLOWED_UPLOAD_TYPES =
   'audio/mpeg,audio/x-ms-wma,audio/vnd.rn-realaudio,audio/x-wav,image/gif,image/jpeg,image/png,image/tiff,image/vnd.microsoft.icon,image/vnd.djvu,image/svg+xml,text/css,text/csv,text/html,text/plain,text/xml,video/mpeg,video/mp4,video/quicktime,video/x-ms-wmv,video/x-msvideo,video/x-flv,video/web,application/msword,application/vnd.ms-powerpoint,application/pdf,application/vnd.ms-excel,application/vnd.oasis.opendocument.presentation,application/vnd.oasis.opendocument.tex,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.graphics,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
@@ -92,6 +92,9 @@ export const ConsoleChannelSettingsGroup = createSettingGroup({
 export const CONSOLE_CHANNEL_SETTINGS = buildSettingSeedsFromSchema(
   CONSOLE_CHANNEL_NAME,
   CONSOLE_CHANNEL_SETTINGS_SCHEMA,
+  {
+    subgroup: 'channel',
+  },
 ) as ChannelSetting<typeof CONSOLE_CHANNEL_NAME>[];
 
 export default ConsoleChannelSettingsGroup;

--- a/packages/api/src/extensions/channels/console/console-channel.settings.ts
+++ b/packages/api/src/extensions/channels/console/console-channel.settings.ts
@@ -13,8 +13,6 @@ import { buildSettingSeedsFromSchema } from '@/setting/runtime-settings.seed';
 
 export const CONSOLE_CHANNEL_NAME = 'console-channel' as const;
 
-export const CONSOLE_CHANNEL_NAMESPACE = 'console_channel' as const;
-
 const CONSOLE_ALLOWED_UPLOAD_TYPES =
   'audio/mpeg,audio/x-ms-wma,audio/vnd.rn-realaudio,audio/x-wav,image/gif,image/jpeg,image/png,image/tiff,image/vnd.microsoft.icon,image/vnd.djvu,image/svg+xml,text/css,text/csv,text/html,text/plain,text/xml,video/mpeg,video/mp4,video/quicktime,video/x-ms-wmv,video/x-msvideo,video/x-flv,video/web,application/msword,application/vnd.ms-powerpoint,application/pdf,application/vnd.ms-excel,application/vnd.oasis.opendocument.presentation,application/vnd.oasis.opendocument.tex,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.graphics,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 
@@ -79,12 +77,12 @@ export const CONSOLE_CHANNEL_SETTINGS_SCHEMA = z
 
 declare global {
   interface RuntimeSettingRegistry {
-    [CONSOLE_CHANNEL_NAMESPACE]: typeof CONSOLE_CHANNEL_SETTINGS_SCHEMA;
+    [CONSOLE_CHANNEL_NAME]: typeof CONSOLE_CHANNEL_SETTINGS_SCHEMA;
   }
 }
 
 export const ConsoleChannelSettingsGroup = createSettingGroup({
-  group: CONSOLE_CHANNEL_NAMESPACE,
+  group: CONSOLE_CHANNEL_NAME,
   schema: CONSOLE_CHANNEL_SETTINGS_SCHEMA,
   scope: 'extension',
   extensionType: 'channel',
@@ -92,7 +90,7 @@ export const ConsoleChannelSettingsGroup = createSettingGroup({
 });
 
 export const CONSOLE_CHANNEL_SETTINGS = buildSettingSeedsFromSchema(
-  CONSOLE_CHANNEL_NAMESPACE,
+  CONSOLE_CHANNEL_NAME,
   CONSOLE_CHANNEL_SETTINGS_SCHEMA,
 ) as ChannelSetting<typeof CONSOLE_CHANNEL_NAME>[];
 

--- a/packages/api/src/extensions/channels/console/globals.d.ts
+++ b/packages/api/src/extensions/channels/console/globals.d.ts
@@ -6,7 +6,6 @@
 
 import {
   CONSOLE_CHANNEL_NAME,
-  CONSOLE_CHANNEL_NAMESPACE,
   CONSOLE_CHANNEL_SETTINGS_SCHEMA,
 } from './console-channel.settings';
 
@@ -22,7 +21,7 @@ declare global {
 
 declare module '@nestjs/event-emitter' {
   interface IHookExtensionsOperationMap {
-    [CONSOLE_CHANNEL_NAMESPACE]: TDefinition<
+    [CONSOLE_CHANNEL_NAME]: TDefinition<
       object,
       SettingMapByType<typeof CONSOLE_CHANNEL_SETTINGS_SCHEMA>
     >;

--- a/packages/api/src/extensions/channels/console/i18n/en.translations.json
+++ b/packages/api/src/extensions/channels/console/i18n/en.translations.json
@@ -1,5 +1,5 @@
 {
-  "console_channel": {
+  "console-channel": {
     "Admin Chat Console": "Admin Chat Console",
     "Allowed domains": "Allowed domains",
     "Comma-separated list of allowed CORS origins.": "Comma-separated list of allowed CORS origins.",

--- a/packages/api/src/extensions/channels/console/i18n/en.translations.json
+++ b/packages/api/src/extensions/channels/console/i18n/en.translations.json
@@ -1,5 +1,5 @@
 {
-  "console-channel": {
+  "console": {
     "Admin Chat Console": "Admin Chat Console",
     "Allowed domains": "Allowed domains",
     "Comma-separated list of allowed CORS origins.": "Comma-separated list of allowed CORS origins.",

--- a/packages/api/src/extensions/channels/console/i18n/fr.translations.json
+++ b/packages/api/src/extensions/channels/console/i18n/fr.translations.json
@@ -1,5 +1,5 @@
 {
-  "console-channel": {
+  "console": {
     "Admin Chat Console": "Testeur Live Chat",
     "Allowed domains": "Domaines autorisés",
     "Comma-separated list of allowed CORS origins.": "Liste séparée par des virgules des origines CORS autorisées.",

--- a/packages/api/src/extensions/channels/console/i18n/fr.translations.json
+++ b/packages/api/src/extensions/channels/console/i18n/fr.translations.json
@@ -1,5 +1,5 @@
 {
-  "console_channel": {
+  "console-channel": {
     "Admin Chat Console": "Testeur Live Chat",
     "Allowed domains": "Domaines autorisés",
     "Comma-separated list of allowed CORS origins.": "Liste séparée par des virgules des origines CORS autorisées.",

--- a/packages/api/src/extensions/channels/web/__test__/index.spec.ts
+++ b/packages/api/src/extensions/channels/web/__test__/index.spec.ts
@@ -104,7 +104,7 @@ describe('WebChannelHandler', () => {
 
   it('should have correct name', () => {
     expect(handler).toBeDefined();
-    expect(handler.getName()).toEqual('web-channel');
+    expect(handler.getName()).toEqual('web');
   });
 
   it('should allow the request if the origin is in the allowed domains', async () => {
@@ -240,7 +240,7 @@ describe('WebChannelHandler', () => {
       assignedAt: null,
       assignedTo: null,
       channel: {
-        name: 'web-channel',
+        name: 'web',
         data: {
           agent: req.headers['user-agent'],
           isSocket: false,

--- a/packages/api/src/extensions/channels/web/base-web-channel.ts
+++ b/packages/api/src/extensions/channels/web/base-web-channel.ts
@@ -69,10 +69,7 @@ import {
   WebOutboundMessageEncoder,
 } from './outbound';
 import { Web } from './types';
-import {
-  WEB_CHANNEL_NAME,
-  WEB_CHANNEL_NAMESPACE,
-} from './web-channel.settings';
+import { WEB_CHANNEL_NAME } from './web-channel.settings';
 
 // Handle multipart uploads (Long Pooling only)
 const upload = multer({
@@ -471,7 +468,7 @@ export default abstract class BaseWebChannelHandler<N extends ChannelName>
       throw new Error('CORS - Invalid origin!');
     }
 
-    const settings = await this.getSettings<typeof WEB_CHANNEL_NAMESPACE>();
+    const settings = await this.getSettings<typeof WEB_CHANNEL_NAME>();
     // Get the allowed origins
     const origins: string[] = settings.allowed_domains.split(',');
     const foundOrigin = origins

--- a/packages/api/src/extensions/channels/web/globals.d.ts
+++ b/packages/api/src/extensions/channels/web/globals.d.ts
@@ -6,7 +6,6 @@
 
 import {
   WEB_CHANNEL_NAME,
-  WEB_CHANNEL_NAMESPACE,
   WEB_CHANNEL_SETTINGS_SCHEMA,
 } from './web-channel.settings';
 
@@ -22,7 +21,7 @@ declare global {
 
 declare module '@nestjs/event-emitter' {
   interface IHookExtensionsOperationMap {
-    [WEB_CHANNEL_NAMESPACE]: TDefinition<
+    [WEB_CHANNEL_NAME]: TDefinition<
       object,
       SettingMapByType<typeof WEB_CHANNEL_SETTINGS_SCHEMA>
     >;

--- a/packages/api/src/extensions/channels/web/i18n/en.translations.json
+++ b/packages/api/src/extensions/channels/web/i18n/en.translations.json
@@ -1,5 +1,5 @@
 {
-  "web-channel": {
+  "web": {
     "Web Channel": "Web Channel",
     "Allowed domains": "Allowed domains",
     "Comma-separated list of allowed CORS origins.": "Comma-separated list of allowed CORS origins.",

--- a/packages/api/src/extensions/channels/web/i18n/en.translations.json
+++ b/packages/api/src/extensions/channels/web/i18n/en.translations.json
@@ -1,5 +1,5 @@
 {
-  "web_channel": {
+  "web-channel": {
     "Web Channel": "Web Channel",
     "Allowed domains": "Allowed domains",
     "Comma-separated list of allowed CORS origins.": "Comma-separated list of allowed CORS origins.",

--- a/packages/api/src/extensions/channels/web/i18n/fr.translations.json
+++ b/packages/api/src/extensions/channels/web/i18n/fr.translations.json
@@ -1,5 +1,5 @@
 {
-  "web-channel": {
+  "web": {
     "Web Channel": "Canal Web",
     "Allowed domains": "Domaines autorisés",
     "Comma-separated list of allowed CORS origins.": "Liste séparée par des virgules des origines CORS autorisées.",

--- a/packages/api/src/extensions/channels/web/i18n/fr.translations.json
+++ b/packages/api/src/extensions/channels/web/i18n/fr.translations.json
@@ -1,5 +1,5 @@
 {
-  "web_channel": {
+  "web-channel": {
     "Web Channel": "Canal Web",
     "Allowed domains": "Domaines autorisés",
     "Comma-separated list of allowed CORS origins.": "Liste séparée par des virgules des origines CORS autorisées.",

--- a/packages/api/src/extensions/channels/web/web-channel.settings.ts
+++ b/packages/api/src/extensions/channels/web/web-channel.settings.ts
@@ -11,7 +11,7 @@ import { config } from '@/config';
 import { createSettingGroup } from '@/setting/create-setting-group';
 import { buildSettingSeedsFromSchema } from '@/setting/runtime-settings.seed';
 
-export const WEB_CHANNEL_NAME = 'web-channel' as const;
+export const WEB_CHANNEL_NAME = 'web' as const;
 
 const WEB_ALLOWED_UPLOAD_TYPES =
   'audio/mpeg,audio/x-ms-wma,audio/vnd.rn-realaudio,audio/x-wav,image/gif,image/jpeg,image/png,image/tiff,image/vnd.microsoft.icon,image/vnd.djvu,image/svg+xml,text/css,text/csv,text/html,text/plain,text/xml,video/mpeg,video/mp4,video/quicktime,video/x-ms-wmv,video/x-msvideo,video/x-flv,video/web,application/msword,application/vnd.ms-powerpoint,application/pdf,application/vnd.ms-excel,application/vnd.oasis.opendocument.presentation,application/vnd.oasis.opendocument.tex,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.graphics,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
@@ -97,6 +97,9 @@ export const WebChannelSettingsGroup = createSettingGroup({
 export const WEB_CHANNEL_SETTINGS = buildSettingSeedsFromSchema(
   WEB_CHANNEL_NAME,
   WEB_CHANNEL_SETTINGS_SCHEMA,
+  {
+    subgroup: 'channel',
+  },
 ) as ChannelSetting<typeof WEB_CHANNEL_NAME>[];
 
 export default WebChannelSettingsGroup;

--- a/packages/api/src/extensions/channels/web/web-channel.settings.ts
+++ b/packages/api/src/extensions/channels/web/web-channel.settings.ts
@@ -13,8 +13,6 @@ import { buildSettingSeedsFromSchema } from '@/setting/runtime-settings.seed';
 
 export const WEB_CHANNEL_NAME = 'web-channel' as const;
 
-export const WEB_CHANNEL_NAMESPACE = 'web_channel' as const;
-
 const WEB_ALLOWED_UPLOAD_TYPES =
   'audio/mpeg,audio/x-ms-wma,audio/vnd.rn-realaudio,audio/x-wav,image/gif,image/jpeg,image/png,image/tiff,image/vnd.microsoft.icon,image/vnd.djvu,image/svg+xml,text/css,text/csv,text/html,text/plain,text/xml,video/mpeg,video/mp4,video/quicktime,video/x-ms-wmv,video/x-msvideo,video/x-flv,video/web,application/msword,application/vnd.ms-powerpoint,application/pdf,application/vnd.ms-excel,application/vnd.oasis.opendocument.presentation,application/vnd.oasis.opendocument.tex,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.graphics,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 
@@ -84,12 +82,12 @@ export const WEB_CHANNEL_SETTINGS_SCHEMA = z
 
 declare global {
   interface RuntimeSettingRegistry {
-    [WEB_CHANNEL_NAMESPACE]: typeof WEB_CHANNEL_SETTINGS_SCHEMA;
+    [WEB_CHANNEL_NAME]: typeof WEB_CHANNEL_SETTINGS_SCHEMA;
   }
 }
 
 export const WebChannelSettingsGroup = createSettingGroup({
-  group: WEB_CHANNEL_NAMESPACE,
+  group: WEB_CHANNEL_NAME,
   schema: WEB_CHANNEL_SETTINGS_SCHEMA,
   scope: 'extension',
   extensionType: 'channel',
@@ -97,7 +95,7 @@ export const WebChannelSettingsGroup = createSettingGroup({
 });
 
 export const WEB_CHANNEL_SETTINGS = buildSettingSeedsFromSchema(
-  WEB_CHANNEL_NAMESPACE,
+  WEB_CHANNEL_NAME,
   WEB_CHANNEL_SETTINGS_SCHEMA,
 ) as ChannelSetting<typeof WEB_CHANNEL_NAME>[];
 

--- a/packages/api/src/extensions/helpers/local-storage/i18n/en.translations.json
+++ b/packages/api/src/extensions/helpers/local-storage/i18n/en.translations.json
@@ -1,5 +1,5 @@
 {
-  "local-storage-helper": {
+  "local-storage": {
     "Local Storage": "Local Storage",
     "Local storage helper": "Local storage helper"
   }

--- a/packages/api/src/extensions/helpers/local-storage/i18n/en.translations.json
+++ b/packages/api/src/extensions/helpers/local-storage/i18n/en.translations.json
@@ -1,5 +1,5 @@
 {
-  "local_storage_helper": {
+  "local-storage-helper": {
     "Local Storage": "Local Storage",
     "Local storage helper": "Local storage helper"
   }

--- a/packages/api/src/extensions/helpers/local-storage/i18n/fr.translations.json
+++ b/packages/api/src/extensions/helpers/local-storage/i18n/fr.translations.json
@@ -1,5 +1,5 @@
 {
-  "local_storage_helper": {
+  "local-storage-helper": {
     "Local Storage": "Stockage local",
     "Local storage helper": "Helper de stockage local"
   }

--- a/packages/api/src/extensions/helpers/local-storage/i18n/fr.translations.json
+++ b/packages/api/src/extensions/helpers/local-storage/i18n/fr.translations.json
@@ -1,5 +1,5 @@
 {
-  "local-storage-helper": {
+  "local-storage": {
     "Local Storage": "Stockage local",
     "Local storage helper": "Helper de stockage local"
   }

--- a/packages/api/src/extensions/helpers/local-storage/index.helper.ts
+++ b/packages/api/src/extensions/helpers/local-storage/index.helper.ts
@@ -33,8 +33,6 @@ import { BaseStorageHelper } from '@/helper/lib/base-storage-helper';
 
 export const LOCAL_STORAGE_HELPER_NAME = 'local-storage-helper' as const;
 
-export const LOCAL_STORAGE_HELPER_NAMESPACE = 'local_storage_helper' as const;
-
 @Injectable()
 export default class LocalStorageHelper
   extends BaseStorageHelper<typeof LOCAL_STORAGE_HELPER_NAME>

--- a/packages/api/src/extensions/helpers/local-storage/index.helper.ts
+++ b/packages/api/src/extensions/helpers/local-storage/index.helper.ts
@@ -31,7 +31,7 @@ import {
 import { config } from '@/config';
 import { BaseStorageHelper } from '@/helper/lib/base-storage-helper';
 
-export const LOCAL_STORAGE_HELPER_NAME = 'local-storage-helper' as const;
+export const LOCAL_STORAGE_HELPER_NAME = 'local-storage' as const;
 
 @Injectable()
 export default class LocalStorageHelper

--- a/packages/api/src/helper/helper.controller.spec.ts
+++ b/packages/api/src/helper/helper.controller.spec.ts
@@ -27,14 +27,14 @@ describe('HelperController', () => {
   it('maps legacy nlu type to llm', () => {
     helperService.getAllByType.mockReturnValue([
       {
-        getName: () => 'llm-helper',
+        getName: () => 'llm',
       } as any,
     ]);
 
     const result = controller.getHelpers('nlu');
 
     expect(helperService.getAllByType).toHaveBeenCalledWith(HelperType.LLM);
-    expect(result).toEqual([{ name: 'llm-helper' }]);
+    expect(result).toEqual([{ name: 'llm' }]);
   });
 
   it('throws for unknown helper type', () => {

--- a/packages/api/src/helper/lib/__test__/settings.ts
+++ b/packages/api/src/helper/lib/__test__/settings.ts
@@ -6,7 +6,7 @@
 
 import { HelperSetting } from '@/helper/types';
 
-export const TEST_HELPER_NAME = 'test-helper';
+export const TEST_HELPER_NAME = 'test';
 
 export default [
   {

--- a/packages/api/src/helper/lib/__test__/settings.ts
+++ b/packages/api/src/helper/lib/__test__/settings.ts
@@ -8,11 +8,9 @@ import { HelperSetting } from '@/helper/types';
 
 export const TEST_HELPER_NAME = 'test-helper';
 
-export const TEST_HELPER_NAMESPACE = 'test_helper';
-
 export default [
   {
-    group: TEST_HELPER_NAMESPACE,
+    group: TEST_HELPER_NAME,
     label: 'test',
     value: 'test',
   },

--- a/packages/api/src/helper/lib/base-helper.ts
+++ b/packages/api/src/helper/lib/base-helper.ts
@@ -8,7 +8,6 @@ import { Inject, OnModuleInit } from '@nestjs/common';
 
 import { SettingService } from '@/setting/services/setting.service';
 import { Extension } from '@/utils/generics/extension';
-import { HyphenToUnderscore } from '@/utils/types/extension';
 
 import { HelperService } from '../helper.service';
 import { HelperName, HelperType } from '../types';
@@ -48,10 +47,10 @@ export default abstract class BaseHelper<N extends HelperName = HelperName>
    *
    * @returns Helper's settings
    */
-  async getSettings<S extends string = HyphenToUnderscore<N>>() {
+  async getSettings<S extends string = N>() {
     const settings = await this.settingService.getSettings();
 
     // @ts-expect-error workaround typing
-    return settings[this.getNamespace() as keyof Settings] as Settings[S];
+    return settings[this.getName() as keyof Settings] as Settings[S];
   }
 }

--- a/packages/api/src/helper/types.ts
+++ b/packages/api/src/helper/types.ts
@@ -70,7 +70,7 @@ export enum HelperType {
   UTIL = 'util',
 }
 
-export type HelperName = `${string}-helper`;
+export type HelperName = string;
 
 interface HelperTypeMap {
   [HelperType.LLM]: BaseLlmHelper<HelperName>;

--- a/packages/api/src/helper/types.ts
+++ b/packages/api/src/helper/types.ts
@@ -5,7 +5,6 @@
  */
 
 import { AnySetting, ExtensionSetting } from '@/setting/types';
-import { HyphenToUnderscore } from '@/utils/types/extension';
 
 import BaseHelper from './lib/base-helper';
 import { BaseLlmHelper } from './lib/base-llm-helper';
@@ -88,7 +87,7 @@ export type HelperRegistry<H extends BaseHelper = BaseHelper> = Map<
 
 export type HelperSetting<N extends HelperName = HelperName> = ExtensionSetting<
   {
-    group: HyphenToUnderscore<N>;
+    group: N;
   },
   AnySetting,
   'id' | 'createdAt' | 'updatedAt' | 'group'

--- a/packages/api/src/i18n/loaders/extension-json.loader.spec.ts
+++ b/packages/api/src/i18n/loaders/extension-json.loader.spec.ts
@@ -71,13 +71,13 @@ describe('ExtensionJsonLoader', () => {
     await writeJsonFile(
       path.join(helpersPath, 'local-storage', 'i18n', 'en.translations.json'),
       {
-        local_storage_helper: { 'Local Storage': 'Local Storage' },
+        'local-storage-helper': { 'Local Storage': 'Local Storage' },
       },
     );
     await writeJsonFile(
       path.join(channelsPath, 'web', 'i18n', 'en.translations.json'),
       {
-        web_channel: { 'Web Channel': 'Web Channel' },
+        'web-channel': { 'Web Channel': 'Web Channel' },
       },
     );
 
@@ -93,8 +93,8 @@ describe('ExtensionJsonLoader', () => {
         messages: { hello: 'Hello' },
         http_request: { 'Request URL': 'Request URL' },
         send_text_message: { 'Message to send': 'Message to send' },
-        local_storage_helper: { 'Local Storage': 'Local Storage' },
-        web_channel: { 'Web Channel': 'Web Channel' },
+        'local-storage-helper': { 'Local Storage': 'Local Storage' },
+        'web-channel': { 'Web Channel': 'Web Channel' },
       },
       fr: {
         messages: { hello: 'Bonjour' },

--- a/packages/api/src/i18n/loaders/extension-json.loader.spec.ts
+++ b/packages/api/src/i18n/loaders/extension-json.loader.spec.ts
@@ -71,13 +71,13 @@ describe('ExtensionJsonLoader', () => {
     await writeJsonFile(
       path.join(helpersPath, 'local-storage', 'i18n', 'en.translations.json'),
       {
-        'local-storage-helper': { 'Local Storage': 'Local Storage' },
+        'local-storage': { 'Local Storage': 'Local Storage' },
       },
     );
     await writeJsonFile(
       path.join(channelsPath, 'web', 'i18n', 'en.translations.json'),
       {
-        'web-channel': { 'Web Channel': 'Web Channel' },
+        web: { 'Web Channel': 'Web Channel' },
       },
     );
 
@@ -93,8 +93,8 @@ describe('ExtensionJsonLoader', () => {
         messages: { hello: 'Hello' },
         http_request: { 'Request URL': 'Request URL' },
         send_text_message: { 'Message to send': 'Message to send' },
-        'local-storage-helper': { 'Local Storage': 'Local Storage' },
-        'web-channel': { 'Web Channel': 'Web Channel' },
+        'local-storage': { 'Local Storage': 'Local Storage' },
+        web: { 'Web Channel': 'Web Channel' },
       },
       fr: {
         messages: { hello: 'Bonjour' },

--- a/packages/api/src/i18n/localize-schema-metadata.spec.ts
+++ b/packages/api/src/i18n/localize-schema-metadata.spec.ts
@@ -107,7 +107,7 @@ describe('localizeSchemaMetadata', () => {
     const schemaSnapshot = JSON.parse(JSON.stringify(schema)) as typeof schema;
     const localized = localizeSchemaMetadata(schema, {
       i18n,
-      ns: 'web-channel',
+      ns: 'web',
     });
 
     expect(schema).toEqual(schemaSnapshot);

--- a/packages/api/src/i18n/localize-schema-metadata.spec.ts
+++ b/packages/api/src/i18n/localize-schema-metadata.spec.ts
@@ -107,7 +107,7 @@ describe('localizeSchemaMetadata', () => {
     const schemaSnapshot = JSON.parse(JSON.stringify(schema)) as typeof schema;
     const localized = localizeSchemaMetadata(schema, {
       i18n,
-      ns: 'web_channel',
+      ns: 'web-channel',
     });
 
     expect(schema).toEqual(schemaSnapshot);

--- a/packages/api/src/setting/controllers/setting.controller.spec.ts
+++ b/packages/api/src/setting/controllers/setting.controller.spec.ts
@@ -28,7 +28,7 @@ import { SettingController } from './setting.controller';
 
 const expectedSettings = settingFixtures.map((setting) => ({
   ...setting,
-  subgroup: null,
+  subgroup: setting.subgroup || null,
 }));
 
 describe('SettingController', () => {

--- a/packages/api/src/setting/default.settings.ts
+++ b/packages/api/src/setting/default.settings.ts
@@ -25,7 +25,7 @@ export const chatbotSettingsSchema = z
     }),
     default_nlu_helper: z
       .string()
-      .default('llm-nlu-helper')
+      .default('llm-nlu')
       .meta({
         title: 'Default NLU helper',
         description: 'Helper used by default to run NLU tasks.',
@@ -51,7 +51,7 @@ export const chatbotSettingsSchema = z
       }),
     default_llm_helper: z
       .string()
-      .default('ollama-helper')
+      .default('ollama')
       .meta({
         title: 'Default LLM helper',
         description: 'Helper used by default for LLM generation tasks.',
@@ -64,7 +64,7 @@ export const chatbotSettingsSchema = z
       }),
     default_storage_helper: z
       .string()
-      .default('local-storage-helper')
+      .default('local-storage')
       .meta({
         title: 'Default storage helper',
         description: 'Helper used to persist chatbot data by default.',

--- a/packages/api/src/setting/runtime-settings.seed.spec.ts
+++ b/packages/api/src/setting/runtime-settings.seed.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import z from 'zod';
+
+import { RuntimeSettingRegistryMap } from '@/setting/services/runtime-settings.service';
+
+import {
+  buildSettingSeedsFromRegistry,
+  buildSettingSeedsFromSchema,
+} from './runtime-settings.seed';
+
+describe('runtime-settings.seed', () => {
+  it('adds subgroup marker when provided to schema seed builder', () => {
+    const schema = z.strictObject({
+      enabled: z.boolean().default(true),
+    });
+
+    expect(
+      buildSettingSeedsFromSchema('web', schema, { subgroup: 'channel' }),
+    ).toEqual([
+      {
+        group: 'web',
+        subgroup: 'channel',
+        label: 'enabled',
+        value: true,
+      },
+    ]);
+  });
+
+  it('adds subgroup marker for channel/helper extension groups from runtime registry', () => {
+    const registry: RuntimeSettingRegistryMap = {
+      web: {
+        schema: z.strictObject({
+          enabled: z.boolean().default(true),
+        }),
+        scope: 'extension',
+        extensionType: 'channel',
+        extensionName: 'web',
+      },
+      ollama: {
+        schema: z.strictObject({
+          base_url: z.string().default('http://localhost:11434'),
+        }),
+        scope: 'extension',
+        extensionType: 'helper',
+        extensionName: 'ollama',
+      },
+      ai_generate_text: {
+        schema: z.strictObject({
+          model: z.string().default('gpt-4.1-mini'),
+        }),
+        scope: 'extension',
+        extensionType: 'action',
+        extensionName: 'ai_generate_text',
+      },
+      chatbot_settings: {
+        schema: z.strictObject({
+          global_fallback: z.boolean().default(true),
+        }),
+        scope: 'global',
+      },
+    };
+    const seeds = buildSettingSeedsFromRegistry(registry);
+    const webSeed = seeds.find(
+      (seed) => seed.group === 'web' && seed.label === 'enabled',
+    );
+    const ollamaSeed = seeds.find(
+      (seed) => seed.group === 'ollama' && seed.label === 'base_url',
+    );
+    const actionSeed = seeds.find(
+      (seed) => seed.group === 'ai_generate_text' && seed.label === 'model',
+    );
+    const globalSeed = seeds.find(
+      (seed) =>
+        seed.group === 'chatbot_settings' && seed.label === 'global_fallback',
+    );
+
+    expect(webSeed).toEqual({
+      group: 'web',
+      subgroup: 'channel',
+      label: 'enabled',
+      value: true,
+    });
+    expect(ollamaSeed).toEqual({
+      group: 'ollama',
+      subgroup: 'helper',
+      label: 'base_url',
+      value: 'http://localhost:11434',
+    });
+    expect(actionSeed).toEqual({
+      group: 'ai_generate_text',
+      label: 'model',
+      value: 'gpt-4.1-mini',
+    });
+    expect(globalSeed).toEqual({
+      group: 'chatbot_settings',
+      label: 'global_fallback',
+      value: true,
+    });
+  });
+});

--- a/packages/api/src/setting/runtime-settings.seed.ts
+++ b/packages/api/src/setting/runtime-settings.seed.ts
@@ -46,9 +46,14 @@ const resolveGroupDefaultValues = (
   return parsed.data;
 };
 
+type BuildSettingSeedsFromSchemaOptions = {
+  subgroup?: string;
+};
+
 export const buildSettingSeedsFromSchema = (
   group: string,
   schema: RuntimeSettingGroupSchema,
+  options?: BuildSettingSeedsFromSchemaOptions,
 ): SettingCreateDto[] => {
   const defaults = resolveGroupDefaultValues(schema, group);
 
@@ -61,6 +66,7 @@ export const buildSettingSeedsFromSchema = (
 
     return {
       group,
+      ...(options?.subgroup ? { subgroup: options.subgroup } : {}),
       label,
       value,
     };
@@ -71,9 +77,17 @@ export const buildSettingSeedsFromRegistry = (
   registry: RuntimeSettingRegistryMap,
 ): SettingCreateDto[] => {
   return Object.entries(registry).flatMap(([group, definition]) => {
+    const subgroup =
+      definition.scope === 'extension' &&
+      (definition.extensionType === 'channel' ||
+        definition.extensionType === 'helper')
+        ? definition.extensionType
+        : undefined;
+
     return buildSettingSeedsFromSchema(
       group,
       definition.schema as RuntimeSettingGroupSchema,
+      subgroup ? { subgroup } : undefined,
     );
   });
 };

--- a/packages/api/src/setting/services/runtime-settings.service.spec.ts
+++ b/packages/api/src/setting/services/runtime-settings.service.spec.ts
@@ -55,7 +55,7 @@ describe('RuntimeSettingsService', () => {
       schema,
       scope: 'extension',
       extensionType: 'channel',
-      extensionName: 'test-channel',
+      extensionName: 'test',
     });
 
     const fieldSchema = runtimeSettingsService.getSchemaFor(group, 'enabled');
@@ -66,7 +66,7 @@ describe('RuntimeSettingsService', () => {
     expect(definitions[group]).toBeDefined();
     expect(definitions[group]?.scope).toBe('extension');
     expect(definitions[group]?.extensionType).toBe('channel');
-    expect(definitions[group]?.extensionName).toBe('test-channel');
+    expect(definitions[group]?.extensionName).toBe('test');
     expect(definitions[group]?.schema.$schema).toBe(
       'http://json-schema.org/draft-07/schema#',
     );
@@ -164,7 +164,7 @@ describe('RuntimeSettingsService', () => {
       schema: customSchema,
       scope: 'extension',
       extensionType: 'helper',
-      extensionName: 'test-helper',
+      extensionName: 'test',
     });
 
     moduleRef = await Test.createTestingModule({
@@ -183,7 +183,7 @@ describe('RuntimeSettingsService', () => {
     expect(definitions[customGroup]).toBeDefined();
     expect(definitions[customGroup]?.scope).toBe('extension');
     expect(definitions[customGroup]?.extensionType).toBe('helper');
-    expect(definitions[customGroup]?.extensionName).toBe('test-helper');
+    expect(definitions[customGroup]?.extensionName).toBe('test');
     expect(definitions[customGroup]?.schema.$schema).toBe(
       'http://json-schema.org/draft-07/schema#',
     );

--- a/packages/api/src/utils/generics/extension.ts
+++ b/packages/api/src/utils/generics/extension.ts
@@ -8,7 +8,7 @@ import { Inject, OnModuleInit } from '@nestjs/common';
 
 import { LoggerService } from '@/logger/logger.service';
 
-import { ExtensionName, HyphenToUnderscore } from '../types/extension';
+import { ExtensionName } from '../types/extension';
 
 export abstract class Extension implements OnModuleInit {
   @Inject(LoggerService)
@@ -18,10 +18,6 @@ export abstract class Extension implements OnModuleInit {
 
   getName() {
     return this.name;
-  }
-
-  getNamespace<N extends ExtensionName = ExtensionName>() {
-    return this.name.replaceAll('-', '_') as HyphenToUnderscore<N>;
   }
 
   async onModuleInit() {}

--- a/packages/api/src/utils/test/fixtures/attachment.ts
+++ b/packages/api/src/utils/test/fixtures/attachment.ts
@@ -22,7 +22,7 @@ export const attachmentFixtures: AttachmentCreateDto[] = [
     size: 3539,
     location: '39991e51-55c6-4a26-9176-b6ba04f180dc.jpg',
     channel: {
-      'web-channel': {
+      web: {
         id: '1',
       },
     },
@@ -37,7 +37,7 @@ export const attachmentFixtures: AttachmentCreateDto[] = [
     size: 3539,
     location: '39991e51-55c6-4a26-9176-b6ba04f180dd.jpg',
     channel: {
-      'web-channel': {
+      web: {
         id: '2',
       },
     },

--- a/packages/api/src/utils/test/fixtures/setting.ts
+++ b/packages/api/src/utils/test/fixtures/setting.ts
@@ -10,11 +10,14 @@ import { SettingCreateDto } from '@/setting/dto/setting.dto';
 import { SettingOrmEntity } from '@/setting/entities/setting.entity';
 import { getRandom } from '@/utils/helpers/safeRandom';
 
+const UNUSED_CHANNEL_GROUP = String(getRandom());
+const UNUSED_HELPER_GROUP = String(getRandom());
+
 export const settingFixtures: SettingCreateDto[] = [
   {
     group: 'chatbot_settings',
     label: 'default_storage_helper',
-    value: 'local-storage-helper',
+    value: 'local-storage',
   },
   {
     group: 'contact',
@@ -67,29 +70,22 @@ export const settingFixtures: SettingCreateDto[] = [
     value: 'US',
   },
   {
-    group: `${getRandom()}-channel`,
+    group: UNUSED_CHANNEL_GROUP,
+    subgroup: 'channel',
     label: `${getRandom()}`,
     value: '',
   },
   {
-    group: `${getRandom()}-helper`,
+    group: UNUSED_HELPER_GROUP,
+    subgroup: 'helper',
     label: `${getRandom()}`,
     value: '',
   },
   {
-    group: `${getRandom()}-channel`,
-    label: `${getRandom()}`,
-    value: '',
-  },
-  {
-    group: `${getRandom()}-helper`,
-    label: `${getRandom()}`,
-    value: '',
-  },
-  {
-    group: 'local-storage-helper',
+    group: 'local-storage',
+    subgroup: 'helper',
     label: 'default storage helper label',
-    value: 'local-storage-helper',
+    value: 'local-storage',
   },
 ];
 

--- a/packages/api/src/utils/test/fixtures/setting.ts
+++ b/packages/api/src/utils/test/fixtures/setting.ts
@@ -67,27 +67,27 @@ export const settingFixtures: SettingCreateDto[] = [
     value: 'US',
   },
   {
-    group: `${getRandom()}_channel`,
+    group: `${getRandom()}-channel`,
     label: `${getRandom()}`,
     value: '',
   },
   {
-    group: `${getRandom()}_helper`,
+    group: `${getRandom()}-helper`,
     label: `${getRandom()}`,
     value: '',
   },
   {
-    group: `${getRandom()}_channel`,
+    group: `${getRandom()}-channel`,
     label: `${getRandom()}`,
     value: '',
   },
   {
-    group: `${getRandom()}_helper`,
+    group: `${getRandom()}-helper`,
     label: `${getRandom()}`,
     value: '',
   },
   {
-    group: 'local_storage_helper',
+    group: 'local-storage-helper',
     label: 'default storage helper label',
     value: 'local-storage-helper',
   },

--- a/packages/api/src/utils/test/fixtures/subscriber.ts
+++ b/packages/api/src/utils/test/fixtures/subscriber.ts
@@ -39,7 +39,7 @@ const subscribers: TSubscriberFixtures['values'][] = [
     gender: 'male',
     country: 'FR',
     channel: {
-      name: 'messenger-channel',
+      name: 'messenger',
     },
     labels: [],
     lastvisit: new Date('2020-01-01T20:40:03.249Z'),
@@ -54,7 +54,7 @@ const subscribers: TSubscriberFixtures['values'][] = [
     gender: 'male',
     country: 'US',
     channel: {
-      name: 'web-channel',
+      name: 'web',
     },
     labels: [],
     lastvisit: new Date('2021-01-01T20:40:03.249Z'),
@@ -69,7 +69,7 @@ const subscribers: TSubscriberFixtures['values'][] = [
     gender: 'male',
     country: 'US',
     channel: {
-      name: 'web-channel',
+      name: 'web',
     },
     labels: [],
     lastvisit: new Date('2022-01-01T20:40:03.249Z'),
@@ -84,7 +84,7 @@ const subscribers: TSubscriberFixtures['values'][] = [
     gender: 'male',
     country: 'US',
     channel: {
-      name: 'web-channel',
+      name: 'web',
     },
     labels: [],
     lastvisit: new Date('2024-01-01T20:40:03.249Z'),

--- a/packages/api/src/utils/test/mocks/subscriber.ts
+++ b/packages/api/src/utils/test/mocks/subscriber.ts
@@ -23,7 +23,7 @@ export const subscriberInstance: Subscriber = {
   lastvisit: new Date(),
   retainedFrom: new Date(),
   channel: {
-    name: 'web-channel',
+    name: 'web',
   },
   labels: [],
   avatar: null,

--- a/packages/api/src/utils/test/providers/setting-service.provider.ts
+++ b/packages/api/src/utils/test/providers/setting-service.provider.ts
@@ -9,10 +9,10 @@ import { SettingService } from '@/setting';
 export const SettingServiceProvider = {
   provide: SettingService,
   useValue: {
-    default_nlu_helper: 'llm-nlu-helper',
+    default_nlu_helper: 'llm-nlu',
     getSettings: jest.fn().mockResolvedValue({
       chatbot_settings: {
-        default_nlu_helper: 'llm-nlu-helper',
+        default_nlu_helper: 'llm-nlu',
         global_fallback: true,
         fallback_message: ['Global fallback message'],
       },

--- a/packages/api/src/websocket/websocket.gateway.spec.ts
+++ b/packages/api/src/websocket/websocket.gateway.spec.ts
@@ -42,7 +42,7 @@ describe('WebsocketGateway', () => {
       createSocket('admin-1'), // Admin user 1
       createSocket('admin-2'), // Admin user 2
       createSocket('admin-3'), // Admin user 3
-      createSocket('subscriber', { channel: 'web-channel' }), // Subscriber
+      createSocket('subscriber', { channel: 'web' }), // Subscriber
     ];
 
     await app.listen(3000);

--- a/packages/api/src/websocket/websocket.gateway.ts
+++ b/packages/api/src/websocket/websocket.gateway.ts
@@ -214,7 +214,7 @@ export class WebsocketGateway
           next();
         } else if (
           // Or, the WS connection is established with a chat widget using the web channel (subscriber)
-          searchParams.get('channel') === 'web-channel'
+          searchParams.get('channel') === 'web'
         ) {
           session.anonymous =
             typeof session.anonymous === 'undefined' ? true : session.anonymous;

--- a/packages/api/src/workflow/contexts/workflow-runtime.context.spec.ts
+++ b/packages/api/src/workflow/contexts/workflow-runtime.context.spec.ts
@@ -29,7 +29,7 @@ class TestEventWrapper extends TriggerEventWrapper {
 
   getContextData(): Record<string, unknown> {
     return {
-      channel: { name: 'web-channel' },
+      channel: { name: 'web' },
       initiator: this.getInitiator(),
     };
   }
@@ -112,7 +112,7 @@ describe('WorkflowRuntimeContext', () => {
     expect(context.state).toMatchObject({
       locale: 'en',
       channel: {
-        name: 'web-channel',
+        name: 'web',
       },
       initiator: {
         id: 'owner-1',

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -469,6 +469,7 @@
     "ttl_seconds": "TTL (seconds)",
     "global": "Global",
     "workflow": "Workflow",
+    "thread": "Thread",
     "run": "Run",
     "textarea": "Text Area",
     "checkbox": "Checkbox",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -468,6 +468,7 @@
     "ttl_seconds": "TTL (secondes)",
     "global": "Global",
     "workflow": "Workflow",
+    "thread": "Fil de discussion",
     "run": "Exécution",
     "textarea": "Zone de texte",
     "checkbox": "Case à cocher",

--- a/packages/frontend/src/app-components/widget/ChatWidget.tsx
+++ b/packages/frontend/src/app-components/widget/ChatWidget.tsx
@@ -62,7 +62,7 @@ const ChatWidgetComponent = ({
   const widgetConfig = useMemo(
     () => ({
       apiUrl,
-      channel: "console-channel",
+      channel: "console",
       language: i18n.language,
       primaryColor,
       mode: resolvedMode,

--- a/packages/frontend/src/components/settings/settings.utils.test.ts
+++ b/packages/frontend/src/components/settings/settings.utils.test.ts
@@ -18,7 +18,7 @@ describe("settings utils", () => {
   describe("resolveSettingsGroupTitle", () => {
     it("returns localized schema title when available", () => {
       const schemas: ISettingSchemasMap = {
-        web_channel: {
+        "web-channel": {
           schema: {
             title: "Web Channel",
           },
@@ -29,7 +29,7 @@ describe("settings utils", () => {
       };
       const t = vi.fn().mockReturnValue("fallback");
 
-      expect(resolveSettingsGroupTitle("web_channel", schemas, t)).toBe(
+      expect(resolveSettingsGroupTitle("web-channel", schemas, t)).toBe(
         "Web Channel",
       );
       expect(t).not.toHaveBeenCalled();

--- a/packages/frontend/src/components/settings/settings.utils.test.ts
+++ b/packages/frontend/src/components/settings/settings.utils.test.ts
@@ -18,20 +18,18 @@ describe("settings utils", () => {
   describe("resolveSettingsGroupTitle", () => {
     it("returns localized schema title when available", () => {
       const schemas: ISettingSchemasMap = {
-        "web-channel": {
+        web: {
           schema: {
             title: "Web Channel",
           },
           scope: "extension",
           extensionType: "channel",
-          extensionName: "web-channel",
+          extensionName: "web",
         },
       };
       const t = vi.fn().mockReturnValue("fallback");
 
-      expect(resolveSettingsGroupTitle("web-channel", schemas, t)).toBe(
-        "Web Channel",
-      );
+      expect(resolveSettingsGroupTitle("web", schemas, t)).toBe("Web Channel");
       expect(t).not.toHaveBeenCalled();
     });
 

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -75,7 +75,7 @@ Once the widget is built, you can easily embed it into any webpage. Here's an ex
   ReactDOM.render(
     el(HexabotWidget, {
       apiUrl: 'https://api.yourdomain.com',
-      channel: 'web-channel',
+      channel: 'web',
       token: 'token123',
       primaryColor: '#1ba089',
     }),
@@ -113,7 +113,7 @@ To prevent the website css from conflicting with the chat widget css, we can lev
   ReactDOM.render(
     React.createElement(HexabotWidget, {
       apiUrl: 'https://api.yourdomain.com',
-      channel: 'web-channel',
+      channel: 'web',
       token: 'token123',
       primaryColor: '#1ba089',
     }),

--- a/packages/widget/public/index.html
+++ b/packages/widget/public/index.html
@@ -34,7 +34,7 @@
       ReactDOM.render(
         React.createElement(HexabotWidget, {
           apiUrl: "http://localhost:4000",
-          channel: "web-channel",
+          channel: "web",
           token: "token123",
           primaryColor: "#1ba089",
         }),

--- a/packages/widget/src/constants/defaultConfig.ts
+++ b/packages/widget/src/constants/defaultConfig.ts
@@ -8,7 +8,7 @@ import { Config } from "../types/config.types";
 
 export const DEFAULT_CONFIG: Config = {
   apiUrl: "http://localhost:3000/api",
-  channel: "console-channel",
+  channel: "console",
   language: "en",
   maxUploadSize: 20 * 1024 * 1024, // 20 MB in bytes
   theme: {

--- a/packages/widget/src/main.tsx
+++ b/packages/widget/src/main.tsx
@@ -16,7 +16,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <ChatWidget
       {...{
         apiUrl: "http://localhost:3000/api",
-        channel: "web-channel",
+        channel: "web",
         language: "en",
         primaryColor: "#1BA089",
       }}

--- a/packages/widget/src/providers/ChatProvider.tsx
+++ b/packages/widget/src/providers/ChatProvider.tsx
@@ -478,7 +478,7 @@ const ChatProvider: React.FC<{
   useSubscribe("settings", ({ profile, messages = [] }: ChannelSettings) => {
     setProfile(profile);
 
-    if (config.channel === "console-channel" && !profile) {
+    if (config.channel === "console" && !profile) {
       handleSubscription();
     }
 

--- a/packages/widget/src/providers/ThemeProvider.test.tsx
+++ b/packages/widget/src/providers/ThemeProvider.test.tsx
@@ -79,7 +79,7 @@ describe("ThemeProvider", () => {
     });
     mockUseConfig.mockReturnValue({
       apiUrl: "https://example.com/api",
-      channel: "console-channel",
+      channel: "console",
       language: "en",
       maxUploadSize: 10,
       theme: { mode: "system" },
@@ -122,7 +122,7 @@ describe("ThemeProvider", () => {
   it("uses the top-level config mode over nested theme mode", async () => {
     mockUseConfig.mockReturnValue({
       apiUrl: "https://example.com/api",
-      channel: "console-channel",
+      channel: "console",
       language: "en",
       maxUploadSize: 10,
       mode: "light",

--- a/packages/widget/src/utils/webhook-url.test.ts
+++ b/packages/widget/src/utils/webhook-url.test.ts
@@ -12,24 +12,24 @@ describe("buildWebhookUrl", () => {
   it("returns the base webhook URL when workflow id is not provided", () => {
     expect(
       buildWebhookUrl({
-        channel: "console-channel",
+        channel: "console",
       }),
-    ).toBe("/webhook/console-channel/");
+    ).toBe("/webhook/console/");
   });
 
   it("adds workflow_id query param when workflow id is provided", () => {
     expect(
       buildWebhookUrl({
-        channel: "console-channel",
+        channel: "console",
         workflowId: "workflow-id-123",
       }),
-    ).toBe("/webhook/console-channel/?workflow_id=workflow-id-123");
+    ).toBe("/webhook/console/?workflow_id=workflow-id-123");
   });
 
   it("preserves existing query params and appends workflow_id", () => {
     expect(
       buildWebhookUrl({
-        channel: "console-channel",
+        channel: "console",
         workflowId: "workflow-id-123",
         query: {
           first_name: "John",
@@ -37,16 +37,16 @@ describe("buildWebhookUrl", () => {
         },
       }),
     ).toBe(
-      "/webhook/console-channel/?first_name=John&last_name=Doe&workflow_id=workflow-id-123",
+      "/webhook/console/?first_name=John&last_name=Doe&workflow_id=workflow-id-123",
     );
   });
 
   it("url-encodes workflow_id value", () => {
     expect(
       buildWebhookUrl({
-        channel: "console-channel",
+        channel: "console",
         workflowId: "wf id/1",
       }),
-    ).toBe("/webhook/console-channel/?workflow_id=wf+id%2F1");
+    ).toBe("/webhook/console/?workflow_id=wf+id%2F1");
   });
 });


### PR DESCRIPTION
# Motivation

Remove extension naming suffix and namespace to reduce complexity:
- Suffixless channel/helper IDs are now canonical in typing and validation
- Built-in names/defaults now use suffixless IDs
- Routing/channel resolution now uses direct channel names (no -channel concatenation/splitting)
- Settings seeding/cleanup moved to explicit marker logic

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
