### PR TITLE
fix: resolve subscriber labels filter issue

### DIFF
--- a/packages/api/src/chat/controllers/subscriber.controller.ts
+++ b/packages/api/src/chat/controllers/subscriber.controller.ts
@@ -18,7 +18,7 @@ import { Request } from 'express';
 import { FindManyOptions } from 'typeorm';
 
 import { AttachmentService } from '@/attachment/services/attachment.service';
-import { UuidParam } from '@/utils';
+import { TFilterNestedKeysOfType, UuidParam } from '@/utils';
 import { BaseOrmController } from '@/utils/generics/base-orm.controller';
 import { generateInitialsAvatar } from '@/utils/helpers/avatar';
 import { PopulatePipe } from '@/utils/pipes/populate.pipe';
@@ -31,6 +31,16 @@ import {
 } from '../dto/subscriber.dto';
 import { SubscriberOrmEntity } from '../entities/subscriber.entity';
 import { SubscriberService } from '../services/subscriber.service';
+
+export const SUBSCRIBER_ALLOWED_FILTER_FIELDS: TFilterNestedKeysOfType<SubscriberOrmEntity>[] =
+  [
+    'firstName',
+    'lastName',
+    'assignedTo.id',
+    'channel.name',
+    // TODO : type need to be enhanced to include 'labels'
+    'labels' as any,
+  ];
 
 @Controller('subscriber')
 export class SubscriberController extends BaseOrmController<SubscriberOrmEntity> {
@@ -56,14 +66,7 @@ export class SubscriberController extends BaseOrmController<SubscriberOrmEntity>
     @Query(
       new TypeOrmSearchFilterPipe<SubscriberOrmEntity>({
         // TODO : Check if the field email should be added to Subscriber schema
-        allowedFields: [
-          'firstName',
-          'lastName',
-          'assignedTo.id',
-          'channel.name',
-          // TODO : type need to be enhanced to include 'labels'
-          'labels' as any,
-        ],
+        allowedFields: SUBSCRIBER_ALLOWED_FILTER_FIELDS,
         defaultSort: ['createdAt', 'desc'],
       }),
     )
@@ -82,12 +85,7 @@ export class SubscriberController extends BaseOrmController<SubscriberOrmEntity>
   async filterCount(
     @Query(
       new TypeOrmSearchFilterPipe<SubscriberOrmEntity>({
-        allowedFields: [
-          'firstName',
-          'lastName',
-          'assignedTo.id',
-          'channel.name',
-        ],
+        allowedFields: SUBSCRIBER_ALLOWED_FILTER_FIELDS,
       }),
     )
     options: FindManyOptions<SubscriberOrmEntity> = {},

--- a/packages/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/packages/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -12,7 +12,6 @@ import { Controller, useForm } from "react-hook-form";
 import { WithEntityButton } from "@/app-components/buttons/entities/WithEntityButton";
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntityDistinctSelect from "@/app-components/inputs/AutoCompleteEntityDistinctSelect";
-import { useTanstackQueryClient } from "@/hooks/crud/useTanstack";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { isCountOrCollectionQuery } from "@/hooks/useEntityMutationSubscription";
 import { useToast } from "@/hooks/useToast";
@@ -30,8 +29,7 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
 }) => {
   const { t } = useTranslate();
   const { toast } = useToast();
-  const queryClient = useTanstackQueryClient();
-  const { mutateAsync: updateSubscriber } = useUpdate(EntityType.SUBSCRIBER, {
+  const { mutate: updateSubscriber } = useUpdate(EntityType.SUBSCRIBER, {
     onError: () => {
       rest.onError?.();
       toast.error(t("message.internal_server_error"));
@@ -47,15 +45,19 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
     formState: { errors },
     handleSubmit,
   } = useForm<ISubscriberAttributes>();
-  const onSubmitForm = async (params: ISubscriberAttributes) => {
-    if (subscriber?.id) {
-      await updateSubscriber({ id: subscriber.id, params });
-
-      queryClient.refetchQueries({
-        predicate: ({ queryKey }) =>
-          isCountOrCollectionQuery(queryKey, EntityType.SUBSCRIBER),
-      });
-    }
+  const onSubmitForm = (params: ISubscriberAttributes) => {
+    if (subscriber?.id)
+      updateSubscriber(
+        { id: subscriber.id, params },
+        {
+          onSuccess(_d, _v, _o, context) {
+            context.client.refetchQueries({
+              predicate: ({ queryKey }) =>
+                isCountOrCollectionQuery(queryKey, EntityType.SUBSCRIBER),
+            });
+          },
+        },
+      );
   };
 
   useEffect(() => {

--- a/packages/frontend/src/components/subscribers/SubscriberForm.tsx
+++ b/packages/frontend/src/components/subscribers/SubscriberForm.tsx
@@ -12,7 +12,9 @@ import { Controller, useForm } from "react-hook-form";
 import { WithEntityButton } from "@/app-components/buttons/entities/WithEntityButton";
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntityDistinctSelect from "@/app-components/inputs/AutoCompleteEntityDistinctSelect";
+import { useTanstackQueryClient } from "@/hooks/crud/useTanstack";
 import { useUpdate } from "@/hooks/crud/useUpdate";
+import { isCountOrCollectionQuery } from "@/hooks/useEntityMutationSubscription";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
@@ -28,7 +30,8 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
 }) => {
   const { t } = useTranslate();
   const { toast } = useToast();
-  const { mutate: updateSubscriber } = useUpdate(EntityType.SUBSCRIBER, {
+  const queryClient = useTanstackQueryClient();
+  const { mutateAsync: updateSubscriber } = useUpdate(EntityType.SUBSCRIBER, {
     onError: () => {
       rest.onError?.();
       toast.error(t("message.internal_server_error"));
@@ -44,9 +47,14 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
     formState: { errors },
     handleSubmit,
   } = useForm<ISubscriberAttributes>();
-  const onSubmitForm = (params: ISubscriberAttributes) => {
+  const onSubmitForm = async (params: ISubscriberAttributes) => {
     if (subscriber?.id) {
-      updateSubscriber({ id: subscriber.id, params });
+      await updateSubscriber({ id: subscriber.id, params });
+
+      queryClient.refetchQueries({
+        predicate: ({ queryKey }) =>
+          isCountOrCollectionQuery(queryKey, EntityType.SUBSCRIBER),
+      });
     }
   };
 
@@ -97,7 +105,7 @@ export const SubscriberForm: FC<ComponentFormProps<ISubscriber>> = ({
                             onChange(selected.map(({ id }) => id))
                           }
                           label={t("label.labels")}
-                          labelKey="name"
+                          labelKey="title"
                           sortKey="group"
                           groupKey="name"
                           defaultGroupTitle={t("title.default_group")}

--- a/packages/frontend/src/components/subscribers/index.tsx
+++ b/packages/frontend/src/components/subscribers/index.tsx
@@ -86,7 +86,7 @@ export const Subscribers = () => {
           <ChipEntity
             id={label}
             key={label}
-            field="name"
+            field="title"
             entity={EntityType.LABEL}
           />
         )),
@@ -139,6 +139,7 @@ export const Subscribers = () => {
         field: "id",
         value: id,
         label: t("label.labels"),
+        labelKey: "title",
         onChange: setId,
       },
     ],

--- a/packages/frontend/src/hooks/useEntityMutationSubscription.ts
+++ b/packages/frontend/src/hooks/useEntityMutationSubscription.ts
@@ -99,7 +99,7 @@ type QueryParams = {
   where?: Record<string, unknown>;
 };
 // Matches count/collection queries for the targeted entity.
-const isCountOrCollectionQuery = (
+export const isCountOrCollectionQuery = (
   queryKey: readonly unknown[],
   entity: EntityType,
 ) => {


### PR DESCRIPTION
# Motivation
This PR fixes :
- The missing  of a cache refresh mechanism (count / collection) after updating a subscriber labels  
- Missing Labels (name -> title) filter labelKey

