### PR TITLE
fix: seed admin credentials using cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ npm install -g @hexabot-ai/cli
    This starts the required services in development mode.
 
 
-UI Admin Panel is accessible via http://localhost:8080, the default credentials are :
-
-- **Username:** admin@admin.admin
-- **Password:** adminadmin
+UI Admin Panel is accessible via http://localhost:8080.
+When you run `hexabot create`, the CLI prompts for admin first name, last name,
+email, and password, then stores them in `.env` as `SEED_ADMIN_*` values used
+by the initial API seed.
 
 ## Documentation
 

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -25,6 +25,14 @@ API_IS_PRIMARY_NODE=true
 I18N_TRANSLATION_FILENAME=messages
 # Enables Nest Commander CLI execution when set to true.
 HEXABOT_CLI=false
+# Default admin user seeded on first startup in non-production environments.
+SEED_ADMIN_FIRST_NAME=admin
+# Default admin user last name used during initial seeding.
+SEED_ADMIN_LAST_NAME=admin
+# Default admin user email used during initial seeding.
+SEED_ADMIN_EMAIL=admin@admin.admin
+# Default admin user password used during initial seeding.
+SEED_ADMIN_PASSWORD=adminadmin
 
 # -----------------------------------------------------------------------------
 # Sessions & security

--- a/packages/api/src/user/seeds/user.seed-model.spec.ts
+++ b/packages/api/src/user/seeds/user.seed-model.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { userModels } from './user.seed-model';
+
+const ENV_KEYS = [
+  'SEED_ADMIN_FIRST_NAME',
+  'SEED_ADMIN_LAST_NAME',
+  'SEED_ADMIN_EMAIL',
+  'SEED_ADMIN_PASSWORD',
+];
+
+describe('userModels', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  it('uses fallback admin values when no env overrides are provided', () => {
+    const [seeded] = userModels(['admin-role']);
+
+    expect(seeded).toMatchObject({
+      username: 'admin',
+      firstName: 'admin',
+      lastName: 'admin',
+      email: 'admin@admin.admin',
+      password: 'adminadmin',
+      roles: ['admin-role'],
+      avatar: null,
+    });
+  });
+
+  it('uses env overrides and infers username from email', () => {
+    process.env.SEED_ADMIN_FIRST_NAME = 'Anis';
+    process.env.SEED_ADMIN_LAST_NAME = 'Bot';
+    process.env.SEED_ADMIN_EMAIL = 'Anis.Bot+Owner@example.com';
+    process.env.SEED_ADMIN_PASSWORD = 'Admin#123';
+
+    const [seeded] = userModels(['admin-role']);
+
+    expect(seeded).toMatchObject({
+      username: 'anis.botowner',
+      firstName: 'Anis',
+      lastName: 'Bot',
+      email: 'Anis.Bot+Owner@example.com',
+      password: 'Admin#123',
+    });
+  });
+
+  it('falls back to admin username when email local-part is unusable', () => {
+    process.env.SEED_ADMIN_EMAIL = '+@example.com';
+
+    const [seeded] = userModels(['admin-role']);
+
+    expect(seeded.username).toBe('admin');
+  });
+});

--- a/packages/api/src/user/seeds/user.seed-model.ts
+++ b/packages/api/src/user/seeds/user.seed-model.ts
@@ -6,14 +6,32 @@
 
 import { UserCreateDto } from '../dto/user.dto';
 
+const resolveSeedValue = (key: string, fallback: string) => {
+  return process.env[key]?.trim() || fallback;
+};
+const resolveSeedAdminEmail = () => {
+  return resolveSeedValue('SEED_ADMIN_EMAIL', 'admin@admin.admin');
+};
+const resolveSeedAdminUsername = (email: string) => {
+  const localPart = email.split('@')[0]?.trim().toLowerCase() || '';
+  const normalized = localPart.replace(/[^a-z0-9._-]/g, '');
+
+  return normalized || 'admin';
+};
+
 export const userModels = (roles: string[]): UserCreateDto[] => {
+  const firstName = resolveSeedValue('SEED_ADMIN_FIRST_NAME', 'admin');
+  const lastName = resolveSeedValue('SEED_ADMIN_LAST_NAME', 'admin');
+  const email = resolveSeedAdminEmail();
+  const password = resolveSeedValue('SEED_ADMIN_PASSWORD', 'adminadmin');
+
   return [
     {
-      username: 'admin',
-      firstName: 'admin',
-      lastName: 'admin',
-      email: 'admin@admin.admin',
-      password: 'adminadmin',
+      username: resolveSeedAdminUsername(email),
+      firstName,
+      lastName,
+      email,
+      password,
       roles,
       avatar: null,
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "*.{ts}": "eslint --fix --config eslint.config-staged.cjs"
   },
   "dependencies": {
+    "@inquirer/prompts": "^7.10.1",
     "axios": "^1.7.7",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",

--- a/packages/cli/src/commands/__tests__/create.test.ts
+++ b/packages/cli/src/commands/__tests__/create.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { jest } from '@jest/globals';
+import { Command } from 'commander';
+
+const ensureProjectConfig = jest.fn();
+const loadProjectConfig = jest.fn();
+const bootstrapEnvFile = jest.fn();
+const upsertEnvVariables = jest.fn();
+const detectPackageManager = jest.fn();
+const installDependencies = jest.fn();
+const normalizePackageManager = jest.fn();
+const downloadAndExtractTemplate = jest.fn();
+const validateProjectName = jest.fn();
+const runDev = jest.fn();
+const input = jest.fn();
+const password = jest.fn();
+
+jest.unstable_mockModule('../../core/config.js', () => ({
+  ensureProjectConfig,
+  loadProjectConfig,
+}));
+
+jest.unstable_mockModule('../../core/env.js', () => ({
+  bootstrapEnvFile,
+  upsertEnvVariables,
+}));
+
+jest.unstable_mockModule('../../core/package-manager.js', () => ({
+  detectPackageManager,
+  installDependencies,
+  normalizePackageManager,
+}));
+
+jest.unstable_mockModule('../../services/templates.js', () => ({
+  downloadAndExtractTemplate,
+}));
+
+jest.unstable_mockModule('../../utils/validation.js', () => ({
+  validateProjectName,
+}));
+
+jest.unstable_mockModule('../dev.js', () => ({
+  runDev,
+}));
+
+jest.unstable_mockModule('@inquirer/prompts', () => ({
+  input,
+  password,
+}));
+
+let registerCreateCommand: (program: Command) => void;
+
+const initialCwd = process.cwd();
+const initialStdinTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+const initialStdoutTTY = Object.getOwnPropertyDescriptor(
+  process.stdout,
+  'isTTY',
+);
+let tempDir: string;
+let exitSpy: ReturnType<typeof jest.spyOn>;
+
+const restoreTTY = () => {
+  if (initialStdinTTY) {
+    Object.defineProperty(process.stdin, 'isTTY', initialStdinTTY);
+  } else {
+    delete (process.stdin as { isTTY?: boolean }).isTTY;
+  }
+
+  if (initialStdoutTTY) {
+    Object.defineProperty(process.stdout, 'isTTY', initialStdoutTTY);
+  } else {
+    delete (process.stdout as { isTTY?: boolean }).isTTY;
+  }
+};
+const setTTY = (enabled: boolean) => {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    configurable: true,
+    value: enabled,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value: enabled,
+  });
+};
+
+beforeAll(async () => {
+  ({ registerCreateCommand } = await import('../create.js'));
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hexabot-create-'));
+  process.chdir(tempDir);
+  setTTY(true);
+
+  validateProjectName.mockReturnValue(true);
+  detectPackageManager.mockReturnValue('pnpm');
+  (normalizePackageManager as any).mockImplementation((value: unknown) => {
+    return typeof value === 'string' ? value.toLowerCase() : undefined;
+  });
+  loadProjectConfig.mockReturnValue({
+    packageManager: 'pnpm',
+    env: {
+      local: '.env',
+      localExample: '.env.example',
+      docker: '.env.docker',
+      dockerExample: '.env.docker.example',
+    },
+  });
+  (globalThis as any).fetch = jest.fn(async () => ({
+    ok: true,
+    json: async () => ({ tag_name: 'v1.0.0' }),
+  }));
+  exitSpy = jest.spyOn(process, 'exit').mockImplementation((code?: any) => {
+    throw new Error(`process.exit:${code ?? ''}`);
+  });
+});
+
+afterEach(() => {
+  process.chdir(initialCwd);
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  restoreTTY();
+  jest.restoreAllMocks();
+});
+
+describe('registerCreateCommand', () => {
+  it('prompts admin credentials and persists them to local env values', async () => {
+    (input as any)
+      .mockResolvedValueOnce('Anis')
+      .mockResolvedValueOnce('Bot')
+      .mockResolvedValueOnce('anis@example.com');
+    (password as any).mockResolvedValueOnce('Admin#123');
+
+    const program = new Command();
+    registerCreateCommand(program);
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'create',
+      'anisbot',
+      '--template',
+      'marrouchi/hexabot-v3-template',
+    ]);
+
+    const [templateUrl, projectPath] = (downloadAndExtractTemplate as any).mock
+      .calls[0];
+    expect(templateUrl).toBe(
+      'https://github.com/marrouchi/hexabot-v3-template/archive/refs/tags/v1.0.0.zip',
+    );
+    expect(projectPath.endsWith(`${path.sep}anisbot`)).toBe(true);
+    expect(bootstrapEnvFile).toHaveBeenCalledWith(
+      projectPath,
+      '.env.example',
+      '.env',
+      { quiet: true },
+    );
+    expect(upsertEnvVariables).toHaveBeenCalledWith(projectPath, '.env', {
+      SEED_ADMIN_FIRST_NAME: 'Anis',
+      SEED_ADMIN_LAST_NAME: 'Bot',
+      SEED_ADMIN_EMAIL: 'anis@example.com',
+      SEED_ADMIN_PASSWORD: 'Admin#123',
+    });
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(input).toHaveBeenCalledTimes(3);
+    expect(password).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails cleanly when create runs in a non-interactive terminal', async () => {
+    setTTY(false);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const program = new Command();
+    registerCreateCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'test', 'create', 'anisbot']),
+    ).rejects.toThrow('process.exit:1');
+    expect(errorSpy).toHaveBeenCalled();
+    expect(input).not.toHaveBeenCalled();
+    expect(password).not.toHaveBeenCalled();
+    expect(upsertEnvVariables).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -7,11 +7,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { input, password } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { Command } from 'commander';
 
 import { ensureProjectConfig, loadProjectConfig } from '../core/config.js';
-import { bootstrapEnvFile } from '../core/env.js';
+import { bootstrapEnvFile, upsertEnvVariables } from '../core/env.js';
 import {
   detectPackageManager,
   installDependencies,
@@ -31,6 +32,13 @@ interface CreateCommandOptions {
   dev?: boolean;
   docker?: boolean;
   force?: boolean;
+}
+
+interface AdminSeedCredentials {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
 }
 
 export const registerCreateCommand = (program: Command) => {
@@ -96,6 +104,14 @@ const createProject = async (
         { quiet: true },
       );
     }
+
+    const adminCredentials = await promptSeedAdminCredentials();
+    upsertEnvVariables(projectPath, config.env.local, {
+      SEED_ADMIN_FIRST_NAME: adminCredentials.firstName,
+      SEED_ADMIN_LAST_NAME: adminCredentials.lastName,
+      SEED_ADMIN_EMAIL: adminCredentials.email,
+      SEED_ADMIN_PASSWORD: adminCredentials.password,
+    });
 
     if (options.noInstall) {
       console.log(
@@ -169,6 +185,68 @@ const fetchLatestReleaseTag = async (templateRepo: string) => {
 
   return data.tag_name;
 };
+const requireValue = (label: string) => {
+  return (value: string) => {
+    if (!value.trim()) {
+      return `${label} is required.`;
+    }
+
+    return true;
+  };
+};
+const validateEmail = (value: string) => {
+  if (!value.trim()) {
+    return 'Email is required.';
+  }
+
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailPattern.test(value.trim())) {
+    return 'Enter a valid email address.';
+  }
+
+  return true;
+};
+const assertInteractiveTerminal = () => {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error(
+      'hexabot create requires an interactive terminal to capture admin credentials.',
+    );
+  }
+};
+const promptSeedAdminCredentials = async (): Promise<AdminSeedCredentials> => {
+  assertInteractiveTerminal();
+
+  const firstName = (
+    await input({
+      message: 'Admin first name',
+      validate: requireValue('First name'),
+    })
+  ).trim();
+  const lastName = (
+    await input({
+      message: 'Admin last name',
+      validate: requireValue('Last name'),
+    })
+  ).trim();
+  const email = (
+    await input({
+      message: 'Admin email',
+      validate: validateEmail,
+    })
+  ).trim();
+  const adminPassword = await password({
+    message: 'Admin password',
+    mask: '*',
+    validate: requireValue('Password'),
+  });
+
+  return {
+    firstName,
+    lastName,
+    email,
+    password: adminPassword,
+  };
+};
 const logSuccessMessage = (
   projectName: string,
   options: { docker?: boolean },
@@ -176,7 +254,7 @@ const logSuccessMessage = (
   console.log('\n');
   console.log(chalk.green(`🎉 Project ${projectName} created successfully.`));
   console.log('\n');
-  console.log(chalk.bgYellow.black(`Next steps:`));
+  console.log(chalk.bgYellow(`Next steps:`));
   console.log(chalk.gray(`1. Navigate to the project folder:`));
   console.log(chalk.yellow(`   cd ${projectName}`));
   if (options.docker) {
@@ -192,10 +270,6 @@ const logSuccessMessage = (
   }
   console.log(chalk.gray(`3. Explore docker helpers if needed:`));
   console.log(chalk.yellow(`   hexabot docker up --services postgres`));
-  console.log(
-    chalk.gray(
-      `Need env files? Run ${chalk.white('hexabot env init --docker')}`,
-    ),
-  );
+  console.log(chalk.gray(`Need env files? Run hexabot env init --docker`));
   console.log('\n');
 };

--- a/packages/cli/src/core/__tests__/env.test.ts
+++ b/packages/cli/src/core/__tests__/env.test.ts
@@ -10,7 +10,12 @@ import * as path from 'path';
 
 import { jest } from '@jest/globals';
 
-import { bootstrapEnvFile, listEnvStatus, resolveEnvExample } from '../env.js';
+import {
+  bootstrapEnvFile,
+  listEnvStatus,
+  resolveEnvExample,
+  upsertEnvVariables,
+} from '../env.js';
 
 describe('env helpers', () => {
   let tempDir: string;
@@ -93,5 +98,34 @@ describe('env helpers', () => {
     expect(resolveEnvExample(tempDir, '.missing', defaultExample)).toBe(
       defaultExample,
     );
+  });
+
+  it('upserts env variables without duplicating existing keys', () => {
+    fs.writeFileSync(
+      path.join(tempDir, '.env'),
+      [
+        'PORT=3000',
+        'SEED_ADMIN_EMAIL=old@example.com',
+        'SEED_ADMIN_EMAIL=legacy@example.com',
+      ].join('\n'),
+    );
+
+    upsertEnvVariables(tempDir, '.env', {
+      SEED_ADMIN_EMAIL: 'new@example.com',
+      SEED_ADMIN_PASSWORD: 'P@ss "word"',
+    });
+
+    const nextEnv = fs.readFileSync(path.join(tempDir, '.env'), 'utf-8');
+    const emailMatches = nextEnv.match(/^SEED_ADMIN_EMAIL=/gm) || [];
+    expect(emailMatches).toHaveLength(1);
+    expect(nextEnv).toContain('SEED_ADMIN_EMAIL=new@example.com');
+    expect(nextEnv).toContain('SEED_ADMIN_PASSWORD="P@ss \\"word\\""');
+    expect(nextEnv.endsWith('\n')).toBe(true);
+  });
+
+  it('throws when attempting to upsert a missing env file', () => {
+    expect(() =>
+      upsertEnvVariables(tempDir, '.missing', { KEY: 'value' }),
+    ).toThrow('Env file ".missing" is missing.');
   });
 });

--- a/packages/cli/src/core/env.ts
+++ b/packages/cli/src/core/env.ts
@@ -88,3 +88,65 @@ export const resolveEnvExample = (
 
   return defaultExample;
 };
+
+const ENV_BARE_VALUE = /^[A-Za-z0-9._/:@-]*$/;
+const formatEnvValue = (value: string) => {
+  if (ENV_BARE_VALUE.test(value)) {
+    return value;
+  }
+
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')}"`;
+};
+const escapeRegExp = (value: string) => {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};
+
+export const upsertEnvVariables = (
+  projectRoot: string,
+  envFile: string,
+  values: Record<string, string>,
+) => {
+  const envPath = path.join(projectRoot, envFile);
+  if (!fs.existsSync(envPath)) {
+    throw new Error(`Env file "${envFile}" is missing.`);
+  }
+
+  const source = fs.readFileSync(envPath, 'utf-8');
+  let lines = source.length > 0 ? source.split(/\r?\n/) : [];
+
+  // Remove trailing blank line to avoid repetitive gaps after writes.
+  while (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  for (const [key, rawValue] of Object.entries(values)) {
+    const keyPattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=`);
+    const nextLine = `${key}=${formatEnvValue(rawValue)}`;
+    let updated = false;
+    const nextLines: string[] = [];
+
+    for (const line of lines) {
+      if (!keyPattern.test(line)) {
+        nextLines.push(line);
+        continue;
+      }
+
+      if (!updated) {
+        nextLines.push(nextLine);
+        updated = true;
+      }
+      // Skip duplicate declarations for the same key.
+    }
+
+    if (!updated) {
+      nextLines.push(nextLine);
+    }
+
+    lines = nextLines;
+  }
+
+  fs.writeFileSync(envPath, `${lines.join('\n')}\n`, 'utf-8');
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@inquirer/prompts':
+        specifier: ^7.10.1
+        version: 7.10.1(@types/node@22.19.1)
       axios:
         specifier: ^1.7.7
         version: 1.12.2
@@ -2258,8 +2261,21 @@ packages:
     resolution: {integrity: sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==}
     engines: {node: '>=18'}
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
   '@inquirer/checkbox@4.2.4':
     resolution: {integrity: sha512-2n9Vgf4HSciFq8ttKXk+qy+GsyTXPV1An6QAwe/8bkbbqvG4VW1I/ZY1pNu2rf+h9bdzMLPbRSfcNxkHBy/Ydw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2276,8 +2292,26 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/core@10.2.2':
     resolution: {integrity: sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2294,8 +2328,26 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/expand@4.0.20':
     resolution: {integrity: sha512-Dt9S+6qUg94fEvgn54F2Syf0Z3U8xmnBI9ATq2f5h9xt09fs2IJXSCIXyyVHwvggKWFXEY/7jATRo2K6Dkn6Ow==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2312,12 +2364,34 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/figures@1.0.13':
     resolution: {integrity: sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==}
     engines: {node: '>=18'}
 
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
   '@inquirer/input@4.2.4':
     resolution: {integrity: sha512-cwSGpLBMwpwcZZsc6s1gThm0J+it/KIJ+1qFL2euLmSKUMGumJ5TcbMgxEjMjNHRGadouIYbiIgruKoDZk7klw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2334,8 +2408,35 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/password@4.0.20':
     resolution: {integrity: sha512-nxSaPV2cPvvoOmRygQR+h0B+Av73B01cqYLcr7NXcGXhbmsYfUb8fDdw2Us1bI2YsX+VvY7I7upgFYsyf8+Nug==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -2361,6 +2462,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/rawlist@4.1.8':
     resolution: {integrity: sha512-CQ2VkIASbgI2PxdzlkeeieLRmniaUU1Aoi5ggEdm6BIyqopE9GuDXdDOj9XiwOqK5qm72oI2i6J+Gnjaa26ejg==}
     engines: {node: '>=18'}
@@ -2379,8 +2489,35 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/select@4.3.4':
     resolution: {integrity: sha512-Qp20nySRmfbuJBBsgPU7E/cL62Hf250vMZRzYDcBHty2zdD1kKCnoDFWRr0WO2ZzaXp3R7a4esaVGJUx0E6zvA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -4649,6 +4786,9 @@ packages:
 
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -11313,6 +11453,8 @@ snapshots:
 
   '@inquirer/ansi@1.0.0': {}
 
+  '@inquirer/ansi@1.0.2': {}
+
   '@inquirer/checkbox@4.2.4(@types/node@20.12.12)':
     dependencies:
       '@inquirer/ansi': 1.0.0
@@ -11323,12 +11465,29 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.12
 
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/confirm@5.1.18(@types/node@20.12.12)':
     dependencies:
       '@inquirer/core': 10.2.2(@types/node@20.12.12)
       '@inquirer/type': 3.0.8(@types/node@20.12.12)
     optionalDependencies:
       '@types/node': 20.12.12
+
+  '@inquirer/confirm@5.1.21(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
 
   '@inquirer/core@10.2.2(@types/node@20.12.12)':
     dependencies:
@@ -11343,6 +11502,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.12
 
+  '@inquirer/core@10.3.2(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/editor@4.2.20(@types/node@20.12.12)':
     dependencies:
       '@inquirer/core': 10.2.2(@types/node@20.12.12)
@@ -11350,6 +11522,14 @@ snapshots:
       '@inquirer/type': 3.0.8(@types/node@20.12.12)
     optionalDependencies:
       '@types/node': 20.12.12
+
+  '@inquirer/editor@4.2.23(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
 
   '@inquirer/expand@4.0.20(@types/node@20.12.12)':
     dependencies:
@@ -11359,6 +11539,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.12
 
+  '@inquirer/expand@4.0.23(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/external-editor@1.0.2(@types/node@20.12.12)':
     dependencies:
       chardet: 2.1.0
@@ -11366,7 +11554,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.12
 
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.1)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.0
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/figures@1.0.13': {}
+
+  '@inquirer/figures@1.0.15': {}
 
   '@inquirer/input@4.2.4(@types/node@20.12.12)':
     dependencies:
@@ -11375,12 +11572,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.12
 
+  '@inquirer/input@4.3.1(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/number@3.0.20(@types/node@20.12.12)':
     dependencies:
       '@inquirer/core': 10.2.2(@types/node@20.12.12)
       '@inquirer/type': 3.0.8(@types/node@20.12.12)
     optionalDependencies:
       '@types/node': 20.12.12
+
+  '@inquirer/number@3.0.23(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
 
   '@inquirer/password@4.0.20(@types/node@20.12.12)':
     dependencies:
@@ -11389,6 +11600,29 @@ snapshots:
       '@inquirer/type': 3.0.8(@types/node@20.12.12)
     optionalDependencies:
       '@types/node': 20.12.12
+
+  '@inquirer/password@4.0.23(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.1)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.1)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.1)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.1)
+      '@inquirer/input': 4.3.1(@types/node@22.19.1)
+      '@inquirer/number': 3.0.23(@types/node@22.19.1)
+      '@inquirer/password': 4.0.23(@types/node@22.19.1)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.1)
+      '@inquirer/search': 3.2.2(@types/node@22.19.1)
+      '@inquirer/select': 4.4.2(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
 
   '@inquirer/prompts@7.3.2(@types/node@20.12.12)':
     dependencies:
@@ -11420,6 +11654,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.12
 
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/rawlist@4.1.8(@types/node@20.12.12)':
     dependencies:
       '@inquirer/core': 10.2.2(@types/node@20.12.12)
@@ -11437,6 +11679,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.12
 
+  '@inquirer/search@3.2.2(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/select@4.3.4(@types/node@20.12.12)':
     dependencies:
       '@inquirer/ansi': 1.0.0
@@ -11446,6 +11697,20 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 20.12.12
+
+  '@inquirer/select@4.4.2(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/type@3.0.10(@types/node@22.19.1)':
+    optionalDependencies:
+      '@types/node': 22.19.1
 
   '@inquirer/type@3.0.8(@types/node@20.12.12)':
     optionalDependencies:
@@ -14026,6 +14291,8 @@ snapshots:
     optional: true
 
   chardet@2.1.0: {}
+
+  chardet@2.1.1: {}
 
   cheerio-select@2.1.0:
     dependencies:


### PR DESCRIPTION
# Motivation

Add the ability for the user to setup the initial admin credentials when creating a new project using the CLI.

# Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
