### PR TITLE
fix: add missing agentic pkg publishing

### DIFF
--- a/.github/workflows/v3-alpha-npm.yml
+++ b/.github/workflows/v3-alpha-npm.yml
@@ -6,7 +6,42 @@ on:
       - "v3.*-alpha.*"
 
 jobs:
+  publish-agentic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          standalone: true
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org/"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.V3_NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install --filter "@hexabot-ai/agentic..." --prod=false
+
+      - name: Build the package
+        run: pnpm --filter "@hexabot-ai/agentic..." run build
+
+      - name: Publish to npm
+        working-directory: packages/agentic
+        run: pnpm publish --tag alpha --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.V3_NPM_TOKEN }}
+
   publish-package:
+    needs: publish-agentic
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/bump-version-v3.sh
+++ b/bump-version-v3.sh
@@ -11,7 +11,7 @@ fi
 RELEASE_TYPE=$1
 ROOT_DIR=$(pwd)
 TARGET_BRANCH="dev"
-PUBLISH_PACKAGES=("@hexabot-ai/api" "@hexabot-ai/cli" "@hexabot-ai/widget")
+PUBLISH_PACKAGES=("@hexabot-ai/agentic" "@hexabot-ai/api" "@hexabot-ai/cli" "@hexabot-ai/widget")
 BUMP_ONLY_PACKAGES=("@hexabot-ai/frontend")
 VERSION_PACKAGES=("${PUBLISH_PACKAGES[@]}" "${BUMP_ONLY_PACKAGES[@]}")
 ALLOWED_RELEASE_TYPES=("prepatch" "preminor" "prerelease")


### PR DESCRIPTION
# Motivation

- Added agentic to the version-bumped/published package list in bump-version-v3.sh
- Updated v3 alpha workflow to publish agentic first, then publish api/cli/widget only after that succeeds in v3-alpha-npm.yml

This prevents shipping an API version that depends on a non-existent agentic version.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
