### PR TITLE
fix: attachment circular dep

### DIFF
--- a/packages/api/src/attachment/attachment.module.ts
+++ b/packages/api/src/attachment/attachment.module.ts
@@ -6,7 +6,7 @@
 
 import { existsSync, mkdirSync } from 'fs';
 
-import { Module, OnApplicationBootstrap } from '@nestjs/common';
+import { forwardRef, Module, OnApplicationBootstrap } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AppInstance } from '@/app.instance';
@@ -19,7 +19,10 @@ import { AttachmentRepository } from './repositories/attachment.repository';
 import { AttachmentService } from './services/attachment.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AttachmentOrmEntity]), UserModule],
+  imports: [
+    TypeOrmModule.forFeature([AttachmentOrmEntity]),
+    forwardRef(() => UserModule),
+  ],
   providers: [AttachmentRepository, AttachmentService],
   controllers: [AttachmentController],
   exports: [AttachmentService],

--- a/packages/api/src/user/dto/assigned-profile.dto.ts
+++ b/packages/api/src/user/dto/assigned-profile.dto.ts
@@ -6,8 +6,8 @@
 
 import { Exclude, Expose } from 'class-transformer';
 
-import { ChannelName } from '@/channel';
-import { SubscriberChannelData } from '@/chat';
+import type { ChannelName } from '@/channel/types';
+import type { SubscriberChannelData } from '@/chat/types/channel';
 
 import { UserProvider } from '../types/user-provider.type';
 


### PR DESCRIPTION
# Motivation

UndefinedModuleException is caused by a circular-load timing issue in production-style entry (require('@hexabot-ai/api')), where AttachmentModule eagerly references UserModule before it is fully initialized.

This is aggravated by DTO barrel imports (@/chat, @/channel) that trigger broad module loading during UserModule evaluation.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
