### PR TITLE
fix(widget): resovle list/carousel cropped layout issues

### DIFF
--- a/packages/widget/src/components/Message.scss
+++ b/packages/widget/src/components/Message.scss
@@ -42,7 +42,7 @@
     flex-direction: row;
     position: relative;
     max-width: calc(100% - 40px); // same as avatar spacing
-    width: auto;
+    width: 100%;
 
     .hb-message--avatar {
       width: 32px;
@@ -59,6 +59,9 @@
       flex-direction: column;
       overflow: hidden;
       word-break: break-word;
+      width: 100%;
+      max-width: 256px;
+
 
         .hb-message--text {
           padding: 0.625rem 1.25rem;

--- a/packages/widget/src/components/messages/ListMessage.scss
+++ b/packages/widget/src/components/messages/ListMessage.scss
@@ -1,6 +1,5 @@
 .hb-message--list {
   border-radius: 0.5rem;
-  width: 256px;
   color: var(--hb-color-text-primary);
   background-color: var(--hb-color-surface-message-received);
 
@@ -13,10 +12,12 @@
     }
   }
 
+  .hb-message--list-element:not(:last-child){
+    border-bottom: var(--hb-color-border-subtle) 0.0625rem solid;
+  }
+
   .hb-message--list-element {
     position: relative;
-    border-bottom: 0.0625rem solid;
-    border-bottom-color: var(--hb-color-border-subtle);
     padding: 1rem;
 
     .hb-message--list-element-content {


### PR DESCRIPTION
# Motivation
Resolve list/carousel cropped layout issues.

# Demonstration
<video src="https://github.com/user-attachments/assets/ee36017f-ef1c-4afc-91a4-030152d5049c"></video>

# Cropped layout
<img width="298" height="604" alt="image" src="https://github.com/user-attachments/assets/dad2181f-c5c6-48ef-98f4-1dbcd464901e" />
<img width="298" height="604" alt="image" src="https://github.com/user-attachments/assets/f2a845fd-ce06-4111-b37a-a982ab116573" />

# Extra separator after the final List item 
<img width="378" height="349" alt="image" src="https://github.com/user-attachments/assets/b0f5e219-7be5-4d38-966d-d52cd5f74401" />
<img width="378" height="349" alt="image" src="https://github.com/user-attachments/assets/b215501d-8611-4ec6-b215-42d5af893984" />



