### PR TITLE
feat(frontend): show latest workflows in Pinned widget with view action

### DIFF
--- a/packages/frontend/src/components/dashboard/components/PinnedWorkflowsCard.tsx
+++ b/packages/frontend/src/components/dashboard/components/PinnedWorkflowsCard.tsx
@@ -13,22 +13,30 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { Play } from "lucide-react";
+import { Workflow } from "@hexabot-ai/types";
+import { Eye } from "lucide-react";
 
-import { getWorkflowIcon } from "../utils/transform.util";
+import { WORKFLOW_TYPES } from "@/constants/workflow.constants";
+import { useAppRouter } from "@/hooks/useAppRouter";
+import { useTranslate } from "@/hooks/useTranslate";
 
 import { IconContainer } from "./IconContainer";
 
-export const PinnedWorkflowsCard = ({ workflow }: { workflow: any }) => {
+export const PinnedWorkflowsCard = ({ workflow }: { workflow: Workflow }) => {
   const theme = useTheme();
-  const isEnabled = workflow.status === "Enabled";
-  const statusColor = isEnabled
-    ? theme.palette.success.main
-    : theme.palette.text.disabled;
-  const Icon = getWorkflowIcon(workflow.type);
+  const router = useAppRouter();
+  const { t } = useTranslate();
+  const workflowTypeInfo = WORKFLOW_TYPES[workflow.type];
+  const Icon = workflowTypeInfo.icon;
+  const openWorkflow = () => {
+    router.push({
+      pathname: `/workflow-editor/${workflow.id}`,
+    });
+  };
 
   return (
     <Card
+      onClick={openWorkflow}
       elevation={0}
       sx={{
         borderRadius: 3,
@@ -42,7 +50,7 @@ export const PinnedWorkflowsCard = ({ workflow }: { workflow: any }) => {
           border: `1px solid ${alpha(theme.palette.primary.main, 1)}`,
           boxShadow: "0 4px 20px rgba(0,0,0,0.08)",
           transform: "translateY(-2px)",
-          "& .play-button": { opacity: 1, transform: "scale(1)" },
+          "& .view-button": { opacity: 1, transform: "scale(1)" },
         },
       }}
     >
@@ -67,25 +75,21 @@ export const PinnedWorkflowsCard = ({ workflow }: { workflow: any }) => {
             <Typography variant="subtitle2" fontWeight="bold" noWrap>
               {workflow.name}
             </Typography>
-            <Box
-              sx={{
-                width: 6,
-                height: 6,
-                borderRadius: "50%",
-                bgcolor: statusColor,
-                boxShadow: isEnabled ? `0 0 8px ${statusColor}` : "none",
-              }}
-            />
           </Box>
           <Typography variant="caption" color="text.secondary" display="block">
-            {workflow.type} • {workflow.lastRun}
+            {t(workflowTypeInfo.labelKey)}
           </Typography>
         </Box>
 
         {/* Hover Action */}
         <IconButton
-          className="play-button"
+          className="view-button"
           color="primary"
+          aria-label={t("label.view")}
+          onClick={(event) => {
+            event.stopPropagation();
+            openWorkflow();
+          }}
           sx={{
             position: "absolute",
             right: 16,
@@ -96,7 +100,7 @@ export const PinnedWorkflowsCard = ({ workflow }: { workflow: any }) => {
             "&:hover": { bgcolor: theme.palette.primary.main, color: "white" },
           }}
         >
-          <Play size={18} fill="currentColor" />
+          <Eye size={18} />
         </IconButton>
       </CardContent>
     </Card>

--- a/packages/frontend/src/components/dashboard/components/PinnedWorkflowsCard.tsx
+++ b/packages/frontend/src/components/dashboard/components/PinnedWorkflowsCard.tsx
@@ -4,6 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
+import { Workflow } from "@hexabot-ai/types";
 import {
   alpha,
   Box,
@@ -13,7 +14,6 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { Workflow } from "@hexabot-ai/types";
 import { Eye } from "lucide-react";
 
 import { WORKFLOW_TYPES } from "@/constants/workflow.constants";

--- a/packages/frontend/src/components/dashboard/mockData.ts
+++ b/packages/frontend/src/components/dashboard/mockData.ts
@@ -52,33 +52,6 @@ export const mockAttentionItems = [
   },
 ];
 
-export const mockPinnedWorkflows = [
-  {
-    id: "wf-1",
-    name: "Customer Support Bot",
-    type: "Conversational",
-    status: "Enabled",
-    lastRun: "2m ago",
-    lastResult: "success",
-  },
-  {
-    id: "wf-2",
-    name: "Nightly Data Sync",
-    type: "Scheduled",
-    status: "Enabled",
-    lastRun: "4h ago",
-    lastResult: "success",
-  },
-  {
-    id: "wf-3",
-    name: "Manual User Export",
-    type: "Manual",
-    status: "Draft",
-    lastRun: "2d ago",
-    lastResult: "warning",
-  },
-];
-
 export const mockRecentActivity = [
   {
     id: "evt-1",

--- a/packages/frontend/src/components/dashboard/utils/transform.util.ts
+++ b/packages/frontend/src/components/dashboard/utils/transform.util.ts
@@ -8,11 +8,8 @@ import { alpha } from "@mui/material";
 import {
   AlertCircle,
   AlertTriangle,
-  Calendar,
-  FileText,
   LucideIcon,
   Mail,
-  MousePointer2,
   PlayIcon,
   RefreshCcw,
   Settings,
@@ -60,13 +57,6 @@ export const getColor = (c: string) => {
   };
 
   return colors[c] || theme.palette.primary.main;
-};
-
-export const getWorkflowIcon = (type: string): LucideIcon => {
-  if (type === "Conversational") return FileText;
-  if (type === "Scheduled") return Calendar;
-
-  return MousePointer2;
 };
 
 export const getActivityIcon = (text: string) => {

--- a/packages/frontend/src/components/dashboard/widgets/PinnedWorkflows.tsx
+++ b/packages/frontend/src/components/dashboard/widgets/PinnedWorkflows.tsx
@@ -5,12 +5,24 @@
  */
 
 import { Box, Button, Grid } from "@mui/material";
+import { Workflow } from "@hexabot-ai/types";
+
+import { useFind } from "@/hooks/crud/useFind";
+import { EntityType } from "@/services/types";
 
 import { PinnedWorkflowsCard } from "../components/PinnedWorkflowsCard";
 import { TitleWithActions } from "../components/TitleWithActions";
-import { mockPinnedWorkflows } from "../mockData";
 
 export const PinnedWorkflows = () => {
+  const { data: latestWorkflows } = useFind<Workflow>(
+    { entity: EntityType.WORKFLOW },
+    {
+      hasCount: false,
+      initialSortState: [{ field: "createdAt", sort: "desc" }],
+      initialPaginationState: { page: 0, pageSize: 3 },
+    },
+  );
+
   return (
     <Box>
       <TitleWithActions
@@ -22,9 +34,9 @@ export const PinnedWorkflows = () => {
         }
       />
       <Grid container spacing={2} justifyContent="center" alignItems="center">
-        {mockPinnedWorkflows.map((wf) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={wf.id}>
-            <PinnedWorkflowsCard workflow={wf} />
+        {latestWorkflows.map((workflow) => (
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={workflow.id}>
+            <PinnedWorkflowsCard workflow={workflow} />
           </Grid>
         ))}
       </Grid>

--- a/packages/frontend/src/components/dashboard/widgets/PinnedWorkflows.tsx
+++ b/packages/frontend/src/components/dashboard/widgets/PinnedWorkflows.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Box, Button, Grid } from "@mui/material";
-import { Workflow } from "@hexabot-ai/types";
 
 import { useFind } from "@/hooks/crud/useFind";
 import { EntityType } from "@/services/types";
@@ -14,7 +13,7 @@ import { PinnedWorkflowsCard } from "../components/PinnedWorkflowsCard";
 import { TitleWithActions } from "../components/TitleWithActions";
 
 export const PinnedWorkflows = () => {
-  const { data: latestWorkflows } = useFind<Workflow>(
+  const { data: latestWorkflows } = useFind(
     { entity: EntityType.WORKFLOW },
     {
       hasCount: false,


### PR DESCRIPTION
### Motivation
- Replace the hard-coded pinned mock list with real data so the dashboard shows the 3 most recently created workflows.
- Use canonical workflow type icons (conversational/manual/scheduled) for clarity and consistency with the visual editor.
- Change the hover action from a "play" affordance to a view/magnify affordance that opens the workflow in the visual editor.
- Remove obsolete mock data and unused helpers to keep the dashboard code clean.

### Description
- Query the API for workflows using `useFind` against `EntityType.WORKFLOW`, sorted by `createdAt desc` and limited to 3 items to populate the Pinned section.
- Update `PinnedWorkflowsCard` to use `WORKFLOW_TYPES` metadata for icon and label, replace the `Play` icon with an `Eye` icon, and wire both the card click and icon click to navigate to `/workflow-editor/:id` via `useAppRouter`.
- Remove the `mockPinnedWorkflows` data and the now-unused `getWorkflowIcon` helper from the dashboard transform utilities.
- Tighten typing for the component props to use the `Workflow` type from `@hexabot-ai/types`.

### Testing
- Ran `pnpm --filter @hexabot-ai/frontend lint`, which failed due to the environment/Corepack failing to download `pnpm@9.12.0` (network/proxy 403), so lint checks could not complete.
- Pre-commit checks that rely on the workspace tooling could not run because of the same package manager download failure.
- No frontend unit/test runs were executed after the network-limited lint failure in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec66e607f0832d940bba696cd72cd3)