### PR TITLE
fix(frontend): update Quick Actions channel link, icon, and i18n

### DIFF
--- a/packages/frontend/src/components/dashboard/mockData.ts
+++ b/packages/frontend/src/components/dashboard/mockData.ts
@@ -4,22 +4,27 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Activity, Play, Settings, XCircle } from "lucide-react";
+import { Activity, Play, Webhook, XCircle } from "lucide-react";
 
 import { RouterType } from "@/services/types";
 
 export const mockQuickActions = [
   {
     id: "create",
-    label: "Create Workflow",
+    label: "button.create_workflow",
     icon: Activity,
     url: `/${RouterType.WORKFLOW_EDITOR}`,
-  }, // icon will be handled in component
-  { id: "run", label: "Run Manual Workflow", icon: Play, url: "" },
-  { id: "connect", label: "Connect Channel", icon: Settings, url: "" },
+  },
+  { id: "run", label: "button.run_manual_workflow", icon: Play, url: "" },
+  {
+    id: "connect",
+    label: "menu.channel_sources",
+    icon: Webhook,
+    url: "/settings/sources",
+  },
   {
     id: "failed",
-    label: "View Failed Runs",
+    label: "button.view_failed_runs",
     icon: XCircle,
     url: "/workflow/runs?status=failed",
   },

--- a/packages/frontend/src/components/dashboard/mockData.ts
+++ b/packages/frontend/src/components/dashboard/mockData.ts
@@ -6,9 +6,17 @@
 
 import { Activity, Play, Webhook, XCircle } from "lucide-react";
 
+import type { TTranslationKeys } from "@/i18n/i18n.types";
 import { RouterType } from "@/services/types";
 
-export const mockQuickActions = [
+type TQuickAction = {
+  id: string;
+  label: TTranslationKeys;
+  icon: typeof Activity;
+  url: string;
+};
+
+export const mockQuickActions: TQuickAction[] = [
   {
     id: "create",
     label: "button.create_workflow",

--- a/packages/frontend/src/components/dashboard/widgets/QuickActions.tsx
+++ b/packages/frontend/src/components/dashboard/widgets/QuickActions.tsx
@@ -7,17 +7,19 @@
 import { Box, Button, Stack, Typography, useTheme } from "@mui/material";
 
 import { useAppRouter } from "@/hooks/useAppRouter";
+import { useTranslate } from "@/hooks/useTranslate";
 
 import { mockQuickActions } from "../mockData";
 
 export const QuickActions = () => {
   const router = useAppRouter();
   const theme = useTheme();
+  const { t } = useTranslate();
 
   return (
     <Box>
       <Typography variant="h6" mb={2}>
-        Quick Actions
+        {t("title.quick_actions")}
       </Typography>
       <Stack direction="row" gap={2} flexWrap="wrap">
         {mockQuickActions.map(({ icon: Icon, id, url, label }) => (
@@ -27,7 +29,7 @@ export const QuickActions = () => {
             startIcon={<Icon size={18} color={theme.palette.primary.main} />}
             onClick={() => url && router.push(url)}
           >
-            {label}
+            {t(label)}
           </Button>
         ))}
       </Stack>


### PR DESCRIPTION
### Motivation
- Make the dashboard Quick Actions widget localizable and ensure the "Connect Channel" action navigates to the Channel Sources page and uses the same icon as the menu for consistency.

### Description
- Use `useTranslate()` in `QuickActions` to localize the widget title and each action label.
- Replace hardcoded labels in `mockQuickActions` with translation keys and update the Connect action to use the `Webhook` icon and `"/settings/sources"` URL.
- Modified files: `packages/frontend/src/components/dashboard/widgets/QuickActions.tsx` and `packages/frontend/src/components/dashboard/mockData.ts`.

### Testing
- Attempted to run `pnpm --filter @hexabot-ai/frontend lint`, but it failed due to Corepack being unable to download `pnpm@9.12.0` from the registry (network/proxy 403), so lint checks could not complete.
- Pre-commit package checks were likewise blocked by the same Corepack/pnpm download error, so automated pre-commit validations did not run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6e474958832d94c419e6ac216ebe)