### PR TITLE
refactor(agentic): remove redundant workflow aliases

### DIFF
--- a/packages/agentic/src/index.ts
+++ b/packages/agentic/src/index.ts
@@ -49,7 +49,7 @@ export type {
 
 export {
   compileWorkflow,
-  Workflow as Workflow,
+  Workflow,
   WorkflowEventEmitter,
   WorkflowRunner,
   type FlowStepPath,

--- a/packages/agentic/src/workflow.ts
+++ b/packages/agentic/src/workflow.ts
@@ -18,7 +18,7 @@ import {
   validateWorkflow,
   type FlowStep,
 } from './dsl.types';
-import { safeRenameTaskInDefinition as safeRenameTaskInDefinitionHelper } from './utils/workflow-definition';
+import { safeRenameTaskInDefinition as renameTaskInDefinition } from './utils/workflow-definition';
 import {
   compileWorkflow,
   type WorkflowCompileOptions,
@@ -327,11 +327,7 @@ export class Workflow {
     currentTaskName: string,
     nextTaskName: string,
   ): WorkflowDefinition {
-    return safeRenameTaskInDefinitionHelper(
-      definition,
-      currentTaskName,
-      nextTaskName,
-    );
+    return renameTaskInDefinition(definition, currentTaskName, nextTaskName);
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Remove trivial indirection and a redundant re-export to simplify the `@hexabot-ai/agentic` API surface and reduce dead/unused aliasing without changing runtime behavior.

### Description
- Updated `packages/agentic/src/workflow.ts` to forward to the real helper by importing `safeRenameTaskInDefinition` (renamed locally to `renameTaskInDefinition`) and calling it directly from `Workflow.safeRenameTaskInDefinition` instead of using an extra alias.
- Simplified the package entry by exporting `Workflow` directly in `packages/agentic/src/index.ts` instead of the redundant `Workflow as Workflow` alias.

### Testing
- Ran lint via `pnpm --filter @hexabot-ai/agentic lint`, which failed due to Corepack attempting to fetch `pnpm@9.12.0` and encountering network/proxy restrictions in the environment (automated check failed).
- Ran TypeScript build/check via `tsc -p packages/agentic/tsconfig.build.cjs.json --noEmit`, which failed due to missing local type definitions (e.g. `jest`) and a deprecation/configuration gate in this environment (automated check failed).
- Executed `git diff --check` to validate whitespace/merge issues, which passed (automated repository check succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8245dcbc832dbf9d75ea36cb955a)