### PR TITLE
fix(widget): keep on-primary text light for default teal primary

### DIFF
--- a/packages/widget/src/theme/theme.utils.test.ts
+++ b/packages/widget/src/theme/theme.utils.test.ts
@@ -59,6 +59,7 @@ describe("resolveWidgetTheme", () => {
     });
 
     expect(theme.palette.primary).toBe("#1BA089");
+    expect(theme.palette.onPrimary).toBe("#FCFCFC");
     expect(theme.tokens.surface.header).toBe("#1BA089");
   });
 

--- a/packages/widget/src/theme/theme.utils.ts
+++ b/packages/widget/src/theme/theme.utils.ts
@@ -23,6 +23,7 @@ const DEFAULT_LIGHT_PRIMARY_COLOR = "#0074D9";
 const DEFAULT_DARK_PRIMARY_COLOR = "#111827";
 const WHITE_TEXT_COLOR = "#FCFCFC";
 const DARK_TEXT_COLOR = "#343842";
+const MIN_ACCEPTABLE_LIGHT_TEXT_CONTRAST = 3;
 const HEX_COLOR_PATTERN = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 const COLOR_FUNCTION_PATTERN = /^(rgba?|hsla?)\(/i;
 const DEFAULT_TYPOGRAPHY: ThemeTypography = {
@@ -80,10 +81,13 @@ const contrastRatio = (first: string, second: string): number => {
   return chroma.contrast(first, second);
 };
 const getReadableTextColor = (backgroundColor: string): string => {
-  return contrastRatio(backgroundColor, WHITE_TEXT_COLOR) >=
-    contrastRatio(backgroundColor, DARK_TEXT_COLOR)
-    ? WHITE_TEXT_COLOR
-    : DARK_TEXT_COLOR;
+  const lightTextContrast = contrastRatio(backgroundColor, WHITE_TEXT_COLOR);
+
+  if (lightTextContrast >= MIN_ACCEPTABLE_LIGHT_TEXT_CONTRAST) {
+    return WHITE_TEXT_COLOR;
+  }
+
+  return DARK_TEXT_COLOR;
 };
 const toRgbaColor = (value: string, alpha: number): string => {
   const [red, green, blue] = chroma(value)


### PR DESCRIPTION
### Motivation
- Medium-bright brand primary colors (e.g. `#1BA089`) resolved their readable foreground by simply picking the higher contrast color, which made header/launcher text/icons render dark and lose the intended light-on-primary look.

### Description
- Added `MIN_ACCEPTABLE_LIGHT_TEXT_CONTRAST = 3` and changed `getReadableTextColor` to prefer light (`#FCFCFC`) when white meets that minimum contrast, otherwise fall back to the dark text color.  
- Updated `resolveWidgetTheme` unit test in `packages/widget/src/theme/theme.utils.test.ts` to assert `palette.onPrimary` is `#FCFCFC` for normalized `1ba089`.  
- Changes are limited to `packages/widget/src/theme/theme.utils.ts` and the corresponding test file.

### Testing
- Updated unit test `packages/widget/src/theme/theme.utils.test.ts` to lock the expected `onPrimary` behavior (test added).  
- Attempted to run `pnpm --filter @hexabot-ai/widget run typecheck`, but it failed in this environment due to Corepack/pnpm download being blocked by network/proxy (registry fetch returned 403).  
- The repository pre-commit checks also failed for the same environment network error, so validation could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8d376658832daa0ea770c6a84fb1)