### PR TITLE
fix(api): ws connection for authenticated users

### DIFF
--- a/packages/api/src/extensions/channels/web/base-web-channel.ts
+++ b/packages/api/src/extensions/channels/web/base-web-channel.ts
@@ -166,6 +166,10 @@ export default abstract class BaseWebChannelHandler<N extends ChannelName>
       const sourceId = this.getSourceIdFromHandshake(client);
 
       if (!sourceId) {
+        if (client.request.session.passport?.user?.id) {
+          return;
+        }
+
         this.logger.warn('Missing source_id in websocket handshake');
         client.disconnect();
 

--- a/packages/api/src/extensions/channels/web/base-web-channel.ts
+++ b/packages/api/src/extensions/channels/web/base-web-channel.ts
@@ -167,6 +167,7 @@ export default abstract class BaseWebChannelHandler<N extends ChannelName>
 
       if (!sourceId) {
         if (client.request.session.passport?.user?.id) {
+          // Core websocket connection for system notifications (not the web/console channel one)
           return;
         }
 

--- a/packages/api/src/websocket/websocket.gateway.ts
+++ b/packages/api/src/websocket/websocket.gateway.ts
@@ -244,6 +244,7 @@ export class WebsocketGateway
         const userId = session.passport?.user?.id;
 
         if (!rawSourceId && userId) {
+          // Core websocket connection for system notifications (not the web/console channel one)
           next();
 
           return;

--- a/packages/api/src/websocket/websocket.gateway.ts
+++ b/packages/api/src/websocket/websocket.gateway.ts
@@ -239,7 +239,15 @@ export class WebsocketGateway
           return;
         }
         const session = client.request.session;
-        const sourceId = this.normalizeSourceId(searchParams.get('source_id'));
+        const rawSourceId = searchParams.get('source_id');
+        const sourceId = this.normalizeSourceId(rawSourceId);
+        const userId = session.passport?.user?.id;
+
+        if (!rawSourceId && userId) {
+          next();
+
+          return;
+        }
 
         if (!sourceId) {
           next(
@@ -274,7 +282,7 @@ export class WebsocketGateway
 
         if (
           // Either the WS connection is with an authenticated user
-          session.passport?.user?.id
+          userId
         ) {
           session.save((err) => {
             if (err) {


### PR DESCRIPTION
# Motivation

Fixes admin websocket subscriptions being rejected when no source_id is present.

The admin frontend opens a credentialed Socket.IO connection for entity/workflow subscriptions, but it does not send a channel source_id. The API gateway was validating source_id before allowing authenticated admin sessions, so the socket failed with: `Missing or invalid source_id in websocket handshake`

As a result, /entity/subscribe/ never ran and entity mutation events were not received by the frontend, leaving workflow create/delete updates out of sync in the flows drawer.



# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
