### PR TITLE
fix(cli): update admin default password length

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -213,7 +213,7 @@ const validateAdminPassword = (value: string) => {
   }
 
   // Keep the rule simple and explicit for CLI UX. Complexity policies vary by org.
-  const minLength = 12;
+  const minLength = 8;
   if (trimmed.length < minLength) {
     return `Password must be at least ${minLength} characters.`;
   }


### PR DESCRIPTION
## What changed?
This PR changes the admin password length from 12 to 8 when creating a project via CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lowered the minimum admin password length requirement from 12 to 8 characters, streamlining the password setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->