### PR TITLE
fix(frontend): add missing i18n translation keys

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -84,7 +84,13 @@
     "file_error": "File not found",
     "audio_error": "Audio not found",
     "video_error": "Video not found",
+    "start": "Start",
+    "stop": "Stop",
     "wait_message": "Please wait",
+    "conditional_operator": "Condition",
+    "parallel_indicator": "Parallel",
+    "loop_indicator": "Loop",
+    "conditional_indicator": "Conditional",
     "license_activated_modal_title": "License activated successfully",
     "license_activated_modal_description": "Your license key has been validated and paid features are now available.",
     "license_activated_modal_cta_hint": "Click Continue to refresh your session and unlock eligible features.",
@@ -954,6 +960,11 @@
         },
         "empty_state": "No strategy options available."
       }
+    },
+    "port_label": {
+      "memory": "Memory",
+      "model": "Model",
+      "tools": "Tools"
     },
     "yaml_editor": {
       "show": "Show YAML editor",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -84,7 +84,13 @@
     "file_error": "Fichier introuvable",
     "audio_error": "Audio introuvable",
     "video_error": "Vidéo introuvable",
+    "start": "Début",
+    "stop": "Fin",
     "wait_message": "Veuillez patienter",
+    "conditional_operator": "Condition",
+    "parallel_indicator": "Parallèle",
+    "loop_indicator": "Boucle",
+    "conditional_indicator": "Conditionnel",
     "license_activated_modal_title": "Licence activée avec succès",
     "license_activated_modal_description": "Votre clé de licence a été validée et les fonctionnalités payantes sont maintenant disponibles.",
     "license_activated_modal_cta_hint": "Cliquez sur Continuer pour rafraîchir votre session et débloquer les fonctionnalités éligibles.",
@@ -956,6 +962,11 @@
         },
         "empty_state": "Aucune option de stratégie disponible."
       }
+    },
+    "port_label": {
+      "memory": "Mémoire",
+      "model": "Modèle",
+      "tools": "Outils"
     },
     "yaml_editor": {
       "show": "Afficher l'éditeur YAML",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -655,8 +655,6 @@
       "logs_errors": "Journaux / Erreurs"
     },
     "inspector": "Inspecteur",
-    "latest_run": "Dernière exécution",
-    "run_at": "Exécution {{0}}",
     "unknown": "Inconnu",
     "upgrade_required": "Mise à niveau requise",
     "plan_badge_starter": "STARTER",


### PR DESCRIPTION
## What changed?
This PR will add missing i18n translation keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added English translations for workflow controls (`start`, `stop`) and operator indicators (conditional operator, conditional indicator, parallel indicator, loop indicator).
  * Added visual editor port labels for memory, model, and tools.
  * Extended French translations to include the new workflow/control and port-label strings, and removed two obsolete inspector strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->