### PR TITLE
feat(graph): gradient border for running nodes

### DIFF
--- a/packages/graph/src/workflow/components/workflow-nodes/GenericNodeRightContent.tsx
+++ b/packages/graph/src/workflow/components/workflow-nodes/GenericNodeRightContent.tsx
@@ -6,29 +6,47 @@
 
 import { type CSSProperties, type PropsWithChildren } from "react";
 
+import { useWorkflowNode } from "../../hooks/useWorkflowNode";
 import { useWorkflowNodeTheme } from "../../hooks/useWorkflowNodeTheme";
 import {
   ENodeType,
-  TNodeCardContentVariant,
+  type NodeExecutionState,
+  type TNodeCardContentVariant,
 } from "../../types/workflow-node.types";
 
 import { GenericNodeDeleteButton } from "./GenericNodeDeleteButton";
+
+const ANIMATED_EXECUTION_BORDER_STATES = new Set<NodeExecutionState>([
+  "running",
+  "start",
+  "suspended",
+]);
 
 export const GenericNodeRightContent = <T extends ENodeType = ENodeType>({
   children,
   variant = "title-only",
 }: PropsWithChildren<{ variant?: TNodeCardContentVariant }>) => {
   const { bgColor, borderColor } = useWorkflowNodeTheme<T>();
+  const { executionState } = useWorkflowNode<T>();
+  const hasAnimatedExecutionBorder =
+    executionState !== undefined &&
+    ANIMATED_EXECUTION_BORDER_STATES.has(executionState);
   const style = {
     "--workflow-node-bg-color": bgColor,
     "--workflow-node-border-color": borderColor,
   } as CSSProperties;
+  const className = [
+    "workflow-node-card",
+    `workflow-node-card--${variant}`,
+    hasAnimatedExecutionBorder
+      ? "workflow-node-card--animated-execution-border"
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <div
-      className={`workflow-node-card workflow-node-card--${variant}`}
-      style={style}
-    >
+    <div className={className} style={style}>
       <GenericNodeDeleteButton />
       {children}
     </div>

--- a/packages/graph/src/workflow/styles/node.css
+++ b/packages/graph/src/workflow/styles/node.css
@@ -44,6 +44,25 @@
   gap: 6px;
 }
 
+.workflow-node-card--animated-execution-border {
+  border-color: transparent;
+  background:
+    linear-gradient(
+        var(--workflow-node-bg-color, #ffffff),
+        var(--workflow-node-bg-color, #ffffff)
+      )
+      padding-box,
+    conic-gradient(
+        from var(--workflow-node-execution-border-angle),
+        #d8e830 0deg,
+        #6cc96d 120deg,
+        #4cc4e5 240deg,
+        #d8e830 360deg
+      )
+      border-box;
+  animation: workflow-node-execution-border-spin 0.8s linear infinite;
+}
+
 .workflow-node-title-row {
   display: flex;
   flex-direction: row;
@@ -196,8 +215,28 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .workflow-node-card--animated-execution-border {
+    animation: none;
+  }
+
   .workflow-icon-spin {
     animation: none;
+  }
+}
+
+@property --workflow-node-execution-border-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes workflow-node-execution-border-spin {
+  from {
+    --workflow-node-execution-border-angle: 0deg;
+  }
+
+  to {
+    --workflow-node-execution-border-angle: 360deg;
   }
 }
 

--- a/packages/graph/src/workflow/utils/workflow-theme.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-theme.utils.test.ts
@@ -18,7 +18,7 @@ describe("workflow-theme.utils", () => {
   it("returns running state config with an animated icon", () => {
     const runningConfig = getWorkflowStateConfig("running");
 
-    expect(runningConfig?.color).toBe("#4dc4e6");
+    expect(runningConfig?.color).toBeUndefined();
     const runningIcon = runningConfig?.icon as
       | ((props: { className?: string; size?: number }) => IconProbeResult)
       | undefined;
@@ -29,6 +29,30 @@ describe("workflow-theme.utils", () => {
 
     expect(iconElement?.props.className).toContain("workflow-icon-spin");
     expect(iconElement?.props.className).toContain("existing");
+  });
+
+  it("preserves node colors while running", () => {
+    const resolved = resolveWorkflowStepTheme({
+      action: { name: "send_message", color: "#336699" },
+      status: "running",
+      mode: "light",
+    });
+
+    expect(resolved.iconColor).toBe("#336699");
+    expect(resolved.borderColor).toBe("#336699");
+    expect(resolved.bgColor).toContain("#ffffff 95%");
+  });
+
+  it("preserves node colors while suspended", () => {
+    const resolved = resolveWorkflowStepTheme({
+      action: { name: "send_message", color: "#336699" },
+      status: "suspended",
+      mode: "light",
+    });
+
+    expect(resolved.iconColor).toBe("#336699");
+    expect(resolved.borderColor).toBe("#336699");
+    expect(resolved.bgColor).toContain("#ffffff 95%");
   });
 
   it("uses action accent colors when no state override is present", () => {

--- a/packages/graph/src/workflow/utils/workflow-theme.utils.ts
+++ b/packages/graph/src/workflow/utils/workflow-theme.utils.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { ActionStatus } from "@hexabot-ai/agentic";
+import type { ActionStatus } from "@hexabot-ai/agentic";
 import * as Icons from "lucide-react";
 import { createElement, type ComponentProps } from "react";
 
@@ -16,7 +16,7 @@ import type {
 
 type WorkflowStateConfig = {
   icon: WorkflowIcon;
-  color: string;
+  color?: string;
 };
 
 type WorkflowThemeInput = {
@@ -44,22 +44,31 @@ const WorkflowRunningIcon: WorkflowIcon = ({
     className: appendClassName(className, "workflow-icon-spin"),
   });
 };
+const WORKFLOW_STATE_ICONS: Partial<Record<ActionStatus, WorkflowIcon>> = {
+  running: WorkflowRunningIcon,
+  failed: Icons.TriangleAlert,
+  suspended: Icons.SquarePause,
+};
+const WORKFLOW_STATE_COLOR_OVERRIDES: Partial<Record<ActionStatus, string>> = {
+  failed: "#FF0000",
+};
 
 export const getWorkflowStateConfig = (
   status?: ActionStatus,
 ): WorkflowStateConfig | undefined => {
-  switch (status) {
-    case "running":
-      return { icon: WorkflowRunningIcon, color: "#4dc4e6" };
-    case "completed":
-      return undefined;
-    case "failed":
-      return { icon: Icons.TriangleAlert, color: "#FF0000" };
-    case "suspended":
-      return { icon: Icons.SquarePause, color: "#4dc4e6" };
-    default:
-      return undefined;
+  if (!status) {
+    return undefined;
   }
+
+  const icon = WORKFLOW_STATE_ICONS[status];
+
+  if (!icon) {
+    return undefined;
+  }
+
+  const color = WORKFLOW_STATE_COLOR_OVERRIDES[status];
+
+  return color ? { icon, color } : { icon };
 };
 
 export const resolveWorkflowStepTheme = ({
@@ -70,8 +79,11 @@ export const resolveWorkflowStepTheme = ({
 }: WorkflowThemeInput): ResolvedWorkflowTheme => {
   const isDarkMode = mode === "dark";
   const stateConfig = getWorkflowStateConfig(status);
+  const stateColorOverride = status
+    ? WORKFLOW_STATE_COLOR_OVERRIDES[status]
+    : undefined;
   const borderColor =
-    stateConfig?.color ?? baseTheme?.borderColor ?? action?.color;
+    stateColorOverride ?? baseTheme?.borderColor ?? action?.color;
   const iconName = baseTheme?.icon ?? action?.icon;
   const namedIcon =
     iconName && iconName in Icons
@@ -91,7 +103,7 @@ export const resolveWorkflowStepTheme = ({
             isDarkMode ? DEFAULT_DARK_MIX_TARGET : DEFAULT_LIGHT_MIX_TARGET
           } ${isDarkMode ? "85%" : "95%"})`
         : undefined),
-    iconColor: stateConfig?.color ?? baseTheme?.iconColor ?? borderColor,
+    iconColor: stateColorOverride ?? baseTheme?.iconColor ?? borderColor,
     borderColor,
   };
 };


### PR DESCRIPTION
## What changed?

Adds an animated gradient border for active workflow nodes without changing their existing node colors.

- Running/start and suspended nodes now show a rotating yellow/green/blue gradient border.
- Removed legacy running/suspended color overrides so node backgrounds, icon colors, and borders stay based on their normal theme.
- Kept failed-state red override behavior unchanged.
- Added coverage for preserving node colors during running and suspended states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added animated execution border effect for workflow nodes to provide visual feedback during task execution.

* **Tests**
  * Updated theme configuration test coverage to ensure consistent styling behavior across execution states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->