### PR TITLE
fix(api): block prototype pollution in TypeORM search filter pipe

### DIFF
--- a/packages/api/src/utils/generics/base-orm.repository.ts
+++ b/packages/api/src/utils/generics/base-orm.repository.ts
@@ -9,6 +9,8 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { instanceToPlain, plainToInstance } from 'class-transformer';
 import camelCase from 'lodash/camelCase';
 import set from 'lodash/set';
+
+import { hasForbiddenSegment } from '../helpers/safe-property-path';
 import {
   DataSource,
   DeepPartial,
@@ -330,7 +332,9 @@ export abstract class BaseOrmRepository<
         ) as Record<string, unknown>;
         const target = entity as Record<string, unknown>;
         for (const [path, value] of Object.entries(flattenedUpdates)) {
-          set(target, path, value);
+          if (!hasForbiddenSegment(path)) {
+            set(target, path, value);
+          }
         }
       } else {
         Object.assign(entity, updates);

--- a/packages/api/src/utils/generics/base-orm.repository.ts
+++ b/packages/api/src/utils/generics/base-orm.repository.ts
@@ -9,8 +9,6 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { instanceToPlain, plainToInstance } from 'class-transformer';
 import camelCase from 'lodash/camelCase';
 import set from 'lodash/set';
-
-import { hasForbiddenSegment } from '../helpers/safe-property-path';
 import {
   DataSource,
   DeepPartial,
@@ -34,6 +32,7 @@ import { BaseOrmEntity } from '@/database/entities/base.entity';
 import { LoggerService } from '@/logger/logger.service';
 import { flatten } from '@/utils/helpers/flatten';
 
+import { hasForbiddenSegment } from '../helpers/safe-property-path';
 import {
   DtoAction,
   InferCreateDto,

--- a/packages/api/src/utils/helpers/safe-property-path.spec.ts
+++ b/packages/api/src/utils/helpers/safe-property-path.spec.ts
@@ -1,0 +1,30 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { hasForbiddenSegment } from './safe-property-path';
+
+describe('hasForbiddenSegment', () => {
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'should detect forbidden key "%s" as a standalone segment',
+    (key) => {
+      expect(hasForbiddenSegment(key)).toBe(true);
+    },
+  );
+
+  it.each(['__proto__.polluted', 'a.constructor.b', 'x.prototype'])(
+    'should detect forbidden key in nested path "%s"',
+    (path) => {
+      expect(hasForbiddenSegment(path)).toBe(true);
+    },
+  );
+
+  it.each(['name', 'user.email', 'nested.deep.field'])(
+    'should allow safe path "%s"',
+    (path) => {
+      expect(hasForbiddenSegment(path)).toBe(false);
+    },
+  );
+});

--- a/packages/api/src/utils/helpers/safe-property-path.ts
+++ b/packages/api/src/utils/helpers/safe-property-path.ts
@@ -1,0 +1,11 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function hasForbiddenSegment(path: string): boolean {
+  return path.split('.').some((segment) => FORBIDDEN_KEYS.has(segment));
+}

--- a/packages/api/src/utils/pipes/typeorm-search-filter.pipe.spec.ts
+++ b/packages/api/src/utils/pipes/typeorm-search-filter.pipe.spec.ts
@@ -74,6 +74,21 @@ describe('TypeOrmSearchFilterPipe', () => {
     expect(result.take).toBe(10);
   });
 
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'should block prototype-polluting key "%s" in assignNestedWhereValue',
+    (forbidden) => {
+      const target: Record<string, unknown> = {};
+      (pipe as any).assignNestedWhereValue(
+        target,
+        `${forbidden}.polluted`,
+        'yes',
+      );
+
+      expect(target).toEqual({});
+      expect(({} as any).polluted).toBeUndefined();
+    },
+  );
+
   it('should parse sort parameter and fallback to default sort', async () => {
     const withSort = await pipe.transform(
       {

--- a/packages/api/src/utils/pipes/typeorm-search-filter.pipe.spec.ts
+++ b/packages/api/src/utils/pipes/typeorm-search-filter.pipe.spec.ts
@@ -112,9 +112,7 @@ describe('TypeOrmSearchFilterPipe', () => {
       const right = { [forbidden]: 'malicious' } as any;
       (pipe as any).mergeWhereObjects(left, right);
 
-      expect(Object.prototype.hasOwnProperty.call(left, forbidden)).toBe(
-        false,
-      );
+      expect(Object.prototype.hasOwnProperty.call(left, forbidden)).toBe(false);
       expect(({} as any).malicious).toBeUndefined();
     },
   );

--- a/packages/api/src/utils/pipes/typeorm-search-filter.pipe.spec.ts
+++ b/packages/api/src/utils/pipes/typeorm-search-filter.pipe.spec.ts
@@ -89,6 +89,36 @@ describe('TypeOrmSearchFilterPipe', () => {
     },
   );
 
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'should block prototype-polluting key "%s" in parseSort',
+    async (forbidden) => {
+      const result = await pipe.transform(
+        {
+          where: {},
+          sort: `${forbidden}.polluted asc`,
+        } as any,
+        {} as any,
+      );
+
+      expect(result.order).toEqual({ createdAt: 'DESC' });
+      expect(({} as any).polluted).toBeUndefined();
+    },
+  );
+
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'should block prototype-polluting key "%s" in mergeWhereObjects',
+    (forbidden) => {
+      const left = {} as any;
+      const right = { [forbidden]: 'malicious' } as any;
+      (pipe as any).mergeWhereObjects(left, right);
+
+      expect(Object.prototype.hasOwnProperty.call(left, forbidden)).toBe(
+        false,
+      );
+      expect(({} as any).malicious).toBeUndefined();
+    },
+  );
+
   it('should parse sort parameter and fallback to default sort', async () => {
     const withSort = await pipe.transform(
       {

--- a/packages/api/src/utils/pipes/typeorm-search-filter.pipe.ts
+++ b/packages/api/src/utils/pipes/typeorm-search-filter.pipe.ts
@@ -10,7 +10,6 @@ import {
   Logger,
   PipeTransform,
 } from '@nestjs/common';
-import set from 'lodash/set';
 import {
   FindManyOptions,
   FindOptionsOrder,
@@ -22,6 +21,7 @@ import {
   Not,
 } from 'typeorm';
 
+import { hasForbiddenSegment } from '../helpers/safe-property-path';
 import {
   TFilterNestedKeysOfType,
   TSearchFilterValue,
@@ -200,13 +200,23 @@ export class TypeOrmSearchFilterPipe<T>
     }
 
     const [field = '', direction = 'desc'] = sort.trim().split(/\s+/);
-    if (!field) {
+    if (!field || hasForbiddenSegment(field)) {
       return undefined;
     }
 
     const normalized = direction.toLowerCase() === 'asc' ? 'ASC' : 'DESC';
+    const segments = field.split('.');
+    const result: Record<string, unknown> = {};
+    let cursor = result;
 
-    return set({}, field, normalized) as FindOptionsOrder<T>;
+    for (let i = 0; i < segments.length - 1; i++) {
+      cursor[segments[i]] = {};
+      cursor = cursor[segments[i]] as Record<string, unknown>;
+    }
+
+    cursor[segments[segments.length - 1]] = normalized;
+
+    return result as FindOptionsOrder<T>;
   }
 
   private parseDefaultSort(): FindOptionsOrder<T> | undefined {
@@ -391,23 +401,13 @@ export class TypeOrmSearchFilterPipe<T>
     }
   }
 
-  private static readonly FORBIDDEN_KEYS = new Set([
-    '__proto__',
-    'constructor',
-    'prototype',
-  ]);
-
   private assignNestedWhereValue(
     target: Record<string, unknown>,
     path: string,
     value: unknown,
   ): void {
-    if (value === undefined) return;
+    if (value === undefined || hasForbiddenSegment(path)) return;
     const segments = path.split('.');
-
-    if (segments.some((s) => TypeOrmSearchFilterPipe.FORBIDDEN_KEYS.has(s))) {
-      return;
-    }
 
     let cursor = target;
 
@@ -427,7 +427,7 @@ export class TypeOrmSearchFilterPipe<T>
     right: FindOptionsWhere<T>,
   ): FindOptionsWhere<T> {
     for (const [key, value] of Object.entries(right)) {
-      if (value === undefined) {
+      if (value === undefined || hasForbiddenSegment(key)) {
         continue;
       }
 

--- a/packages/api/src/utils/pipes/typeorm-search-filter.pipe.ts
+++ b/packages/api/src/utils/pipes/typeorm-search-filter.pipe.ts
@@ -391,6 +391,12 @@ export class TypeOrmSearchFilterPipe<T>
     }
   }
 
+  private static readonly FORBIDDEN_KEYS = new Set([
+    '__proto__',
+    'constructor',
+    'prototype',
+  ]);
+
   private assignNestedWhereValue(
     target: Record<string, unknown>,
     path: string,
@@ -398,6 +404,11 @@ export class TypeOrmSearchFilterPipe<T>
   ): void {
     if (value === undefined) return;
     const segments = path.split('.');
+
+    if (segments.some((s) => TypeOrmSearchFilterPipe.FORBIDDEN_KEYS.has(s))) {
+      return;
+    }
+
     let cursor = target;
 
     for (let index = 0; index < segments.length - 1; index++) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened path validation to block unsafe nested property names, preventing prototype-pollution and ensuring invalid sort fields fall back to the default ordering.
* **Tests**
  * Added parameterized tests validating path-safety across parsing, sorting, and object-merge scenarios to ensure robust fallback behavior and protection against injection attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->