### PR TITLE
fix(agentic): resolve not executed steps after suspension resume

### DIFF
--- a/packages/agentic/src/__tests__/suspension-rebuilder.test.ts
+++ b/packages/agentic/src/__tests__/suspension-rebuilder.test.ts
@@ -220,6 +220,54 @@ describe('rebuildSuspension', () => {
     expect(deps.executeFlow).toHaveBeenCalledWith(compiled.flow, state, [], 1);
   });
 
+  it('continues outer flow after resuming a suspension inside a conditional branch', async () => {
+    const branchTask = createTask('branch_task');
+    const afterTask = createTask('after_task');
+    const branchStep: CompiledStep = {
+      type: StepType.Task,
+      id: '0.branch.0.0:branch_task',
+      label: 'branch_task',
+      taskName: 'branch_task',
+    };
+    const conditionalStep: CompiledStep = {
+      type: StepType.Conditional,
+      id: '0:conditional',
+      label: 'conditional',
+      branches: [{ id: '0:branch_0', steps: [branchStep] }],
+    };
+    const outerStep: CompiledStep = {
+      type: StepType.Task,
+      id: '1:after_task',
+      label: 'after_task',
+      taskName: 'after_task',
+    };
+    const compiled = createCompiledWorkflow([conditionalStep, outerStep], {
+      branch_task: branchTask,
+      after_task: afterTask,
+    });
+    const state: ExecutionState = {
+      input: {},
+      output: {},
+      iterationStack: [],
+    };
+    const deps = createDeps(compiled);
+    deps.executeFlow = jest
+      .fn()
+      .mockResolvedValue(undefined) as SuspensionRebuilderDeps['executeFlow'];
+
+    const suspension = rebuildSuspension(deps, {
+      state,
+      stepId: '0.branch.0.0:branch_task',
+    });
+
+    await suspension?.continue({ reply: 'ok' });
+
+    expect(deps.captureTaskOutput).toHaveBeenCalledWith(branchTask, state, {
+      reply: 'ok',
+    });
+    expect(deps.executeFlow).toHaveBeenCalledWith(compiled.flow, state, [], 1);
+  });
+
   it('rebuilds a parallel suspension and continues remaining siblings when needed', async () => {
     const firstTask = createTask('child_a');
     const secondTask = createTask('child_b');

--- a/packages/agentic/src/suspension-rebuilder.ts
+++ b/packages/agentic/src/suspension-rebuilder.ts
@@ -390,7 +390,7 @@ export function buildSuspensionForPath(
           return next;
         }
 
-        return undefined;
+        return deps.executeFlow(steps, state, pathPrefix, current + 1);
       },
     };
   }


### PR DESCRIPTION
## What changed?
This PR resolves not executed steps after suspension resume bug


## How to reproduce 
If we execute this workflow all the steps outside the conditional group will be not executed (the step 3 in this example)
<img width="1796" height="346" alt="image" src="https://github.com/user-attachments/assets/5ee28211-cc00-4037-a02d-87c9786583fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where workflows with conditional branches would incorrectly halt instead of continuing to the next step after branch completion.

* **Tests**
  * Enhanced test coverage for conditional branch suspension and resumption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->