### PR TITLE
fix(frontend): remove invalid Grid direction prop in Header

### DIFF
--- a/packages/frontend/src/layout/Header.tsx
+++ b/packages/frontend/src/layout/Header.tsx
@@ -23,7 +23,13 @@ export const Header: FC = () => {
         <Grid maxWidth={0}>
           <Toolbar />
         </Grid>
-        <Grid ml={2} alignItems="center" gap={1} direction="row" display="flex">
+        <Grid
+          ml={2}
+          alignItems="center"
+          gap={1}
+          display="flex"
+          flexDirection="row"
+        >
           <HexabotLogo />
         </Grid>
       </Grid>


### PR DESCRIPTION
### Motivation
- Fix a MUI prop-type warning caused by using `direction` on a non-`container` `Grid` in the header while preserving layout.

### Description
- Replace `direction="row"` on the `Grid` in `packages/frontend/src/layout/Header.tsx` with `display="flex"` and `flexDirection="row"` so the visual layout is unchanged and MUI prop rules are satisfied.

### Testing
- Ran `pnpm --filter @hexabot-ai/frontend typecheck` (passed) and `pnpm --filter @hexabot-ai/frontend lint` (passed), while `pnpm --filter @hexabot-ai/frontend test` and `pnpm --filter @hexabot-ai/frontend build` failed in this environment due to unresolved internal package entry `@hexabot-ai/agentic` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f042c9126c832db7cd6bfd28e230a3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated header layout styling implementation for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->