### PR TITLE
docs: update Admin UI localhost port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ hexabot create my-project --pm npm
 
 Default local endpoints:
 
-- Admin UI: `http://localhost:8080`
+- Admin UI: `http://localhost:3000`
 - API: `http://localhost:3000/api`
 - API docs (non-production): `http://localhost:3000/docs`
 


### PR DESCRIPTION
### Motivation
- Update the README to reflect the correct Admin UI default local endpoint `http://localhost:3000` instead of `http://localhost:8080`.

### Description
- Edited `README.md` to change the "Default local endpoints" entry for Admin UI from `http://localhost:8080` to `http://localhost:3000`.

### Testing
- Repository pre-commit checks and linters executed as part of the commit flow and completed successfully, and the change is documentation-only so no package tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07c2dfac4832d8b8a1b163b8411cb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated default local endpoints documentation to reflect Admin UI now running on port 3000 instead of port 8080.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->