### PR TITLE
fix(frontend): debounced workflow def update

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/useYamlEditorController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/useYamlEditorController.ts
@@ -35,7 +35,7 @@ export function useYamlEditorController() {
   const completionDisposableRef = useRef<IDisposable | null>(null);
   const onChange = useCallback(
     (nextValue?: string) => {
-      updateDefinitionState(nextValue || "");
+      updateDefinitionState(nextValue || "", { persist: "debounced" });
     },
     [updateDefinitionState],
   );

--- a/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowDefinitionState.ts
+++ b/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowDefinitionState.ts
@@ -5,10 +5,8 @@
  */
 
 import {
-  Workflow as WorkflowHelper,
   type WorkflowCompileOptions,
   type WorkflowDefinition,
-  validateWorkflow,
 } from "@hexabot-ai/agentic";
 import { WorkflowVersionAction } from "@hexabot-ai/types";
 import type { Workflow } from "@hexabot-ai/types";
@@ -28,6 +26,12 @@ import { useApiClient } from "@/hooks/useApiClient";
 import { useSafeCallback } from "@/hooks/useSafeCallback";
 import { EntityType, QueryType } from "@/services/types";
 
+import {
+  applyWorkflowDefinitionStateUpdate,
+  commitWorkflowDefinitionUpdate,
+  stringifyWorkflowDefinitionUpdate,
+  type UpdateWorkflowDefinitionStateOptions,
+} from "../utils/workflow-definition-state.utils";
 import { getDefinition } from "../utils/workflow-definition.utils";
 
 type UseWorkflowDefinitionStateArgs = {
@@ -198,50 +202,50 @@ export const useWorkflowDefinitionState = ({
 
     return baseline !== yaml;
   }, [currentVersion?.definitionYml, workflow?.currentVersion, yaml]);
-  // Commit new definition version
+  const commitDefinitionUpdate = useCallback(
+    (nextDefinitionYml: string) =>
+      commitWorkflowDefinitionUpdate({
+        actions: actionValidationMetadata,
+        bindingKinds,
+        commitVersion,
+        definitionYml: nextDefinitionYml,
+        workflowId: workflow?.id,
+      }),
+    [actionValidationMetadata, bindingKinds, commitVersion, workflow?.id],
+  );
   const debouncedDefinitionUpdate = useSafeCallback(
     debounce((nextDefinitionYml: string) => {
-      if (!workflow?.id) {
-        return;
-      }
-
-      const validation = validateWorkflow(nextDefinitionYml, {
-        bindingKinds,
-        actions: actionValidationMetadata,
-      });
-
-      if (!validation.success) {
-        return;
-      }
-
-      commitVersion({
-        action: WorkflowVersionAction.update,
-        definitionYml: nextDefinitionYml,
-      });
+      commitDefinitionUpdate(nextDefinitionYml);
     }, 4000),
-    [actionValidationMetadata, bindingKinds, workflow?.id, commitVersion],
+    [commitDefinitionUpdate],
     (memoizedFn) => {
       memoizedFn.clear();
     },
   );
-  // Update local YML stae
   const updateDefinitionState = useCallback(
-    (nextDefinition: string | WorkflowDefinition) => {
-      const nextSignature =
-        typeof nextDefinition === "string"
-          ? nextDefinition
-          : WorkflowHelper.stringifyDefinition(nextDefinition);
-
-      if (definitionSignatureRef.current === nextSignature) {
-        return;
-      }
-
-      definitionSignatureRef.current = nextSignature;
-
-      setYaml(nextSignature);
-      debouncedDefinitionUpdate(nextSignature);
+    (
+      nextDefinition: string | WorkflowDefinition,
+      options?: UpdateWorkflowDefinitionStateOptions,
+    ) => {
+      applyWorkflowDefinitionStateUpdate({
+        clearDebouncedCommit: debouncedDefinitionUpdate.clear,
+        commitImmediately: commitDefinitionUpdate,
+        currentSignature: definitionSignatureRef.current,
+        nextDefinition,
+        options,
+        savedDefinitionYml: currentVersion?.definitionYml ?? "",
+        scheduleDebouncedCommit: debouncedDefinitionUpdate,
+        setSignature: (nextDefinitionYml) => {
+          definitionSignatureRef.current = nextDefinitionYml;
+        },
+        setYaml,
+      });
     },
-    [debouncedDefinitionUpdate],
+    [
+      commitDefinitionUpdate,
+      currentVersion?.definitionYml,
+      debouncedDefinitionUpdate,
+    ],
   );
   // Immediate commit of the definition version
   const persistDefinition = useCallback(() => {
@@ -250,19 +254,16 @@ export const useWorkflowDefinitionState = ({
     }
 
     definitionSignatureRef.current =
-      WorkflowHelper.stringifyDefinition(definition);
+      stringifyWorkflowDefinitionUpdate(definition);
     debouncedDefinitionUpdate.clear();
-    commitVersion({
-      action: WorkflowVersionAction.update,
-      definitionYml: definitionSignatureRef.current,
-    });
+    commitDefinitionUpdate(definitionSignatureRef.current);
   }, [
+    commitDefinitionUpdate,
     debouncedDefinitionUpdate,
     definition,
     definitionError,
     workflow?.id,
     isDefinitionDirty,
-    commitVersion,
   ]);
   const publishVersion = useCallback(
     (versionId?: string) => {

--- a/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
@@ -316,7 +316,6 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
         workflows,
         updateWorkflow,
         debouncedWorkflowUpdate,
-        updateDefinition: updateDefinitionState,
         persistDefinition,
         publishVersion,
         unpublishVersion,

--- a/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
+++ b/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
@@ -24,7 +24,13 @@ import { EntityType } from "@/services/types";
 import type { IAction } from "@/types/action.types";
 import type { EntityAttributes } from "@/types/base.types";
 
+import type { UpdateWorkflowDefinitionStateOptions } from "../utils/workflow-definition-state.utils";
+
 type WorkflowAttributes = EntityAttributes<EntityType.WORKFLOW>;
+type UpdateWorkflowDefinitionState = (
+  nextDefinition: string | WorkflowDefinition,
+  options?: UpdateWorkflowDefinitionStateOptions,
+) => void;
 
 export interface IWorkflowContext {
   getWorkflowFromCache: (id: string) => Workflow | undefined;
@@ -40,7 +46,7 @@ export interface IWorkflowContext {
   removeWorkflowParams: () => Promise<void>;
   updateWorkflowURL: (workflowIid: string, nodeIds?: string[]) => Promise<void>;
   yaml: string;
-  updateDefinitionState: (nextDefinition: string | WorkflowDefinition) => void;
+  updateDefinitionState: UpdateWorkflowDefinitionState;
   workflow?: Workflow;
   workflows?: Workflow[];
   debouncedWorkflowUpdate: ((params: Partial<WorkflowAttributes>) => void) &
@@ -54,7 +60,6 @@ export interface IWorkflowContext {
     },
     Workflow
   >;
-  updateDefinition: (definition: WorkflowDefinition) => void;
   persistDefinition: () => void;
   publishVersion: (versionId?: string) => void;
   unpublishVersion: () => void;

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-definition-state.utils.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-definition-state.utils.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { WorkflowVersionAction } from "@hexabot-ai/types";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyWorkflowDefinitionStateUpdate,
+  commitWorkflowDefinitionUpdate,
+  type UpdateWorkflowDefinitionStateOptions,
+} from "./workflow-definition-state.utils";
+
+const SAVED_YAML = [
+  "defs:",
+  "  first_task:",
+  "    kind: task",
+  "    action: noop",
+  "flow:",
+  "  - do: first_task",
+  "outputs:",
+  "  result: =$output.first_task",
+  "",
+].join("\n");
+const NEXT_YAML = [
+  "defs:",
+  "  next_task:",
+  "    kind: task",
+  "    action: noop",
+  "flow:",
+  "  - do: next_task",
+  "outputs:",
+  "  result: =$output.next_task",
+  "",
+].join("\n");
+const createUpdateHarness = ({
+  currentSignature = SAVED_YAML,
+  savedDefinitionYml = SAVED_YAML,
+}: {
+  currentSignature?: string;
+  savedDefinitionYml?: string;
+} = {}) => {
+  let signature = currentSignature;
+  const setYaml = vi.fn();
+  const scheduleDebouncedCommit = vi.fn();
+  const clearDebouncedCommit = vi.fn();
+  const commitImmediately = vi.fn();
+  const apply = (
+    nextDefinition: string,
+    options?: UpdateWorkflowDefinitionStateOptions,
+  ) =>
+    applyWorkflowDefinitionStateUpdate({
+      clearDebouncedCommit,
+      commitImmediately,
+      currentSignature: signature,
+      nextDefinition,
+      options,
+      savedDefinitionYml,
+      scheduleDebouncedCommit,
+      setSignature: (nextSignature) => {
+        signature = nextSignature;
+      },
+      setYaml,
+    });
+
+  return {
+    apply,
+    clearDebouncedCommit,
+    commitImmediately,
+    getSignature: () => signature,
+    scheduleDebouncedCommit,
+    setYaml,
+  };
+};
+
+describe("workflow definition state persistence", () => {
+  it("schedules YAML editor changes through the debounced commit path", () => {
+    const harness = createUpdateHarness();
+
+    harness.apply(NEXT_YAML, { persist: "debounced" });
+
+    expect(harness.getSignature()).toBe(NEXT_YAML);
+    expect(harness.setYaml).toHaveBeenCalledWith(NEXT_YAML);
+    expect(harness.scheduleDebouncedCommit).toHaveBeenCalledWith(NEXT_YAML);
+    expect(harness.commitImmediately).not.toHaveBeenCalled();
+    expect(harness.clearDebouncedCommit).not.toHaveBeenCalled();
+  });
+
+  it("commits visual updates immediately by default", () => {
+    const harness = createUpdateHarness();
+
+    harness.apply(NEXT_YAML);
+
+    expect(harness.getSignature()).toBe(NEXT_YAML);
+    expect(harness.setYaml).toHaveBeenCalledWith(NEXT_YAML);
+    expect(harness.clearDebouncedCommit).toHaveBeenCalledTimes(1);
+    expect(harness.commitImmediately).toHaveBeenCalledWith(NEXT_YAML);
+    expect(harness.scheduleDebouncedCommit).not.toHaveBeenCalled();
+  });
+
+  it("clears a pending debounced change before an immediate save", () => {
+    const harness = createUpdateHarness({
+      currentSignature: NEXT_YAML,
+      savedDefinitionYml: SAVED_YAML,
+    });
+
+    harness.apply(NEXT_YAML);
+
+    expect(harness.setYaml).not.toHaveBeenCalled();
+    expect(harness.clearDebouncedCommit).toHaveBeenCalledTimes(1);
+    expect(harness.commitImmediately).toHaveBeenCalledWith(NEXT_YAML);
+    expect(harness.scheduleDebouncedCommit).not.toHaveBeenCalled();
+  });
+
+  it("does not create a workflow version for invalid YAML", () => {
+    const commitVersion = vi.fn();
+    const committed = commitWorkflowDefinitionUpdate({
+      commitVersion,
+      definitionYml: "defs: [",
+      workflowId: "workflow-1",
+    });
+
+    expect(committed).toBe(false);
+    expect(commitVersion).not.toHaveBeenCalled();
+  });
+
+  it("creates a workflow version for valid YAML", () => {
+    const commitVersion = vi.fn();
+    const committed = commitWorkflowDefinitionUpdate({
+      commitVersion,
+      definitionYml: NEXT_YAML,
+      workflowId: "workflow-1",
+    });
+
+    expect(committed).toBe(true);
+    expect(commitVersion).toHaveBeenCalledWith({
+      action: WorkflowVersionAction.update,
+      definitionYml: NEXT_YAML,
+    });
+  });
+});

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-definition-state.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-definition-state.utils.ts
@@ -1,0 +1,112 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import {
+  Workflow as WorkflowHelper,
+  type ValidateWorkflowOptions,
+  type WorkflowDefinition,
+  validateWorkflow,
+} from "@hexabot-ai/agentic";
+import { WorkflowVersionAction } from "@hexabot-ai/types";
+
+type WorkflowDefinitionPersistMode = "debounced" | "immediate";
+
+export type UpdateWorkflowDefinitionStateOptions = {
+  persist?: WorkflowDefinitionPersistMode;
+};
+
+type CommitWorkflowDefinitionVersion = (payload: {
+  action: WorkflowVersionAction;
+  definitionYml: string;
+}) => void;
+
+type CommitWorkflowDefinitionUpdateArgs = ValidateWorkflowOptions & {
+  commitVersion: CommitWorkflowDefinitionVersion;
+  definitionYml: string;
+  workflowId?: string;
+};
+
+type ApplyWorkflowDefinitionStateUpdateArgs = {
+  clearDebouncedCommit: () => void;
+  commitImmediately: (definitionYml: string) => void;
+  currentSignature: string;
+  nextDefinition: string | WorkflowDefinition;
+  options?: UpdateWorkflowDefinitionStateOptions;
+  savedDefinitionYml: string;
+  scheduleDebouncedCommit: (definitionYml: string) => void;
+  setSignature: (definitionYml: string) => void;
+  setYaml: (definitionYml: string) => void;
+};
+
+export const stringifyWorkflowDefinitionUpdate = (
+  nextDefinition: string | WorkflowDefinition,
+) =>
+  typeof nextDefinition === "string"
+    ? nextDefinition
+    : WorkflowHelper.stringifyDefinition(nextDefinition);
+
+export const commitWorkflowDefinitionUpdate = ({
+  actions,
+  bindingKinds,
+  commitVersion,
+  definitionYml,
+  workflowId,
+}: CommitWorkflowDefinitionUpdateArgs) => {
+  if (!workflowId) {
+    return false;
+  }
+
+  const validation = validateWorkflow(definitionYml, {
+    actions,
+    bindingKinds,
+  });
+
+  if (!validation.success) {
+    return false;
+  }
+
+  commitVersion({
+    action: WorkflowVersionAction.update,
+    definitionYml,
+  });
+
+  return true;
+};
+
+export const applyWorkflowDefinitionStateUpdate = ({
+  clearDebouncedCommit,
+  commitImmediately,
+  currentSignature,
+  nextDefinition,
+  options,
+  savedDefinitionYml,
+  scheduleDebouncedCommit,
+  setSignature,
+  setYaml,
+}: ApplyWorkflowDefinitionStateUpdateArgs) => {
+  const nextSignature = stringifyWorkflowDefinitionUpdate(nextDefinition);
+  const persistMode = options?.persist ?? "immediate";
+  const hasChanged = currentSignature !== nextSignature;
+
+  if (hasChanged) {
+    setSignature(nextSignature);
+    setYaml(nextSignature);
+  }
+
+  if (persistMode === "debounced") {
+    if (hasChanged) {
+      scheduleDebouncedCommit(nextSignature);
+    }
+
+    return;
+  }
+
+  clearDebouncedCommit();
+
+  if (savedDefinitionYml !== nextSignature) {
+    commitImmediately(nextSignature);
+  }
+};


### PR DESCRIPTION
## What changed?

- Split workflow definition persistence by edit source.
- YAML editor changes still use debounced autosave.
- Visual editor changes now persist immediately by default.
- Removed the unused updateDefinition workflow context alias.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Optimized workflow definition persistence strategy with debounced batching for improved visual editor responsiveness and performance during editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->