### PR TITLE
fix: missing yml def on new workflow

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/forms/WorkflowForm.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/forms/WorkflowForm.tsx
@@ -22,11 +22,12 @@ import {
   toJsonSchema,
 } from "@/app-components/inputs/JsonSchemaObjectBuilder";
 import { useCreate } from "@/hooks/crud/useCreate";
+import { useTanstackQueryClient } from "@/hooks/crud/useTanstack";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
-import { EntityType } from "@/services/types";
+import { EntityType, QueryType } from "@/services/types";
 import type { EntityAttributes } from "@/types/base.types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
 
@@ -149,6 +150,7 @@ export const WorkflowForm: FC<
 
   translateRef.current = t;
 
+  const queryClient = useTanstackQueryClient();
   const { toast } = useToast();
   const { refetchUser } = useAuth();
   const { definition, definitionYaml, onCreated, onUpdated } =
@@ -233,6 +235,9 @@ export const WorkflowForm: FC<
   >(EntityType.WORKFLOW, {
     ...options,
     onSuccess: (created) => {
+      void queryClient.invalidateQueries({
+        queryKey: [QueryType.item, EntityType.WORKFLOW, created.id],
+      });
       onCreated?.(created);
       options.onSuccess();
     },

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
@@ -29,6 +29,7 @@ import {
   getSchemaDefaults,
   getSchemaPropertyNames,
 } from "../../../../utils/schema-defaults.utils";
+import { createBaseDefinition } from "../../../../utils/workflow-definition.utils";
 import { useStepDrawerClose } from "../../StepDrawer/withStepDrawerLayout";
 
 import type { ActionFormDrawerFooterProps } from "./ActionFormDrawerFooter";
@@ -116,8 +117,13 @@ export const useActionFormDrawerController = ({
   onClose,
 }: UseActionFormDrawerControllerParams): UseActionFormDrawerControllerResult => {
   const { t } = useTranslate();
-  const { definition, updateDefinitionState, isSaving, taskDefinitions } =
-    useWorkflow();
+  const {
+    workflow,
+    definition,
+    updateDefinitionState,
+    isSaving,
+    taskDefinitions,
+  } = useWorkflow();
   const { actionsByName } = useWorkflowActionsCatalog();
   const selectedActionNode = useSelectedActionNode();
   const selectedNodeId = selectedActionNode?.id;
@@ -308,7 +314,10 @@ export const useActionFormDrawerController = ({
     );
   };
   const handleSave = () => {
-    if (!definition || !taskName || !actionSchema) {
+    const currentDefinition =
+      definition ?? (isCreateMode && workflow ? createBaseDefinition() : null);
+
+    if (!currentDefinition || !taskName || !actionSchema) {
       return;
     }
 
@@ -356,14 +365,15 @@ export const useActionFormDrawerController = ({
       };
       const nextStep: FlowStep = { do: nextTaskName };
       const definitionWithTask: WorkflowDefinition = {
-        ...definition,
+        ...currentDefinition,
         defs: {
-          ...(definition.defs ?? {}),
+          ...(currentDefinition.defs ?? {}),
           [nextTaskName]: nextTask,
         },
         outputs:
-          definition.outputs && Object.keys(definition.outputs).length > 0
-            ? definition.outputs
+          currentDefinition.outputs &&
+          Object.keys(currentDefinition.outputs).length > 0
+            ? currentDefinition.outputs
             : { result: `=$output.${nextTaskName}` },
       };
       const insertedDefinition = target.insertPath
@@ -375,7 +385,7 @@ export const useActionFormDrawerController = ({
         : null;
       const nextDefinition: WorkflowDefinition = insertedDefinition ?? {
         ...definitionWithTask,
-        flow: [...(definition.flow ?? []), nextStep],
+        flow: [...(currentDefinition.flow ?? []), nextStep],
       };
 
       updateDefinitionState(nextDefinition);
@@ -412,9 +422,9 @@ export const useActionFormDrawerController = ({
         : {}),
     };
     let nextDefinition: WorkflowDefinition = {
-      ...definition,
+      ...currentDefinition,
       defs: {
-        ...(definition.defs ?? {}),
+        ...(currentDefinition.defs ?? {}),
         [taskName]: nextTask,
       },
     };
@@ -438,11 +448,12 @@ export const useActionFormDrawerController = ({
     updateDefinitionState(nextDefinition);
     handleSaveClose();
   };
+  const canSaveDefinition = Boolean(definition || (isCreateMode && workflow));
   const saveDisabled =
     hasInputVisibleErrors ||
     hasActionSettingsVisibleErrors ||
     hasExecutionSettingsVisibleErrors ||
-    !definition ||
+    !canSaveDefinition ||
     !taskName ||
     !actionSchema ||
     isSaving ||


### PR DESCRIPTION
## What changed?

- Fix first-time action drawer Save button being disabled after creating a new workflow.
- Invalidate the newly created workflow cache entry so the editor reloads populated version data.
- Allow create-mode action save to use a base workflow definition while the new workflow definition hydrates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cache management during workflow creation to ensure newly created workflows are immediately available throughout the application.
  * Improved form save logic in workflow creation mode to properly update the workflow definition and allow saving in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->