### PR TITLE
fix(frontend): api query cache key

### DIFF
--- a/packages/frontend/src/hooks/useApiClient.test.ts
+++ b/packages/frontend/src/hooks/useApiClient.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { QueryType } from "@/services/types";
+
+import { getApiClientQueryKey } from "./useApiClient";
+
+describe("getApiClientQueryKey", () => {
+  it("keeps the legacy key shape for API methods without params", () => {
+    expect(getApiClientQueryKey("getCurrentSession")).toEqual([
+      QueryType.item,
+      "getCurrentSession",
+    ]);
+  });
+
+  it.each([
+    ["getActions", ["manual"], [QueryType.item, "getActions", "manual"]],
+    [
+      "getFailedWorkflowRunsLast24h",
+      [3],
+      [QueryType.item, "getFailedWorkflowRunsLast24h", 3],
+    ],
+    [
+      "getMcpTools",
+      ["server-id"],
+      [QueryType.item, "getMcpTools", "server-id"],
+    ],
+  ] as const)("includes %s params in the query key", (method, params, key) => {
+    expect(getApiClientQueryKey(method, params)).toEqual(key);
+  });
+});

--- a/packages/frontend/src/hooks/useApiClient.ts
+++ b/packages/frontend/src/hooks/useApiClient.ts
@@ -126,6 +126,11 @@ export const useEntityApiClient = <TE extends THook["entity"]>(entity: TE) => {
   return getApiClientByEntity(entity);
 };
 
+export const getApiClientQueryKey = (
+  methodName: keyof ApiClient,
+  params: readonly unknown[] = [],
+) => [QueryType.item, methodName, ...params] as const;
+
 export const useApiClientQuery = <
   N extends keyof ApiClient,
   F extends ApiClient[N],
@@ -140,7 +145,7 @@ export const useApiClientQuery = <
 
   return useTanstackQuery({
     ...rest,
-    queryKey: [QueryType.item, methodName],
+    queryKey: getApiClientQueryKey(methodName, params),
     queryFn: () => (apiClient[methodName] as Function)(...params),
   });
 };


### PR DESCRIPTION
## What changed?

Fixes stale API-client query cache entries by including method params in useApiClientQuery keys.

Previously, parameterized calls like getActions(workflowType) reused the same React Query key across different params, which could show the wrong workflow action catalog after switching workflow types. The shared query key now includes params, covering existing parameterized usages: workflow actions, failed workflow runs, and MCP tools.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API query caching to properly distinguish between calls with different parameters, preventing incorrect cached results from being reused.

* **Tests**
  * Added test coverage for query key generation to ensure proper caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->