### PR TITLE
feat(api): brand startup log as Hexabot and print running URL

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Type, ValidationPipe } from '@nestjs/common';
+import { ConsoleLogger, Logger, Type, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import bodyParser from 'body-parser';
@@ -24,6 +24,12 @@ import { RedisIoAdapter } from './websocket/adapters/redis-io.adapter';
 moduleAlias.addAliases({
   '@': __dirname,
 });
+
+class HexabotBootstrapLogger extends ConsoleLogger {
+  override log(message: unknown, context?: string) {
+    super.log(message, context === 'NestApplication' ? 'Hexabot' : context);
+  }
+}
 
 const rawBodyBuffer = (req, res, buf, encoding) => {
   if (buf?.length) {
@@ -54,6 +60,7 @@ export async function createHexabotApplication<
   await resolveDynamicProviders();
   const app = await NestFactory.create<TApp>(moduleRef, {
     bodyParser: false,
+    logger: new HexabotBootstrapLogger(),
   });
 
   app.set('query parser', 'extended');
@@ -134,6 +141,8 @@ export async function bootstrapHexabotApp(
   const host = options.listen?.host ?? '0.0.0.0';
 
   await app.listen(port, host);
+  const appUrl = await app.getUrl();
+  Logger.log(`Hexabot is running at ${appUrl}`, 'Hexabot');
 
   return app;
 }


### PR DESCRIPTION
### Motivation
- Make the application startup logs clearer and branded by replacing the default Nest context name with `Hexabot` so the standard Nest startup line reads as Hexabot instead of `NestApplication`.
- Surface the resolved runtime address (URL + port) in logs immediately after startup so developers can quickly see where the server is listening.

### Description
- Add `HexabotBootstrapLogger` (extends `ConsoleLogger`) that overrides `log` to rewrite the `context` value `NestApplication` to `Hexabot`.
- Pass an instance of `HexabotBootstrapLogger` into `NestFactory.create` via the `logger` option in `createHexabotApplication`.
- After `await app.listen(...)`, call `app.getUrl()` and log the resolved URL with `Logger.log` under the `Hexabot` context.

### Testing
- Ran `pnpm --filter @hexabot-ai/api run typecheck` which completed successfully.
- Ran `pnpm --filter @hexabot-ai/api run lint` which completed successfully.
- Ran `pnpm --filter @hexabot-ai/api run test` which failed due to unrelated workspace/module type-resolution issues (missing `@hexabot-ai/types` / `@hexabot-ai/agentic`) and not because of this change.
- Ran `pnpm --filter @hexabot-ai/api run build` which failed due to dependent frontend type errors in the workspace unrelated to the bootstrap logging change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f6098348832d8c2e827b1e609ac4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application logging with improved context labeling during startup.
  * Application now displays the runtime URL when the server starts up for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->