### PR TITLE
fix(api): holistic prototype pollution guard in base-orm repository

### DIFF
--- a/packages/api/src/utils/generics/base-orm.repository.spec.ts
+++ b/packages/api/src/utils/generics/base-orm.repository.spec.ts
@@ -6,7 +6,7 @@
 
 import { randomUUID } from 'crypto';
 
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { TestingModule } from '@nestjs/testing';
 import { In, InsertEvent, RemoveEvent, Repository, UpdateEvent } from 'typeorm';
@@ -271,6 +271,69 @@ describe('BaseOrmRepository', () => {
       expect(result.dummy).toBe(payload.dummy);
       const stored = await ormRepository.findOne({ where: { id: result.id } });
       expect(stored!.dummy).toBe(payload.dummy);
+    });
+  });
+
+  describe('prototype pollution guard', () => {
+    it('should reject create with __proto__ key', async () => {
+      const payload = JSON.parse('{"__proto__":{"polluted":true}}');
+      await expect(dummyRepository.create(payload)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('should reject create with nested forbidden key', async () => {
+      await expect(
+        dummyRepository.create({
+          dummy: 'safe',
+          dynamicField: { constructor: { polluted: true } },
+        } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should reject createMany with forbidden key', async () => {
+      await expect(
+        dummyRepository.createMany([
+          { dummy: 'safe' },
+          { prototype: { polluted: true } } as any,
+        ]),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should reject updateOne with forbidden key', async () => {
+      const target = baselineEntities[0];
+      const payload = JSON.parse('{"__proto__":{"polluted":true}}');
+      await expect(
+        dummyRepository.updateOne(target.id, payload),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should reject updateOne with nested forbidden key in flatten mode', async () => {
+      const target = baselineEntities[0];
+      const payload = JSON.parse(
+        '{"dynamicField":{"__proto__":{"polluted":true}}}',
+      );
+      await expect(
+        dummyRepository.updateOne(target.id, payload, {
+          shouldFlatten: true,
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should reject updateMany with forbidden key', async () => {
+      await expect(
+        dummyRepository.updateMany({}, {
+          constructor: { polluted: true },
+        } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should allow safe payloads through', async () => {
+      const result = await dummyRepository.create({
+        dummy: 'safe payload',
+        dynamicField: { constructorName: 'safe', nested: { value: true } },
+      });
+      expect(result.dummy).toBe('safe payload');
     });
   });
 

--- a/packages/api/src/utils/generics/base-orm.repository.spec.ts
+++ b/packages/api/src/utils/generics/base-orm.repository.spec.ts
@@ -328,6 +328,31 @@ describe('BaseOrmRepository', () => {
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
+    it('should reject create with forbidden key inside array value', async () => {
+      const payload = {
+        dummy: 'safe',
+        dynamicField: {
+          items: JSON.parse('[{"__proto__":{"polluted":true}}]'),
+        },
+      };
+      await expect(
+        dummyRepository.create(payload as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should reject createMany with forbidden key nested in array', async () => {
+      await expect(
+        dummyRepository.createMany([
+          {
+            dummy: 'safe',
+            dynamicField: {
+              items: JSON.parse('[{"constructor":{"polluted":true}}]'),
+            },
+          } as any,
+        ]),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
     it('should allow safe payloads through', async () => {
       const result = await dummyRepository.create({
         dummy: 'safe payload',

--- a/packages/api/src/utils/generics/base-orm.repository.ts
+++ b/packages/api/src/utils/generics/base-orm.repository.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Inject, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { instanceToPlain, plainToInstance } from 'class-transformer';
 import camelCase from 'lodash/camelCase';
@@ -31,6 +31,7 @@ import {
 import { BaseOrmEntity } from '@/database/entities/base.entity';
 import { LoggerService } from '@/logger/logger.service';
 import { flatten } from '@/utils/helpers/flatten';
+import { hasForbiddenSegment } from '@/utils/helpers/safe-property-path';
 
 import {
   DtoAction,
@@ -138,6 +139,18 @@ export abstract class BaseOrmRepository<
     }
 
     return result;
+  }
+
+  private assertSafePayload(data: unknown): void {
+    if (!data || typeof data !== 'object') return;
+
+    const flatKeys = Object.keys(
+      flatten(data as Record<string, unknown>) as Record<string, unknown>,
+    );
+    const forbidden = flatKeys.find((key) => hasForbiddenSegment(key));
+    if (forbidden) {
+      throw new BadRequestException(`Forbidden property path: "${forbidden}"`);
+    }
   }
 
   public actionDtoToEntity<Action extends DtoAction>(
@@ -269,6 +282,7 @@ export abstract class BaseOrmRepository<
   }
 
   async create(payload: InferCreateDto<Entity>): Promise<InferPlain<Entity>> {
+    this.assertSafePayload(payload);
     const entity = this.repository.create(this.actionDtoToEntity(payload));
     await this.emitEvent<EHook.preCreate>({
       action: EHook.preCreate,
@@ -290,6 +304,7 @@ export abstract class BaseOrmRepository<
   async createMany(
     payloads: InferCreateDto<Entity>[],
   ): Promise<InferPlain<Entity>[]> {
+    payloads.forEach((payload) => this.assertSafePayload(payload));
     const entities = this.repository.create(
       payloads.map((payload) => this.actionDtoToEntity(payload)),
     );
@@ -320,6 +335,7 @@ export abstract class BaseOrmRepository<
     payload: InferUpdateDto<Entity>,
     options?: UpdateOneOptions,
   ): Promise<InferPlain<Entity>> {
+    this.assertSafePayload(payload);
     const entity = await this.findOneEntity(idOrOptions);
     const databaseEntity = await this.findOneEntity(idOrOptions);
     if (entity && databaseEntity) {
@@ -383,6 +399,7 @@ export abstract class BaseOrmRepository<
     options: FindManyOptions<Entity> = {} as FindManyOptions<Entity>,
     payload: InferUpdateDto<Entity>,
   ): Promise<InferPlain<Entity>[]> {
+    this.assertSafePayload(payload);
     const entities = await this.findEntities(options);
 
     if (!entities.length) {

--- a/packages/api/src/utils/generics/base-orm.repository.ts
+++ b/packages/api/src/utils/generics/base-orm.repository.ts
@@ -144,12 +144,24 @@ export abstract class BaseOrmRepository<
   private assertSafePayload(data: unknown): void {
     if (!data || typeof data !== 'object') return;
 
-    const flatKeys = Object.keys(
-      flatten(data as Record<string, unknown>) as Record<string, unknown>,
-    );
-    const forbidden = flatKeys.find((key) => hasForbiddenSegment(key));
-    if (forbidden) {
-      throw new BadRequestException(`Forbidden property path: "${forbidden}"`);
+    if (Array.isArray(data)) {
+      data.forEach((item) => this.assertSafePayload(item));
+
+      return;
+    }
+
+    const flat = flatten(data as Record<string, unknown>) as Record<
+      string,
+      unknown
+    >;
+
+    for (const [key, value] of Object.entries(flat)) {
+      if (hasForbiddenSegment(key)) {
+        throw new BadRequestException(`Forbidden property path: "${key}"`);
+      }
+      if (Array.isArray(value)) {
+        value.forEach((item) => this.assertSafePayload(item));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds `assertSafePayload()` validation to `create`, `createMany`, `updateOne`, and `updateMany` in `BaseOrmRepository`
- Reuses the existing `hasForbiddenSegment` helper to reject `__proto__`, `constructor`, and `prototype` keys in flattened payloads before they reach the ORM layer
- Extends the fix from #1940 (search filter) to cover all write paths

## Context
This is a follow-up to #1940 which addressed prototype pollution in search filters. While that PR hardened the query/filter path, the create and update paths in `BaseOrmRepository` were still unguarded. This PR closes that gap.

Closes #5

## Test plan
- [x] 7 new test cases covering `__proto__`, `constructor`, `prototype` in create/createMany/updateOne/updateMany
- [x] Safe payload passthrough test to avoid false positives
- [x] Pre-commit hooks pass with related tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Write operations (create, createMany, updateOne, updateMany) now enforce payload safety and reject requests containing forbidden property patterns, including nested keys and array-contained values.

* **Tests**
  * Added tests verifying rejection of unsafe payloads (various nesting/array scenarios) and acceptance of valid payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->