### PR TITLE
fix(api): resolve not loaded thread scoped memory store

### DIFF
--- a/packages/api/src/workflow/services/memory.service.spec.ts
+++ b/packages/api/src/workflow/services/memory.service.spec.ts
@@ -147,6 +147,27 @@ describe('MemoryService (TypeORM)', () => {
     expect(store.instances[runDefinition.slug]).toBeInstanceOf(SchemaInstance);
   });
 
+  it('passes threadId when loading scoped memory records', async () => {
+    const findScopedSpy = jest.spyOn(memoryRecordService, 'findActiveByScope');
+    const context = createContext();
+
+    await memoryService.buildStore(
+      {
+        ownerId: userFixtureIds.admin,
+        workflowId: memoryWorkflowFixtureId,
+        threadId: 'thread-1',
+      },
+      context,
+    );
+
+    expect(findScopedSpy).toHaveBeenCalledWith({
+      ownerId: userFixtureIds.admin,
+      workflowId: memoryWorkflowFixtureId,
+      threadId: 'thread-1',
+      runId: undefined,
+    });
+  });
+
   it('updates memory and persists it through the store proxy', async () => {
     const context = createContext();
     const store = await memoryService.buildStore(

--- a/packages/api/src/workflow/services/memory.service.ts
+++ b/packages/api/src/workflow/services/memory.service.ts
@@ -40,6 +40,7 @@ export class MemoryService {
     const records = await this.memoryRecordService.findActiveByScope({
       ownerId,
       workflowId,
+      threadId,
       runId,
     });
 


### PR DESCRIPTION
## What changed?
This PR fixes an issue where thread-based memory was not loading correctly. To support the memory feature, we now pass the threadId to the findActiveByScope method so it can load the right context for each workflow run.

## Updates 
- After the fix
<img width="321" height="77" alt="image" src="https://github.com/user-attachments/assets/623373ee-239a-4cd7-9881-49188fcab614" />

- Before the fix
<img width="321" height="23" alt="image" src="https://github.com/user-attachments/assets/38b4e55d-a4c5-4a26-9c32-0f7b548f3bbe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Memory records now properly scoped to specific threads for accurate data isolation.

* **Tests**
  * Added test coverage validating thread-specific memory record retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->