### PR TITLE
fix: centralize jest cleanup routine

### DIFF
--- a/packages/api/src/analytics/controllers/stats.controller.spec.ts
+++ b/packages/api/src/analytics/controllers/stats.controller.spec.ts
@@ -12,7 +12,6 @@ import {
   installStatsFixturesTypeOrm,
   statsFixtures,
 } from '@/utils/test/fixtures/stats';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowRunService } from '@/workflow/services/workflow-run.service';
 import { WorkflowService } from '@/workflow/services/workflow.service';
@@ -51,13 +50,6 @@ describe('StatsController', () => {
     });
     module = testingModule;
     [statsController] = await getMocks([StatsController]);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(() => {

--- a/packages/api/src/analytics/repositories/stats.repository.spec.ts
+++ b/packages/api/src/analytics/repositories/stats.repository.spec.ts
@@ -11,7 +11,6 @@ import {
   installStatsFixturesTypeOrm,
   statsFixtures,
 } from '@/utils/test/fixtures/stats';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { StatsType } from '../entities/stats.entity';
@@ -36,13 +35,6 @@ describe('StatsRepository (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('findMessages', () => {
     it('should return messages', async () => {

--- a/packages/api/src/analytics/services/stats.service.spec.ts
+++ b/packages/api/src/analytics/services/stats.service.spec.ts
@@ -12,7 +12,6 @@ import {
   installStatsFixturesTypeOrm,
   statsFixtures,
 } from '@/utils/test/fixtures/stats';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowRunService } from '@/workflow/services/workflow-run.service';
 import { WorkflowService } from '@/workflow/services/workflow.service';
@@ -69,13 +68,6 @@ describe('StatsService', () => {
       StatsRepository,
     ]);
     eventEmitter = module.get(EventEmitter2);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(() => {

--- a/packages/api/src/attachment/controllers/attachment.controller.spec.ts
+++ b/packages/api/src/attachment/controllers/attachment.controller.spec.ts
@@ -27,7 +27,6 @@ import {
 } from '@/utils/test/fixtures/attachment';
 import { installSettingFixturesTypeOrm } from '@/utils/test/fixtures/setting';
 import { installUserFixturesTypeOrm } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { attachment, attachmentFile } from '../mocks/attachment.mock';
@@ -82,10 +81,6 @@ describe('AttachmentController', () => {
     }))!;
 
     helperService.register(new LocalStorageHelper());
-  });
-
-  afterAll(async () => {
-    await closeTypeOrmConnections();
   });
 
   afterEach(() => {

--- a/packages/api/src/attachment/repositories/attachment.repository.spec.ts
+++ b/packages/api/src/attachment/repositories/attachment.repository.spec.ts
@@ -15,7 +15,6 @@ import {
   installAttachmentFixturesTypeOrm,
 } from '@/utils/test/fixtures/attachment';
 import { installUserFixturesTypeOrm } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -54,13 +53,6 @@ describe('AttachmentRepository (TypeORM)', () => {
       await repository.deleteOne(id);
       createdAttachmentIds.delete(id);
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('configuration', () => {

--- a/packages/api/src/channel/source.controller.spec.ts
+++ b/packages/api/src/channel/source.controller.spec.ts
@@ -12,7 +12,6 @@ import { DataSource, Repository } from 'typeorm';
 import { MessageOrmEntity } from '@/chat/entities/message.entity';
 import { ThreadOrmEntity } from '@/chat/entities/thread.entity';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SourceOrmEntity } from './entities/source.entity';
@@ -134,14 +133,6 @@ describe('SourceController (TypeORM cascade)', () => {
     sourceRepository = dataSource.getRepository(SourceOrmEntity);
     threadRepository = dataSource.getRepository(ThreadOrmEntity);
     messageRepository = dataSource.getRepository(MessageOrmEntity);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-
-    await closeTypeOrmConnections();
   });
 
   it('prevents deleting a source and preserves linked threads and messages', async () => {

--- a/packages/api/src/chat/controllers/label-group.controller.spec.ts
+++ b/packages/api/src/chat/controllers/label-group.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   installLabelGroupFixturesTypeOrm,
   labelGroupFixtures,
 } from '@/utils/test/fixtures/label-group';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelGroupCreateDto } from '../dto/label-group.dto';
@@ -46,13 +45,6 @@ describe('LabelGroupController', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findPage', () => {

--- a/packages/api/src/chat/controllers/label.controller.spec.ts
+++ b/packages/api/src/chat/controllers/label.controller.spec.ts
@@ -13,7 +13,6 @@ import { In } from 'typeorm';
 
 import { installLabelFixturesTypeOrm } from '@/utils/test/fixtures/label';
 import { installSubscriberFixturesTypeOrm } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelCreateDto, LabelUpdateDto } from '../dto/label.dto';
@@ -53,13 +52,6 @@ describe('LabelController (TypeORM)', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findPage', () => {

--- a/packages/api/src/chat/controllers/message.controller.spec.ts
+++ b/packages/api/src/chat/controllers/message.controller.spec.ts
@@ -14,7 +14,6 @@ import {
   installMessageFixturesTypeOrm,
   messageFixtures,
 } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MessageController } from './message.controller';
@@ -85,13 +84,6 @@ describe('MessageController (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOne', () => {

--- a/packages/api/src/chat/controllers/subscriber.controller.spec.ts
+++ b/packages/api/src/chat/controllers/subscriber.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   installSubscriberFixturesTypeOrm,
   subscriberFixtures,
 } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SubscriberController } from './subscriber.controller';
@@ -81,13 +80,6 @@ describe('SubscriberController (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOne', () => {

--- a/packages/api/src/chat/controllers/thread.controller.spec.ts
+++ b/packages/api/src/chat/controllers/thread.controller.spec.ts
@@ -12,7 +12,6 @@ import { ThreadOrmEntity } from '@/chat/entities/thread.entity';
 import { ThreadService } from '@/chat/services/thread.service';
 import { TypeOrmSearchFilterPipe } from '@/utils/pipes/typeorm-search-filter.pipe';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -63,13 +62,6 @@ describe('ThreadController (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('count', () => {

--- a/packages/api/src/chat/repositories/label-group.repository.spec.ts
+++ b/packages/api/src/chat/repositories/label-group.repository.spec.ts
@@ -13,7 +13,6 @@ import {
   installLabelGroupFixturesTypeOrm,
   labelGroupFixtures,
 } from '@/utils/test/fixtures/label-group';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelGroupRepository } from './label-group.repository';
@@ -55,13 +54,6 @@ describe('LabelGroupRepository (TypeORM)', () => {
       const ids = createdGroupIds.splice(0);
       await Promise.all(ids.map((id) => labelGroupRepository.deleteOne(id)));
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('populate helpers', () => {

--- a/packages/api/src/chat/repositories/label.repository.spec.ts
+++ b/packages/api/src/chat/repositories/label.repository.spec.ts
@@ -10,7 +10,6 @@ import { In } from 'typeorm';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { labelFixtures } from '@/utils/test/fixtures/label';
 import { installSubscriberFixturesTypeOrm } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelRepository } from './label.repository';
@@ -42,13 +41,6 @@ describe('LabelRepository (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/chat/repositories/message.repository.spec.ts
+++ b/packages/api/src/chat/repositories/message.repository.spec.ts
@@ -10,7 +10,6 @@ import { Repository } from 'typeorm';
 
 import { MessageOrmEntity } from '@/chat/entities/message.entity';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MessageRepository } from './message.repository';
@@ -46,13 +45,6 @@ describe('MessageRepository (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/chat/repositories/subscriber.repository.spec.ts
+++ b/packages/api/src/chat/repositories/subscriber.repository.spec.ts
@@ -18,7 +18,6 @@ import {
   installSubscriberFixturesTypeOrm,
   subscriberFixtures,
 } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SubscriberRepository } from './subscriber.repository';
@@ -86,13 +85,6 @@ describe('SubscriberRepository (TypeORM)', () => {
       await labelRepository.delete(createdLabelIds);
       createdLabelIds.length = 0;
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   const createPersistedSubscriber = async (

--- a/packages/api/src/chat/services/label.service.spec.ts
+++ b/packages/api/src/chat/services/label.service.spec.ts
@@ -10,7 +10,6 @@ import { In } from 'typeorm';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { labelFixtures } from '@/utils/test/fixtures/label';
 import { installSubscriberFixturesTypeOrm } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelRepository } from '../repositories/label.repository';
@@ -47,13 +46,6 @@ describe('LabelService (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findAllAndPopulate', () => {

--- a/packages/api/src/chat/services/message.service.spec.ts
+++ b/packages/api/src/chat/services/message.service.spec.ts
@@ -13,7 +13,6 @@ import {
   installMessageFixturesTypeOrm,
   messageFixtures,
 } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 describe('MessageService (TypeORM)', () => {
@@ -79,13 +78,6 @@ describe('MessageService (TypeORM)', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/chat/services/subscriber.service.spec.ts
+++ b/packages/api/src/chat/services/subscriber.service.spec.ts
@@ -26,7 +26,6 @@ import { UserService } from '@/user/services/user.service';
 import { installLabelGroupFixturesTypeOrm } from '@/utils/test/fixtures/label-group';
 import { installSubscriberFixturesTypeOrm } from '@/utils/test/fixtures/subscriber';
 import { sortRowsBy } from '@/utils/test/sort';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
@@ -138,13 +137,6 @@ describe('SubscriberService (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/cms/controllers/content-type.controller.spec.ts
+++ b/packages/api/src/cms/controllers/content-type.controller.spec.ts
@@ -12,7 +12,6 @@ import {
   contentTypeOrmFixtures,
   installContentTypeFixturesTypeOrm,
 } from '@/utils/test/fixtures/contenttype';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeCreateDto } from '../dto/contentType.dto';
@@ -42,13 +41,6 @@ describe('ContentTypeController (TypeORM)', () => {
       ContentTypeService,
     ]);
     logger = controller.logger;
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(async () => {

--- a/packages/api/src/cms/controllers/content.controller.spec.ts
+++ b/packages/api/src/cms/controllers/content.controller.spec.ts
@@ -15,7 +15,6 @@ import {
   installContentFixturesTypeOrm,
 } from '@/utils/test/fixtures/content';
 import { installContentTypeFixturesTypeOrm } from '@/utils/test/fixtures/contenttype';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeService } from '../services/content-type.service';
@@ -56,13 +55,6 @@ describe('ContentController (TypeORM)', () => {
         RagService,
       ]);
     logger = controller.logger;
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(async () => {

--- a/packages/api/src/cms/controllers/menu.controller.spec.ts
+++ b/packages/api/src/cms/controllers/menu.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   offerMenuFixture,
   rootMenuFixtures,
 } from '@/utils/test/fixtures/menu';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuType } from '../entities/menu.entity';
@@ -39,13 +38,6 @@ describe('MenuController (TypeORM)', () => {
     module = testingModule;
     [controller, menuService] = await getMocks([MenuController, MenuService]);
     logger = controller.logger;
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(async () => {

--- a/packages/api/src/cms/repositories/content-type.repository.spec.ts
+++ b/packages/api/src/cms/repositories/content-type.repository.spec.ts
@@ -8,7 +8,6 @@ import { randomUUID } from 'crypto';
 
 import { TestingModule } from '@nestjs/testing';
 
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeRepository } from './content-type.repository';
@@ -29,13 +28,6 @@ describe('ContentTypeRepository (TypeORM)', () => {
       ContentTypeRepository,
       ContentRepository,
     ]);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('deleteOne cascade', () => {

--- a/packages/api/src/cms/repositories/menu.repository.spec.ts
+++ b/packages/api/src/cms/repositories/menu.repository.spec.ts
@@ -10,7 +10,6 @@ import {
   installMenuFixturesTypeOrm,
   rootMenuFixtures,
 } from '@/utils/test/fixtures/menu';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuType } from '../entities/menu.entity';
@@ -32,13 +31,6 @@ describe('MenuRepository (TypeORM)', () => {
     });
     module = testingModule;
     [repository] = await getMocks([MenuRepository]);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(async () => {

--- a/packages/api/src/cms/services/content-type.service.spec.ts
+++ b/packages/api/src/cms/services/content-type.service.spec.ts
@@ -10,7 +10,6 @@ import {
   contentTypeOrmFixtures,
   installContentTypeFixturesTypeOrm,
 } from '@/utils/test/fixtures/contenttype';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeDto } from '../dto/contentType.dto';
@@ -32,13 +31,6 @@ describe('ContentTypeService (TypeORM)', () => {
     });
     module = testingModule;
     [service] = await getMocks([ContentTypeService]);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(async () => {

--- a/packages/api/src/cms/services/content.service.spec.ts
+++ b/packages/api/src/cms/services/content.service.spec.ts
@@ -13,7 +13,6 @@ import {
   installContentFixturesTypeOrm,
 } from '@/utils/test/fixtures/content';
 import { installContentTypeFixturesTypeOrm } from '@/utils/test/fixtures/contenttype';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeService } from './content-type.service';
@@ -45,13 +44,6 @@ describe('ContentService (TypeORM)', () => {
       ContentTypeService,
     ]);
     logger = contentService.logger;
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(async () => {

--- a/packages/api/src/cms/services/menu.service.spec.ts
+++ b/packages/api/src/cms/services/menu.service.spec.ts
@@ -17,7 +17,6 @@ import {
   offersMenuFixtures,
   rootMenuFixtures,
 } from '@/utils/test/fixtures/menu';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuType } from '../entities/menu.entity';
@@ -40,13 +39,6 @@ describe('MenuService (TypeORM)', () => {
     });
     module = testingModule;
     [menuService, cacheManager] = await getMocks([MenuService, CACHE_MANAGER]);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(async () => {

--- a/packages/api/src/extension/cleanup.service.spec.ts
+++ b/packages/api/src/extension/cleanup.service.spec.ts
@@ -11,7 +11,6 @@ import LocalStorageHelper from '@/extensions/helpers/local-storage/index.helper'
 import { HelperService } from '@/helper/helper.service';
 import { SettingService } from '@/setting/services/setting.service';
 import { installSettingFixturesTypeOrm } from '@/utils/test/fixtures/setting';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { CleanupService } from './cleanup.service';
@@ -53,13 +52,6 @@ describe('CleanupService', () => {
     initialSettings = await settingService.findAll();
 
     helperService.register(new LocalStorageHelper());
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(async () => {

--- a/packages/api/src/extensions/channels/web/__test__/index.spec.ts
+++ b/packages/api/src/extensions/channels/web/__test__/index.spec.ts
@@ -24,7 +24,6 @@ import { MenuService } from '@/cms/services/menu.service';
 import { installLabelGroupFixturesTypeOrm } from '@/utils/test/fixtures/label-group';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
@@ -152,7 +151,6 @@ describe('WebChannelHandler', () => {
     if (module) {
       await module.close();
     }
-    await closeTypeOrmConnections();
   });
 
   it('should have correct name', () => {

--- a/packages/api/src/i18n/controllers/language.controller.spec.ts
+++ b/packages/api/src/i18n/controllers/language.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   installLanguageFixturesTypeOrm,
   languageFixtures,
 } from '@/utils/test/fixtures/language';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LanguageUpdateDto } from '../dto/language.dto';
@@ -47,7 +46,6 @@ describe('LanguageController', () => {
   });
 
   afterEach(jest.clearAllMocks);
-  afterAll(closeTypeOrmConnections);
 
   describe('findOne', () => {
     it('should find one translation by id', async () => {

--- a/packages/api/src/i18n/controllers/translation.controller.spec.ts
+++ b/packages/api/src/i18n/controllers/translation.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   translationFixtures,
 } from '@/utils/test/fixtures/translation';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowService } from '@/workflow/services/workflow.service';
 
@@ -57,7 +56,6 @@ describe('TranslationController', () => {
   });
 
   afterEach(jest.clearAllMocks);
-  afterAll(closeTypeOrmConnections);
 
   describe('findOne', () => {
     it('should find one translation by id', async () => {

--- a/packages/api/src/migration/migration.service.spec.ts
+++ b/packages/api/src/migration/migration.service.spec.ts
@@ -16,7 +16,6 @@ import { config } from '@/config';
 import { LoggerService } from '@/logger/logger.service';
 import { MetadataOrmEntity } from '@/setting/entities/metadata.entity';
 import { MetadataService } from '@/setting/services/metadata.service';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MigrationOrmEntity } from './migration.entity';
@@ -110,7 +109,6 @@ describe('MigrationService', () => {
     if (testingModule) {
       await testingModule.close();
     }
-    await closeTypeOrmConnections();
   });
 
   afterEach(() => {

--- a/packages/api/src/setting/controllers/setting.controller.spec.ts
+++ b/packages/api/src/setting/controllers/setting.controller.spec.ts
@@ -14,7 +14,6 @@ import {
   settingFixtures,
 } from '@/utils/test/fixtures/setting';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -55,13 +54,6 @@ describe('SettingController', () => {
         RuntimeSettingsService,
         I18nService,
       ]);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   beforeEach(() => {

--- a/packages/api/src/setting/repositories/setting.repository.spec.ts
+++ b/packages/api/src/setting/repositories/setting.repository.spec.ts
@@ -15,7 +15,6 @@ import {
   installSettingFixturesTypeOrm,
   settingFixtures,
 } from '@/utils/test/fixtures/setting';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SettingOrmEntity } from '../entities/setting.entity';
@@ -50,13 +49,6 @@ describe('SettingRepository (TypeORM)', () => {
       await repository.delete(createdIds);
       createdIds.length = 0;
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findAll', () => {

--- a/packages/api/src/setting/services/setting.service.spec.ts
+++ b/packages/api/src/setting/services/setting.service.spec.ts
@@ -13,7 +13,6 @@ import {
   settingFixtures,
 } from '@/utils/test/fixtures/setting';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -59,13 +58,6 @@ describe('SettingService', () => {
         SettingRepository,
         RuntimeSettingsService,
       ]);
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   beforeEach(() => {

--- a/packages/api/src/user/controllers/auth.controller.spec.ts
+++ b/packages/api/src/user/controllers/auth.controller.spec.ts
@@ -12,7 +12,6 @@ import { installLanguageFixturesTypeOrm } from '@/utils/test/fixtures/language';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
 import { MailerServiceProvider } from '@/utils/test/providers/mailer-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LocalAuthController } from './auth.controller';
@@ -78,13 +77,6 @@ describe('AuthController (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('session payload', () => {
     it('should include license snapshot in /auth/me payload', async () => {

--- a/packages/api/src/user/controllers/model.controller.spec.ts
+++ b/packages/api/src/user/controllers/model.controller.spec.ts
@@ -8,7 +8,6 @@ import { ModelFull } from '@hexabot-ai/types';
 import { TestingModule } from '@nestjs/testing';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelService } from '../services/model.service';
@@ -40,13 +39,6 @@ describe('ModelController (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('find', () => {
     it('should find models', async () => {

--- a/packages/api/src/user/controllers/permission.controller.spec.ts
+++ b/packages/api/src/user/controllers/permission.controller.spec.ts
@@ -9,7 +9,6 @@ import { NotFoundException } from '@nestjs/common';
 import { TestingModule } from '@nestjs/testing';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { PermissionCreateDto } from '../dto/permission.dto';
@@ -62,13 +61,6 @@ describe('PermissionController (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('find', () => {
     it('should find permissions', async () => {

--- a/packages/api/src/user/controllers/role.controller.spec.ts
+++ b/packages/api/src/user/controllers/role.controller.spec.ts
@@ -11,7 +11,6 @@ import { Request } from 'express';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { roleFixtureIds, roleOrmFixtures } from '@/utils/test/fixtures/role';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { RoleCreateDto, RoleUpdateDto } from '../dto/role.dto';
@@ -61,13 +60,6 @@ describe('RoleController (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findPage', () => {

--- a/packages/api/src/user/controllers/user.controller.spec.ts
+++ b/packages/api/src/user/controllers/user.controller.spec.ts
@@ -16,7 +16,6 @@ import { installLanguageFixturesTypeOrm } from '@/utils/test/fixtures/language';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
 import { MailerServiceProvider } from '@/utils/test/providers/mailer-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -99,13 +98,6 @@ describe('UserController (TypeORM)', () => {
     }
     roles = await roleService.findAll();
     user = await userService.findOne({ where: { username: 'admin' } });
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(jest.clearAllMocks);

--- a/packages/api/src/user/repositories/credential.repository.spec.ts
+++ b/packages/api/src/user/repositories/credential.repository.spec.ts
@@ -12,7 +12,6 @@ import { Repository } from 'typeorm';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { CredentialOrmEntity } from '../entities/credential.entity';
@@ -61,13 +60,6 @@ describe('CredentialRepository (TypeORM)', () => {
       await ormRepository.delete(createdCredentialIds);
       createdCredentialIds.length = 0;
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   const createPersistedCredential = async (

--- a/packages/api/src/user/repositories/model.repository.spec.ts
+++ b/packages/api/src/user/repositories/model.repository.spec.ts
@@ -11,7 +11,6 @@ import {
   installPermissionFixturesTypeOrm,
   permissionOrmFixtures,
 } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelOrmEntity as ModelEntity } from '../entities/model.entity';
@@ -48,13 +47,6 @@ describe('ModelRepository (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/user/repositories/permission.repository.spec.ts
+++ b/packages/api/src/user/repositories/permission.repository.spec.ts
@@ -11,7 +11,6 @@ import {
   installPermissionFixturesTypeOrm,
   permissionOrmFixtures,
 } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Action } from '../types/action.type';
@@ -59,13 +58,6 @@ describe('PermissionRepository (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/user/repositories/role.repository.spec.ts
+++ b/packages/api/src/user/repositories/role.repository.spec.ts
@@ -13,7 +13,6 @@ import {
 } from '@/utils/test/fixtures/permission';
 import { roleFixtureIds } from '@/utils/test/fixtures/role';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { PermissionRepository } from './permission.repository';
@@ -57,13 +56,6 @@ describe('RoleRepository (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/user/repositories/user.repository.spec.ts
+++ b/packages/api/src/user/repositories/user.repository.spec.ts
@@ -13,7 +13,6 @@ import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { roleFixtureIds } from '@/utils/test/fixtures/role';
 import { userFixtures } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { RoleRepository } from './role.repository';
@@ -54,13 +53,6 @@ describe('UserRepository (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/user/services/auth.service.spec.ts
+++ b/packages/api/src/user/services/auth.service.spec.ts
@@ -8,7 +8,6 @@ import type { User } from '@hexabot-ai/types';
 import { TestingModule } from '@nestjs/testing';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { UserRepository } from '../repositories/user.repository';
@@ -42,13 +41,6 @@ describe('AuthService (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('validateUser', () => {
     const adminEmail = 'admin@admin.admin';

--- a/packages/api/src/user/services/model.service.spec.ts
+++ b/packages/api/src/user/services/model.service.spec.ts
@@ -9,7 +9,6 @@ import { TestingModule } from '@nestjs/testing';
 
 import { modelFixtureIds, modelOrmFixtures } from '@/utils/test/fixtures/model';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelOrmEntity as ModelEntity } from '../entities/model.entity';
@@ -53,13 +52,6 @@ describe('ModelService (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('findOneAndPopulate', () => {
     it('should find a model and populate its permissions', async () => {

--- a/packages/api/src/user/services/passwordReset.service.spec.ts
+++ b/packages/api/src/user/services/passwordReset.service.spec.ts
@@ -16,7 +16,6 @@ import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permissi
 import { users } from '@/utils/test/fixtures/user';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
 import { MailerServiceProvider } from '@/utils/test/providers/mailer-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { UserRepository } from '../repositories/user.repository';
@@ -70,13 +69,6 @@ describe('PasswordResetService (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('requestReset', () => {
     it('should send an email with a token', async () => {

--- a/packages/api/src/user/services/permission.service.spec.ts
+++ b/packages/api/src/user/services/permission.service.spec.ts
@@ -11,7 +11,6 @@ import {
   installPermissionFixturesTypeOrm,
   permissionOrmFixtures,
 } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelRepository } from '../repositories/model.repository';
@@ -58,13 +57,6 @@ describe('PermissionService (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('findOneAndPopulate', () => {
     it('should find a permission and populate its role and model', async () => {

--- a/packages/api/src/user/services/role.service.spec.ts
+++ b/packages/api/src/user/services/role.service.spec.ts
@@ -9,7 +9,6 @@ import { TestingModule } from '@nestjs/testing';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { roleFixtureIds, roleOrmFixtures } from '@/utils/test/fixtures/role';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { PermissionRepository } from '../repositories/permission.repository';
@@ -55,13 +54,6 @@ describe('RoleService (TypeORM)', () => {
     permissions = await permissionRepository.find({
       where: { role: { id: roleFixtureIds.admin } },
     });
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(jest.clearAllMocks);

--- a/packages/api/src/user/services/user.service.spec.ts
+++ b/packages/api/src/user/services/user.service.spec.ts
@@ -10,7 +10,6 @@ import { TestingModule } from '@nestjs/testing';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { userFixtures } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { UserRepository } from '../repositories/user.repository';
@@ -55,13 +54,6 @@ describe('UserService (TypeORM)', () => {
   }, 30000);
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
 
   describe('findOneAndPopulate', () => {
     it('should find one user and populate its roles', async () => {

--- a/packages/api/src/utils/generics/base-orm.controller.spec.ts
+++ b/packages/api/src/utils/generics/base-orm.controller.spec.ts
@@ -16,7 +16,6 @@ import {
   dummyFixtures,
   installDummyFixturesTypeOrm,
 } from '@/utils/test/fixtures/dummy';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { DummyController } from '../test/dummy/controllers/dummy.controller';
@@ -51,13 +50,6 @@ describe('BaseOrmController', () => {
       await dummyService.deleteOne(id);
       createdIds.delete(id);
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('count', () => {

--- a/packages/api/src/utils/generics/base-orm.repository.spec.ts
+++ b/packages/api/src/utils/generics/base-orm.repository.spec.ts
@@ -18,7 +18,6 @@ import {
   installDummyFixturesTypeOrm,
 } from '@/utils/test/fixtures/dummy';
 import {
-  closeTypeOrmConnections,
   getLastTypeOrmDataSource,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
@@ -52,13 +51,6 @@ describe('BaseOrmRepository', () => {
     baselineEntities = await ormRepository.save(
       ormRepository.create(dummyFixtures),
     );
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('utility methods', () => {

--- a/packages/api/src/utils/generics/base-orm.service.spec.ts
+++ b/packages/api/src/utils/generics/base-orm.service.spec.ts
@@ -17,7 +17,6 @@ import {
   dummyFixtures,
   installDummyFixturesTypeOrm,
 } from '@/utils/test/fixtures/dummy';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 describe('BaseOrmService', () => {
@@ -52,13 +51,6 @@ describe('BaseOrmService', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('utilities', () => {

--- a/packages/api/src/workflow/controllers/mcp-server.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/mcp-server.controller.spec.ts
@@ -17,7 +17,6 @@ import {
   mcpServerFixtureIds,
   mcpServerOrmFixtures,
 } from '@/utils/test/fixtures/mcp-server';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { McpClientPoolService } from '../services/mcp-client-pool.service';
@@ -82,13 +81,6 @@ describe('McpServerController (TypeORM)', () => {
       await service.deleteOne(id);
       createdIds.delete(id);
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('create', () => {

--- a/packages/api/src/workflow/controllers/memory-definition.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/memory-definition.controller.spec.ts
@@ -18,7 +18,6 @@ import {
   memoryDefinitionFixtureIds,
   memoryDefinitionOrmFixtures,
 } from '@/utils/test/fixtures/memory-definition';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MemoryDefinitionService } from '../services/memory-definition.service';
@@ -75,13 +74,6 @@ describe('MemoryDefinitionController (TypeORM)', () => {
       await service.deleteOne(id);
       createdIds.delete(id);
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('create', () => {

--- a/packages/api/src/workflow/controllers/workflow-run.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow-run.controller.spec.ts
@@ -16,7 +16,6 @@ import {
   workflowRunFixtureIds,
   workflowRunOrmFixtures,
 } from '@/utils/test/fixtures/workflow-run';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { WorkflowRunService } from '../services/workflow-run.service';
@@ -47,13 +46,6 @@ describe('WorkflowRunController (TypeORM)', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findMany', () => {

--- a/packages/api/src/workflow/controllers/workflow-version.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow-version.controller.spec.ts
@@ -17,7 +17,6 @@ import {
   installMessagingWorkflowFixturesTypeOrm,
   installScheduledWorkflowFixturesTypeOrm,
 } from '@/utils/test/fixtures/workflow';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { WorkflowVersionService } from '../services/workflow-version.service';
@@ -89,13 +88,6 @@ describe('WorkflowVersionController (TypeORM)', () => {
       await workflowService.deleteOne(id);
       createdWorkflowIds.delete(id);
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findMany', () => {

--- a/packages/api/src/workflow/controllers/workflow.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow.controller.spec.ts
@@ -36,7 +36,6 @@ import {
   messagingWorkflowFixtures,
 } from '@/utils/test/fixtures/workflow';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import {
   conversationalWorkflowInputJsonSchema,
@@ -200,13 +199,6 @@ describe('WorkflowController (TypeORM)', () => {
       await workflowService.deleteOne(id);
       createdWorkflowIds.delete(id);
     }
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findMany', () => {

--- a/packages/api/src/workflow/services/agentic.service.spec.ts
+++ b/packages/api/src/workflow/services/agentic.service.spec.ts
@@ -23,7 +23,6 @@ import {
   installMessagingWorkflowFixturesTypeOrm,
   messagingWorkflowDefinition,
 } from '@/utils/test/fixtures/workflow';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowContextFactory } from '@/workflow/contexts/workflow-context-factory';
 import { WorkflowRunOrmEntity } from '@/workflow/entities/workflow-run.entity';
@@ -178,13 +177,6 @@ describe('AgenticService (TypeORM)', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('handleEvent', () => {

--- a/packages/api/src/workflow/services/memory-definition.service.spec.ts
+++ b/packages/api/src/workflow/services/memory-definition.service.spec.ts
@@ -12,7 +12,6 @@ import {
   memoryDefinitionOrmFixtures,
 } from '@/utils/test/fixtures/memory-definition';
 import { installMemoryRecordFixturesTypeOrm } from '@/utils/test/fixtures/memory-record';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MemoryScope } from '../types';
@@ -54,13 +53,6 @@ describe('MemoryDefinitionService (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findBySlug', () => {

--- a/packages/api/src/workflow/services/memory-record.service.spec.ts
+++ b/packages/api/src/workflow/services/memory-record.service.spec.ts
@@ -22,7 +22,6 @@ import {
 } from '@/utils/test/fixtures/memory-record';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
 import {
-  closeTypeOrmConnections,
   getLastTypeOrmDataSource,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
@@ -68,13 +67,6 @@ describe('MemoryRecordService (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('findActiveByScope', () => {

--- a/packages/api/src/workflow/services/memory.service.spec.ts
+++ b/packages/api/src/workflow/services/memory.service.spec.ts
@@ -19,7 +19,6 @@ import {
   memoryWorkflowFixtureId,
 } from '@/utils/test/fixtures/memory-record';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import type { WorkflowRuntimeContext } from '../contexts/workflow-runtime.context';
@@ -79,13 +78,6 @@ describe('MemoryService (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   it('throws when ownerId is missing', async () => {

--- a/packages/api/src/workflow/services/workflow-run.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-run.service.spec.ts
@@ -16,7 +16,6 @@ import {
   installUserFixturesTypeOrm,
   userFixtureIds,
 } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { WorkflowRunOrmEntity } from '../entities/workflow-run.entity';
@@ -132,13 +131,6 @@ describe('WorkflowRunService (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('state transitions', () => {

--- a/packages/api/src/workflow/services/workflow-scheduler.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-scheduler.service.spec.ts
@@ -18,7 +18,6 @@ import { userFixtureIds } from '@/utils/test/fixtures/user';
 import { installScheduledWorkflowFixturesTypeOrm } from '@/utils/test/fixtures/workflow';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
 import {
-  closeTypeOrmConnections,
   getLastTypeOrmDataSource,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
@@ -128,7 +127,6 @@ describe('WorkflowSchedulerService (TypeORM)', () => {
     if (module) {
       await module.close();
     }
-    await closeTypeOrmConnections();
   });
 
   it('registers cron jobs for scheduled workflows and triggers the agent handler', async () => {

--- a/packages/api/src/workflow/services/workflow-version.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-version.service.spec.ts
@@ -19,7 +19,6 @@ import {
   userFixtureIds,
 } from '@/utils/test/fixtures/user';
 import {
-  closeTypeOrmConnections,
   getLastTypeOrmDataSource,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
@@ -67,13 +66,6 @@ describe('WorkflowVersionService (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   describe('createSnapshot', () => {

--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -17,7 +17,6 @@ import {
   installUserFixturesTypeOrm,
   userFixtureIds,
 } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import {
   conversationalWorkflowInputJsonSchema,
@@ -107,13 +106,6 @@ describe('WorkflowService (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
-  });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   it('creates workflows and returns stored definitions', async () => {


### PR DESCRIPTION
## What changed?

<!--
Use this single section for everything.
Helpful format (all optional except summary):

Summary: What changed in 1-3 sentences?
Why: Why is this needed?
How to review: Where should reviewers focus?
Validation: What did you test/check?
Links: Related issues/PRs (e.g. Closes #123)

Tip: Keep this concise and practical.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified test cleanup across many suites by removing explicit database-connection teardown so shared test harness handles resource cleanup.

* **Refactor**
  * Consolidated and trimmed redundant teardown code in ~50–60 test files to reduce duplication and improve test maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->