### PR TITLE
Fix/workflow throw error

### DIFF
--- a/packages/api/src/workflow/entities/workflow.entity.ts
+++ b/packages/api/src/workflow/entities/workflow.entity.ts
@@ -181,8 +181,8 @@ export class WorkflowOrmEntity extends BaseOrmEntity<WorkflowDto> {
       });
       await event.manager.save(WorkflowVersionOrmEntity, version);
     } catch (error: any) {
-      const code = error?.code ?? error?.driverError?.code;
-      if (typeof code !== 'string' || !code.startsWith('SQLITE_CONSTRAINT')) {
+      const codes = [error?.code, error?.driverError?.code];
+      if (!codes.includes('SQLITE_CONSTRAINT_UNIQUE')) {
         throw error;
       }
     }


### PR DESCRIPTION
## What changed?

The current code using startsWith('SQLITE_CONSTRAINT') will suppress all constraint failures—including foreign key, NOT NULL, and CHECK constraint violations—not just the duplicate blank-version case. Since better-sqlite3 provides extended error codes, this should be narrowed to the specific constraint type.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Enhanced error handling accuracy for workflow definition version creation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->