### PR TITLE
fix: resolve autocomplete api client query issue

### DIFF
--- a/packages/api/src/bindings/runtime-bindings.service.spec.ts
+++ b/packages/api/src/bindings/runtime-bindings.service.spec.ts
@@ -166,7 +166,7 @@ describe('RuntimeBindingsService', () => {
     expect(
       mcpToolsDefinition?.properties?.tool_names?.['ui:options'],
     ).toMatchObject({
-      methodName: 'getMcpTools',
+      apiPath: '/mcpserver/:id/tools',
       labelKey: 'name',
       idFormPath: 'server_id',
       disableSearch: true,

--- a/packages/api/src/bindings/runtime-bindings.service.spec.ts
+++ b/packages/api/src/bindings/runtime-bindings.service.spec.ts
@@ -166,11 +166,9 @@ describe('RuntimeBindingsService', () => {
     expect(
       mcpToolsDefinition?.properties?.tool_names?.['ui:options'],
     ).toMatchObject({
-      entity: 'McpServer',
-      valueKey: 'name',
+      methodName: 'getMcpTools',
       labelKey: 'name',
       idFormPath: 'server_id',
-      routeParamKey: 'id',
       disableSearch: true,
     });
     expect(modelDefinition?.properties?.provider?.type).toBe('string');

--- a/packages/api/src/extensions/actions/ai/mcp.binding.ts
+++ b/packages/api/src/extensions/actions/ai/mcp.binding.ts
@@ -30,7 +30,7 @@ export const aiMcpToolBindingSchema = z.strictObject({
         'Optional allow-list of MCP tool names. Leave empty to expose all server tools.',
       'ui:widget': 'AutoCompleteWidget',
       'ui:options': {
-        methodName: 'getMcpTools',
+        apiPath: '/mcpserver/:id/tools',
         labelKey: 'name',
         idKey: 'name',
         valueKey: 'name',

--- a/packages/api/src/extensions/actions/ai/mcp.binding.ts
+++ b/packages/api/src/extensions/actions/ai/mcp.binding.ts
@@ -30,12 +30,12 @@ export const aiMcpToolBindingSchema = z.strictObject({
         'Optional allow-list of MCP tool names. Leave empty to expose all server tools.',
       'ui:widget': 'AutoCompleteWidget',
       'ui:options': {
-        entity: 'McpServer',
-        valueKey: 'name',
+        methodName: 'getMcpTools',
         labelKey: 'name',
+        idKey: 'name',
         idFormPath: 'server_id',
-        routeParamKey: 'id',
         disableSearch: true,
+        multiple: true,
       },
     }),
 });

--- a/packages/api/src/extensions/actions/ai/mcp.binding.ts
+++ b/packages/api/src/extensions/actions/ai/mcp.binding.ts
@@ -33,6 +33,7 @@ export const aiMcpToolBindingSchema = z.strictObject({
         methodName: 'getMcpTools',
         labelKey: 'name',
         idKey: 'name',
+        valueKey: 'name',
         idFormPath: 'server_id',
         disableSearch: true,
         multiple: true,

--- a/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
@@ -133,7 +133,7 @@ const AutoCompleteApiQuerySelect = <
           );
         });
 
-    return filtered.sort((a, b) =>
+    return [...filtered].sort((a, b) =>
       normalizeSearchValue(b?.[sortKey]).localeCompare(
         normalizeSearchValue(a?.[sortKey]),
       ),
@@ -157,6 +157,7 @@ const AutoCompleteApiQuerySelect = <
   return (
     <AutoCompleteSelect<Value, Label, Multiple>
       ref={ref}
+      {...rest}
       idKey={idKey}
       labelKey={labelKey}
       options={options}
@@ -164,7 +165,6 @@ const AutoCompleteApiQuerySelect = <
       onSearch={setSearchText}
       loading={isFetching}
       data-multiple={rest.multiple}
-      {...rest}
     />
   );
 };

--- a/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
@@ -11,26 +11,10 @@ import type { ReactNode } from "react";
 import { forwardRef, useMemo, useState } from "react";
 
 import { useApiClientQuery } from "@/hooks/useApiClient";
-import { ApiClient } from "@/services/api.class";
-
 import AutoCompleteSelect from "./AutoCompleteSelect";
 
-export type ApiClientMethodName = {
-  [K in keyof ApiClient]: ApiClient[K] extends (...args: any[]) => any
-    ? K
-    : never;
-}[keyof ApiClient];
-
-type ApiClientMethod<N extends ApiClientMethodName> = Extract<
-  ApiClient[N],
-  (...args: any[]) => any
->;
-
 type AutoCompleteApiQuerySelectProps<
-  N extends ApiClientMethodName,
-  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
-    ? Item
-    : never,
+  Value = Record<string, unknown>,
   Label extends keyof Value = keyof Value,
   Multiple extends boolean | undefined = true,
 > = Omit<
@@ -49,13 +33,13 @@ type AutoCompleteApiQuerySelectProps<
   valueKey?: string;
   sortKey?: string;
   labelKey: Label;
-  methodName: N;
-  params?: Parameters<ApiClientMethod<N>>;
+  apiPath: string;
+  queryParams?: Record<string, unknown>;
   inputLabelSx?: unknown;
   disableSearch?: boolean;
   error?: boolean;
   helperText?: string | null | undefined;
-  preprocess?: (data: Awaited<ReturnType<ApiClientMethod<N>>>) => Value[];
+  preprocess?: (data: Value[]) => Value[];
   noOptionsWarning?: string;
   isDisabledWhenEmpty?: boolean;
   queryEnabled?: boolean;
@@ -77,16 +61,13 @@ const resolveByPath = (target: unknown, path: string) => {
   return get(target as Record<string, unknown>, path);
 };
 const AutoCompleteApiQuerySelect = <
-  N extends ApiClientMethodName,
-  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
-    ? Item
-    : never,
+  Value = Record<string, unknown>,
   Label extends keyof Value = keyof Value,
   Multiple extends boolean | undefined = true,
 >(
   {
-    methodName,
-    params,
+    apiPath,
+    queryParams,
     disableSearch,
     preprocess,
     idKey = "id",
@@ -96,20 +77,18 @@ const AutoCompleteApiQuerySelect = <
     queryEnabled = true,
     staleTime,
     ...rest
-  }: AutoCompleteApiQuerySelectProps<N, Value, Label, Multiple>,
+  }: AutoCompleteApiQuerySelectProps<Value, Label, Multiple>,
   ref,
 ) => {
   const [searchText, setSearchText] = useState("");
-  const { data, isFetching } = useApiClientQuery(methodName, {
-    params: (params || []) as any,
+  const { data, isFetching } = useApiClientQuery("getByPath", {
+    params: [apiPath, queryParams],
     enabled: queryEnabled,
     staleTime,
   });
   const rawOptions = useMemo(() => {
     if (preprocess) {
-      return preprocess(
-        data as Awaited<ReturnType<ApiClientMethod<N>>>,
-      ) as Value[];
+      return preprocess(data as Value[]) as Value[];
     }
 
     return Array.isArray(data) ? (data as Value[]) : [];
@@ -172,14 +151,11 @@ const AutoCompleteApiQuerySelect = <
 AutoCompleteApiQuerySelect.displayName = "AutoCompleteApiQuerySelect";
 
 export default forwardRef(AutoCompleteApiQuerySelect) as unknown as <
-  N extends ApiClientMethodName,
-  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
-    ? Item
-    : never,
+  Value = Record<string, unknown>,
   Label extends keyof Value = keyof Value,
   Multiple extends boolean | undefined = true,
 >(
-  props: AutoCompleteApiQuerySelectProps<N, Value, Label, Multiple> & {
+  props: AutoCompleteApiQuerySelectProps<Value, Label, Multiple> & {
     ref?: React.ForwardedRef<HTMLDivElement>;
   },
 ) => ReturnType<typeof AutoCompleteApiQuerySelect>;

--- a/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
@@ -1,0 +1,185 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { ChipTypeMap } from "@mui/material";
+import { AutocompleteProps } from "@mui/material/Autocomplete";
+import get from "lodash/get";
+import type { ReactNode } from "react";
+import { forwardRef, useMemo, useState } from "react";
+
+import { useApiClientQuery } from "@/hooks/useApiClient";
+import { ApiClient } from "@/services/api.class";
+
+import AutoCompleteSelect from "./AutoCompleteSelect";
+
+export type ApiClientMethodName = {
+  [K in keyof ApiClient]: ApiClient[K] extends (...args: any[]) => any
+    ? K
+    : never;
+}[keyof ApiClient];
+
+type ApiClientMethod<N extends ApiClientMethodName> = Extract<
+  ApiClient[N],
+  (...args: any[]) => any
+>;
+
+type AutoCompleteApiQuerySelectProps<
+  N extends ApiClientMethodName,
+  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
+    ? Item
+    : never,
+  Label extends keyof Value = keyof Value,
+  Multiple extends boolean | undefined = true,
+> = Omit<
+  AutocompleteProps<
+    Value,
+    Multiple,
+    false,
+    false,
+    ChipTypeMap["defaultComponent"]
+  >,
+  "renderInput" | "options" | "value" | "defaultValue" | "label"
+> & {
+  value?: Multiple extends true ? string[] : string | null;
+  label: ReactNode;
+  idKey?: string;
+  valueKey?: string;
+  sortKey?: string;
+  labelKey: Label;
+  methodName: N;
+  params?: Parameters<ApiClientMethod<N>>;
+  inputLabelSx?: unknown;
+  disableSearch?: boolean;
+  error?: boolean;
+  helperText?: string | null | undefined;
+  preprocess?: (data: Awaited<ReturnType<ApiClientMethod<N>>>) => Value[];
+  noOptionsWarning?: string;
+  isDisabledWhenEmpty?: boolean;
+  queryEnabled?: boolean;
+  staleTime?: number;
+};
+
+const normalizeSearchValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  return String(value).toLowerCase();
+};
+const resolveByPath = (target: unknown, path: string) => {
+  if (!path) {
+    return target;
+  }
+
+  return get(target as Record<string, unknown>, path);
+};
+const AutoCompleteApiQuerySelect = <
+  N extends ApiClientMethodName,
+  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
+    ? Item
+    : never,
+  Label extends keyof Value = keyof Value,
+  Multiple extends boolean | undefined = true,
+>(
+  {
+    methodName,
+    params,
+    disableSearch,
+    preprocess,
+    idKey = "id",
+    valueKey,
+    sortKey = "id",
+    labelKey,
+    queryEnabled = true,
+    staleTime,
+    ...rest
+  }: AutoCompleteApiQuerySelectProps<N, Value, Label, Multiple>,
+  ref,
+) => {
+  const [searchText, setSearchText] = useState("");
+  const { data, isFetching } = useApiClientQuery(methodName, {
+    params: (params || []) as any,
+    enabled: queryEnabled,
+    staleTime,
+  });
+  const rawOptions = useMemo(() => {
+    if (preprocess) {
+      return preprocess(
+        data as Awaited<ReturnType<ApiClientMethod<N>>>,
+      ) as Value[];
+    }
+
+    return Array.isArray(data) ? (data as Value[]) : [];
+  }, [data, preprocess]);
+  const resolvedSavePath = valueKey?.trim() || idKey;
+  const options = useMemo(() => {
+    const filtered = disableSearch
+      ? rawOptions
+      : rawOptions.filter((option) => {
+          if (!searchText) {
+            return true;
+          }
+
+          return [
+            resolveByPath(option, resolvedSavePath),
+            option?.[labelKey],
+          ].some((fieldValue) =>
+            normalizeSearchValue(fieldValue).includes(
+              searchText.trim().toLowerCase(),
+            ),
+          );
+        });
+
+    return filtered.sort((a, b) =>
+      normalizeSearchValue(b?.[sortKey]).localeCompare(
+        normalizeSearchValue(a?.[sortKey]),
+      ),
+    );
+  }, [
+    disableSearch,
+    labelKey,
+    rawOptions,
+    resolvedSavePath,
+    searchText,
+    sortKey,
+  ]);
+  const valueWithSavePath = useMemo(() => {
+    if (rest.multiple) {
+      return Array.isArray(rest.value) ? rest.value : [];
+    }
+
+    return typeof rest.value === "string" ? rest.value : "";
+  }, [rest.multiple, rest.value]);
+
+  return (
+    <AutoCompleteSelect<Value, Label, Multiple>
+      ref={ref}
+      idKey={idKey}
+      labelKey={labelKey}
+      options={options}
+      value={valueWithSavePath as any}
+      onSearch={setSearchText}
+      loading={isFetching}
+      data-multiple={rest.multiple}
+      {...rest}
+    />
+  );
+};
+
+AutoCompleteApiQuerySelect.displayName = "AutoCompleteApiQuerySelect";
+
+export default forwardRef(AutoCompleteApiQuerySelect) as unknown as <
+  N extends ApiClientMethodName,
+  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
+    ? Item
+    : never,
+  Label extends keyof Value = keyof Value,
+  Multiple extends boolean | undefined = true,
+>(
+  props: AutoCompleteApiQuerySelectProps<N, Value, Label, Multiple> & {
+    ref?: React.ForwardedRef<HTMLDivElement>;
+  },
+) => ReturnType<typeof AutoCompleteApiQuerySelect>;

--- a/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from "react";
 import { forwardRef, useMemo, useState } from "react";
 
 import { useApiClientQuery } from "@/hooks/useApiClient";
+
 import AutoCompleteSelect from "./AutoCompleteSelect";
 
 type AutoCompleteApiQuerySelectProps<

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
@@ -8,11 +8,9 @@ import type { RJSFSchema, WidgetProps } from "@rjsf/utils";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
 
-import AutoCompleteApiQuerySelect, {
-  ApiClientMethodName,
-} from "@/app-components/inputs/AutoCompleteApiQuerySelect";
+import AutoCompleteApiQuerySelect from "@/app-components/inputs/AutoCompleteApiQuerySelect";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
-import type { RouteParams } from "@/services/api.class";
+import { resolveRoute, type RouteParams } from "@/services/api.class";
 import { Format, normalizeEntity } from "@/services/types";
 import { IEntityMapTypes } from "@/types/base.types";
 
@@ -37,7 +35,7 @@ type AutoCompleteWidgetOptions = Omit<
   labelKey?: string;
   routeParamKey?: string;
   multiple?: boolean;
-  methodName?: ApiClientMethodName;
+  apiPath?: string;
   valueKey?: string;
   idKey?: string;
 };
@@ -54,7 +52,7 @@ const AutoCompleteWidgetWrapper = ({
   queryEnabled = true,
   onChange,
   enableEntityAddButton,
-  methodName,
+  apiPath,
   idKey,
   ...rest
 }: AutoCompleteWidgetOptions & {
@@ -80,16 +78,12 @@ const AutoCompleteWidgetWrapper = ({
     [multiple, value],
   );
 
-  if (methodName) {
-    const dependencyParam = routeParams
-      ? Object.values(routeParams).find(
-          (candidate) => candidate !== undefined && candidate !== null,
-        )
-      : undefined;
+  if (apiPath) {
+    const resolvedApiPath = resolveRoute(apiPath, routeParams);
 
     return (
-      <AutoCompleteApiQuerySelect<any, string, any, boolean>
-        methodName={methodName}
+      <AutoCompleteApiQuerySelect<any, any, boolean>
+        apiPath={resolvedApiPath}
         valueKey={valueKey}
         idKey={idKey}
         labelKey={labelKey}
@@ -97,7 +91,6 @@ const AutoCompleteWidgetWrapper = ({
         inputLabelSx={inputLabelSx}
         value={normalizedValue}
         multiple={multiple}
-        params={dependencyParam !== undefined ? [dependencyParam] : []}
         queryEnabled={queryEnabled}
         onChange={(_e, selected, ..._) => {
           onChange(
@@ -175,7 +168,7 @@ export const AutoCompleteWidget = ({
     idFormPath,
     routeParamKey = "id",
     multiple: uiMultiple,
-    methodName,
+    apiPath,
     idKey = "id",
     ...props
   } = uiSchema?.["ui:options"] as AutoCompleteWidgetOptions;
@@ -212,11 +205,11 @@ export const AutoCompleteWidget = ({
     onChange(isMultiple ? [] : "");
   }, [dependencyQueryConfig.dependencyValue, idFormPath, isMultiple, onChange]);
 
-  if (methodName || entity) {
+  if (apiPath || entity) {
     return (
       <AutoCompleteWidgetWrapper
         entity={entity ? normalizeEntity(entity) : undefined}
-        methodName={methodName}
+        apiPath={apiPath}
         idKey={idKey}
         value={value}
         label={label}

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
@@ -13,6 +13,9 @@ import type { RouteParams } from "@/services/api.class";
 import { Format, normalizeEntity } from "@/services/types";
 import { IEntityMapTypes } from "@/types/base.types";
 
+import AutoCompleteApiQuerySelect, {
+  ApiClientMethodName,
+} from "../../AutoCompleteApiQuerySelect";
 import { Rjsf } from "../fields/AutoCompleteField";
 
 import {
@@ -34,6 +37,9 @@ type AutoCompleteWidgetOptions = Omit<
   labelKey?: string;
   routeParamKey?: string;
   multiple?: boolean;
+  methodName?: ApiClientMethodName;
+  valueKey?: string;
+  idKey?: string;
 };
 
 const AutoCompleteWidgetWrapper = ({
@@ -48,12 +54,14 @@ const AutoCompleteWidgetWrapper = ({
   queryEnabled = true,
   onChange,
   enableEntityAddButton,
+  methodName,
+  idKey,
   ...rest
 }: AutoCompleteWidgetOptions & {
   label?: ReactNode;
   inputLabelSx?: unknown;
   value: any;
-  entity: keyof IEntityMapTypes;
+  entity?: keyof IEntityMapTypes;
   multiple?: boolean;
   routeParams?: RouteParams;
   queryEnabled?: boolean;
@@ -71,6 +79,45 @@ const AutoCompleteWidgetWrapper = ({
           : "",
     [multiple, value],
   );
+
+  if (methodName) {
+    const dependencyParam = routeParams
+      ? Object.values(routeParams).find(
+          (candidate) => candidate !== undefined && candidate !== null,
+        )
+      : undefined;
+
+    return (
+      <AutoCompleteApiQuerySelect<any, string, any, boolean>
+        methodName={methodName}
+        valueKey={valueKey}
+        idKey={idKey}
+        labelKey={labelKey}
+        label={label ?? ""}
+        inputLabelSx={inputLabelSx}
+        value={normalizedValue}
+        multiple={multiple}
+        params={dependencyParam !== undefined ? [dependencyParam] : []}
+        queryEnabled={queryEnabled}
+        onChange={(_e, selected, ..._) => {
+          onChange(
+            toAutoCompleteWidgetValue({
+              selection: Array.isArray(selected)
+                ? selected.map((s) => s[labelKey])
+                : selected?.[labelKey],
+              valueKey,
+              multiple,
+            }),
+          );
+        }}
+        {...rest}
+      />
+    );
+  }
+
+  if (!entity) {
+    return null;
+  }
 
   return (
     <AutoCompleteEntitySelect<any, string, boolean>
@@ -128,6 +175,8 @@ export const AutoCompleteWidget = ({
     idFormPath,
     routeParamKey = "id",
     multiple: uiMultiple,
+    methodName,
+    idKey = "id",
     ...props
   } = uiSchema?.["ui:options"] as AutoCompleteWidgetOptions;
   const isMultiple = schema?.type === "array" || Boolean(uiMultiple);
@@ -163,10 +212,12 @@ export const AutoCompleteWidget = ({
     onChange(isMultiple ? [] : "");
   }, [dependencyQueryConfig.dependencyValue, idFormPath, isMultiple, onChange]);
 
-  if (entity) {
+  if (methodName || entity) {
     return (
       <AutoCompleteWidgetWrapper
-        entity={normalizeEntity(entity)}
+        entity={entity ? normalizeEntity(entity) : undefined}
+        methodName={methodName}
+        idKey={idKey}
         value={value}
         label={label}
         inputLabelSx={inputLabelSx}

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
@@ -103,8 +103,8 @@ const AutoCompleteWidgetWrapper = ({
           onChange(
             toAutoCompleteWidgetValue({
               selection: Array.isArray(selected)
-                ? selected.map((s) => s[labelKey])
-                : selected?.[labelKey],
+                ? selected.map((s) => s?.[valueKey] ?? s?.[labelKey])
+                : (selected?.[valueKey] ?? selected?.[labelKey]),
               valueKey,
               multiple,
             }),

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
@@ -8,14 +8,14 @@ import type { RJSFSchema, WidgetProps } from "@rjsf/utils";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
 
+import AutoCompleteApiQuerySelect, {
+  ApiClientMethodName,
+} from "@/app-components/inputs/AutoCompleteApiQuerySelect";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import type { RouteParams } from "@/services/api.class";
 import { Format, normalizeEntity } from "@/services/types";
 import { IEntityMapTypes } from "@/types/base.types";
 
-import AutoCompleteApiQuerySelect, {
-  ApiClientMethodName,
-} from "../../AutoCompleteApiQuerySelect";
 import { Rjsf } from "../fields/AutoCompleteField";
 
 import {

--- a/packages/frontend/src/services/api.class.ts
+++ b/packages/frontend/src/services/api.class.ts
@@ -39,7 +39,7 @@ export type RouteParams = Record<
   string | number | boolean | null | undefined
 >;
 
-const resolveRoute = (route: string, params?: RouteParams) => {
+export const resolveRoute = (route: string, params?: RouteParams) => {
   if (!params) {
     return route;
   }
@@ -112,6 +112,15 @@ export const ROUTES = {
 
 export class TranslatableMethods {
   constructor(protected readonly request: AxiosInstance) {}
+
+  async getByPath<TResponse = unknown>(
+    path: string,
+    params?: Record<string, unknown>,
+  ) {
+    const { data } = await this.request.get<TResponse>(path, { params });
+
+    return data;
+  }
 
   async getWorkflowBindings() {
     const { data } = await this.request.get<WorkflowBindingsCatalog>(


### PR DESCRIPTION
## What changed?
Adds a new component called AutoCompleteApiQuerySelect. 
It lets you create a select input for API endpoints that are not entities.

## Demonstration
<video src="https://github.com/user-attachments/assets/e87b1bab-cf95-400a-a522-75fd06ef1b8e"></video>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API-backed autocomplete input that loads, filters, and sorts remote options.
  * Forms can fetch selectable MCP tools via an API method and support multi-select.

* **Refactor**
  * Autocomplete widget unified to support API-driven and entity-driven selection; accepts optional query parameters and improved value/key handling.

* **Tests**
  * Updated test expectations for the autocomplete UI configuration for tool selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->