### PR TITLE
fix(api): cap unbounded async concurrency with p-limit

### DIFF
--- a/packages/api/src/app.service.ts
+++ b/packages/api/src/app.service.ts
@@ -7,6 +7,7 @@
 import type { IntegrationHealthResponse } from '@hexabot-ai/types';
 import { ForbiddenException, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import pLimit from 'p-limit';
 
 import { BaseOrmEntity } from './database';
 import { HealthService } from './health/health.service';
@@ -80,8 +81,10 @@ export class AppService {
         ),
       ),
     );
-
-    await Promise.all(subscribe.map((room) => req.socket.join(room)));
+    const socketLimit = pLimit(15);
+    await Promise.all(
+      subscribe.map((room) => socketLimit(() => req.socket.join(room))),
+    );
 
     return res.status(200).json({
       success: true,

--- a/packages/api/src/attachment/guards/attachment-ability.guard.ts
+++ b/packages/api/src/attachment/guards/attachment-ability.guard.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/common';
 import { isUUID } from 'class-validator';
 import { Request } from 'express';
+import pLimit from 'p-limit';
 import qs from 'qs';
 import { FindOneOptions, In } from 'typeorm';
 
@@ -179,10 +180,12 @@ export class AttachmentGuard implements CanActivate {
       return false;
     }
 
+    const dbLimit = pLimit(10);
+
     return (
       await Promise.all(
         permissions.map(([identity, action]) =>
-          this.hasPermission(user, identity, action),
+          dbLimit(() => this.hasPermission(user, identity, action)),
         ),
       )
     ).every(Boolean);
@@ -244,9 +247,13 @@ export class AttachmentGuard implements CanActivate {
             throw new BadRequestException('Invalid resource ref');
           }
 
+          const dbLimit = pLimit(10);
+
           return (
             await Promise.all(
-              resourceRef.map((c) => this.isAuthorized(Action.READ, user, c)),
+              resourceRef.map((c) =>
+                dbLimit(() => this.isAuthorized(Action.READ, user, c)),
+              ),
             )
           ).every(Boolean);
         } else {

--- a/packages/api/src/channel/lib/Handler.ts
+++ b/packages/api/src/channel/lib/Handler.ts
@@ -18,6 +18,7 @@ import { Inject, Injectable, OnModuleInit, Type } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { Request, Response } from 'express';
 import mime from 'mime';
+import pLimit from 'p-limit';
 import z from 'zod';
 
 import { AttachmentService } from '@/attachment/services/attachment.service';
@@ -230,18 +231,21 @@ export default abstract class ChannelHandler<
 
     const metadatas = await this.getMessageAttachments(event);
     const subscriber = event.getInitiator();
+    const storageLimit = pLimit(4);
     const attachments = await Promise.all(
-      metadatas.map(({ file, name, type, size }) => {
-        return this.attachmentService.store(file, {
-          name: `${name ? `${name}-` : ''}${randomUUID()}.${mime.extension(type)}`,
-          type,
-          size,
-          resourceRef: AttachmentResourceRef.MessageAttachment,
-          access: AttachmentAccess.Private,
-          createdByRef: AttachmentCreatedByRef.Subscriber,
-          createdBy: subscriber.id,
-        });
-      }),
+      metadatas.map(({ file, name, type, size }) =>
+        storageLimit(() =>
+          this.attachmentService.store(file, {
+            name: `${name ? `${name}-` : ''}${randomUUID()}.${mime.extension(type)}`,
+            type,
+            size,
+            resourceRef: AttachmentResourceRef.MessageAttachment,
+            access: AttachmentAccess.Private,
+            createdByRef: AttachmentCreatedByRef.Subscriber,
+            createdBy: subscriber.id,
+          }),
+        ),
+      ),
     );
 
     event.setPersistedAttachments(attachments);

--- a/packages/api/src/i18n/controllers/translation.controller.ts
+++ b/packages/api/src/i18n/controllers/translation.controller.ts
@@ -15,6 +15,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
+import pLimit from 'p-limit';
 import { FindManyOptions, In, Not } from 'typeorm';
 import { DeleteResult } from 'typeorm/driver/mongodb/typings';
 
@@ -110,10 +111,13 @@ export class TranslationController extends BaseOrmController<TranslationOrmEntit
       return str && strings.indexOf(str) == pos;
     });
     // Perform refresh
+    const dbLimit = pLimit(10);
     const queue = strings.map((str) =>
-      this.translationService.findOneOrCreate(
-        { where: { str } },
-        { str, translations: defaultTrans },
+      dbLimit(() =>
+        this.translationService.findOneOrCreate(
+          { where: { str } },
+          { str, translations: defaultTrans },
+        ),
       ),
     );
     await Promise.all(queue);

--- a/packages/api/src/i18n/loaders/extension-json.loader.ts
+++ b/packages/api/src/i18n/loaders/extension-json.loader.ts
@@ -16,6 +16,7 @@ import {
   I18nLoader,
   I18nTranslation,
 } from 'nestjs-i18n';
+import pLimit from 'p-limit';
 import { Observable, Subject, merge, of, switchMap } from 'rxjs';
 
 import { deepMerge, isPlainObject } from '@/utils/helpers/object';
@@ -158,17 +159,18 @@ export class ExtensionJsonLoader extends I18nLoader implements OnModuleDestroy {
   private async resolveExtensionTranslationFiles(
     extensionRootPaths: string[],
   ): Promise<string[]> {
+    const fsLimit = pLimit(8);
     const i18nDirectories = (
       await Promise.all(
         extensionRootPaths.map((rootPath) =>
-          this.findI18nDirectories(rootPath),
+          fsLimit(() => this.findI18nDirectories(rootPath)),
         ),
       )
     ).flat();
     const translationFiles = (
       await Promise.all(
         i18nDirectories.map((i18nDir) =>
-          this.findTranslationFilesInI18nDirectory(i18nDir),
+          fsLimit(() => this.findTranslationFilesInI18nDirectory(i18nDir)),
         ),
       )
     ).flat();
@@ -185,17 +187,20 @@ export class ExtensionJsonLoader extends I18nLoader implements OnModuleDestroy {
     if (!entries) {
       return [];
     }
+    const fsLimit = pLimit(8);
     const nestedResults = await Promise.all(
       entries
         .filter((entry) => entry.isDirectory())
-        .map(async (entry) => {
-          const entryPath = path.join(rootPath, entry.name);
-          if (entry.name === 'i18n') {
-            return [entryPath];
-          }
+        .map((entry) =>
+          fsLimit(async () => {
+            const entryPath = path.join(rootPath, entry.name);
+            if (entry.name === 'i18n') {
+              return [entryPath];
+            }
 
-          return this.findI18nDirectories(entryPath);
-        }),
+            return this.findI18nDirectories(entryPath);
+          }),
+        ),
     );
 
     return nestedResults.flat();

--- a/packages/api/src/i18n/loaders/extension-json.loader.ts
+++ b/packages/api/src/i18n/loaders/extension-json.loader.ts
@@ -163,7 +163,7 @@ export class ExtensionJsonLoader extends I18nLoader implements OnModuleDestroy {
     const i18nDirectories = (
       await Promise.all(
         extensionRootPaths.map((rootPath) =>
-          fsLimit(() => this.findI18nDirectories(rootPath)),
+          fsLimit(() => this.findI18nDirectories(rootPath, fsLimit)),
         ),
       )
     ).flat();
@@ -180,14 +180,16 @@ export class ExtensionJsonLoader extends I18nLoader implements OnModuleDestroy {
     );
   }
 
-  private async findI18nDirectories(rootPath: string): Promise<string[]> {
+  private async findI18nDirectories(
+    rootPath: string,
+    fsLimit: ReturnType<typeof pLimit>,
+  ): Promise<string[]> {
     const entries = await fs
       .readdir(rootPath, { withFileTypes: true })
       .catch(() => null);
     if (!entries) {
       return [];
     }
-    const fsLimit = pLimit(8);
     const nestedResults = await Promise.all(
       entries
         .filter((entry) => entry.isDirectory())
@@ -198,7 +200,7 @@ export class ExtensionJsonLoader extends I18nLoader implements OnModuleDestroy {
               return [entryPath];
             }
 
-            return this.findI18nDirectories(entryPath);
+            return this.findI18nDirectories(entryPath, fsLimit);
           }),
         ),
     );

--- a/packages/api/src/workflow/utils/memory-store.ts
+++ b/packages/api/src/workflow/utils/memory-store.ts
@@ -5,6 +5,7 @@
  */
 
 import { MemoryDefinition, MemoryRecordFull } from '@hexabot-ai/types';
+import pLimit from 'p-limit';
 import { ZodSchema, z } from 'zod';
 
 import { cloneObject } from '@/utils/helpers/clone';
@@ -376,27 +377,30 @@ export class MemoryStore {
       return {};
     }
 
+    const dbLimit = pLimit(8);
     const updates = await Promise.all(
-      entries.map(async ([slug, value]) => {
-        const currentValue = this.raw[slug];
-        const canMerge =
-          currentValue !== null &&
-          value !== null &&
-          typeof currentValue === 'object' &&
-          typeof value === 'object' &&
-          !Array.isArray(currentValue) &&
-          !Array.isArray(value);
-        const nextValue = canMerge
-          ? deepMerge(cloneObject(currentValue), value)
-          : value;
-        const parsedValue = await this.updateStoreEntry(
-          slug,
-          nextValue,
-          persistRecord,
-        );
+      entries.map(([slug, value]) =>
+        dbLimit(async () => {
+          const currentValue = this.raw[slug];
+          const canMerge =
+            currentValue !== null &&
+            value !== null &&
+            typeof currentValue === 'object' &&
+            typeof value === 'object' &&
+            !Array.isArray(currentValue) &&
+            !Array.isArray(value);
+          const nextValue = canMerge
+            ? deepMerge(cloneObject(currentValue), value)
+            : value;
+          const parsedValue = await this.updateStoreEntry(
+            slug,
+            nextValue,
+            persistRecord,
+          );
 
-        return [slug, parsedValue] as const;
-      }),
+          return [slug, parsedValue] as const;
+        }),
+      ),
     );
 
     return Object.fromEntries(updates);


### PR DESCRIPTION
## What changed?

**Summary:** Replaced unbounded `Promise.all(array.map(async ...))` fan-out with `p-limit` in 6 API hotspots where input size is user/config-driven.

**Why:** Unbounded async loops can spike DB/socket/filesystem pressure under large payloads, causing event-loop contention and degraded tail latency. `p-limit` (already a dependency) caps concurrency with sensible per-domain defaults.

**Hotspots capped:**
| File | I/O type | Concurrency cap |
|------|----------|----------------|
| `extension-json.loader.ts` | Filesystem traversal | 8 |
| `translation.controller.ts` | DB upserts (findOneOrCreate) | 10 |
| `Handler.ts` | Attachment storage | 4 |
| `attachment-ability.guard.ts` | DB permission checks | 10 |
| `memory-store.ts` | DB memory entry persistence | 8 |
| `app.service.ts` | Socket room joins | 15 |

**How to review:** Each file has a small, isolated change — `pLimit(N)` wrapping the existing `.map()` callback. No behavior or response payload changes.

**Validation:** Typecheck and lint pass. Existing behavior preserved — only execution concurrency is bounded.

Closes anis-marrouchi/Hexabot#4
Related upstream issue: Hexastack/Hexabot#1863

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Stability**
  * Introduced controlled concurrency across backend operations to improve reliability and prevent overload: throttled room subscriptions, authorization checks, attachment storage, translation refreshes, extension file scanning, and workflow data updates—yielding steadier performance under load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->