### PR TITLE
fix(frontend): resolve channels static workflow column values

### DIFF
--- a/packages/frontend/src/components/sources/index.tsx
+++ b/packages/frontend/src/components/sources/index.tsx
@@ -7,6 +7,7 @@
 import { Action, type SourceFull } from "@hexabot-ai/types";
 import {
   Button,
+  Chip,
   IconButton,
   Menu,
   MenuItem,
@@ -19,6 +20,7 @@ import { GridColDef } from "@mui/x-data-grid";
 import { ChevronDown, Copy, Plus, Webhook } from "lucide-react";
 import { MouseEvent, useMemo, useState } from "react";
 
+import { ChipEntity } from "@/app-components/displays/ChipEntity";
 import {
   ColumnActionType,
   useActionColumns,
@@ -205,7 +207,18 @@ export const Sources = () => {
       headerName: t("label.workflow"),
       disableColumnMenu: true,
       headerAlign: "left",
-      renderCell: ({ row }) => row.defaultWorkflow?.name || t("label.none"),
+      renderCell: ({ value }) =>
+        value ? (
+          <ChipEntity
+            id={value}
+            key={value}
+            field="name"
+            color="primary"
+            entity={EntityType.WORKFLOW}
+          />
+        ) : (
+          <Chip label={t("label.none")} />
+        ),
     },
     {
       maxWidth: 140,


### PR DESCRIPTION
## What changed?
Fixes an issue where the workflow column in the channels (sources) page DataGrid always shows a None value, so now it correctly displays the proper workflow name if available else the not available message.

## Screenshot 
- After the fix
> <img width="1681" height="230" alt="image" src="https://github.com/user-attachments/assets/0f32a77d-1acd-48a8-baff-b442653120c6" />

- Before the fix
> <img width="1681" height="230" alt="image" src="https://github.com/user-attachments/assets/3030dcb4-b9a9-4db1-a3e5-6606c2ad1d49" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the workflow column display with improved visual formatting for workflow entities and better handling of cases where no workflow is assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->