### PR TITLE
Autocomplete: use generic `apiPath` (add `getByPath` / `resolveRoute`)

### DIFF
--- a/packages/api/src/bindings/runtime-bindings.service.spec.ts
+++ b/packages/api/src/bindings/runtime-bindings.service.spec.ts
@@ -166,7 +166,7 @@ describe('RuntimeBindingsService', () => {
     expect(
       mcpToolsDefinition?.properties?.tool_names?.['ui:options'],
     ).toMatchObject({
-      methodName: 'getMcpTools',
+      apiPath: '/mcpserver/:id/tools',
       labelKey: 'name',
       idFormPath: 'server_id',
       disableSearch: true,

--- a/packages/api/src/extensions/actions/ai/mcp.binding.ts
+++ b/packages/api/src/extensions/actions/ai/mcp.binding.ts
@@ -30,7 +30,7 @@ export const aiMcpToolBindingSchema = z.strictObject({
         'Optional allow-list of MCP tool names. Leave empty to expose all server tools.',
       'ui:widget': 'AutoCompleteWidget',
       'ui:options': {
-        methodName: 'getMcpTools',
+        apiPath: '/mcpserver/:id/tools',
         labelKey: 'name',
         idKey: 'name',
         valueKey: 'name',

--- a/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteApiQuerySelect.tsx
@@ -11,26 +11,10 @@ import type { ReactNode } from "react";
 import { forwardRef, useMemo, useState } from "react";
 
 import { useApiClientQuery } from "@/hooks/useApiClient";
-import { ApiClient } from "@/services/api.class";
-
 import AutoCompleteSelect from "./AutoCompleteSelect";
 
-export type ApiClientMethodName = {
-  [K in keyof ApiClient]: ApiClient[K] extends (...args: any[]) => any
-    ? K
-    : never;
-}[keyof ApiClient];
-
-type ApiClientMethod<N extends ApiClientMethodName> = Extract<
-  ApiClient[N],
-  (...args: any[]) => any
->;
-
 type AutoCompleteApiQuerySelectProps<
-  N extends ApiClientMethodName,
-  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
-    ? Item
-    : never,
+  Value = Record<string, unknown>,
   Label extends keyof Value = keyof Value,
   Multiple extends boolean | undefined = true,
 > = Omit<
@@ -49,13 +33,13 @@ type AutoCompleteApiQuerySelectProps<
   valueKey?: string;
   sortKey?: string;
   labelKey: Label;
-  methodName: N;
-  params?: Parameters<ApiClientMethod<N>>;
+  apiPath: string;
+  queryParams?: Record<string, unknown>;
   inputLabelSx?: unknown;
   disableSearch?: boolean;
   error?: boolean;
   helperText?: string | null | undefined;
-  preprocess?: (data: Awaited<ReturnType<ApiClientMethod<N>>>) => Value[];
+  preprocess?: (data: Value[]) => Value[];
   noOptionsWarning?: string;
   isDisabledWhenEmpty?: boolean;
   queryEnabled?: boolean;
@@ -77,16 +61,13 @@ const resolveByPath = (target: unknown, path: string) => {
   return get(target as Record<string, unknown>, path);
 };
 const AutoCompleteApiQuerySelect = <
-  N extends ApiClientMethodName,
-  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
-    ? Item
-    : never,
+  Value = Record<string, unknown>,
   Label extends keyof Value = keyof Value,
   Multiple extends boolean | undefined = true,
 >(
   {
-    methodName,
-    params,
+    apiPath,
+    queryParams,
     disableSearch,
     preprocess,
     idKey = "id",
@@ -96,20 +77,18 @@ const AutoCompleteApiQuerySelect = <
     queryEnabled = true,
     staleTime,
     ...rest
-  }: AutoCompleteApiQuerySelectProps<N, Value, Label, Multiple>,
+  }: AutoCompleteApiQuerySelectProps<Value, Label, Multiple>,
   ref,
 ) => {
   const [searchText, setSearchText] = useState("");
-  const { data, isFetching } = useApiClientQuery(methodName, {
-    params: (params || []) as any,
+  const { data, isFetching } = useApiClientQuery("getByPath", {
+    params: [apiPath, queryParams],
     enabled: queryEnabled,
     staleTime,
   });
   const rawOptions = useMemo(() => {
     if (preprocess) {
-      return preprocess(
-        data as Awaited<ReturnType<ApiClientMethod<N>>>,
-      ) as Value[];
+      return preprocess(data as Value[]) as Value[];
     }
 
     return Array.isArray(data) ? (data as Value[]) : [];
@@ -172,14 +151,11 @@ const AutoCompleteApiQuerySelect = <
 AutoCompleteApiQuerySelect.displayName = "AutoCompleteApiQuerySelect";
 
 export default forwardRef(AutoCompleteApiQuerySelect) as unknown as <
-  N extends ApiClientMethodName,
-  Value = ApiClientMethod<N> extends (...args: any[]) => Promise<(infer Item)[]>
-    ? Item
-    : never,
+  Value = Record<string, unknown>,
   Label extends keyof Value = keyof Value,
   Multiple extends boolean | undefined = true,
 >(
-  props: AutoCompleteApiQuerySelectProps<N, Value, Label, Multiple> & {
+  props: AutoCompleteApiQuerySelectProps<Value, Label, Multiple> & {
     ref?: React.ForwardedRef<HTMLDivElement>;
   },
 ) => ReturnType<typeof AutoCompleteApiQuerySelect>;

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
@@ -8,11 +8,9 @@ import type { RJSFSchema, WidgetProps } from "@rjsf/utils";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef } from "react";
 
-import AutoCompleteApiQuerySelect, {
-  ApiClientMethodName,
-} from "@/app-components/inputs/AutoCompleteApiQuerySelect";
+import AutoCompleteApiQuerySelect from "@/app-components/inputs/AutoCompleteApiQuerySelect";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
-import type { RouteParams } from "@/services/api.class";
+import { resolveRoute, type RouteParams } from "@/services/api.class";
 import { Format, normalizeEntity } from "@/services/types";
 import { IEntityMapTypes } from "@/types/base.types";
 
@@ -37,7 +35,7 @@ type AutoCompleteWidgetOptions = Omit<
   labelKey?: string;
   routeParamKey?: string;
   multiple?: boolean;
-  methodName?: ApiClientMethodName;
+  apiPath?: string;
   valueKey?: string;
   idKey?: string;
 };
@@ -54,7 +52,7 @@ const AutoCompleteWidgetWrapper = ({
   queryEnabled = true,
   onChange,
   enableEntityAddButton,
-  methodName,
+  apiPath,
   idKey,
   ...rest
 }: AutoCompleteWidgetOptions & {
@@ -80,16 +78,12 @@ const AutoCompleteWidgetWrapper = ({
     [multiple, value],
   );
 
-  if (methodName) {
-    const dependencyParam = routeParams
-      ? Object.values(routeParams).find(
-          (candidate) => candidate !== undefined && candidate !== null,
-        )
-      : undefined;
+  if (apiPath) {
+    const resolvedApiPath = resolveRoute(apiPath, routeParams);
 
     return (
-      <AutoCompleteApiQuerySelect<any, string, any, boolean>
-        methodName={methodName}
+      <AutoCompleteApiQuerySelect<any, any, boolean>
+        apiPath={resolvedApiPath}
         valueKey={valueKey}
         idKey={idKey}
         labelKey={labelKey}
@@ -97,7 +91,6 @@ const AutoCompleteWidgetWrapper = ({
         inputLabelSx={inputLabelSx}
         value={normalizedValue}
         multiple={multiple}
-        params={dependencyParam !== undefined ? [dependencyParam] : []}
         queryEnabled={queryEnabled}
         onChange={(_e, selected, ..._) => {
           onChange(
@@ -175,7 +168,7 @@ export const AutoCompleteWidget = ({
     idFormPath,
     routeParamKey = "id",
     multiple: uiMultiple,
-    methodName,
+    apiPath,
     idKey = "id",
     ...props
   } = uiSchema?.["ui:options"] as AutoCompleteWidgetOptions;
@@ -212,11 +205,11 @@ export const AutoCompleteWidget = ({
     onChange(isMultiple ? [] : "");
   }, [dependencyQueryConfig.dependencyValue, idFormPath, isMultiple, onChange]);
 
-  if (methodName || entity) {
+  if (apiPath || entity) {
     return (
       <AutoCompleteWidgetWrapper
         entity={entity ? normalizeEntity(entity) : undefined}
-        methodName={methodName}
+        apiPath={apiPath}
         idKey={idKey}
         value={value}
         label={label}

--- a/packages/frontend/src/services/api.class.ts
+++ b/packages/frontend/src/services/api.class.ts
@@ -39,7 +39,7 @@ export type RouteParams = Record<
   string | number | boolean | null | undefined
 >;
 
-const resolveRoute = (route: string, params?: RouteParams) => {
+export const resolveRoute = (route: string, params?: RouteParams) => {
   if (!params) {
     return route;
   }
@@ -112,6 +112,15 @@ export const ROUTES = {
 
 export class TranslatableMethods {
   constructor(protected readonly request: AxiosInstance) {}
+
+  async getByPath<TResponse = unknown>(
+    path: string,
+    params?: Record<string, unknown>,
+  ) {
+    const { data } = await this.request.get<TResponse>(path, { params });
+
+    return data;
+  }
 
   async getWorkflowBindings() {
     const { data } = await this.request.get<WorkflowBindingsCatalog>(


### PR DESCRIPTION
### Motivation

- Decouple autocomplete inputs from concrete `ApiClient` method names and support dynamic, parametric routes for fetching option lists.
- Provide a small URL resolution helper and a generic client method to fetch arbitrary endpoints by path.

### Description

- Export `resolveRoute` from `frontend/src/services/api.class.ts` and add `TranslatableMethods.getByPath` to perform GET requests by path with query params.
- Refactor `AutoCompleteApiQuerySelect` to accept `apiPath` and `queryParams` instead of `methodName`/`params`, simplify component generics, and call the new `getByPath` via `useApiClientQuery`.
- Update `AutoCompleteWidget` to resolve `apiPath` with `routeParams` using `resolveRoute` and forward the resolved path to `AutoCompleteApiQuerySelect`, and replace `methodName` option with `apiPath` in widget options.
- Change MCP binding schema `ui:options` to use `apiPath: '/mcpserver/:id/tools'` and update the runtime bindings spec to expect `apiPath` in the generated UI options.

### Testing

- Ran unit tests with `yarn test`, including the updated `packages/api/src/bindings/runtime-bindings.service.spec.ts`, and they passed.
- Verified TypeScript compilation/build (`yarn build`) succeeded without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4484ab2c4832da5d258ab9e48a83f)