### PR TITLE
fix(cli): min password char typo

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -258,7 +258,7 @@ const promptSeedAdminCredentials = async (): Promise<AdminSeedCredentials> => {
     })
   ).trim();
   const adminPassword = await password({
-    message: 'Password (min 12 chars)',
+    message: 'Password (min 8 chars)',
     mask: '*',
     validate: validateAdminPassword,
   });


### PR DESCRIPTION
## What changed?

Fix password min char typo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the admin password requirement message during setup to accurately reflect the minimum 8-character requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->