### PR TITLE
fix: remove label_id

### DIFF
--- a/packages/api/src/channel/lib/__test__/label.mock.ts
+++ b/packages/api/src/channel/lib/__test__/label.mock.ts
@@ -12,12 +12,6 @@ const baseLabel: Label = {
   ...modelInstance,
   title: '',
   name: '',
-  label_id: {
-    messenger: '',
-    web: '',
-    dimelo: '',
-    twitter: '',
-  },
   description: '',
   builtin: false,
   group: null,
@@ -27,12 +21,6 @@ export const labelMock: Label = {
   ...baseLabel,
   title: 'Label',
   name: 'label',
-  label_id: {
-    messenger: 'none',
-    web: 'none',
-    dimelo: 'none',
-    twitter: 'none',
-  },
 };
 
 export const customerLabelsMock: Label[] = [
@@ -40,22 +28,10 @@ export const customerLabelsMock: Label[] = [
     ...baseLabel,
     title: 'Client',
     name: 'client',
-    label_id: {
-      messenger: 'none',
-      web: 'none',
-      dimelo: 'none',
-      twitter: 'none',
-    },
   },
   {
     ...baseLabel,
     title: 'Professional',
     name: 'profressional',
-    label_id: {
-      messenger: 'none',
-      web: 'none',
-      dimelo: 'none',
-      twitter: 'none',
-    },
   },
 ];

--- a/packages/api/src/chat/controllers/label.controller.spec.ts
+++ b/packages/api/src/chat/controllers/label.controller.spec.ts
@@ -139,7 +139,6 @@ describe('LabelController (TypeORM)', () => {
         title: createUniqueLabelTitle(),
         name: createUniqueLabelName(),
         description: 'A sample label description',
-        label_id: { web: randomString() },
       };
       const createSpy = jest.spyOn(labelService, 'create');
       const result = await labelController.create(payload);

--- a/packages/api/src/chat/dto/label.dto.ts
+++ b/packages/api/src/chat/dto/label.dto.ts
@@ -6,13 +6,7 @@
 
 import { labelFullSchema, labelSchema } from '@hexabot-ai/types';
 import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
-import {
-  IsNotEmpty,
-  IsObject,
-  IsOptional,
-  IsString,
-  Matches,
-} from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, Matches } from 'class-validator';
 
 import { IsUUIDv4 } from '@/utils/decorators/is-uuid.decorator';
 import { TDto } from '@/utils/types/dto.types';
@@ -43,11 +37,6 @@ export class LabelCreateDto {
   @IsOptional()
   @IsString()
   description?: string;
-
-  @ApiPropertyOptional({ description: 'Label id', type: Object })
-  @IsOptional()
-  @IsObject()
-  label_id?: Record<string, any>;
 }
 
 export class LabelUpdateDto extends PartialType(LabelCreateDto) {}

--- a/packages/api/src/chat/entities/label.entity.ts
+++ b/packages/api/src/chat/entities/label.entity.ts
@@ -16,7 +16,6 @@ import {
 } from 'typeorm';
 
 import { AuditLabel } from '@/audit/decorators/audit-label.decorator';
-import { JsonColumn } from '@/database/decorators/json-column.decorator';
 import { BaseOrmEntity } from '@/database/entities/base.entity';
 import { AsRelation } from '@/utils/decorators/relation-ref.decorator';
 
@@ -50,9 +49,6 @@ export class LabelOrmEntity extends BaseOrmEntity<LabelDto> {
 
   @RelationId((label: LabelOrmEntity) => label.group)
   private readonly groupId?: string | null;
-
-  @JsonColumn({ nullable: true })
-  label_id?: Record<string, any> | null;
 
   @Column({ type: 'text', nullable: true })
   description?: string | null;

--- a/packages/api/src/chat/repositories/subscriber.repository.spec.ts
+++ b/packages/api/src/chat/repositories/subscriber.repository.spec.ts
@@ -134,12 +134,6 @@ describe('SubscriberRepository (TypeORM)', () => {
       title: `Generated Label ${unique}`,
       name: `generated_label_${unique}`,
       builtin: false,
-      label_id: {
-        messenger: `messenger_${unique}`,
-        web: `web_${unique}`,
-        twitter: `twitter_${unique}`,
-        dimelo: `dimelo_${unique}`,
-      },
       description: null,
     });
     const saved = await labelRepository.save(label);

--- a/packages/api/src/utils/test/fixtures/label.ts
+++ b/packages/api/src/utils/test/fixtures/label.ts
@@ -23,34 +23,16 @@ export const contentLabelDefaultValues: TLabelFixtures['defaultValues'] = {
 export const labels: TLabelFixtures['values'][] = [
   {
     description: 'test description 1',
-    label_id: {
-      messenger: 'messenger',
-      web: 'web',
-      twitter: 'twitter',
-      dimelo: 'dimelo',
-    },
     name: 'TEST_TITLE_1',
     title: 'test title 1',
   },
   {
     description: 'test description 2',
-    label_id: {
-      messenger: 'messenger',
-      web: 'web',
-      twitter: 'twitter',
-      dimelo: 'dimelo',
-    },
     name: 'TEST_TITLE_2',
     title: 'test title 2',
   },
   {
     description: 'test description 3',
-    label_id: {
-      messenger: 'messenger',
-      web: 'web',
-      twitter: 'twitter',
-      dimelo: 'dimelo',
-    },
     name: 'TEST_TITLE_3',
     title: 'test title 3',
   },
@@ -78,7 +60,6 @@ export const installLabelFixturesTypeOrm = async (dataSource: DataSource) => {
       builtin: fixture.builtin ?? false,
       description:
         fixture.description === undefined ? null : fixture.description,
-      label_id: fixture.label_id === undefined ? null : fixture.label_id,
       group: group ? ({ id: group } as Pick<LabelGroupOrmEntity, 'id'>) : null,
     });
   });

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -470,7 +470,6 @@
     "pending": "Pending",
     "source": "Source",
     "source_ref": "Source Ref",
-    "label_id": "Label ID",
     "email": "E-mail",
     "roles": "Roles",
     "method": "HTTP",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -470,7 +470,6 @@
     "pending": "En attente",
     "source": "Source",
     "source_ref": "Référence source",
-    "label_id": "Label ID",
     "email": "E-mail",
     "roles": "Rôles",
     "method": "HTTP",

--- a/packages/frontend/src/components/labels/index.tsx
+++ b/packages/frontend/src/components/labels/index.tsx
@@ -105,14 +105,6 @@ export const Labels = () => {
     },
     {
       minWidth: 140,
-      field: "label_id",
-      headerName: t("label.label_id"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-    },
-    {
-      minWidth: 140,
       field: "createdAt",
       headerName: t("label.createdAt"),
       disableColumnMenu: true,

--- a/packages/types/src/chat/label.ts
+++ b/packages/types/src/chat/label.ts
@@ -20,7 +20,6 @@ const labelAliasMap = {
 const labelStubObjectSchema = baseStubSchema.extend({
   title: z.string(),
   name: z.string(),
-  label_id: z.record(z.string(), z.unknown()).nullable().optional(),
   description: nullableOptionalStringSchema,
   builtin: z.coerce.boolean(),
 });


### PR DESCRIPTION
## What changed?

Removes the deprecated external `label_id` mapping from labels across API, shared types, and frontend.

### Changes
- Removed `label_id` from label entity, DTOs, and shared `@hexabot-ai/types` schemas.
- Removed the Label ID column from the frontend labels table.
- Cleaned related fixtures, mocks, tests, and translations.
- Kept subscriber-label relation `label_id` join-table usage unchanged.

### Validation
- Types/API/frontend typecheck, lint, tests, and builds pass.
- `label_id` search now only returns the subscriber join-table column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Label ID field from the labels management interface and underlying API layer, simplifying label creation and removing unnecessary ID configuration requirements.
  
* **Localization**
  * Updated label-related translations across all supported languages, removing the Label ID translation entry and adding new translations for pending, source, and source_ref fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->