### PR TITLE
feat(cli): show optional Hexabot skills install hint after project creation

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -306,4 +306,11 @@ const logSuccessMessage = (
   console.log(chalk.yellow(`   hexabot docker up --services postgres`));
   console.log(chalk.gray(`Need env files? Run hexabot env init --docker`));
   console.log('\n');
+  console.log(chalk.bgBlue('Optional: Install Hexabot skills'));
+  console.log(
+    chalk.gray('You can add official skills to accelerate your workflow:'),
+  );
+  console.log(chalk.yellow('   npx skills add hexabot-ai/action-creator'));
+  console.log(chalk.yellow('   npx skills add hexabot-ai/workflow-writer'));
+  console.log('\n');
 };

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -306,7 +306,7 @@ const logSuccessMessage = (
   console.log(chalk.yellow(`   hexabot docker up --services postgres`));
   console.log(chalk.gray(`Need env files? Run hexabot env init --docker`));
   console.log('\n');
-  console.log(chalk.bgBlue('Optional: Install Hexabot skills'));
+  console.log(chalk.blue('Optional: Install Hexabot skills'));
   console.log(
     chalk.gray('You can add official skills to accelerate your workflow:'),
   );


### PR DESCRIPTION
### Motivation
- Let users know they can optionally install official Hexabot skills immediately after scaffolding to accelerate common workflows.

### Description
- Print an "Optional: Install Hexabot skills" hint in `logSuccessMessage` in `packages/cli/src/commands/create.ts` that shows the two example commands `npx skills add hexabot-ai/action-creator` and `npx skills add hexabot-ai/workflow-writer`.

### Testing
- Ran `pnpm --filter @hexabot-ai/cli typecheck` which completed successfully and pre-commit checks (typecheck + staged `eslint`) passed during commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5c3c8a80832db54bb2535f324a84)