### PR TITLE
fix(frontend): fixes blob-shaped API errors from failed blob responses

### DIFF
--- a/packages/frontend/src/hooks/useApiClient.test.ts
+++ b/packages/frontend/src/hooks/useApiClient.test.ts
@@ -8,7 +8,10 @@ import { describe, expect, it } from "vitest";
 
 import { QueryType } from "@/services/types";
 
-import { getApiClientQueryKey } from "./useApiClient";
+import {
+  getApiClientQueryKey,
+  normalizeErrorResponseData,
+} from "./useApiClient";
 
 describe("getApiClientQueryKey", () => {
   it("keeps the legacy key shape for API methods without params", () => {
@@ -32,5 +35,37 @@ describe("getApiClientQueryKey", () => {
     ],
   ] as const)("includes %s params in the query key", (method, params, key) => {
     expect(getApiClientQueryKey(method, params)).toEqual(key);
+  });
+});
+
+describe("normalizeErrorResponseData", () => {
+  it("parses JSON blob error bodies", async () => {
+    const error = {
+      statusCode: 403,
+      message: "You are not allowed to export this workflow",
+    };
+    const blob = new Blob([JSON.stringify(error)], {
+      type: "application/json",
+    });
+
+    await expect(normalizeErrorResponseData(blob)).resolves.toEqual(error);
+  });
+
+  it("returns text blob error bodies as strings", async () => {
+    const blob = new Blob(["Export failed"], {
+      type: "text/plain",
+    });
+
+    await expect(normalizeErrorResponseData(blob)).resolves.toBe(
+      "Export failed",
+    );
+  });
+
+  it("leaves binary blob error bodies unchanged", async () => {
+    const blob = new Blob(["Export failed"], {
+      type: "application/octet-stream",
+    });
+
+    await expect(normalizeErrorResponseData(blob)).resolves.toBe(blob);
   });
 });

--- a/packages/frontend/src/hooks/useApiClient.ts
+++ b/packages/frontend/src/hooks/useApiClient.ts
@@ -28,6 +28,39 @@ type IsEmptyArray<T> = T extends any[]
     ? true
     : false
   : false;
+
+const isBlob = (data: unknown): data is Blob => {
+  return typeof Blob !== "undefined" && data instanceof Blob;
+};
+
+export const normalizeErrorResponseData = async (data: unknown) => {
+  if (!isBlob(data)) {
+    return data;
+  }
+
+  const contentType = data.type.toLowerCase();
+
+  if (
+    contentType &&
+    !contentType.includes("json") &&
+    !contentType.startsWith("text/")
+  ) {
+    return data;
+  }
+
+  const text = await data.text();
+
+  if (!text) {
+    return data;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+};
+
 export const useAxiosInstance = () => {
   const { apiUrl } = useConfig();
   const router = useAppRouter();
@@ -84,7 +117,9 @@ export const useAxiosInstance = () => {
           postMessage({ event: "logout" });
         }
 
-        return Promise.reject(error.response.data);
+        return Promise.reject(
+          await normalizeErrorResponseData(error.response.data),
+        );
       },
     );
 


### PR DESCRIPTION
## What changed?

When a request uses responseType: "blob" and the backend returns a JSON error, Axios exposes the error body as a Blob. The global API interceptor now normalizes blob error bodies before rejecting, so downstream mutation handlers and toast.error() receive the expected string/object error shape.
