### PR TITLE
feat(api): add mcp crud ops for mcp servers

### DIFF
--- a/packages/api/src/mcp/README.md
+++ b/packages/api/src/mcp/README.md
@@ -2,7 +2,7 @@
 
 This module exposes Hexabot API capabilities through the Model Context Protocol
 (MCP) so coding agents can inspect and manage workflows, workflow runs, memory
-definitions, actions, credentials, and CMS content.
+definitions, actions, credentials, MCP servers, and CMS content.
 
 The implementation uses `@rekog/mcp-nest` with Streamable HTTP transport.
 Authentication is Hexabot-native: users create personal MCP bearer tokens from
@@ -194,6 +194,15 @@ created.
 Credential secret values are never returned. The MCP tools remove the `value`
 field from all credential responses and do not support searching by secret
 value.
+
+### MCP servers
+
+| Tool | Permission | Purpose |
+| --- | --- | --- |
+| `hexabot_mcp_server_search` | `mcpserver:read` | Search configured MCP servers. |
+| `hexabot_mcp_server_get` | `mcpserver:read` | Read one configured MCP server. |
+| `hexabot_mcp_server_create` | `mcpserver:create` | Create an MCP server configuration. |
+| `hexabot_mcp_server_update` | `mcpserver:update` | Update an MCP server configuration. |
 
 ### CMS and RAG content
 

--- a/packages/api/src/mcp/tools/hexabot-mcp.tools.spec.ts
+++ b/packages/api/src/mcp/tools/hexabot-mcp.tools.spec.ts
@@ -4,10 +4,14 @@
  * Full terms: see LICENSE.md.
  */
 
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 import { WorkflowOrmEntity } from '@/workflow/entities/workflow.entity';
-import { WorkflowType, WorkflowVersionAction } from '@/workflow/types';
+import {
+  McpServerTransport,
+  WorkflowType,
+  WorkflowVersionAction,
+} from '@/workflow/types';
 
 import { HexabotMcpRequest } from '../types';
 
@@ -49,6 +53,7 @@ const buildTools = (overrides: Record<string, unknown> = {}) => {
   const credentialService = overrides.credentialService ?? ({} as any);
   const contentTypeService = overrides.contentTypeService ?? ({} as any);
   const contentService = overrides.contentService ?? ({} as any);
+  const mcpServerService = overrides.mcpServerService ?? ({} as any);
 
   return new HexabotMcpTools(
     workflowService as any,
@@ -61,6 +66,7 @@ const buildTools = (overrides: Record<string, unknown> = {}) => {
     credentialService as any,
     contentTypeService as any,
     contentService as any,
+    mcpServerService as any,
   );
 };
 
@@ -75,6 +81,154 @@ describe('HexabotMcpTools', () => {
 
     expect(credential).not.toHaveProperty('value');
     expect(JSON.stringify(credential)).not.toContain('secret-token');
+  });
+
+  it('searches MCP servers with pagination and filters', async () => {
+    const server = {
+      id: 'mcp-server-id',
+      name: 'Primary MCP Server',
+      transport: McpServerTransport.http,
+    };
+    const mcpServerService = {
+      findAndPopulate: jest.fn().mockResolvedValue([server]),
+      count: jest.fn().mockResolvedValue(1),
+    };
+    const tools = buildTools({ mcpServerService });
+    const credentialId = '11111111-1111-4111-8111-111111111111';
+
+    await expect(
+      tools.searchMcpServers({
+        query: 'primary',
+        enabled: true,
+        transport: McpServerTransport.http,
+        credentialId,
+        limit: 10,
+        skip: 5,
+        sortBy: 'name',
+        sortDirection: 'ASC',
+      }),
+    ).resolves.toEqual({
+      items: [server],
+      total: 1,
+      limit: 10,
+      skip: 5,
+    });
+
+    const options = mcpServerService.findAndPopulate.mock.calls[0][0];
+    expect(options).toMatchObject({
+      take: 10,
+      skip: 5,
+      order: { name: 'ASC' },
+    });
+    expect(options.where).toHaveLength(3);
+    expect(
+      options.where.map((clause: Record<string, unknown>) =>
+        Object.keys(clause),
+      ),
+    ).toEqual([
+      ['enabled', 'transport', 'credential', 'name'],
+      ['enabled', 'transport', 'credential', 'url'],
+      ['enabled', 'transport', 'credential', 'command'],
+    ]);
+    expect(options.where).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          enabled: true,
+          transport: McpServerTransport.http,
+          credential: { id: credentialId },
+        }),
+      ]),
+    );
+    expect(mcpServerService.count).toHaveBeenCalledWith({
+      where: options.where,
+    });
+  });
+
+  it('returns one MCP server when it exists', async () => {
+    const server = {
+      id: 'mcp-server-id',
+      name: 'Primary MCP Server',
+    };
+    const mcpServerService = {
+      findOneAndPopulate: jest.fn().mockResolvedValue(server),
+    };
+    const tools = buildTools({ mcpServerService });
+
+    await expect(
+      tools.getMcpServer({ id: '11111111-1111-4111-8111-111111111111' }),
+    ).resolves.toEqual(server);
+    expect(mcpServerService.findOneAndPopulate).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111',
+    );
+  });
+
+  it('throws NotFoundException when an MCP server is missing', async () => {
+    const mcpServerService = {
+      findOneAndPopulate: jest.fn().mockResolvedValue(null),
+    };
+    const tools = buildTools({ mcpServerService });
+
+    await expect(
+      tools.getMcpServer({ id: '11111111-1111-4111-8111-111111111111' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('creates an MCP server with default transport and enabled state', async () => {
+    const created = {
+      id: 'mcp-server-id',
+      name: 'Primary MCP Server',
+      enabled: true,
+      transport: McpServerTransport.http,
+      url: 'https://mcp.example.com/main',
+    };
+    const mcpServerService = {
+      create: jest.fn().mockResolvedValue(created),
+    };
+    const tools = buildTools({ mcpServerService });
+
+    await expect(
+      tools.createMcpServer({
+        name: 'Primary MCP Server',
+        url: 'https://mcp.example.com/main',
+      }),
+    ).resolves.toEqual(created);
+
+    expect(mcpServerService.create).toHaveBeenCalledWith({
+      name: 'Primary MCP Server',
+      enabled: true,
+      transport: McpServerTransport.http,
+      url: 'https://mcp.example.com/main',
+    });
+  });
+
+  it('updates an existing MCP server with mutable fields only', async () => {
+    const existing = {
+      id: '11111111-1111-4111-8111-111111111111',
+      name: 'Primary MCP Server',
+    };
+    const updated = {
+      ...existing,
+      enabled: false,
+    };
+    const mcpServerService = {
+      findOneAndPopulate: jest.fn().mockResolvedValue(existing),
+      updateOne: jest.fn().mockResolvedValue(updated),
+    };
+    const tools = buildTools({ mcpServerService });
+
+    await expect(
+      tools.updateMcpServer({
+        id: existing.id,
+        enabled: false,
+      }),
+    ).resolves.toEqual(updated);
+
+    expect(mcpServerService.findOneAndPopulate).toHaveBeenCalledWith(
+      existing.id,
+    );
+    expect(mcpServerService.updateOne).toHaveBeenCalledWith(existing.id, {
+      enabled: false,
+    });
   });
 
   it('validates and commits workflow YAML versions', async () => {

--- a/packages/api/src/mcp/tools/hexabot-mcp.tools.ts
+++ b/packages/api/src/mcp/tools/hexabot-mcp.tools.ts
@@ -23,6 +23,7 @@ import { ContentTypeService } from '@/cms/services/content-type.service';
 import { ContentService } from '@/cms/services/content.service';
 import { CredentialService } from '@/user/services/credential.service';
 import { WorkflowNewVersionDto } from '@/workflow/dto/workflow-version.dto';
+import { McpServerOrmEntity } from '@/workflow/entities/mcp-server.entity';
 import { WorkflowRunOrmEntity } from '@/workflow/entities/workflow-run.entity';
 import { WorkflowVersionOrmEntity } from '@/workflow/entities/workflow-version.entity';
 import { WorkflowOrmEntity } from '@/workflow/entities/workflow.entity';
@@ -32,12 +33,14 @@ import {
 } from '@/workflow/lib/trigger-event-wrapper';
 import { parseWorkflowDefinition } from '@/workflow/lib/workflow-definition';
 import { AgenticService } from '@/workflow/services/agentic.service';
+import { McpServerService } from '@/workflow/services/mcp-server.service';
 import { MemoryDefinitionService } from '@/workflow/services/memory-definition.service';
 import { WorkflowRunService } from '@/workflow/services/workflow-run.service';
 import { WorkflowVersionService } from '@/workflow/services/workflow-version.service';
 import { WorkflowService } from '@/workflow/services/workflow.service';
 import {
   DirectionType,
+  McpServerTransport,
   MemoryScope,
   WorkflowType,
   WorkflowVersionAction,
@@ -67,6 +70,16 @@ const workflowPayloadSchema = {
   zoom: z.number().optional(),
   direction: z.enum(DirectionType).optional(),
 };
+const mcpServerPayloadSchema = {
+  name: z.string().min(1).optional(),
+  enabled: z.boolean().optional(),
+  transport: z.enum(McpServerTransport).optional(),
+  url: z.string().nullable().optional(),
+  command: z.string().nullable().optional(),
+  args: z.array(z.string()).nullable().optional(),
+  cwd: z.string().nullable().optional(),
+  credential: uuidSchema.nullable().optional(),
+};
 
 type PaginationArgs = {
   limit: number;
@@ -88,6 +101,7 @@ export class HexabotMcpTools {
     private readonly credentialService: CredentialService,
     private readonly contentTypeService: ContentTypeService,
     private readonly contentService: ContentService,
+    private readonly mcpServerService: McpServerService,
   ) {}
 
   @McpPermission('workflow', Action.READ)
@@ -721,6 +735,109 @@ export class HexabotMcpTools {
     }
 
     return HexabotMcpTools.sanitizeCredential(credential);
+  }
+
+  @McpPermission('mcpserver', Action.READ)
+  @ToolGuards([McpPermissionGuard])
+  @Tool({
+    name: 'hexabot_mcp_server_search',
+    description: 'Search configured MCP servers.',
+    parameters: z.object({
+      query: z.string().optional(),
+      enabled: z.boolean().optional(),
+      transport: z.enum(McpServerTransport).optional(),
+      credentialId: uuidSchema.optional(),
+      ...paginationSchema,
+    }),
+  })
+  async searchMcpServers(
+    args: {
+      query?: string;
+      enabled?: boolean;
+      transport?: McpServerTransport;
+      credentialId?: string;
+    } & PaginationArgs,
+  ) {
+    const base = {
+      ...(args.enabled !== undefined ? { enabled: args.enabled } : {}),
+      ...(args.transport ? { transport: args.transport } : {}),
+      ...(args.credentialId ? { credential: { id: args.credentialId } } : {}),
+    };
+    const where = args.query
+      ? [
+          { ...base, name: this.contains(args.query) },
+          { ...base, url: this.contains(args.query) },
+          { ...base, command: this.contains(args.query) },
+        ]
+      : base;
+
+    return await this.listWithCount(
+      this.mcpServerService,
+      this.findOptions<McpServerOrmEntity>(args, where as any),
+    );
+  }
+
+  @McpPermission('mcpserver', Action.READ)
+  @ToolGuards([McpPermissionGuard])
+  @Tool({
+    name: 'hexabot_mcp_server_get',
+    description: 'Read one configured MCP server.',
+    parameters: z.object({
+      id: uuidSchema,
+    }),
+  })
+  async getMcpServer(args: { id: string }) {
+    const server = await this.mcpServerService.findOneAndPopulate(args.id);
+    if (!server) {
+      throw new NotFoundException(`MCP server ${args.id} not found`);
+    }
+
+    return server;
+  }
+
+  @McpPermission('mcpserver', Action.CREATE)
+  @ToolGuards([McpPermissionGuard])
+  @Tool({
+    name: 'hexabot_mcp_server_create',
+    description: 'Create an MCP server configuration.',
+    parameters: z.object({
+      ...mcpServerPayloadSchema,
+      name: z.string().min(1),
+    }),
+  })
+  async createMcpServer(args: {
+    name: string;
+    enabled?: boolean;
+    transport?: McpServerTransport;
+    url?: string | null;
+    command?: string | null;
+    args?: string[] | null;
+    cwd?: string | null;
+    credential?: string | null;
+  }) {
+    return await this.mcpServerService.create({
+      enabled: true,
+      transport: McpServerTransport.http,
+      ...args,
+    } as any);
+  }
+
+  @McpPermission('mcpserver', Action.UPDATE)
+  @ToolGuards([McpPermissionGuard])
+  @Tool({
+    name: 'hexabot_mcp_server_update',
+    description: 'Update an MCP server configuration.',
+    parameters: z.object({
+      id: uuidSchema,
+      ...mcpServerPayloadSchema,
+    }),
+  })
+  async updateMcpServer(args: { id: string } & Record<string, unknown>) {
+    const { id, ...updates } = args;
+
+    await this.getMcpServer({ id });
+
+    return await this.mcpServerService.updateOne(id, updates as any);
   }
 
   @McpPermission('contenttype', Action.READ)


### PR DESCRIPTION
## What changed?

- Added MCP tools to search, read, create, and update configured MCP servers.
- Wired the tools through `McpServerService` with existing `mcpserver` permissions.
- Documented the new MCP server tool surface and added focused unit coverage.
