### PR TITLE
fix: jest port

### DIFF
--- a/packages/api/src/utils/test/port.ts
+++ b/packages/api/src/utils/test/port.ts
@@ -1,0 +1,48 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+const DEFAULT_JEST_PORT = 3001;
+const JEST_HOST = '127.0.0.1';
+const parsePort = (value: string | undefined, envName: string): number => {
+  if (!value) {
+    return DEFAULT_JEST_PORT;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new Error(
+      `Invalid ${envName} "${value}". Expected a TCP port between 1 and 65535.`,
+    );
+  }
+
+  const port = Number(value);
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(
+      `Invalid ${envName} "${value}". Expected a TCP port between 1 and 65535.`,
+    );
+  }
+
+  return port;
+};
+
+export const getJestPort = (): number =>
+  parsePort(process.env.JEST_PORT, 'JEST_PORT');
+
+export const getJestHost = (): string => JEST_HOST;
+
+export const getJestBaseUrl = (): string =>
+  `http://${getJestHost()}:${getJestPort()}`;
+
+export const configureJestNetworkEnv = () => {
+  const port = getJestPort();
+  const baseUrl = `http://${getJestHost()}:${port}`;
+  const apiOrigin = process.env.JEST_API_ORIGIN ?? `${baseUrl}/api`;
+
+  process.env.PORT = `${port}`;
+  process.env.API_ORIGIN = apiOrigin;
+
+  return { port, baseUrl, apiOrigin };
+};

--- a/packages/api/src/websocket/websocket.gateway.spec.ts
+++ b/packages/api/src/websocket/websocket.gateway.spec.ts
@@ -7,6 +7,7 @@
 import { INestApplication } from '@nestjs/common';
 import { Socket, io } from 'socket.io-client';
 
+import { getJestBaseUrl, getJestHost, getJestPort } from '@/utils/test/port';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SocketEventDispatcherService } from './services/socket-event-dispatcher.service';
@@ -27,7 +28,7 @@ describe('WebsocketGateway', () => {
     gateway = app.get<WebsocketGateway>(WebsocketGateway);
 
     createSocket = (id: string, query: any = {}) => {
-      const socket = io('http://localhost:3000', {
+      const socket = io(getJestBaseUrl(), {
         autoConnect: false,
         transports: ['websocket'],
         query: { EIO: '4', transport: 'websocket', ...query },
@@ -45,7 +46,7 @@ describe('WebsocketGateway', () => {
       createSocket('subscriber', { channel: 'web' }), // Subscriber
     ];
 
-    await app.listen(3000);
+    await app.listen(getJestPort(), getJestHost());
   });
 
   afterAll(async () => {

--- a/packages/api/test/global-setup.ts
+++ b/packages/api/test/global-setup.ts
@@ -7,37 +7,47 @@
 import net from 'net';
 import 'tsconfig-paths/register';
 
-const API_PORT = Number(process.env.API_PORT ?? 3000);
+import { configureJestNetworkEnv, getJestHost } from '@/utils/test/port';
 
 function isPortInUse(port: number): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    const onError = (err: NodeJS.ErrnoException) => {
-      // Typical “port already in use”
-      if (err.code === 'EADDRINUSE') {
-        resolve(true);
+    const socket = net.createConnection({ host: getJestHost(), port });
+    const cleanup = () => {
+      socket.removeAllListeners();
+      socket.destroy();
+    };
+    const finish = (inUse: boolean) => {
+      cleanup();
+      resolve(inUse);
+    };
+
+    socket.once('connect', () => finish(true));
+    socket.once('timeout', () => finish(false));
+    socket.once('error', (err: NodeJS.ErrnoException) => {
+      cleanup();
+      // Some sandboxes deny loopback probes; the test listener will still
+      // surface real bind failures.
+      if (
+        err.code === 'ECONNREFUSED' ||
+        err.code === 'EPERM' ||
+        err.code === 'EACCES'
+      ) {
+        resolve(false);
       } else {
         reject(err);
       }
-    };
-    const onListen = () => {
-      server.close(() => resolve(false));
-    };
-
-    server.once('error', onError);
-    server.once('listening', onListen);
-
-    server.unref();
-    server.listen(port);
+    });
+    socket.setTimeout(1000);
   });
 }
 
 export = async function globalSetup() {
-  const inUse = await isPortInUse(API_PORT);
+  const { port } = configureJestNetworkEnv();
+  const inUse = await isPortInUse(port);
 
   if (inUse) {
     throw new Error(
-      `Port ${API_PORT} is already in use. Please stop the running service before executing Jest tests.`,
+      `Jest port ${port} is already in use on ${getJestHost()}. Set JEST_PORT to an available port before executing Jest tests.`,
     );
   }
 };

--- a/packages/api/test/setup-tests.ts
+++ b/packages/api/test/setup-tests.ts
@@ -6,7 +6,10 @@
 
 import * as dotenv from 'dotenv';
 
+import { configureJestNetworkEnv } from '@/utils/test/port';
+
 dotenv.config({ path: '../.env' });
+configureJestNetworkEnv();
 
 let mockSession = null;
 


### PR DESCRIPTION
## What changed?

- Configure API Jest runs to use a dedicated test port instead of the app default `3000`
- Add a shared Jest port helper with `JEST_PORT` override support
- Update websocket tests to use the Jest test host/port instead of hardcoded `localhost:3000`