### PR TITLE
fix(api): ws workflow exec events limit

### DIFF
--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -19,15 +19,18 @@ import {
 } from '@/utils/test/fixtures/user';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { WebsocketGateway } from '@/websocket';
 import {
   conversationalWorkflowInputJsonSchema,
   scheduledWorkflowInputJsonSchema,
 } from '@/workflow/schemas/workflow-input-schemas';
 
 import { WorkflowUpdateDto } from '../dto/workflow.dto';
+import { WorkflowRunRepository } from '../repositories/workflow-run.repository';
 import { WorkflowRepository } from '../repositories/workflow.repository';
 import { WorkflowType, WorkflowVersionAction } from '../types';
 
+import { WorkflowRunService } from './workflow-run.service';
 import { WorkflowVersionService } from './workflow-version.service';
 import { WorkflowService } from './workflow.service';
 
@@ -35,12 +38,16 @@ describe('WorkflowService (TypeORM)', () => {
   let module: TestingModule;
   let workflowService: WorkflowService;
   let workflowVersionService: WorkflowVersionService;
+  let workflowRunService: WorkflowRunService;
   let workflowRepository: WorkflowRepository;
   let workflow: Workflow;
   let definitionYml: string;
   let counter = 0;
   let creatorId: string;
-
+  const gatewayMock = {
+    joinSockets: jest.fn(),
+    broadcastWorkflowEvent: jest.fn(),
+  };
   const buildWorkflowDefinition = (): {
     metadata: { name: string; description: string };
     definition: WorkflowDefinition;
@@ -59,23 +66,64 @@ describe('WorkflowService (TypeORM)', () => {
       },
     };
   };
+  const createWorkflowForType = async (
+    type: WorkflowType,
+  ): Promise<Workflow> => {
+    if (type === WorkflowType.conversational) {
+      return workflow;
+    }
+
+    return await workflowService.create({
+      name: `${type}_workflow_${++counter}`,
+      description: `Workflow event broadcast test for ${type}`,
+      type,
+      schedule: type === WorkflowType.scheduled ? '*/10 * * * * *' : null,
+      createdBy: creatorId,
+    });
+  };
+  const createWorkflowRun = async (
+    targetWorkflow: Workflow,
+    context: Record<string, unknown> | null = {
+      initiatorId: creatorId,
+      workflowId: targetWorkflow.id,
+      threadId: 'thread-1',
+    },
+  ) => {
+    return await workflowRunService.create({
+      workflow: targetWorkflow.id,
+      triggeredBy: creatorId,
+      input: {},
+      context,
+    });
+  };
 
   beforeAll(async () => {
     const testing = await buildTestingMocks({
       autoInjectFrom: ['providers'],
-      providers: [WorkflowService, WorkflowVersionService],
+      providers: [
+        WorkflowService,
+        WorkflowVersionService,
+        WorkflowRunService,
+        WorkflowRunRepository,
+        { provide: WebsocketGateway, useValue: gatewayMock },
+      ],
       typeorm: {
         fixtures: installUserFixturesTypeOrm,
       },
     });
 
     module = testing.module;
-    [workflowService, workflowVersionService, workflowRepository] =
-      await testing.getMocks([
-        WorkflowService,
-        WorkflowVersionService,
-        WorkflowRepository,
-      ]);
+    [
+      workflowService,
+      workflowVersionService,
+      workflowRunService,
+      workflowRepository,
+    ] = await testing.getMocks([
+      WorkflowService,
+      WorkflowVersionService,
+      WorkflowRunService,
+      WorkflowRepository,
+    ]);
   });
 
   beforeEach(async () => {
@@ -240,6 +288,58 @@ describe('WorkflowService (TypeORM)', () => {
     const picked = await workflowService.pickWorkflow();
 
     expect(picked).toBeNull();
+  });
+
+  describe('workflow execution websocket events', () => {
+    it.each([
+      WorkflowType.conversational,
+      WorkflowType.manual,
+      WorkflowType.scheduled,
+    ])('broadcasts execution events for %s workflows', async (workflowType) => {
+      const targetWorkflow = await createWorkflowForType(workflowType);
+      const run = await createWorkflowRun(targetWorkflow);
+
+      await workflowService.sendWorkflowStart({ runId: run.id });
+
+      expect(gatewayMock.broadcastWorkflowEvent).toHaveBeenCalledTimes(1);
+      expect(gatewayMock.broadcastWorkflowEvent).toHaveBeenCalledWith({
+        runId: run.id,
+        t: expect.any(Number),
+        workflowId: targetWorkflow.id,
+        initiatorId: creatorId,
+        threadId: 'thread-1',
+        workflowEvent: 'workflow:start',
+      });
+    });
+
+    it('does not broadcast when the workflow event has no run id', async () => {
+      await workflowService.sendWorkflowStart({});
+
+      expect(gatewayMock.broadcastWorkflowEvent).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['context is missing', null],
+      ['initiatorId is missing', { workflowId: 'workflow-id' }],
+      ['workflowId is missing', { initiatorId: 'initiator-id' }],
+    ])('does not broadcast when run %s', async (_label, context) => {
+      const run = await createWorkflowRun(workflow, context);
+
+      await workflowService.sendWorkflowStart({ runId: run.id });
+
+      expect(gatewayMock.broadcastWorkflowEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not broadcast when the context workflow id does not resolve', async () => {
+      const run = await createWorkflowRun(workflow, {
+        initiatorId: creatorId,
+        workflowId: userFixtureIds.admin,
+      });
+
+      await workflowService.sendWorkflowStart({ runId: run.id });
+
+      expect(gatewayMock.broadcastWorkflowEvent).not.toHaveBeenCalled();
+    });
   });
 
   it('validates manual input with the provided schema', () => {

--- a/packages/api/src/workflow/services/workflow.service.ts
+++ b/packages/api/src/workflow/services/workflow.service.ts
@@ -208,57 +208,77 @@ export class WorkflowService extends BaseOrmService<WorkflowOrmEntity> {
 
       return;
     }
-    const { initiatorId, workflowId, threadId } = workflowRun?.context;
-    const workflow = await this.findOne(workflowId);
-    const canBroadcastEvents =
-      initiatorId &&
-      workflow?.type &&
-      [WorkflowType.conversational].includes(workflow.type);
+    const { initiatorId, workflowId, threadId } = workflowRun.context;
+    if (
+      typeof initiatorId !== 'string' ||
+      !initiatorId ||
+      typeof workflowId !== 'string' ||
+      !workflowId
+    ) {
+      this.logger.error(
+        'workflowRun context requires initiatorId and workflowId',
+      );
 
-    if (canBroadcastEvents) {
-      this.gateway.broadcastWorkflowEvent({
-        ...payload,
-        t,
-        workflowId,
-        initiatorId,
-        threadId: typeof threadId === 'string' ? threadId : undefined,
-        workflowEvent: workflowEvent.replace('hook:', ''),
-      });
+      return;
     }
+
+    const workflow = await this.findOne(workflowId);
+    if (!workflow?.type) {
+      this.logger.error('workflow is required');
+
+      return;
+    }
+
+    this.gateway.broadcastWorkflowEvent({
+      ...payload,
+      t,
+      workflowId,
+      initiatorId,
+      threadId: typeof threadId === 'string' ? threadId : undefined,
+      workflowEvent: workflowEvent.replace('hook:', ''),
+    });
   }
 
   @OnEvent('hook:workflow:start')
-  sendWorkflowStart(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
-    this.sendWorkflowEvent('hook:workflow:start', payload);
+  async sendWorkflowStart(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
+    await this.sendWorkflowEvent('hook:workflow:start', payload);
   }
 
   @OnEvent('hook:workflow:finish')
-  sendWorkflowFinish(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
-    this.sendWorkflowEvent('hook:workflow:finish', payload);
+  async sendWorkflowFinish(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
+    await this.sendWorkflowEvent('hook:workflow:finish', payload);
   }
 
   @OnEvent('hook:workflow:failure')
-  sendWorkflowFailure(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
-    this.sendWorkflowEvent('hook:workflow:failure', payload);
+  async sendWorkflowFailure(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
+    await this.sendWorkflowEvent('hook:workflow:failure', payload);
   }
 
   @OnEvent('hook:step:start')
-  sendWorkflowStepStart(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
-    this.sendWorkflowEvent('hook:step:start', payload);
+  async sendWorkflowStepStart(
+    payload: WorkflowEventMap[keyof WorkflowEventMap],
+  ) {
+    await this.sendWorkflowEvent('hook:step:start', payload);
   }
 
   @OnEvent('hook:step:suspended')
-  sendWorkflowStepSuspended(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
-    this.sendWorkflowEvent('hook:step:suspended', payload);
+  async sendWorkflowStepSuspended(
+    payload: WorkflowEventMap[keyof WorkflowEventMap],
+  ) {
+    await this.sendWorkflowEvent('hook:step:suspended', payload);
   }
 
   @OnEvent('hook:step:success')
-  sendWorkflowStepSuccess(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
-    this.sendWorkflowEvent('hook:step:success', payload);
+  async sendWorkflowStepSuccess(
+    payload: WorkflowEventMap[keyof WorkflowEventMap],
+  ) {
+    await this.sendWorkflowEvent('hook:step:success', payload);
   }
 
   @OnEvent('hook:step:error')
-  sendWorkflowStepError(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
-    this.sendWorkflowEvent('hook:step:error', payload);
+  async sendWorkflowStepError(
+    payload: WorkflowEventMap[keyof WorkflowEventMap],
+  ) {
+    await this.sendWorkflowEvent('hook:step:error', payload);
   }
 }


### PR DESCRIPTION
## What changed?

Workflow execution WS events are no longer limited to conversational workflows. Broadcasts now require valid runId, run context, initiatorId, workflowId, and a resolvable workflow, then emit the same payload shape to the existing initiator-scoped workflow room.