### PR TITLE
fix: live workflow run debugger updates

### DIFF
--- a/packages/agentic/src/step-executors/task-executor.test.ts
+++ b/packages/agentic/src/step-executors/task-executor.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Action } from '../action/action.types';
-import { BaseWorkflowContext } from '../context';
+import { BaseWorkflowContext, type StepExecutionRecord } from '../context';
 import type { RuntimeSuspensionRequest } from '../runner-runtime-control';
 import { createDeferred } from '../utils/deferred';
 import {
@@ -72,26 +72,54 @@ const createCompiled = (task: CompiledTask): CompiledWorkflow =>
 const createEnv = (
   compiled: CompiledWorkflow,
   stepInfo: StepInfo,
-): StepExecutorEnv => ({
-  compiled,
-  context: new TestContext(),
-  runId: 'run-123',
-  buildInstanceStepInfo: jest.fn().mockReturnValue(stepInfo),
-  markSnapshot: jest.fn(),
-  recordStepExecution: jest.fn(),
-  emit: jest.fn(),
-  setCurrentStep: jest.fn(),
-  waitForStepSuspension: jest
-    .fn()
-    .mockImplementation(
-      () => new Promise<RuntimeSuspensionRequest>(() => undefined),
-    ),
-  clearStepSuspensions: jest.fn(),
-  primeStepResumeData: jest.fn(),
-  captureTaskOutput: jest.fn().mockResolvedValue(undefined),
-  executeFlow: jest.fn(),
-  executeStep: jest.fn(),
-});
+): StepExecutorEnv => {
+  const stepRecords: Record<string, StepExecutionRecord> = {};
+
+  return {
+    compiled,
+    context: new TestContext(),
+    runId: 'run-123',
+    buildInstanceStepInfo: jest.fn().mockReturnValue(stepInfo),
+    markSnapshot: jest.fn(),
+    recordStepExecution: jest.fn((step, update) => {
+      const existing =
+        stepRecords[step.id] ??
+        ({
+          id: step.id,
+          name: step.name,
+          status: 'pending',
+        } satisfies StepExecutionRecord);
+      const context =
+        existing.context || update.context
+          ? { ...existing.context, ...update.context }
+          : undefined;
+      const nextRecord = {
+        ...existing,
+        ...update,
+        id: step.id,
+        name: step.name,
+        status: update.status ?? existing.status,
+        context,
+      } satisfies StepExecutionRecord;
+
+      stepRecords[step.id] = nextRecord;
+
+      return nextRecord;
+    }),
+    emit: jest.fn(),
+    setCurrentStep: jest.fn(),
+    waitForStepSuspension: jest
+      .fn()
+      .mockImplementation(
+        () => new Promise<RuntimeSuspensionRequest>(() => undefined),
+      ),
+    clearStepSuspensions: jest.fn(),
+    primeStepResumeData: jest.fn(),
+    captureTaskOutput: jest.fn().mockResolvedValue(undefined),
+    executeFlow: jest.fn(),
+    executeStep: jest.fn(),
+  };
+};
 const step: TaskStep = {
   id: '0:test_task',
   type: StepType.Task,
@@ -153,10 +181,18 @@ describe('executeTaskStep', () => {
     expect(env.emit).toHaveBeenCalledWith('hook:step:start', {
       runId: 'run-123',
       step: stepInfo,
+      stepExecution: expect.objectContaining({
+        id: stepInfo.id,
+        status: 'running',
+      }),
     });
     expect(env.emit).toHaveBeenCalledWith('hook:step:success', {
       runId: 'run-123',
       step: stepInfo,
+      stepExecution: expect.objectContaining({
+        id: stepInfo.id,
+        status: 'completed',
+      }),
     });
     expect(env.setCurrentStep).toHaveBeenLastCalledWith(undefined);
   });
@@ -215,6 +251,16 @@ describe('executeTaskStep', () => {
       'suspended',
       'awaiting_user',
     );
+    expect(env.emit).toHaveBeenCalledWith('hook:step:suspended', {
+      runId: 'run-123',
+      step: stepInfo,
+      stepExecution: expect.objectContaining({
+        id: stepInfo.id,
+        status: 'suspended',
+      }),
+      reason: 'awaiting_user',
+      data: { channel: 'sms' },
+    });
 
     await suspension?.continue({ reply: 'Sure' });
 
@@ -228,6 +274,14 @@ describe('executeTaskStep', () => {
         output: { reply: 'SURE' },
       }),
     );
+    expect(env.emit).toHaveBeenCalledWith('hook:step:success', {
+      runId: 'run-123',
+      step: stepInfo,
+      stepExecution: expect.objectContaining({
+        id: stepInfo.id,
+        status: 'completed',
+      }),
+    });
   });
 
   it('marks failure and rethrows errors from the task', async () => {
@@ -250,6 +304,10 @@ describe('executeTaskStep', () => {
     expect(env.emit).toHaveBeenCalledWith('hook:step:error', {
       runId: 'run-123',
       step: stepInfo,
+      stepExecution: expect.objectContaining({
+        id: stepInfo.id,
+        status: 'failed',
+      }),
       error: expect.any(Error),
     });
     expect(env.setCurrentStep).toHaveBeenLastCalledWith(undefined);

--- a/packages/agentic/src/step-executors/task-executor.ts
+++ b/packages/agentic/src/step-executors/task-executor.ts
@@ -51,7 +51,7 @@ export async function executeTaskStep(
     accumulator: state.accumulator,
   };
   const inputs = await evaluateMapping(task.inputs, scope);
-  env.recordStepExecution(stepInfo, {
+  const stepExecution = env.recordStepExecution(stepInfo, {
     action: task.actionName,
     status: 'running',
     startedAt: Date.now(),
@@ -61,7 +61,11 @@ export async function executeTaskStep(
   env.beginStepExecution?.(stepInfo.id);
   env.setCurrentStep(stepInfo);
   env.markSnapshot(stepInfo, 'running');
-  env.emit('hook:step:start', { runId: env.runId, step: stepInfo });
+  env.emit('hook:step:start', {
+    runId: env.runId,
+    step: stepInfo,
+    stepExecution,
+  });
 
   try {
     const actionPromise = Promise.resolve().then(() =>
@@ -126,14 +130,18 @@ const completeTask = async (
   result: unknown,
 ) => {
   await env.captureTaskOutput(task, state, result);
-  env.recordStepExecution(stepInfo, {
+  const stepExecution = env.recordStepExecution(stepInfo, {
     status: 'completed',
     endedAt: Date.now(),
     output: result,
     context: { after: env.context.snapshot() },
   });
   env.markSnapshot(stepInfo, 'completed');
-  env.emit('hook:step:success', { runId: env.runId, step: stepInfo });
+  env.emit('hook:step:success', {
+    runId: env.runId,
+    step: stepInfo,
+    stepExecution,
+  });
   env.clearStepSuspensions(stepId);
 };
 const recordSuspension = (
@@ -142,7 +150,7 @@ const recordSuspension = (
   reason?: string,
   data?: unknown,
 ) => {
-  env.recordStepExecution(stepInfo, {
+  const stepExecution = env.recordStepExecution(stepInfo, {
     status: 'suspended',
     endedAt: Date.now(),
     reason,
@@ -152,6 +160,7 @@ const recordSuspension = (
   env.emit('hook:step:suspended', {
     runId: env.runId,
     step: stepInfo,
+    stepExecution,
     reason,
     data,
   });
@@ -231,14 +240,20 @@ const recordTaskFailure = (
   stepInfo: Suspension['step'],
   error: unknown,
 ) => {
-  env.recordStepExecution(stepInfo, {
+  const normalizedError = normalizeError(error);
+  const stepExecution = env.recordStepExecution(stepInfo, {
     status: 'failed',
     endedAt: Date.now(),
-    error: normalizeError(error),
+    error: normalizedError,
     context: { after: env.context.snapshot() },
   });
   env.markSnapshot(stepInfo, 'failed', normalizeErrorMessage(error));
-  env.emit('hook:step:error', { runId: env.runId, step: stepInfo, error });
+  env.emit('hook:step:error', {
+    runId: env.runId,
+    step: stepInfo,
+    stepExecution,
+    error,
+  });
 };
 const normalizeError = (error: unknown): { message: string; stack?: string } =>
   error instanceof Error

--- a/packages/agentic/src/step-executors/types.ts
+++ b/packages/agentic/src/step-executors/types.ts
@@ -39,7 +39,7 @@ export type StepExecutorEnv = {
   recordStepExecution: (
     step: StepInfo,
     update: Partial<StepExecutionRecord>,
-  ) => void;
+  ) => StepExecutionRecord;
   emit: <K extends keyof WorkflowEventMap>(
     event: K,
     payload: WorkflowEventMap[K],

--- a/packages/agentic/src/workflow-event-emitter.ts
+++ b/packages/agentic/src/workflow-event-emitter.ts
@@ -4,6 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
+import type { StepExecutionRecord } from './context';
+
 export enum StepType {
   Task = 'task',
   Parallel = 'parallel',
@@ -17,6 +19,12 @@ export type StepInfo = {
   type: StepType;
 };
 
+export type StepWorkflowEventPayload = {
+  runId?: string;
+  step: StepInfo;
+  stepExecution?: StepExecutionRecord;
+};
+
 export type WorkflowEventMap = {
   'hook:workflow:start': { runId?: string };
   'hook:workflow:finish': { runId?: string; output: Record<string, unknown> };
@@ -27,12 +35,10 @@ export type WorkflowEventMap = {
     reason?: string;
     data?: unknown;
   };
-  'hook:step:start': { runId?: string; step: StepInfo };
-  'hook:step:success': { runId?: string; step: StepInfo };
-  'hook:step:error': { runId?: string; step: StepInfo; error: unknown };
-  'hook:step:suspended': {
-    runId?: string;
-    step: StepInfo;
+  'hook:step:start': StepWorkflowEventPayload;
+  'hook:step:success': StepWorkflowEventPayload;
+  'hook:step:error': StepWorkflowEventPayload & { error: unknown };
+  'hook:step:suspended': StepWorkflowEventPayload & {
     reason?: string;
     data?: unknown;
   };

--- a/packages/agentic/src/workflow-runner.ts
+++ b/packages/agentic/src/workflow-runner.ts
@@ -425,7 +425,7 @@ export class WorkflowRunner {
   private recordStepExecution(
     step: StepInfo,
     update: Partial<StepExecutionRecord>,
-  ) {
+  ): StepExecutionRecord {
     const existing = this.stepLog[step.id];
     const base: StepExecutionRecord =
       existing ??
@@ -438,14 +438,21 @@ export class WorkflowRunner {
       existing?.context || update.context
         ? { ...existing?.context, ...update.context }
         : undefined;
-
-    this.stepLog[step.id] = {
+    const nextRecord: StepExecutionRecord = {
       ...base,
       ...update,
       id: step.id,
       name: step.name,
       status: update.status ?? base.status,
       context: mergedContext,
+    };
+
+    this.stepLog[step.id] = nextRecord;
+
+    return {
+      ...nextRecord,
+      context: nextRecord.context ? { ...nextRecord.context } : undefined,
+      error: nextRecord.error ? { ...nextRecord.error } : undefined,
     };
   }
 

--- a/packages/api/src/websocket/websocket.gateway.ts
+++ b/packages/api/src/websocket/websocket.gateway.ts
@@ -5,7 +5,7 @@
  */
 
 import { type WorkflowEventMap } from '@hexabot-ai/agentic';
-import { StdEventType, Subscriber } from '@hexabot-ai/types';
+import { StdEventType, Subscriber, type WorkflowRun } from '@hexabot-ai/types';
 import { ForbiddenException, Optional } from '@nestjs/common';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import {
@@ -69,6 +69,7 @@ export class WebsocketGateway
     Partial<Pick<WorkflowContextState, 'initiatorId'>> & {
       workflowId: string;
       threadId?: string;
+      workflowRun?: WorkflowRun;
       workflowEvent: string;
       t: number;
     }): void {

--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -5,6 +5,8 @@
  */
 
 import {
+  StepType,
+  type StepExecutionRecord,
   WorkflowDefinition,
   Workflow as WorkflowHelper,
 } from '@hexabot-ai/agentic';
@@ -305,12 +307,58 @@ describe('WorkflowService (TypeORM)', () => {
       expect(gatewayMock.broadcastWorkflowEvent).toHaveBeenCalledWith({
         runId: run.id,
         t: expect.any(Number),
+        workflowRun: expect.objectContaining({
+          id: run.id,
+          workflow: targetWorkflow.id,
+        }),
         workflowId: targetWorkflow.id,
         initiatorId: creatorId,
         threadId: 'thread-1',
         workflowEvent: 'workflow:start',
       });
     });
+
+    it.each([WorkflowType.manual, WorkflowType.scheduled])(
+      'broadcasts step execution records for %s workflow events',
+      async (workflowType) => {
+        const targetWorkflow = await createWorkflowForType(workflowType);
+        const run = await createWorkflowRun(targetWorkflow);
+        const step = {
+          id: '0:greet',
+          name: 'greet',
+          type: StepType.Task,
+        };
+        const stepExecution: StepExecutionRecord = {
+          ...step,
+          action: 'greet',
+          status: 'running',
+          startedAt: 1700000000000,
+          input: { name: 'Ada' },
+        };
+
+        await workflowService.sendWorkflowStepStart({
+          runId: run.id,
+          step,
+          stepExecution,
+        });
+
+        expect(gatewayMock.broadcastWorkflowEvent).toHaveBeenCalledTimes(1);
+        expect(gatewayMock.broadcastWorkflowEvent).toHaveBeenCalledWith({
+          runId: run.id,
+          step,
+          stepExecution,
+          t: expect.any(Number),
+          workflowRun: expect.objectContaining({
+            id: run.id,
+            workflow: targetWorkflow.id,
+          }),
+          workflowId: targetWorkflow.id,
+          initiatorId: creatorId,
+          threadId: 'thread-1',
+          workflowEvent: 'step:start',
+        });
+      },
+    );
 
     it('does not broadcast when the workflow event has no run id', async () => {
       await workflowService.sendWorkflowStart({});

--- a/packages/api/src/workflow/services/workflow.service.ts
+++ b/packages/api/src/workflow/services/workflow.service.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { WorkflowEventMap } from '@hexabot-ai/agentic';
+import type { WorkflowEventMap } from '@hexabot-ai/agentic';
 import { WorkflowFull, Workflow } from '@hexabot-ai/types';
 import {
   BadRequestException,
@@ -232,6 +232,7 @@ export class WorkflowService extends BaseOrmService<WorkflowOrmEntity> {
     this.gateway.broadcastWorkflowEvent({
       ...payload,
       t,
+      workflowRun,
       workflowId,
       initiatorId,
       threadId: typeof threadId === 'string' ? threadId : undefined,
@@ -247,6 +248,13 @@ export class WorkflowService extends BaseOrmService<WorkflowOrmEntity> {
   @OnEvent('hook:workflow:finish')
   async sendWorkflowFinish(payload: WorkflowEventMap[keyof WorkflowEventMap]) {
     await this.sendWorkflowEvent('hook:workflow:finish', payload);
+  }
+
+  @OnEvent('hook:workflow:suspended')
+  async sendWorkflowSuspended(
+    payload: WorkflowEventMap[keyof WorkflowEventMap],
+  ) {
+    await this.sendWorkflowEvent('hook:workflow:suspended', payload);
   }
 
   @OnEvent('hook:workflow:failure')

--- a/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowExecutionState.ts
+++ b/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowExecutionState.ts
@@ -7,7 +7,7 @@
 import { type WorkflowExecutionStateMap } from "@hexabot-ai/graph";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { useSubscribe } from "@/websocket/socket-hooks";
+import { useWorkflowEventSubscription } from "@/websocket/workflow-event-hooks";
 
 import type {
   NodeExecutionState,
@@ -82,7 +82,7 @@ export const useWorkflowExecutionState = (flowId?: string) => {
     [flowId, scheduleExecutionAction],
   );
 
-  useSubscribe("workflow", handleWorkflowExecutionEvent);
+  useWorkflowEventSubscription(handleWorkflowExecutionEvent);
 
   useEffect(() => {
     clearExecutionTimeouts();

--- a/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
+++ b/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
@@ -8,7 +8,6 @@ import type {
   CompiledStep,
   TaskDefinition,
   WorkflowDefinition,
-  WorkflowEventMap,
 } from "@hexabot-ai/agentic";
 import type {
   FlowStepPath,
@@ -88,16 +87,10 @@ export interface WorkflowContextProps {
   workflow?: Workflow;
 }
 
-export type WorkflowEvent<
-  T extends keyof WorkflowEventMap = keyof WorkflowEventMap,
-> = T extends `${string}:${infer Rest}` ? Rest : T;
-
-export type SubscribeWorkflowProps =
-  WorkflowEventMap[keyof WorkflowEventMap] & {
-    workflowEvent: WorkflowEvent;
-    workflowId?: string;
-    t: number;
-  };
+export type {
+  SubscribeWorkflowProps,
+  WorkflowEvent,
+} from "@/websocket/types/workflow.types";
 
 export type NodeExecutionState =
   | "idle"

--- a/packages/frontend/src/components/workflow-run-debugger/components/WorkflowRunDebugger.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/WorkflowRunDebugger.tsx
@@ -13,6 +13,8 @@ import { useFind } from "@/hooks/crud/useFind";
 import { useGetFromCache } from "@/hooks/crud/useGet";
 import { EntityType, Format } from "@/services/types";
 
+import { useWorkflowRunLiveUpdates } from "../hooks/useWorkflowRunLiveUpdates";
+
 import { RunHeader } from "./header/RunHeader";
 import { InspectorPanel } from "./panels/inspector-panel/InspectorPanel";
 import { StepTracePanel } from "./panels/step-trace-panel";
@@ -28,6 +30,11 @@ export const WorkflowRunDebugger: FC<WorkflowRunDebuggerProps> = ({
   workflow,
   workflowInput,
 }) => {
+  useWorkflowRunLiveUpdates({
+    workflowId: workflow?.id,
+    initiatorId,
+  });
+
   const getWorkflowVersionFromCache = useGetFromCache(
     EntityType.WORKFLOW_VERSION,
   );

--- a/packages/frontend/src/components/workflow-run-debugger/hooks/useWorkflowRunLiveUpdates.ts
+++ b/packages/frontend/src/components/workflow-run-debugger/hooks/useWorkflowRunLiveUpdates.ts
@@ -1,0 +1,72 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type { WorkflowRun } from "@hexabot-ai/types";
+import { useCallback } from "react";
+
+import { useTanstackQueryClient } from "@/hooks/crud/useTanstack";
+import { EntityType, QueryType } from "@/services/types";
+import type { SubscribeWorkflowProps } from "@/websocket/types/workflow.types";
+import { useWorkflowEventSubscription } from "@/websocket/workflow-event-hooks";
+
+import {
+  isWorkflowRunLiveEventForDebugger,
+  mergeWorkflowRunLiveEvent,
+  shouldWorkflowRunLiveEventTouchQuery,
+} from "../live-workflow-run.utils";
+
+type UseWorkflowRunLiveUpdatesProps = {
+  workflowId?: string;
+  initiatorId?: string;
+};
+
+export const useWorkflowRunLiveUpdates = ({
+  workflowId,
+  initiatorId,
+}: UseWorkflowRunLiveUpdatesProps) => {
+  const queryClient = useTanstackQueryClient();
+  const handleWorkflowEvent = useCallback(
+    (event: SubscribeWorkflowProps) => {
+      if (!isWorkflowRunLiveEventForDebugger(event, workflowId, initiatorId)) {
+        return;
+      }
+
+      const runId = event.workflowRun?.id ?? event.runId;
+
+      if (!runId) {
+        return;
+      }
+
+      queryClient.setQueryData(
+        [QueryType.item, EntityType.WORKFLOW_RUN, runId],
+        (previousRun) =>
+          mergeWorkflowRunLiveEvent(
+            previousRun as WorkflowRun | undefined,
+            event,
+          ),
+      );
+
+      queryClient.setQueriesData(
+        {
+          predicate: ({ queryKey }) =>
+            shouldWorkflowRunLiveEventTouchQuery(queryKey, event),
+        },
+        (collection) => {
+          if (!Array.isArray(collection)) {
+            return collection ? structuredClone(collection) : collection;
+          }
+
+          return collection.includes(runId)
+            ? [...collection]
+            : [runId, ...collection];
+        },
+      );
+    },
+    [initiatorId, queryClient, workflowId],
+  );
+
+  useWorkflowEventSubscription(handleWorkflowEvent);
+};

--- a/packages/frontend/src/components/workflow-run-debugger/live-workflow-run.utils.test.ts
+++ b/packages/frontend/src/components/workflow-run-debugger/live-workflow-run.utils.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { EWorkflowRunStatus, StepType } from "@hexabot-ai/agentic";
+import type { StepExecutionRecord } from "@hexabot-ai/agentic";
+import type { WorkflowRun } from "@hexabot-ai/types";
+import { describe, expect, it } from "vitest";
+
+import type { SubscribeWorkflowProps } from "@/websocket/types/workflow.types";
+
+import {
+  isWorkflowRunLiveEventForDebugger,
+  mergeWorkflowRunLiveEvent,
+  shouldWorkflowRunLiveEventTouchQuery,
+} from "./live-workflow-run.utils";
+
+const workflowId = "workflow-1";
+const initiatorId = "user-1";
+const runId = "run-1";
+const buildRun = (overrides: Partial<WorkflowRun> = {}): WorkflowRun =>
+  ({
+    id: runId,
+    createdAt: new Date(1000),
+    updatedAt: new Date(1000),
+    status: EWorkflowRunStatus.IDLE,
+    workflow: workflowId,
+    workflowVersion: null,
+    triggeredBy: initiatorId,
+    parentRun: null,
+    input: {},
+    output: null,
+    context: {},
+    snapshot: null,
+    stepLog: null,
+    suspendedStep: null,
+    suspensionReason: null,
+    suspensionData: null,
+    suspensionStepExecId: null,
+    suspensionIndex: null,
+    suspensionKey: null,
+    suspensionAwaitResults: null,
+    lastResumeData: null,
+    error: null,
+    suspendedAt: null,
+    finishedAt: null,
+    failedAt: null,
+    duration: null,
+    metadata: null,
+    ...overrides,
+  }) as WorkflowRun;
+const buildEvent = (
+  overrides: Partial<SubscribeWorkflowProps>,
+): SubscribeWorkflowProps =>
+  ({
+    runId,
+    workflowId,
+    initiatorId,
+    workflowRun: buildRun(),
+    workflowEvent: "workflow:start",
+    t: 2000,
+    ...overrides,
+  }) as SubscribeWorkflowProps;
+const buildStepExecution = (
+  overrides: Partial<StepExecutionRecord> = {},
+): StepExecutionRecord => ({
+  id: "0:greet",
+  name: "greet",
+  action: "greet",
+  status: "running",
+  startedAt: 2100,
+  input: { name: "Ada" },
+  ...overrides,
+});
+
+describe("live workflow run utils", () => {
+  it("merges a manual run event sequence into the WorkflowRun cache model", () => {
+    const started = mergeWorkflowRunLiveEvent(
+      undefined,
+      buildEvent({ workflowEvent: "workflow:start", t: 2000 }),
+    );
+    const stepStarted = mergeWorkflowRunLiveEvent(
+      started,
+      buildEvent({
+        workflowEvent: "step:start",
+        t: 2100,
+        step: { id: "0:greet", name: "greet", type: StepType.Task },
+        stepExecution: buildStepExecution(),
+      }),
+    );
+    const stepFinished = mergeWorkflowRunLiveEvent(
+      stepStarted,
+      buildEvent({
+        workflowEvent: "step:success",
+        t: 2400,
+        step: { id: "0:greet", name: "greet", type: StepType.Task },
+        stepExecution: buildStepExecution({
+          status: "completed",
+          endedAt: 2400,
+          output: { ok: true },
+        }),
+      }),
+    );
+    const finished = mergeWorkflowRunLiveEvent(
+      stepFinished,
+      buildEvent({ workflowEvent: "workflow:finish", t: 2500 }),
+    );
+
+    expect(finished?.status).toBe(EWorkflowRunStatus.FINISHED);
+    expect(finished?.workflow).toBe(workflowId);
+    expect(finished?.triggeredBy).toBe(initiatorId);
+    expect(finished?.finishedAt).toEqual(new Date(2500));
+    expect(finished?.stepLog?.["0:greet"]).toEqual(
+      expect.objectContaining({
+        id: "0:greet",
+        status: "completed",
+        input: { name: "Ada" },
+        output: { ok: true },
+      }),
+    );
+  });
+
+  it("merges scheduled workflow suspension events live", () => {
+    const scheduledWorkflowId = "scheduled-workflow";
+    const scheduledRun = buildRun({
+      workflow: scheduledWorkflowId,
+      input: { schedule: "*/5 * * * * *" },
+    });
+    const suspended = mergeWorkflowRunLiveEvent(
+      scheduledRun,
+      buildEvent({
+        workflowId: scheduledWorkflowId,
+        workflowRun: scheduledRun,
+        workflowEvent: "step:suspended",
+        t: 3000,
+        step: { id: "0:await", name: "await", type: StepType.Task },
+        stepExecution: buildStepExecution({
+          id: "0:await",
+          name: "await",
+          status: "suspended",
+          endedAt: 3000,
+          reason: "waiting",
+        }),
+      }),
+    );
+
+    expect(suspended?.status).toBe(EWorkflowRunStatus.SUSPENDED);
+    expect(suspended?.suspendedAt).toEqual(new Date(3000));
+    expect(suspended?.stepLog?.["0:await"]).toEqual(
+      expect.objectContaining({
+        status: "suspended",
+        reason: "waiting",
+      }),
+    );
+  });
+
+  it("filters and touches only matching debugger workflow run collections", () => {
+    const event = buildEvent({ workflowEvent: "step:start" });
+
+    expect(
+      isWorkflowRunLiveEventForDebugger(event, workflowId, initiatorId),
+    ).toBe(true);
+    expect(
+      isWorkflowRunLiveEventForDebugger(event, "other-workflow", initiatorId),
+    ).toBe(false);
+    expect(
+      shouldWorkflowRunLiveEventTouchQuery(
+        [
+          "collection",
+          "WorkflowRun",
+          JSON.stringify({
+            params: {
+              where: {
+                "workflow.id": workflowId,
+                "triggeredBy.id": initiatorId,
+              },
+            },
+          }),
+        ],
+        event,
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/frontend/src/components/workflow-run-debugger/live-workflow-run.utils.ts
+++ b/packages/frontend/src/components/workflow-run-debugger/live-workflow-run.utils.ts
@@ -1,0 +1,197 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { EWorkflowRunStatus } from "@hexabot-ai/agentic";
+import type { WorkflowRun } from "@hexabot-ai/types";
+
+import {
+  mergeEntityCachePayload,
+  mergeStepExecutionRecord,
+  type CacheRecord,
+} from "@/hooks/entity-cache.utils";
+import { EntityType, QueryType } from "@/services/types";
+import type { SubscribeWorkflowProps } from "@/websocket/types/workflow.types";
+
+import { resolveEntityId } from "./utils";
+
+const WORKFLOW_EVENT_STATUS: Partial<Record<string, EWorkflowRunStatus>> = {
+  "workflow:start": EWorkflowRunStatus.RUNNING,
+  "workflow:finish": EWorkflowRunStatus.FINISHED,
+  "workflow:failure": EWorkflowRunStatus.FAILED,
+  "workflow:suspended": EWorkflowRunStatus.SUSPENDED,
+  "step:start": EWorkflowRunStatus.RUNNING,
+  "step:error": EWorkflowRunStatus.FAILED,
+  "step:suspended": EWorkflowRunStatus.SUSPENDED,
+};
+
+type ParsedCollectionParams = {
+  params?: {
+    where?: Record<string, unknown>;
+  };
+  where?: Record<string, unknown>;
+};
+
+const toEventDate = (event: SubscribeWorkflowProps) =>
+  typeof event.t === "number" ? new Date(event.t) : new Date();
+const getWorkflowRunIdFromEvent = (
+  event: SubscribeWorkflowProps,
+): string | undefined => event.workflowRun?.id ?? event.runId;
+const getWorkflowIdFromEvent = (
+  event: SubscribeWorkflowProps,
+): string | undefined =>
+  event.workflowId ?? resolveEntityId(event.workflowRun?.workflow);
+const getInitiatorIdFromEvent = (
+  event: SubscribeWorkflowProps,
+): string | undefined =>
+  event.initiatorId ?? resolveEntityId(event.workflowRun?.triggeredBy);
+
+export const isWorkflowRunLiveEventForDebugger = (
+  event: SubscribeWorkflowProps,
+  workflowId?: string,
+  initiatorId?: string,
+) => {
+  const eventRunId = getWorkflowRunIdFromEvent(event);
+
+  if (!eventRunId) {
+    return false;
+  }
+
+  const eventWorkflowId = getWorkflowIdFromEvent(event);
+
+  if (workflowId && eventWorkflowId && eventWorkflowId !== workflowId) {
+    return false;
+  }
+
+  const eventInitiatorId = getInitiatorIdFromEvent(event);
+
+  if (initiatorId && eventInitiatorId && eventInitiatorId !== initiatorId) {
+    return false;
+  }
+
+  return true;
+};
+
+export const mergeWorkflowRunLiveEvent = (
+  previousRun: WorkflowRun | undefined,
+  event: SubscribeWorkflowProps,
+): WorkflowRun | undefined => {
+  const runId = getWorkflowRunIdFromEvent(event);
+
+  if (!runId) {
+    return previousRun;
+  }
+
+  const eventDate = toEventDate(event);
+  const eventWorkflowRun = event.workflowRun
+    ? mergeEntityCachePayload(
+        EntityType.WORKFLOW_RUN,
+        previousRun as CacheRecord | undefined,
+        event.workflowRun as unknown as CacheRecord,
+      )
+    : {};
+  const status = WORKFLOW_EVENT_STATUS[event.workflowEvent];
+  const nextRun: CacheRecord = {
+    ...(previousRun as unknown as CacheRecord | undefined),
+    ...eventWorkflowRun,
+    id: runId,
+    ...(event.workflowId ? { workflow: event.workflowId } : {}),
+    ...(event.initiatorId ? { triggeredBy: event.initiatorId } : {}),
+    ...(event.threadId ? { thread: event.threadId } : {}),
+    updatedAt: eventDate,
+    ...(status ? { status } : {}),
+  };
+
+  if (event.workflowEvent === "workflow:finish") {
+    nextRun.finishedAt = eventDate;
+  }
+
+  if (event.workflowEvent === "workflow:failure") {
+    nextRun.failedAt = eventDate;
+  }
+
+  if (
+    event.workflowEvent === "workflow:suspended" ||
+    event.workflowEvent === "step:suspended"
+  ) {
+    nextRun.suspendedAt = eventDate;
+  }
+
+  if (event.stepExecution) {
+    const previousStepLog =
+      typeof nextRun.stepLog === "object" && nextRun.stepLog !== null
+        ? (nextRun.stepLog as WorkflowRun["stepLog"])
+        : {};
+
+    nextRun.stepLog = {
+      ...(previousStepLog ?? {}),
+      [event.stepExecution.id]: mergeStepExecutionRecord(
+        previousStepLog?.[event.stepExecution.id],
+        event.stepExecution,
+      ),
+    };
+  }
+
+  return nextRun as WorkflowRun;
+};
+
+const parseCollectionParams = (
+  queryParams: unknown,
+): ParsedCollectionParams => {
+  if (typeof queryParams !== "string") {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(queryParams);
+
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as ParsedCollectionParams)
+      : {};
+  } catch {
+    return {};
+  }
+};
+
+export const shouldWorkflowRunLiveEventTouchQuery = (
+  queryKey: readonly unknown[],
+  event: SubscribeWorkflowProps,
+) => {
+  const [queryType, queryEntity, queryParams] = queryKey;
+
+  if (
+    queryType !== QueryType.collection ||
+    queryEntity !== EntityType.WORKFLOW_RUN
+  ) {
+    return false;
+  }
+
+  const params = parseCollectionParams(queryParams);
+  const where = params.params?.where ?? params.where;
+
+  if (!where) {
+    return true;
+  }
+
+  const workflowFilter = where["workflow.id"];
+
+  if (
+    typeof workflowFilter === "string" &&
+    workflowFilter !== getWorkflowIdFromEvent(event)
+  ) {
+    return false;
+  }
+
+  const initiatorFilter = where["triggeredBy.id"];
+
+  if (
+    typeof initiatorFilter === "string" &&
+    initiatorFilter !== getInitiatorIdFromEvent(event)
+  ) {
+    return false;
+  }
+
+  return true;
+};

--- a/packages/frontend/src/hooks/crud/helpers.ts
+++ b/packages/frontend/src/hooks/crud/helpers.ts
@@ -6,6 +6,10 @@
 
 import { normalize } from "normalizr";
 
+import {
+  mergeEntityCachePayload,
+  type CacheRecord,
+} from "@/hooks/entity-cache.utils";
 import { ENTITY_MAP } from "@/services/entities";
 import { EntityType, QueryType } from "@/services/types";
 import { IBaseSchema, THook } from "@/types/base.types";
@@ -46,11 +50,12 @@ export const useNormalizeAndCache = <
           if (id && newData) {
             queryClient.setQueryData(
               [QueryType.item, entityType, id],
-              (previousData: any) => {
-                return {
-                  ...previousData,
-                  ...newData,
-                };
+              (previousData: CacheRecord | undefined) => {
+                return mergeEntityCachePayload(
+                  entityType as EntityType,
+                  previousData,
+                  newData as CacheRecord,
+                );
               },
             );
           }

--- a/packages/frontend/src/hooks/entity-cache.utils.ts
+++ b/packages/frontend/src/hooks/entity-cache.utils.ts
@@ -1,0 +1,153 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { EWorkflowRunStatus } from "@hexabot-ai/agentic";
+import type { StepExecutionRecord } from "@hexabot-ai/agentic";
+
+import { EntityType } from "@/services/types";
+
+export type CacheRecord = Record<string, unknown>;
+
+const ENTITY_RELATION_KEYS_TO_PRESERVE: Partial<Record<EntityType, string[]>> =
+  {
+    [EntityType.THREAD]: ["subscriber", "source"],
+    [EntityType.WORKFLOW_RUN]: [
+      "workflow",
+      "workflowVersion",
+      "triggeredBy",
+      "thread",
+      "parentRun",
+    ],
+  };
+const TERMINAL_WORKFLOW_RUN_STATUSES = new Set<string>([
+  EWorkflowRunStatus.FINISHED,
+  EWorkflowRunStatus.FAILED,
+]);
+const isObjectRecord = (value: unknown): value is CacheRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+const isStepLog = (
+  value: unknown,
+): value is Record<string, StepExecutionRecord> => isObjectRecord(value);
+const getStepTimestamp = (step: StepExecutionRecord): number => {
+  const startedAt = typeof step.startedAt === "number" ? step.startedAt : 0;
+  const endedAt = typeof step.endedAt === "number" ? step.endedAt : 0;
+
+  return Math.max(startedAt, endedAt);
+};
+
+export const mergeStepExecutionRecord = (
+  previous: StepExecutionRecord | undefined,
+  next: StepExecutionRecord,
+): StepExecutionRecord => {
+  if (!previous) {
+    return { ...next };
+  }
+
+  if (getStepTimestamp(previous) > getStepTimestamp(next)) {
+    return previous;
+  }
+
+  const context =
+    previous.context || next.context
+      ? { ...previous.context, ...next.context }
+      : undefined;
+
+  return {
+    ...previous,
+    ...next,
+    context,
+  };
+};
+
+export const mergeStepExecutionLogs = (
+  previous: unknown,
+  next: unknown,
+): Record<string, StepExecutionRecord> | null | undefined => {
+  if (!isStepLog(previous)) {
+    return isStepLog(next) ? next : (next as null | undefined);
+  }
+
+  if (next == null) {
+    return previous;
+  }
+
+  if (!isStepLog(next)) {
+    return previous;
+  }
+
+  return Object.entries(next).reduce<Record<string, StepExecutionRecord>>(
+    (merged, [stepId, step]) => ({
+      ...merged,
+      [stepId]: mergeStepExecutionRecord(merged[stepId], step),
+    }),
+    { ...previous },
+  );
+};
+
+const preserveRelationObjects = (
+  entityType: EntityType,
+  previousData: CacheRecord | undefined,
+  mergedPayload: CacheRecord,
+) => {
+  const relationKeys = ENTITY_RELATION_KEYS_TO_PRESERVE[entityType] ?? [];
+
+  relationKeys.forEach((relationKey) => {
+    if (
+      isObjectRecord(previousData?.[relationKey]) &&
+      typeof mergedPayload[relationKey] === "string"
+    ) {
+      mergedPayload[relationKey] = previousData?.[relationKey];
+    }
+  });
+};
+const preserveTerminalWorkflowRunState = (
+  previousData: CacheRecord | undefined,
+  mergedPayload: CacheRecord,
+) => {
+  if (
+    typeof previousData?.status !== "string" ||
+    !TERMINAL_WORKFLOW_RUN_STATUSES.has(previousData.status) ||
+    typeof mergedPayload.status !== "string" ||
+    TERMINAL_WORKFLOW_RUN_STATUSES.has(mergedPayload.status)
+  ) {
+    return;
+  }
+
+  mergedPayload.status = previousData.status;
+  ["finishedAt", "failedAt"].forEach((field) => {
+    if (previousData[field] && !mergedPayload[field]) {
+      mergedPayload[field] = previousData[field];
+    }
+  });
+};
+
+export const mergeEntityCachePayload = (
+  entityType: EntityType,
+  previousData: CacheRecord | undefined,
+  nextEntityData: CacheRecord,
+) => {
+  const mergedPayload: CacheRecord = {
+    ...previousData,
+    ...nextEntityData,
+  };
+
+  preserveRelationObjects(entityType, previousData, mergedPayload);
+
+  if (entityType === EntityType.WORKFLOW_RUN) {
+    const mergedStepLog = mergeStepExecutionLogs(
+      previousData?.stepLog,
+      nextEntityData.stepLog,
+    );
+
+    if (mergedStepLog !== undefined) {
+      mergedPayload.stepLog = mergedStepLog;
+    }
+
+    preserveTerminalWorkflowRunState(previousData, mergedPayload);
+  }
+
+  return mergedPayload;
+};

--- a/packages/frontend/src/hooks/useEntityMutationSubscription.test.ts
+++ b/packages/frontend/src/hooks/useEntityMutationSubscription.test.ts
@@ -38,6 +38,38 @@ describe("useEntityMutationSubscription helpers", () => {
     expect(merged.status).toBe("open");
   });
 
+  it("keeps newer live workflow run step state when a stale payload arrives", () => {
+    const previousData = {
+      id: "run-1",
+      status: "finished",
+      finishedAt: new Date(2500),
+      stepLog: {
+        "0:greet": {
+          id: "0:greet",
+          name: "greet",
+          status: "completed",
+          startedAt: 2100,
+          endedAt: 2400,
+        },
+      },
+    };
+    const nextEntityData = {
+      id: "run-1",
+      status: "running",
+      finishedAt: null,
+      stepLog: null,
+    };
+    const merged = mergeEntityCachePayload(
+      EntityType.WORKFLOW_RUN,
+      previousData,
+      nextEntityData,
+    );
+
+    expect(merged.status).toBe("finished");
+    expect(merged.finishedAt).toEqual(previousData.finishedAt);
+    expect(merged.stepLog).toEqual(previousData.stepLog);
+  });
+
   it("matches only infinite thread query keys for refetch", () => {
     expect(
       isThreadInfiniteQuery([QueryType.infinite, EntityType.THREAD, "{}"]),

--- a/packages/frontend/src/hooks/useEntityMutationSubscription.ts
+++ b/packages/frontend/src/hooks/useEntityMutationSubscription.ts
@@ -9,6 +9,10 @@ import { useCallback } from "react";
 
 import { isSameEntity } from "@/hooks/crud/helpers";
 import { useTanstackQueryClient } from "@/hooks/crud/useTanstack";
+import {
+  mergeEntityCachePayload,
+  type CacheRecord,
+} from "@/hooks/entity-cache.utils";
 import { ENTITY_MAP } from "@/services/entities";
 import { EntityType, QueryType } from "@/services/types";
 import { IBaseSchema } from "@/types/base.types";
@@ -32,44 +36,7 @@ const getAffectedEntityTypes = (entityType: EntityType): EntityType[] => {
 const transformEntityPayload = (entityType: EntityType, payload: unknown) =>
   PAYLOAD_TRANSFORMERS_BY_ENTITY_TYPE[entityType]?.(payload) ?? payload;
 
-type CacheRecord = Record<string, unknown>;
-
-export const mergeEntityCachePayload = (
-  entityType: EntityType,
-  previousData: CacheRecord | undefined,
-  nextEntityData: CacheRecord,
-) => {
-  const mergedPayload = {
-    ...previousData,
-    ...nextEntityData,
-  };
-
-  if (
-    entityType === EntityType.THREAD &&
-    typeof previousData?.subscriber === "object" &&
-    previousData.subscriber !== null &&
-    typeof nextEntityData.subscriber === "string"
-  ) {
-    mergedPayload.subscriber = previousData.subscriber;
-  }
-
-  if (
-    entityType === EntityType.THREAD &&
-    typeof previousData?.source === "object" &&
-    previousData.source !== null &&
-    typeof nextEntityData.source === "string"
-  ) {
-    mergedPayload.source = previousData.source;
-  }
-
-  if (entityType === EntityType.THREAD) {
-    return {
-      ...mergedPayload,
-    };
-  }
-
-  return mergedPayload;
-};
+export { mergeEntityCachePayload } from "@/hooks/entity-cache.utils";
 
 type EntityMutationEvent<E extends IBaseSchema = IBaseSchema> = {
   entity: string;

--- a/packages/frontend/src/layout/AuthenticatedLayout.tsx
+++ b/packages/frontend/src/layout/AuthenticatedLayout.tsx
@@ -15,7 +15,7 @@ import useAvailableMenuItems from "@/hooks/useAvailableMenuItems";
 import { useConfig } from "@/hooks/useConfig";
 import { useEntityMutationSubscription } from "@/hooks/useEntityMutationSubscription";
 import { getMenuItems } from "@/utils/menu.util";
-import { useSocketGetQuery } from "@/websocket/socket-hooks";
+import { WorkflowEventProvider } from "@/websocket/workflow-event-hooks";
 
 import { LayoutProps } from ".";
 
@@ -24,7 +24,6 @@ import { theme } from "./theme";
 export const AuthenticatedLayout: React.FC<
   LayoutProps & { hasNoPadding?: boolean }
 > = ({ children, hasNoPadding, isPublicRoute }) => {
-  useSocketGetQuery("/workflow/subscribe/");
   useEntityMutationSubscription();
 
   const [isDesktopNavigationExpanded, setIsDesktopNavigationExpanded] =
@@ -58,33 +57,35 @@ export const AuthenticatedLayout: React.FC<
   }
 
   return (
-    <Box display="flex">
-      <DashboardHeader
-        logo={<HexabotLogo />}
-        menuOpen={isDesktopNavigationExpanded}
-        onToggleMenu={handleToggleHeaderMenu}
-      />
-      <DashboardSidebar
-        menu={availableMenuItems}
-        expanded={isDesktopNavigationExpanded}
-        setExpanded={setIsNavigationExpanded}
-      />
+    <WorkflowEventProvider>
+      <Box display="flex">
+        <DashboardHeader
+          logo={<HexabotLogo />}
+          menuOpen={isDesktopNavigationExpanded}
+          onToggleMenu={handleToggleHeaderMenu}
+        />
+        <DashboardSidebar
+          menu={availableMenuItems}
+          expanded={isDesktopNavigationExpanded}
+          setExpanded={setIsNavigationExpanded}
+        />
 
-      <Grid
-        sx={{
-          padding: hasNoPadding ? 0 : 3,
-          position: "relative",
-          marginTop: "64px",
-          display: "flex",
-          flexDirection: "column",
-          flex: 1,
-          overflow: "auto",
-          width: "calc(100% - 88px)",
-          zIndex: 5,
-        }}
-      >
-        {children}
-      </Grid>
-    </Box>
+        <Grid
+          sx={{
+            padding: hasNoPadding ? 0 : 3,
+            position: "relative",
+            marginTop: "64px",
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            overflow: "auto",
+            width: "calc(100% - 88px)",
+            zIndex: 5,
+          }}
+        >
+          {children}
+        </Grid>
+      </Box>
+    </WorkflowEventProvider>
   );
 };

--- a/packages/frontend/src/websocket/types/workflow.types.ts
+++ b/packages/frontend/src/websocket/types/workflow.types.ts
@@ -1,0 +1,26 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type {
+  StepExecutionRecord,
+  WorkflowEventMap,
+} from "@hexabot-ai/agentic";
+import type { WorkflowRun } from "@hexabot-ai/types";
+
+export type WorkflowEvent<
+  T extends keyof WorkflowEventMap = keyof WorkflowEventMap,
+> = T extends `${string}:${infer Rest}` ? Rest : T;
+
+export type SubscribeWorkflowProps =
+  WorkflowEventMap[keyof WorkflowEventMap] & {
+    initiatorId?: string;
+    stepExecution?: StepExecutionRecord;
+    threadId?: string;
+    workflowRun?: WorkflowRun;
+    workflowEvent: WorkflowEvent;
+    workflowId?: string;
+    t: number;
+  };

--- a/packages/frontend/src/websocket/workflow-event-hooks.tsx
+++ b/packages/frontend/src/websocket/workflow-event-hooks.tsx
@@ -1,0 +1,79 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type { PropsWithChildren } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+
+import type { SubscribeWorkflowProps } from "@/websocket/types/workflow.types";
+
+import { useSocketGetQuery, useSubscribe } from "./socket-hooks";
+
+type WorkflowEventCallback = (event: SubscribeWorkflowProps) => void;
+
+interface WorkflowEventContextValue {
+  subscribe: (callback: WorkflowEventCallback) => () => void;
+}
+
+const WorkflowEventContext = createContext<WorkflowEventContextValue | null>(
+  null,
+);
+const requireWorkflowEventContext = (
+  context: WorkflowEventContextValue | null,
+) => {
+  if (!context) {
+    throw new Error(
+      "useWorkflowEventSubscription must be used within WorkflowEventProvider",
+    );
+  }
+
+  return context;
+};
+
+export const WorkflowEventProvider = ({ children }: PropsWithChildren) => {
+  const subscribersRef = useRef<Set<WorkflowEventCallback>>(new Set());
+
+  useSocketGetQuery("/workflow/subscribe/");
+
+  const subscribe = useCallback((callback: WorkflowEventCallback) => {
+    subscribersRef.current.add(callback);
+
+    return () => {
+      subscribersRef.current.delete(callback);
+    };
+  }, []);
+  const handleWorkflowEvent = useCallback((event: SubscribeWorkflowProps) => {
+    subscribersRef.current.forEach((callback) => {
+      callback(event);
+    });
+  }, []);
+
+  useSubscribe<SubscribeWorkflowProps>("workflow", handleWorkflowEvent);
+
+  const value = useMemo(() => ({ subscribe }), [subscribe]);
+
+  return (
+    <WorkflowEventContext.Provider value={value}>
+      {children}
+    </WorkflowEventContext.Provider>
+  );
+};
+
+export const useWorkflowEventSubscription = (
+  callback: WorkflowEventCallback,
+) => {
+  const context = requireWorkflowEventContext(useContext(WorkflowEventContext));
+
+  useEffect(() => {
+    return context.subscribe(callback);
+  }, [callback, context]);
+};


### PR DESCRIPTION
## What changed?

Fixes live workflow-run debugger updates for manual and scheduled runs by making workflow socket events carry the canonical `StepExecutionRecord` data needed to update `WorkflowRun.stepLog` live.

## Changes

- Enriched agentic/API workflow events with `stepExecution`, workflow/run identifiers, and current `workflowRun` snapshot.
- Updated debugger live handling to merge workflow socket events into the existing `WorkflowRun` query cache instead of keeping separate debugger state.
- Hardened entity cache reconciliation so stale/null refetch payloads do not erase newer live `stepLog` updates.
- Centralized frontend `"workflow"` socket subscription in `WorkflowEventProvider`, shared by the visual editor and debugger.
- Added focused tests for step event payloads, API broadcasts, live debugger merging, and stale cache reconciliation.

