### PR TITLE
Feat/agentic parallel

### DIFF
--- a/packages/agentic/AGENTS.md
+++ b/packages/agentic/AGENTS.md
@@ -30,17 +30,17 @@ Use this file as the predictable entrypoint for AI coding agents working on the 
 - Entry points: `Workflow.fromYaml` / `Workflow.fromDefinition` validate via `validateWorkflow` then compile via `compileWorkflow` into a `CompiledWorkflow`.
 - Runner: `WorkflowRunner.start` executes the compiled flow; `resume` continues after a suspension. `Workflow.run` is a convenience that throws an error carrying suspension details (`stepId`, `reason`, `data`) on suspension.
 - Step ids: generated from the flow path (e.g., `0.branch.1:conditional`); loop iterations append `[i.j]` suffixes.
-- Snapshots: every start/resume returns `{ status, snapshot }` with `WorkflowSnapshot.actions` capturing per-step status (`pending|running|suspended|completed|failed|skipped`).
-- Events: runners can emit to any `emit`/`on`-compatible emitter (`WorkflowEventEmitter` is the built-in helper) with `hook:workflow:start|finish|failure|suspended` and `hook:step:start|success|error|suspended|skipped`.
+- Snapshots: every start/resume returns `{ status, snapshot }` with `WorkflowSnapshot.actions` capturing per-step status (`pending|running|suspended|completed|failed|cancelled|skipped`).
+- Events: runners can emit to any `emit`/`on`-compatible emitter (`WorkflowEventEmitter` is the built-in helper) with `hook:workflow:start|finish|failure|suspended` and `hook:step:start|success|error|cancelled|suspended|skipped`.
 - Evaluation order: task-def inputs are evaluated before marking a step as running; task results are stored raw under `$output.<task>`. Final workflow outputs are evaluated only after the flow completes.
-- Parallel semantics: executed sequentially for determinism; `wait_any` short-circuits after the first completed child, `wait_all` waits for all.
+- Parallel semantics: child steps start concurrently. Each branch receives an isolated `$output`, `$iteration`, `$accumulator`, and context state snapshot from parallel entry; parent `$output` is merged only when the block resolves. `wait_all` merges branch output deltas in child-index order. `wait_any` uses the first successful branch, aborts siblings with `AbortSignal`, and discards loser outputs. Suspensions inside parallel fail the workflow with `ParallelSuspensionError`.
 - Loop semantics:
   - `type: for_each`: iterates over evaluated `for_each.in` (arrays only), threads `$iteration` and accumulator, and optionally checks `until` after each iteration.
   - `type: while`: evaluates `while` before each iteration and then executes loop steps.
   - Accumulated values are exposed under `$output.<loop_name>.<accumulator_alias>` when `name` is set.
 
 ## Actions and settings
-- Create actions with `defineAction` (or extend `AbstractAction`): provide `name` (snake_case), optional `description`, `inputSchema`, `outputSchema`, optional `settingSchema`, and an async `execute`.
+- Create actions with `defineAction` (or extend `AbstractAction`): provide `name` (snake_case), optional `description`, `inputSchema`, `outputSchema`, optional `settingSchema`, and an async `execute`. `execute` receives an `AbortSignal` as `signal`; long-running actions should stop promptly when it is aborted.
 - `AbstractAction.run` handles `parseInput`, merges/parses settings (defaults live in `SettingsSchema`, including `timeout_ms` and retry policy), wraps `execute` with timeout/retries, and validates the output.
 - Suspension: inside `execute`, `await context.workflow.suspend(options)`; the runner marks the step as `suspended` and returns `{ status: 'suspended', step, reason?, data? }`. On resume, the suspended action continues from the `await` with the provided data.
 - Settings merge: `mergeSettings` deep-merges `defaults.settings` with task-def overrides; undefined values do not clobber defaults.
@@ -55,6 +55,7 @@ Use this file as the predictable entrypoint for AI coding agents working on the 
 - `timeout_ms: 0` disables timeouts. Default retries come from `DEFAULT_RETRY_SETTINGS` (3 attempts, exponential backoff starting at 25ms, capped at 10s, no jitter).
 - Task-level output mapping is not supported; the entire raw action result is always stored under `$output.<task>`.
 - `BaseWorkflowContext.workflow` is attached only while running; don’t hold references beyond execution.
+- `context.workflow.suspend()` is valid only outside parallel blocks; inside parallel branches it rejects with `ParallelSuspensionError`.
 
 ## When extending the package
 - Add or adjust DSL shape in `packages/agentic/src/dsl.types.ts` and update `packages/agentic/DSL.md` plus the example workflow if behavior changes.

--- a/packages/agentic/DSL.md
+++ b/packages/agentic/DSL.md
@@ -59,7 +59,7 @@ Example: `defs.understand_request` calls an LLM with a system prompt, user query
 The `flow` array defines the run order. Each item is exactly one of the following blocks:
 
 - `do`: `{ do: <task_name> }` executes the referenced task sequentially.
-- `parallel`: runs multiple `steps` concurrently. The example uses `strategy: wait_all`, meaning downstream steps wait for every child to finish; engines may also support `wait_any`.
+- `parallel`: starts every child `step` concurrently. `strategy: wait_all` waits for every child and merges branch output deltas in child order; `strategy: wait_any` advances with the first successful child, aborts the remaining branches, and discards loser outputs.
 - `conditional`: branching table evaluated top-to-bottom. Keys:
   - `when`: list of branches with `condition` (JSONata boolean) and `steps` to run on match.
   - `else`: optional branch with `steps` when nothing matches.
@@ -77,10 +77,13 @@ The `flow` array defines the run order. Each item is exactly one of the followin
 
 All branches and loop bodies can themselves contain nested `conditional` or `parallel` blocks.
 
+Parallel branches are isolated while they run: each branch sees the `$output`, `$iteration`, `$accumulator`, and context state from the moment the parallel block starts, plus its own writes. Sibling branch outputs are not visible until after the parallel block completes. Tasks inside parallel receive an `AbortSignal` and should stop promptly when it is aborted. Human-in-the-loop suspension is not supported inside parallel branches.
+
 ## Human-in-the-loop pauses
 
 - Use a task whose `action` supports waiting (e.g., `await_user_input`) and set `settings.await_user: true`.
 - The engine should checkpoint the workflow, wait for a reply or timeout, then resume with the captured response stored under `$output.<task>`.
+- Do not place suspending actions inside a `parallel` block. `context.workflow.suspend()` inside parallel fails the workflow with `ParallelSuspensionError`.
 
 ## Final outputs
 
@@ -91,7 +94,7 @@ All branches and loop bodies can themselves contain nested `conditional` or `par
 
 - Tasks inherit `defaults.settings` unless overridden. Common knobs: `timeout_ms`, `retries.max_attempts`, `retries.backoff_ms`, and action-specific parameters like `model`/`temperature`.
 - Engines should surface action failures and retry attempts; a task failing after retries should abort the workflow unless the engine supports optional continuation semantics.
-- Parallel blocks honor task-level retries independently; the block completes based on its `strategy` (e.g., all tasks finishing for `wait_all`).
+- Parallel blocks honor task-level retries independently. `wait_all` fails fast on the first branch failure and aborts siblings. `wait_any` succeeds on the first successful branch, fails fast on the first branch failure before a winner, and aborts losing branches cooperatively via `AbortSignal`.
 
 ## Example walkthrough (`workflow.yml`)
 
@@ -114,5 +117,5 @@ Notable conventions enforced in the example:
 - Prefer descriptive task def names; keep actions generic and reusable.
 - Minimize side effects inside JSONata; use expressions mainly for routing and lightweight data shaping.
 - Treat `context` as read-only; write outputs through tasks designed for persistence if needed.
-- Keep parallel blocks small and bounded with `max_concurrency` when hitting external APIs or rate limits.
+- Keep parallel blocks small when hitting external APIs or rate limits, and make action implementations honor their `AbortSignal`.
 - Surface only the essentials in top-level `outputs` so callers get a clean contract.

--- a/packages/agentic/README.md
+++ b/packages/agentic/README.md
@@ -6,8 +6,8 @@ Typed runtime and YAML DSL for orchestrating multi-step AI/automation workflows.
 - Declarative workflow DSL in YAML or JS objects with JSONata expressions (prefixed by `=`) and clear scopes (`$input`, `$context`, `$output`, `$iteration`, `$accumulator`).
 - Type-safe actions built with `defineAction`, Zod-validated IO, and merged settings (timeouts, retries, plus action-specific options) inherited from workflow defaults.
 - Resumable execution via `WorkflowRunner` and `context.workflow.suspend`, plus snapshots for persistence and replay.
-- Flow primitives: sequential `do`, `parallel` blocks (`wait_all`/`wait_any`), `conditional` branches, and two loop variants: `loop.type: for_each` (iterables) and `loop.type: while` (pre-check condition).
-- Event emitter hooks for observability (`hook:workflow:start|finish|failure|suspended`, `hook:step:start|success|error|suspended|skipped`).
+- Flow primitives: sequential `do`, truly concurrent `parallel` blocks (`wait_all`/`wait_any`), `conditional` branches, and two loop variants: `loop.type: for_each` (iterables) and `loop.type: while` (pre-check condition).
+- Event emitter hooks for observability (`hook:workflow:start|finish|failure|suspended`, `hook:step:start|success|error|cancelled|suspended|skipped`).
 
 ## Installation
 
@@ -89,7 +89,11 @@ export const call_api = defineAction<
   description: 'Fetches data from an API',
   inputSchema: z.object({ id: z.string() }),
   outputSchema: z.object({ body: z.string() }),
-  execute: async ({ input, context, settings, bindings }) => {
+  execute: async ({ input, context, settings, bindings, signal }) => {
+    if (signal.aborted) {
+      throw signal.reason;
+    }
+
     context.log('calling api', {
       id: input.id,
       timeout: settings.timeout_ms,
@@ -100,7 +104,9 @@ export const call_api = defineAction<
 });
 ```
 
-Settings are parsed and merged with workflow defaults before `execute` runs; retries and timeout wrappers are applied automatically. Awaiting `context.workflow.suspend(...)` pauses the workflow until `resume` is called.
+Settings are parsed and merged with workflow defaults before `execute` runs; retries and timeout wrappers are applied automatically. Each action receives an `AbortSignal` as `signal`; long-running actions should stop promptly when it is aborted. Awaiting `context.workflow.suspend(...)` pauses the workflow until `resume` is called, except inside `parallel` branches where suspension fails with `ParallelSuspensionError`.
+
+Parallel branches start concurrently with isolated `$output`, `$iteration`, `$accumulator`, and context state from the parallel entry point. `wait_all` merges successful branch output deltas in child order. `wait_any` advances with the first successful branch, aborts losing branches, and discards loser outputs.
 
 ## Running a workflow from YAML
 
@@ -203,12 +209,14 @@ export const await_user = defineAction<unknown, { reply?: string }, AppContext, 
 
 `Workflow.run` throws an error with suspension details (`stepId`, `reason`, `data`) when this happens; `WorkflowRunner.start` instead returns `{ status: 'suspended', ... }` so hosts can persist state and resume later with `runner.resume`.
 
+Suspending actions must not be placed inside `parallel` blocks.
+
 ## Events and observability
 
 `WorkflowRunner` can publish lifecycle hooks to any emitter-like object with `emit`/`on` (`WorkflowEventEmitterLike`); `WorkflowEventEmitter` is the built-in helper and mirrors these events:
 
 - `hook:workflow:start | finish | failure | suspended`
-- `hook:step:start | success | error | suspended | skipped`
+- `hook:step:start | success | error | cancelled | suspended | skipped`
 
 Attach listeners to stream logs, emit metrics, or capture snapshots for debugging.
 

--- a/packages/agentic/SUSPENSION.md
+++ b/packages/agentic/SUSPENSION.md
@@ -70,6 +70,7 @@ This metadata is required for deterministic replay when a step has multiple `sus
 - `WorkflowSuspendedError` was removed.
 - `Workflow.run(...)` now throws an internal `WorkflowRunSuspendedError` carrying `stepId`, `reason`, and `data`.
 - `NonDeterministicWorkflowError` is exported and used to fail resume when replay metadata does not match runtime behavior.
+- `ParallelSuspensionError` is exported and used when `context.workflow.suspend()` is attempted inside a parallel branch.
 
 ## 3. End-to-end control flow
 
@@ -77,10 +78,12 @@ This metadata is required for deterministic replay when a step has multiple `sus
 
 1. Runner sets status to `running`, initializes state/context, and attaches runtime control.
 2. Task executor starts action execution and simultaneously waits for:
-   - action completion/failure
+   - action completion/failure/cancellation
    - first suspension request from that step
 3. If suspension arrives first, executor returns a `Suspension` continuation to the runner.
 4. Runner sets status to `suspended`, stores continuation, emits `hook:workflow:suspended`, and returns suspended result.
+
+Inside a `parallel` branch, `context.workflow.suspend()` rejects with `ParallelSuspensionError`; the workflow fails instead of returning a suspended result.
 
 ### 3.2 In-action suspension (`RunnerRuntimeControl.suspend`)
 
@@ -97,6 +100,8 @@ Inside `suspend(options)`:
    - if `awaitResults[suspendKey]` exists, return it immediately
    - else if primed resume data exists, return it immediately
 7. Otherwise enqueue a `RuntimeSuspensionRequest` and return its deferred promise.
+
+Parallel branch contexts replace the normal runtime control with one that rejects `suspend()` immediately. This avoids ambiguous multi-branch checkpoints and durable replay anomalies.
 
 ### 3.3 Resume (`Suspension.continue` + `WorkflowRunner.resume`)
 
@@ -220,7 +225,7 @@ Recommended persisted shape:
 `WorkflowRunner.fromPersistedState(...)` calls `rebuildSuspension(...)`, which:
 
 1. Parses `stepId` path and loop iteration suffix (`[i.j]`).
-2. Walks compiled flow tree (`task`, `parallel`, `conditional`, `loop`) to locate suspended node.
+2. Walks compiled flow tree (`task`, `conditional`, `loop`) to locate suspended node. Suspensions whose path is inside `parallel` are rejected because parallel suspension is unsupported.
 3. Builds a continuation that replays only the suspended step, then resumes normal flow.
 4. Injects replay seed and previously resumed data via:
    - `prepareStepReplay(...)`
@@ -263,6 +268,8 @@ Events:
 
 - Action code must `await` `workflow.suspend(...)`. Calling it without `await` can lead to cancellation of that suspend request.
 - `workflow.suspend()` outside an active step throws.
+- `workflow.suspend()` inside `parallel` fails with `ParallelSuspensionError`; move human-in-the-loop waits before or after the parallel block.
+- Actions receive an `AbortSignal` and should observe it so cancelled parallel losers can stop promptly.
 - Timeouts/retries in `AbstractAction.run()` wrap the full action execution; if non-zero timeout is used, suspended wall time counts toward that timeout.
 - `Workflow.run(...)` suspended errors are not exported as a public class; treat them structurally (`stepId`, `reason`, `data`) or use `WorkflowRunner` for explicit status objects.
 
@@ -277,6 +284,6 @@ Relevant tests:
 - `src/step-executors/task-executor.test.ts`
   - in-flight action resume behavior
 - `src/__tests__/suspension-rebuilder.test.ts`
-  - path parsing and continuation rebuild for task/parallel/loop
+  - path parsing and continuation rebuild for task/loop, plus rejection of parallel suspension paths
 - `src/__tests__/workflow.test.ts`
   - `Workflow.run()` suspension throw shape

--- a/packages/agentic/src/__tests__/suspension-rebuilder.test.ts
+++ b/packages/agentic/src/__tests__/suspension-rebuilder.test.ts
@@ -18,7 +18,6 @@ import {
   shouldStopLoop,
   updateAccumulator,
 } from '../step-executors/loop-executor';
-import { executeParallel as runParallelExecutor } from '../step-executors/parallel-executor';
 import type { StepExecutorEnv } from '../step-executors/types';
 import {
   parseSuspendedStepId,
@@ -40,11 +39,6 @@ jest.mock('../step-executors/loop-executor', () => ({
   shouldStopLoop: jest.fn(),
 }));
 
-jest.mock('../step-executors/parallel-executor', () => ({
-  __esModule: true,
-  executeParallel: jest.fn(),
-}));
-
 const mockedRunLoopExecutor = runLoopExecutor as jest.MockedFunction<
   typeof runLoopExecutor
 >;
@@ -53,9 +47,6 @@ const mockedUpdateAccumulator = updateAccumulator as jest.MockedFunction<
 >;
 const mockedShouldStopLoop = shouldStopLoop as jest.MockedFunction<
   typeof shouldStopLoop
->;
-const mockedRunParallelExecutor = runParallelExecutor as jest.MockedFunction<
-  typeof runParallelExecutor
 >;
 
 class TestContext extends BaseWorkflowContext {
@@ -268,7 +259,7 @@ describe('rebuildSuspension', () => {
     expect(deps.executeFlow).toHaveBeenCalledWith(compiled.flow, state, [], 1);
   });
 
-  it('rebuilds a parallel suspension and continues remaining siblings when needed', async () => {
+  it('does not rebuild suspensions inside parallel blocks', () => {
     const firstTask = createTask('child_a');
     const secondTask = createTask('child_b');
     const childA: CompiledStep = {
@@ -308,39 +299,9 @@ describe('rebuildSuspension', () => {
       state,
       stepId: '0.parallel.1:child_b',
     });
-    const nextSuspension = {
-      step: {
-        id: '0.parallel.2:child_c',
-        name: 'child_c',
-        type: StepType.Task,
-      },
-      continue: jest.fn().mockResolvedValue(undefined),
-    };
-    mockedRunParallelExecutor.mockResolvedValue(nextSuspension);
 
-    const result = await suspension?.continue({ payload: true });
-
-    expect(deps.captureTaskOutput).toHaveBeenCalledWith(secondTask, state, {
-      payload: true,
-    });
-    expect(mockedRunParallelExecutor).toHaveBeenCalledWith(
-      expect.anything(),
-      parallelStep,
-      state,
-      [0],
-      2,
-    );
-    expect(result?.step.id).toBe(nextSuspension.step.id);
-
-    await result?.continue({ done: true });
-
-    expect(nextSuspension.continue).toHaveBeenCalledWith({ done: true });
-    expect(deps.executeFlow).toHaveBeenLastCalledWith(
-      compiled.flow,
-      state,
-      [],
-      1,
-    );
+    expect(suspension).toBeNull();
+    expect(deps.captureTaskOutput).not.toHaveBeenCalled();
   });
 
   it('resumes a loop suspension, updating accumulators and continuing execution', async () => {

--- a/packages/agentic/src/__tests__/workflow-runner.test.ts
+++ b/packages/agentic/src/__tests__/workflow-runner.test.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { defineAction } from '../action/action';
 import { BaseWorkflowContext } from '../context';
 import type { Settings, WorkflowDefinition } from '../dsl.types';
+import { ParallelSuspensionError } from '../errors';
 import { compileWorkflow } from '../workflow-compiler';
 import {
   StepType,
@@ -298,6 +299,7 @@ describe('WorkflowRunner', () => {
     });
     const runner = new WorkflowRunner(compiled, { runId: 'run-1' });
     const context = new TestContext({});
+    context.eventEmitter = emitter;
     const result = await runner.start({
       inputData: { items: [10, 20] },
       context,
@@ -313,15 +315,13 @@ describe('WorkflowRunner', () => {
     }
 
     expect(firstExecute).toHaveBeenCalledTimes(1);
-    expect(secondExecute).not.toHaveBeenCalled();
+    expect(secondExecute).toHaveBeenCalledTimes(1);
     expect(echoExecute).toHaveBeenCalledTimes(3);
-    expect(
-      eventLog.filter((entry) => entry.includes('second_task')),
-    ).toHaveLength(0);
+    expect(eventLog).toContain('start:second_task');
     expect(runner.getSnapshot().status).toBe('finished');
     const snapshots = runner.getSnapshot().actions;
     expect(snapshots['0.parallel.0:first_task']?.status).toBe('completed');
-    expect(snapshots['0.parallel.1:second_task']?.status).toBe('skipped');
+    expect(snapshots['0.parallel.1:second_task']?.status).toBe('cancelled');
     expect(snapshots['1.branch.0.0:branch_task']?.status).toBe('completed');
     expect(snapshots['1.branch.1.0:second_task']?.status).toBe('skipped');
   });
@@ -739,6 +739,59 @@ describe('WorkflowRunner', () => {
     }
 
     expect(() => context.workflow).toThrow();
+  });
+
+  it('fails when a parallel branch attempts to suspend', async () => {
+    const suspendAction = defineAction<
+      unknown,
+      { reply: string },
+      TestContext,
+      Settings
+    >({
+      name: 'parallel_suspend_action',
+      inputSchema: z.any(),
+      outputSchema: z.object({ reply: z.string() }),
+      execute: async ({ context }) => {
+        await context.workflow.suspend({ reason: 'not_allowed' });
+
+        return { reply: 'unreachable' };
+      },
+    });
+    const definition: WorkflowDefinition = {
+      defs: createTaskDefs({
+        wait_step: { action: 'parallel_suspend_action' },
+      }),
+      flow: [
+        {
+          parallel: {
+            strategy: 'wait_all',
+            steps: [{ do: 'wait_step' }],
+          },
+        },
+      ],
+      outputs: { reply: '=$output.wait_step.reply' },
+    };
+    const compiled = compileWorkflow(definition, {
+      actions: { parallel_suspend_action: suspendAction },
+    });
+    const runner = new WorkflowRunner(compiled, {
+      runId: 'run-parallel-suspend',
+    });
+    const result = await runner.start({
+      inputData: {},
+      context: new TestContext({}),
+    });
+
+    expect(result.status).toBe('failed');
+    if (result.status === 'failed') {
+      expect(result.error).toBeInstanceOf(ParallelSuspensionError);
+    }
+    expect(
+      runner.getSnapshot().actions['0.parallel.0:wait_step'],
+    ).toMatchObject({
+      status: 'failed',
+      reason: 'workflow.suspend() is not supported inside a parallel block.',
+    });
   });
 
   it('accepts emitter-like implementations without Node EventEmitter', async () => {

--- a/packages/agentic/src/action/__tests__/action.test.ts
+++ b/packages/agentic/src/action/__tests__/action.test.ts
@@ -189,6 +189,7 @@ class FlakyDoubleAction extends DoubleAction {
     context,
     settings,
     bindings,
+    signal,
   }: ActionExecutionArgs<
     z.infer<typeof InputSchema>,
     DoubleContext,
@@ -199,7 +200,7 @@ class FlakyDoubleAction extends DoubleAction {
       throw new Error('Intermittent failure');
     }
 
-    return super.execute({ input, context, settings, bindings });
+    return super.execute({ input, context, settings, bindings, signal });
   }
 }
 

--- a/packages/agentic/src/action/abstract-action.ts
+++ b/packages/agentic/src/action/abstract-action.ts
@@ -8,6 +8,7 @@ import { z, ZodType } from 'zod';
 
 import { BaseWorkflowContext } from '../context';
 import { BaseSettingsSchema } from '../dsl.types';
+import { throwIfAborted } from '../errors';
 import { assertSnakeCaseName } from '../utils/naming';
 import { sleep, withTimeout } from '../utils/timeout';
 
@@ -112,6 +113,7 @@ export abstract class AbstractAction<
     context: C,
     settings?: Partial<RuntimeSettings<S>>,
     bindings?: B,
+    signal?: AbortSignal,
   ): Promise<O> {
     const input = this.parseInput(payload);
     const parsedSettings = this.parseSettings(settings);
@@ -136,6 +138,10 @@ export abstract class AbstractAction<
     const multiplier = retrySettings.multiplier;
 
     while (attempt < maxAttempts) {
+      if (signal) {
+        throwIfAborted(signal);
+      }
+
       try {
         const result = await withTimeout(
           this.execute({
@@ -143,8 +149,10 @@ export abstract class AbstractAction<
             context,
             settings: parsedSettings,
             bindings: parsedBindings,
+            signal: signal ?? new AbortController().signal,
           }),
           timeoutMs,
+          signal,
         );
 
         return this.parseOutput(result);
@@ -166,7 +174,7 @@ export abstract class AbstractAction<
           const jitteredDelay = Math.max(0, Math.round(delay * jitterFactor));
 
           if (jitteredDelay > 0) {
-            await sleep(jitteredDelay);
+            await sleep(jitteredDelay, signal);
           }
         }
 

--- a/packages/agentic/src/action/action.types.ts
+++ b/packages/agentic/src/action/action.types.ts
@@ -34,6 +34,7 @@ export interface ActionExecutionArgs<
   context: C;
   settings: RuntimeSettings<S>;
   bindings: B;
+  signal: AbortSignal;
 }
 
 export interface Action<
@@ -59,6 +60,7 @@ export interface Action<
     context: C,
     settings?: Partial<RuntimeSettings<S>>,
     bindings?: B,
+    signal?: AbortSignal,
   ): Promise<O>;
 }
 

--- a/packages/agentic/src/context.ts
+++ b/packages/agentic/src/context.ts
@@ -42,6 +42,7 @@ export const WORKFLOW_RUN_STATUSES: WorkflowRunStatus[] = [
  * - suspended: action paused via `workflow.suspend`; resumes to completed.
  * - completed: action resolved (either immediately or after resume).
  * - failed: action threw an error.
+ * - cancelled: action was aborted by the workflow scheduler.
  * - skipped: control flow bypassed the step (e.g., alternate branch or wait_any short-circuit).
  */
 export type ActionStatus =
@@ -50,6 +51,7 @@ export type ActionStatus =
   | 'suspended'
   | 'completed'
   | 'failed'
+  | 'cancelled'
   | 'skipped';
 
 export interface SuspensionOptions {

--- a/packages/agentic/src/errors.ts
+++ b/packages/agentic/src/errors.ts
@@ -1,0 +1,43 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+export class WorkflowCancellationError extends Error {
+  constructor(message = 'Workflow execution was cancelled.') {
+    super(message);
+    this.name = 'WorkflowCancellationError';
+  }
+}
+
+export class ParallelSuspensionError extends Error {
+  constructor() {
+    super('workflow.suspend() is not supported inside a parallel block.');
+    this.name = 'ParallelSuspensionError';
+  }
+}
+
+export const isWorkflowCancellationError = (
+  error: unknown,
+): error is WorkflowCancellationError =>
+  error instanceof WorkflowCancellationError ||
+  (error instanceof Error && error.name === 'WorkflowCancellationError');
+
+export const getAbortReason = (signal: AbortSignal): Error => {
+  if (signal.reason instanceof Error) {
+    return signal.reason;
+  }
+
+  if (signal.reason !== undefined) {
+    return new WorkflowCancellationError(String(signal.reason));
+  }
+
+  return new WorkflowCancellationError();
+};
+
+export const throwIfAborted = (signal: AbortSignal): void => {
+  if (signal.aborted) {
+    throw getAbortReason(signal);
+  }
+};

--- a/packages/agentic/src/index.ts
+++ b/packages/agentic/src/index.ts
@@ -92,6 +92,8 @@ export type {
 
 export { NonDeterministicWorkflowError } from './runner-runtime-control';
 
+export { ParallelSuspensionError, WorkflowCancellationError } from './errors';
+
 export {
   compileValue,
   evaluateMapping,

--- a/packages/agentic/src/step-executors/conditional-executor.test.ts
+++ b/packages/agentic/src/step-executors/conditional-executor.test.ts
@@ -48,10 +48,10 @@ const createEnv = (): StepExecutorEnv => {
     outputMapping: {},
     inputParser: { parse: (value: unknown) => value } as any,
   } as any;
-
-  return {
+  const env = {
     compiled,
     context: new TestContext(),
+    signal: new AbortController().signal,
     runId: 'run-1',
     buildInstanceStepInfo: jest.fn(),
     markSnapshot: jest.fn(),
@@ -68,7 +68,12 @@ const createEnv = (): StepExecutorEnv => {
     captureTaskOutput: jest.fn(),
     executeFlow: jest.fn(),
     executeStep: jest.fn(),
-  };
+    fork: jest.fn(),
+  } as StepExecutorEnv;
+
+  env.fork = jest.fn((overrides) => ({ ...env, ...overrides }));
+
+  return env;
 };
 
 describe('executeConditional', () => {

--- a/packages/agentic/src/step-executors/loop-executor.test.ts
+++ b/packages/agentic/src/step-executors/loop-executor.test.ts
@@ -47,10 +47,10 @@ const createEnv = (executeFlow: jest.Mock): StepExecutorEnv => {
     outputMapping: {},
     inputParser: { parse: (value: unknown) => value } as any,
   } as any;
-
-  return {
+  const env = {
     compiled,
     context: new TestContext(),
+    signal: new AbortController().signal,
     runId: 'run-loop',
     buildInstanceStepInfo: jest.fn(),
     markSnapshot: jest.fn(),
@@ -67,7 +67,12 @@ const createEnv = (executeFlow: jest.Mock): StepExecutorEnv => {
     captureTaskOutput: jest.fn(),
     executeFlow,
     executeStep: jest.fn(),
-  };
+    fork: jest.fn(),
+  } as StepExecutorEnv;
+
+  env.fork = jest.fn((overrides) => ({ ...env, ...overrides }));
+
+  return env;
 };
 const createTaskStep = (id: string): CompiledStep => ({
   id,

--- a/packages/agentic/src/step-executors/parallel-executor.test.ts
+++ b/packages/agentic/src/step-executors/parallel-executor.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { BaseWorkflowContext } from '../context';
+import { ParallelSuspensionError } from '../errors';
 import type { RuntimeSuspensionRequest } from '../runner-runtime-control';
 import {
   StepType,
@@ -48,12 +49,14 @@ const createEnv = (): StepExecutorEnv => {
     outputMapping: {},
     inputParser: { parse: (value: unknown) => value } as any,
   } as any;
-
-  return {
+  const env = {
     compiled,
     context: new TestContext(),
+    signal: new AbortController().signal,
     runId: 'run-1',
-    buildInstanceStepInfo: jest.fn(),
+    buildInstanceStepInfo: jest.fn((step: CompiledStep): StepInfo => {
+      return { id: step.id, name: step.label, type: step.type };
+    }),
     markSnapshot: jest.fn(),
     recordStepExecution: jest.fn(),
     emit: jest.fn(),
@@ -68,115 +71,221 @@ const createEnv = (): StepExecutorEnv => {
     captureTaskOutput: jest.fn(),
     executeFlow: jest.fn(),
     executeStep: jest.fn(),
-  };
+    fork: jest.fn(),
+  } as StepExecutorEnv;
+
+  env.fork = jest.fn((overrides) => {
+    const forked = { ...env, ...overrides } as StepExecutorEnv;
+
+    forked.executeStep = jest.fn((step, state, path) =>
+      (env.executeStep as jest.Mock)(step, state, path, forked.signal),
+    );
+    forked.executeFlow = jest.fn((steps, state, path, startIndex) =>
+      (env.executeFlow as jest.Mock)(
+        steps,
+        state,
+        path,
+        startIndex,
+        forked.signal,
+      ),
+    );
+
+    return forked;
+  });
+
+  return env;
+};
+const createStep = (strategy: ParallelStep['strategy']): ParallelStep => ({
+  id: 'parallel',
+  type: StepType.Parallel,
+  label: 'parallel',
+  strategy,
+  steps: [createChild('a'), createChild('b')],
+});
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
 };
 
 describe('executeParallel', () => {
-  it('executes all children when using wait_all', async () => {
+  it('starts all children before waiting when using wait_all', async () => {
     const env = createEnv();
     const state = createState();
-    const step: ParallelStep = {
-      id: 'parallel',
-      type: StepType.Parallel,
-      label: 'parallel',
-      strategy: 'wait_all',
-      steps: [createChild('a'), createChild('b')],
-    };
-    env.executeStep = jest.fn().mockResolvedValue(undefined);
+    const step = createStep('wait_all');
+    const started: string[] = [];
+    const resolvers: Array<() => void> = [];
 
-    const result = await executeParallel(env, step, state, [0]);
+    env.executeStep = jest.fn((child: CompiledStep) => {
+      started.push(child.id);
 
-    expect(result).toBeUndefined();
+      return new Promise<void>((resolve) => {
+        resolvers.push(resolve);
+      });
+    });
+
+    const resultPromise = executeParallel(env, step, state, [0]);
+    await flushPromises();
+
+    expect(started).toEqual(['a', 'b']);
     expect(env.executeStep).toHaveBeenCalledTimes(2);
-    expect(env.executeStep).toHaveBeenNthCalledWith(1, step.steps[0], state, [
-      0,
-      'parallel',
-      0,
-    ]);
-    expect(env.executeStep).toHaveBeenNthCalledWith(2, step.steps[1], state, [
-      0,
-      'parallel',
-      1,
-    ]);
+
+    resolvers.forEach((resolve) => resolve());
+    await expect(resultPromise).resolves.toBeUndefined();
   });
 
-  it('short-circuits on first completion when using wait_any', async () => {
+  it('merges wait_all output deltas in child-index order', async () => {
     const env = createEnv();
     const state = createState();
-    const step: ParallelStep = {
-      id: 'parallel',
-      type: StepType.Parallel,
-      label: 'parallel',
-      strategy: 'wait_any',
-      steps: [createChild('a'), createChild('b')],
-    };
-    env.executeStep = jest.fn().mockResolvedValue(undefined);
+    const step = createStep('wait_all');
 
-    const result = await executeParallel(env, step, state, []);
-
-    expect(result).toBeUndefined();
-    expect(env.executeStep).toHaveBeenCalledTimes(1);
-    expect(env.executeStep).toHaveBeenCalledWith(step.steps[0], state, [
-      'parallel',
-      0,
-    ]);
-  });
-
-  it('continues remaining steps after resuming from suspension (wait_all)', async () => {
-    const env = createEnv();
-    const state = createState();
-    const innerSuspension: Suspension = {
-      step: { id: 'a', name: 'a', type: StepType.Task } as StepInfo,
-      continue: jest.fn().mockResolvedValue(undefined),
-    };
-    const step: ParallelStep = {
-      id: 'parallel',
-      type: StepType.Parallel,
-      label: 'parallel',
-      strategy: 'wait_all',
-      steps: [createChild('a'), createChild('b')],
-    };
-    env.executeStep = jest
-      .fn()
-      .mockResolvedValueOnce(innerSuspension)
-      .mockResolvedValueOnce(undefined);
-
-    const suspension = await executeParallel(env, step, state, []);
-    expect(suspension).toEqual(
-      expect.objectContaining({ step: innerSuspension.step }),
+    state.output.existing = 'keep';
+    env.executeStep = jest.fn(
+      async (child: CompiledStep, branchState: ExecutionState) => {
+        branchState.output.shared = child.id;
+        branchState.output[`${child.id}_only`] = true;
+      },
     );
 
-    const result = await suspension?.continue('resume-data');
-    expect(result).toBeUndefined();
-    expect(innerSuspension.continue).toHaveBeenCalledWith('resume-data');
-    expect(env.executeStep).toHaveBeenCalledTimes(2);
-    expect(env.executeStep).toHaveBeenLastCalledWith(step.steps[1], state, [
-      'parallel',
-      1,
-    ]);
+    await executeParallel(env, step, state, []);
+
+    expect(state.output).toEqual({
+      existing: 'keep',
+      shared: 'b',
+      a_only: true,
+      b_only: true,
+    });
   });
 
-  it('stops after resuming a suspended child when using wait_any', async () => {
+  it('fails wait_all fast and aborts unfinished siblings', async () => {
     const env = createEnv();
     const state = createState();
+    const step = createStep('wait_all');
+    const failure = new Error('branch failed');
+
+    env.executeStep = jest.fn(
+      (
+        child: CompiledStep,
+        _branchState: ExecutionState,
+        _path: Array<number | string>,
+        signal?: AbortSignal,
+      ) => {
+        if (child.id === 'a') {
+          return Promise.reject(failure);
+        }
+
+        return new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        });
+      },
+    );
+
+    await expect(executeParallel(env, step, state, [])).rejects.toThrow(
+      'branch failed',
+    );
+    expect(env.markSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'b' }),
+      'cancelled',
+      'branch failed',
+    );
+  });
+
+  it('wait_any starts every child, keeps only the winner output, and cancels losers', async () => {
+    const env = createEnv();
+    const state = createState();
+    const step = createStep('wait_any');
+    const started: string[] = [];
+
+    env.executeStep = jest.fn(
+      async (
+        child: CompiledStep,
+        branchState: ExecutionState,
+        _path: Array<number | string>,
+        signal?: AbortSignal,
+      ) => {
+        started.push(child.id);
+        if (child.id === 'b') {
+          branchState.output.winner = child.id;
+
+          return undefined;
+        }
+
+        return new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        });
+      },
+    );
+
+    await executeParallel(env, step, state, []);
+
+    expect(started).toEqual(['a', 'b']);
+    expect(state.output).toEqual({ winner: 'b' });
+    expect(env.markSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'a' }),
+      'cancelled',
+      'Parallel wait_any winner selected.',
+    );
+  });
+
+  it('wait_any fails fast before any successful winner', async () => {
+    const env = createEnv();
+    const state = createState();
+    const step = createStep('wait_any');
+
+    env.executeStep = jest.fn(
+      (
+        child: CompiledStep,
+        branchState: ExecutionState,
+        _path: Array<number | string>,
+        signal?: AbortSignal,
+      ) => {
+        if (child.id === 'a') {
+          return Promise.reject(new Error('no winner'));
+        }
+
+        branchState.output.loser = true;
+
+        return new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        });
+      },
+    );
+
+    await expect(executeParallel(env, step, state, [])).rejects.toThrow(
+      'no winner',
+    );
+    expect(state.output).toEqual({});
+    expect(env.markSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'b' }),
+      'cancelled',
+      'no winner',
+    );
+  });
+
+  it('rejects suspensions returned by children', async () => {
+    const env = createEnv();
+    const state = createState();
+    const step = createStep('wait_all');
     const innerSuspension: Suspension = {
       step: { id: 'a', name: 'a', type: StepType.Task } as StepInfo,
       continue: jest.fn().mockResolvedValue(undefined),
     };
-    const step: ParallelStep = {
-      id: 'parallel',
-      type: StepType.Parallel,
-      label: 'parallel',
-      strategy: 'wait_any',
-      steps: [createChild('a'), createChild('b')],
-    };
-    env.executeStep = jest.fn().mockResolvedValueOnce(innerSuspension);
 
-    const suspension = await executeParallel(env, step, state, []);
-    const result = await suspension?.continue('resume-data');
+    env.executeStep = jest.fn((child: CompiledStep) => {
+      if (child.id === 'a') {
+        return Promise.resolve(innerSuspension);
+      }
 
-    expect(result).toBeUndefined();
-    expect(innerSuspension.continue).toHaveBeenCalledWith('resume-data');
-    expect(env.executeStep).toHaveBeenCalledTimes(1);
+      return Promise.resolve(undefined);
+    });
+
+    await expect(executeParallel(env, step, state, [])).rejects.toBeInstanceOf(
+      ParallelSuspensionError,
+    );
   });
 });

--- a/packages/agentic/src/step-executors/parallel-executor.ts
+++ b/packages/agentic/src/step-executors/parallel-executor.ts
@@ -4,67 +4,435 @@
  * Full terms: see LICENSE.md.
  */
 
+import type { BaseWorkflowContext, WorkflowRuntimeControl } from '../context';
+import {
+  getAbortReason,
+  ParallelSuspensionError,
+  throwIfAborted,
+  WorkflowCancellationError,
+} from '../errors';
 import type {
+  CompiledStep,
   ExecutionState,
   ParallelStep,
   Suspension,
 } from '../workflow-types';
 
-import { markStepsSkipped } from './skip-helpers';
-import { wrapSuspensionContinuation } from './suspension-continuation';
+import { markStepsCancelled } from './skip-helpers';
 import type { StepExecutorEnv } from './types';
 
+type BranchResult =
+  | { status: 'fulfilled'; index: number; outputDelta: Record<string, unknown> }
+  | { status: 'failed'; index: number; error: unknown }
+  | { status: 'cancelled'; index: number; error: Error };
+
+type BranchHandle = {
+  index: number;
+  step: CompiledStep;
+  iterationStack: number[];
+  controller: AbortController;
+  promise: Promise<BranchResult>;
+};
+
+type TrackedOutput = {
+  output: Record<string, unknown>;
+  getDelta: () => Record<string, unknown>;
+};
+
 /**
- * Execute a set of steps in parallel order, respecting the configured strategy.
+ * Execute a set of child steps concurrently and resolve according to the configured strategy.
  *
  * @param env Executor environment providing helpers and workflow context.
  * @param step The parallel step definition including strategy and children.
  * @param state Mutable workflow execution state.
  * @param path Path tokens locating this parallel block in the workflow.
- * @param startIndex Index to resume execution from when continuing.
- * @returns A suspension if a child pauses execution, otherwise void.
+ * @returns Always undefined; suspensions are rejected inside parallel blocks.
  */
 export async function executeParallel(
   env: StepExecutorEnv,
   step: ParallelStep,
   state: ExecutionState,
   path: Array<number | string>,
-  startIndex = 0,
 ): Promise<Suspension | void> {
-  for (let index = startIndex; index < step.steps.length; index += 1) {
-    const child = step.steps[index];
-    const childPath = [...path, 'parallel', index];
-    const suspension = await env.executeStep(child, state, childPath);
-    if (suspension) {
-      return wrapSuspensionContinuation(suspension, async () => {
-        if (step.strategy === 'wait_any') {
-          if (index + 1 < step.steps.length) {
-            markStepsSkipped(
-              env,
-              step.steps.slice(index + 1),
-              state.iterationStack,
-            );
-          }
+  if (step.steps.length === 0) {
+    return undefined;
+  }
 
-          return undefined;
-        }
+  throwIfAborted(env.signal);
 
-        return executeParallel(env, step, state, path, index + 1);
-      });
-    }
+  const baseOutput = cloneRecord(state.output);
+  const baseContextState = cloneRecord(env.context.state);
+  const branches = step.steps.map((child, index) =>
+    launchBranch({
+      env,
+      child,
+      index,
+      path,
+      parentState: state,
+      baseOutput,
+      baseContextState,
+    }),
+  );
 
-    if (step.strategy === 'wait_any') {
-      if (index + 1 < step.steps.length) {
-        markStepsSkipped(
-          env,
-          step.steps.slice(index + 1),
-          state.iterationStack,
-        );
-      }
+  if (step.strategy === 'wait_any') {
+    return executeWaitAny(env, branches, state);
+  }
 
-      return undefined;
+  return executeWaitAll(env, branches, state);
+}
+
+async function executeWaitAll(
+  env: StepExecutorEnv,
+  branches: BranchHandle[],
+  state: ExecutionState,
+): Promise<void> {
+  const pending = new Set(branches);
+  const outcomes = new Map<number, BranchResult>();
+
+  while (pending.size > 0) {
+    const { branch, result } = await raceNext(pending);
+    pending.delete(branch);
+    outcomes.set(result.index, result);
+
+    if (result.status === 'failed' || result.status === 'cancelled') {
+      cancelBranches(
+        env,
+        pending,
+        result.error,
+        'Parallel branch execution was cancelled.',
+      );
+      await settleBranches(branches);
+      throw result.error;
     }
   }
 
-  return undefined;
+  mergeBranchOutputs(state, outcomes);
+}
+
+async function executeWaitAny(
+  env: StepExecutorEnv,
+  branches: BranchHandle[],
+  state: ExecutionState,
+): Promise<void> {
+  const pending = new Set(branches);
+  const outcomes = new Map<number, BranchResult>();
+
+  while (pending.size > 0) {
+    const { branch, result } = await raceNext(pending);
+    pending.delete(branch);
+    outcomes.set(result.index, result);
+
+    if (result.status === 'fulfilled') {
+      cancelBranches(
+        env,
+        pending,
+        new WorkflowCancellationError('Parallel wait_any winner selected.'),
+        'Parallel wait_any branch lost the race.',
+      );
+      await settleBranches(branches);
+      mergeBranchOutputs(state, new Map([[result.index, result]]));
+
+      return;
+    }
+
+    cancelBranches(
+      env,
+      pending,
+      result.error,
+      'Parallel branch execution was cancelled.',
+    );
+    await settleBranches(branches);
+    throw result.error;
+  }
+}
+
+function launchBranch({
+  env,
+  child,
+  index,
+  path,
+  parentState,
+  baseOutput,
+  baseContextState,
+}: {
+  env: StepExecutorEnv;
+  child: CompiledStep;
+  index: number;
+  path: Array<number | string>;
+  parentState: ExecutionState;
+  baseOutput: Record<string, unknown>;
+  baseContextState: Record<string, unknown>;
+}): BranchHandle {
+  const controller = createBranchController(env.signal);
+  const trackedOutput = createTrackedOutput(baseOutput);
+  const branchState: ExecutionState = {
+    input: parentState.input,
+    output: trackedOutput.output,
+    iteration: parentState.iteration ? { ...parentState.iteration } : undefined,
+    accumulator: cloneValue(parentState.accumulator),
+    iterationStack: [...parentState.iterationStack],
+  };
+  const branchContext = createParallelBranchContext(
+    env.context,
+    cloneRecord(baseContextState),
+  );
+  const branchEnv = env.fork({
+    context: branchContext,
+    signal: controller.signal,
+    setCurrentStep: () => undefined,
+  });
+  const childPath = [...path, 'parallel', index];
+  const promise = runBranch(
+    branchEnv,
+    child,
+    branchState,
+    childPath,
+    trackedOutput,
+    index,
+  );
+
+  return {
+    index,
+    step: child,
+    iterationStack: [...parentState.iterationStack],
+    controller,
+    promise,
+  };
+}
+
+async function runBranch(
+  env: StepExecutorEnv,
+  child: CompiledStep,
+  branchState: ExecutionState,
+  childPath: Array<number | string>,
+  trackedOutput: TrackedOutput,
+  index: number,
+): Promise<BranchResult> {
+  try {
+    throwIfAborted(env.signal);
+
+    const suspension = await env.executeStep(child, branchState, childPath);
+    if (suspension) {
+      throw new ParallelSuspensionError();
+    }
+
+    throwIfAborted(env.signal);
+
+    return {
+      status: 'fulfilled',
+      index,
+      outputDelta: trackedOutput.getDelta(),
+    };
+  } catch (error) {
+    if (env.signal.aborted) {
+      return { status: 'cancelled', index, error: getAbortReason(env.signal) };
+    }
+
+    return { status: 'failed', index, error };
+  }
+}
+
+async function raceNext(
+  pending: Set<BranchHandle>,
+): Promise<{ branch: BranchHandle; result: BranchResult }> {
+  return Promise.race(
+    [...pending].map((branch) =>
+      branch.promise.then((result) => ({ branch, result })),
+    ),
+  );
+}
+
+async function settleBranches(branches: BranchHandle[]): Promise<void> {
+  await Promise.all(branches.map((branch) => branch.promise.catch(() => null)));
+}
+
+function cancelBranches(
+  env: StepExecutorEnv,
+  branches: Iterable<BranchHandle>,
+  reason: unknown,
+  snapshotReason: string,
+): void {
+  for (const branch of branches) {
+    if (!branch.controller.signal.aborted) {
+      branch.controller.abort(
+        reason instanceof Error
+          ? reason
+          : new WorkflowCancellationError(String(reason)),
+      );
+    }
+
+    markStepsCancelled(
+      env,
+      [branch.step],
+      branch.iterationStack,
+      reason instanceof Error ? reason.message : snapshotReason,
+    );
+  }
+}
+
+function mergeBranchOutputs(
+  state: ExecutionState,
+  outcomes: Map<number, BranchResult>,
+): void {
+  const ordered = [...outcomes.values()].sort((left, right) => {
+    return left.index - right.index;
+  });
+
+  for (const outcome of ordered) {
+    if (outcome.status !== 'fulfilled') {
+      continue;
+    }
+
+    Object.assign(state.output, outcome.outputDelta);
+  }
+}
+
+function createBranchController(parentSignal: AbortSignal): AbortController {
+  const controller = new AbortController();
+
+  if (parentSignal.aborted) {
+    controller.abort(getAbortReason(parentSignal));
+
+    return controller;
+  }
+
+  parentSignal.addEventListener(
+    'abort',
+    () => controller.abort(getAbortReason(parentSignal)),
+    { once: true },
+  );
+
+  return controller;
+}
+
+function createTrackedOutput(
+  baseOutput: Record<string, unknown>,
+): TrackedOutput {
+  const writtenKeys = new Set<string>();
+  const target = cloneRecord(baseOutput);
+  const output = new Proxy(target, {
+    set(record, property, value) {
+      if (typeof property === 'string') {
+        writtenKeys.add(property);
+      }
+
+      return Reflect.set(record, property, value);
+    },
+    deleteProperty(record, property) {
+      if (typeof property === 'string') {
+        writtenKeys.add(property);
+      }
+
+      return Reflect.deleteProperty(record, property);
+    },
+  });
+
+  return {
+    output,
+    getDelta: () =>
+      Object.fromEntries(
+        [...writtenKeys]
+          .filter((key) => Object.prototype.hasOwnProperty.call(target, key))
+          .map((key) => [key, target[key]]),
+      ),
+  };
+}
+
+class ParallelWorkflowRuntimeControl implements WorkflowRuntimeControl {
+  constructor(private readonly getParent: () => WorkflowRuntimeControl) {}
+
+  get status() {
+    return this.getParent().status;
+  }
+
+  get resumeData() {
+    return this.getParent().resumeData;
+  }
+
+  suspend<T = unknown>(): Promise<T> {
+    return Promise.reject(new ParallelSuspensionError());
+  }
+
+  resume(data?: unknown): void {
+    this.getParent().resume(data);
+  }
+
+  getSnapshot() {
+    return this.getParent().getSnapshot();
+  }
+}
+
+function createParallelBranchContext(
+  context: BaseWorkflowContext,
+  branchState: Record<string, unknown>,
+): BaseWorkflowContext {
+  let state = branchState;
+  const workflow = new ParallelWorkflowRuntimeControl(() => context.workflow);
+
+  return new Proxy(context, {
+    get(target, property, receiver) {
+      if (property === 'state') {
+        return state;
+      }
+
+      if (property === 'workflow') {
+        return workflow;
+      }
+
+      if (property === 'snapshot') {
+        return () => cloneRecord(state);
+      }
+
+      if (property === 'attachWorkflowRuntime') {
+        return () => undefined;
+      }
+
+      return Reflect.get(target, property, receiver);
+    },
+    set(target, property, value, receiver) {
+      if (property === 'state') {
+        state = isRecord(value) ? value : {};
+
+        return true;
+      }
+
+      return Reflect.set(target, property, value, receiver);
+    },
+  });
+}
+
+function cloneRecord(value: Record<string, unknown>): Record<string, unknown> {
+  return cloneValue(value) as Record<string, unknown>;
+}
+
+function cloneValue<T>(value: T): T {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(value);
+    } catch {
+      // Fall through to JSON clone below.
+    }
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch {
+    if (Array.isArray(value)) {
+      return [...value] as T;
+    }
+
+    if (isRecord(value)) {
+      return { ...value } as T;
+    }
+
+    return value;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/agentic/src/step-executors/skip-helpers.ts
+++ b/packages/agentic/src/step-executors/skip-helpers.ts
@@ -57,6 +57,38 @@ const markStepSkipped = (
       break;
   }
 };
+const markStepCancelled = (
+  env: SkipStepEnv,
+  step: CompiledStep,
+  iterationStack: number[],
+  reason?: string,
+) => {
+  const stepInfo = env.buildInstanceStepInfo(step, iterationStack);
+  env.markSnapshot(stepInfo, 'cancelled', reason);
+  env.emit('hook:step:cancelled', {
+    runId: env.runId,
+    step: stepInfo,
+    error: new Error(reason ?? 'Step execution was cancelled.'),
+  });
+
+  switch (step.type) {
+    case StepType.Parallel:
+      step.steps.forEach((child) =>
+        markStepCancelled(env, child, iterationStack, reason),
+      );
+      break;
+    case StepType.Conditional:
+      step.branches.forEach((branch) =>
+        branch.steps.forEach((child) =>
+          markStepCancelled(env, child, iterationStack, reason),
+        ),
+      );
+      break;
+    case StepType.Loop:
+    case StepType.Task:
+      break;
+  }
+};
 
 export const markStepsSkipped = (
   env: SkipStepEnv,
@@ -65,4 +97,13 @@ export const markStepsSkipped = (
   reason?: string,
 ) => {
   steps.forEach((step) => markStepSkipped(env, step, iterationStack, reason));
+};
+
+export const markStepsCancelled = (
+  env: SkipStepEnv,
+  steps: CompiledStep[],
+  iterationStack: number[],
+  reason?: string,
+) => {
+  steps.forEach((step) => markStepCancelled(env, step, iterationStack, reason));
 };

--- a/packages/agentic/src/step-executors/task-executor.test.ts
+++ b/packages/agentic/src/step-executors/task-executor.test.ts
@@ -74,10 +74,10 @@ const createEnv = (
   stepInfo: StepInfo,
 ): StepExecutorEnv => {
   const stepRecords: Record<string, StepExecutionRecord> = {};
-
-  return {
+  const env = {
     compiled,
     context: new TestContext(),
+    signal: new AbortController().signal,
     runId: 'run-123',
     buildInstanceStepInfo: jest.fn().mockReturnValue(stepInfo),
     markSnapshot: jest.fn(),
@@ -118,7 +118,12 @@ const createEnv = (
     captureTaskOutput: jest.fn().mockResolvedValue(undefined),
     executeFlow: jest.fn(),
     executeStep: jest.fn(),
-  };
+    fork: jest.fn(),
+  } as StepExecutorEnv;
+
+  env.fork = jest.fn((overrides) => ({ ...env, ...overrides }));
+
+  return env;
 };
 const step: TaskStep = {
   id: '0:test_task',
@@ -150,6 +155,7 @@ describe('executeTaskStep', () => {
       env.context,
       task.settings,
       task.bindings,
+      env.signal,
     );
     expect(env.setCurrentStep).toHaveBeenNthCalledWith(1, stepInfo);
     expect(env.markSnapshot).toHaveBeenNthCalledWith(1, stepInfo, 'running');

--- a/packages/agentic/src/step-executors/task-executor.ts
+++ b/packages/agentic/src/step-executors/task-executor.ts
@@ -4,6 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
+import { getAbortReason, throwIfAborted } from '../errors';
 import type { RuntimeSuspensionRequest } from '../runner-runtime-control';
 import type {
   CompiledTask,
@@ -19,6 +20,7 @@ import type { StepExecutorEnv } from './types';
 type TaskProgressOutcome =
   | { type: 'completed'; value: unknown }
   | { type: 'failed'; error: unknown }
+  | { type: 'cancelled'; error: Error }
   | { type: 'suspended'; request: RuntimeSuspensionRequest };
 
 /**
@@ -43,6 +45,12 @@ export async function executeTaskStep(
   }
 
   const stepInfo = env.buildInstanceStepInfo(step, state.iterationStack);
+  if (env.signal.aborted) {
+    const error = getAbortReason(env.signal);
+    recordTaskCancellation(env, stepInfo, error);
+    throw error;
+  }
+
   const scope: EvaluationScope = {
     input: state.input,
     context: env.context.state,
@@ -51,6 +59,12 @@ export async function executeTaskStep(
     accumulator: state.accumulator,
   };
   const inputs = await evaluateMapping(task.inputs, scope);
+  if (env.signal.aborted) {
+    const error = getAbortReason(env.signal);
+    recordTaskCancellation(env, stepInfo, error);
+    throw error;
+  }
+
   const stepExecution = env.recordStepExecution(stepInfo, {
     action: task.actionName,
     status: 'running',
@@ -68,8 +82,16 @@ export async function executeTaskStep(
   });
 
   try {
+    throwIfAborted(env.signal);
+
     const actionPromise = Promise.resolve().then(() =>
-      task.action.run(inputs, env.context, task.settings, task.bindings),
+      task.action.run(
+        inputs,
+        env.context,
+        task.settings,
+        task.bindings,
+        env.signal,
+      ),
     );
     const outcome = await waitForTaskProgress(env, stepInfo.id, actionPromise);
 
@@ -89,6 +111,12 @@ export async function executeTaskStep(
     if (outcome.type === 'failed') {
       env.clearStepSuspensions(stepInfo.id, outcome.error);
       recordTaskFailure(env, stepInfo, outcome.error);
+      throw outcome.error;
+    }
+
+    if (outcome.type === 'cancelled') {
+      env.clearStepSuspensions(stepInfo.id, outcome.error);
+      recordTaskCancellation(env, stepInfo, outcome.error);
       throw outcome.error;
     }
 
@@ -118,8 +146,29 @@ const waitForTaskProgress = async (
   const suspension = env
     .waitForStepSuspension(stepId)
     .then<TaskProgressOutcome>((request) => ({ type: 'suspended', request }));
+  let cleanupCancellation = () => undefined;
+  const cancellation = new Promise<TaskProgressOutcome>((resolve) => {
+    if (env.signal.aborted) {
+      resolve({ type: 'cancelled', error: getAbortReason(env.signal) });
 
-  return Promise.race([completion, suspension]);
+      return;
+    }
+
+    const onAbort = () => {
+      resolve({ type: 'cancelled', error: getAbortReason(env.signal) });
+    };
+
+    env.signal.addEventListener('abort', onAbort, { once: true });
+    cleanupCancellation = () => {
+      env.signal.removeEventListener('abort', onAbort);
+    };
+  });
+
+  try {
+    return await Promise.race([completion, suspension, cancellation]);
+  } finally {
+    cleanupCancellation();
+  }
 };
 const completeTask = async (
   env: StepExecutorEnv,
@@ -249,6 +298,26 @@ const recordTaskFailure = (
   });
   env.markSnapshot(stepInfo, 'failed', normalizeErrorMessage(error));
   env.emit('hook:step:error', {
+    runId: env.runId,
+    step: stepInfo,
+    stepExecution,
+    error,
+  });
+};
+const recordTaskCancellation = (
+  env: StepExecutorEnv,
+  stepInfo: Suspension['step'],
+  error: unknown,
+) => {
+  const normalizedError = normalizeError(error);
+  const stepExecution = env.recordStepExecution(stepInfo, {
+    status: 'cancelled',
+    endedAt: Date.now(),
+    error: normalizedError,
+    context: { after: env.context.snapshot() },
+  });
+  env.markSnapshot(stepInfo, 'cancelled', normalizeErrorMessage(error));
+  env.emit('hook:step:cancelled', {
     runId: env.runId,
     step: stepInfo,
     stepExecution,

--- a/packages/agentic/src/step-executors/types.ts
+++ b/packages/agentic/src/step-executors/types.ts
@@ -23,9 +23,21 @@ import type {
   Suspension,
 } from '../workflow-types';
 
+export type StepExecutorEnvForkOverrides = {
+  context?: BaseWorkflowContext;
+  signal?: AbortSignal;
+  setCurrentStep?: (step?: StepInfo) => void;
+  captureTaskOutput?: (
+    task: CompiledTask,
+    state: ExecutionState,
+    result: unknown,
+  ) => Promise<void>;
+};
+
 export type StepExecutorEnv = {
   compiled: CompiledWorkflow;
   context: BaseWorkflowContext;
+  signal: AbortSignal;
   runId?: string;
   buildInstanceStepInfo: (
     step: CompiledStep,
@@ -67,4 +79,5 @@ export type StepExecutorEnv = {
     state: ExecutionState,
     path: Array<number | string>,
   ) => Promise<Suspension | void>;
+  fork: (overrides: StepExecutorEnvForkOverrides) => StepExecutorEnv;
 };

--- a/packages/agentic/src/suspension-rebuilder.ts
+++ b/packages/agentic/src/suspension-rebuilder.ts
@@ -10,8 +10,6 @@ import {
   shouldStopLoop,
   updateAccumulator,
 } from './step-executors/loop-executor';
-import { executeParallel as runParallelExecutor } from './step-executors/parallel-executor';
-import { markStepsSkipped } from './step-executors/skip-helpers';
 import { wrapSuspensionContinuation } from './step-executors/suspension-continuation';
 import type { StepExecutorEnv } from './step-executors/types';
 import {
@@ -295,57 +293,7 @@ export function buildSuspensionForPath(
   }
 
   if (step.type === StepType.Parallel) {
-    if (rest[0] !== 'parallel') {
-      return null;
-    }
-
-    const childPath = rest.slice(1);
-    const childSuspension = buildSuspensionForPath(
-      deps,
-      step.steps,
-      state,
-      childPath,
-      [...currentPath, 'parallel'],
-      iterationDepth,
-      suspensionMetadata,
-    );
-
-    if (!childSuspension) {
-      return null;
-    }
-
-    const childIndex =
-      typeof childPath[0] === 'number' ? (childPath[0] as number) : 0;
-
-    return wrapSuspensionContinuation(childSuspension, async () => {
-      if (step.strategy === 'wait_any') {
-        if (childIndex + 1 < step.steps.length) {
-          markStepsSkipped(
-            env,
-            step.steps.slice(childIndex + 1),
-            state.iterationStack ?? [],
-          );
-        }
-
-        return deps.executeFlow(steps, state, pathPrefix, current + 1);
-      }
-
-      const next = await runParallelExecutor(
-        env,
-        step,
-        state,
-        currentPath,
-        childIndex + 1,
-      );
-
-      if (next) {
-        return wrapSuspensionContinuation(next, () =>
-          deps.executeFlow(steps, state, pathPrefix, current + 1),
-        );
-      }
-
-      return deps.executeFlow(steps, state, pathPrefix, current + 1);
-    });
+    return null;
   }
 
   if (step.type === StepType.Conditional) {

--- a/packages/agentic/src/utils/timeout.ts
+++ b/packages/agentic/src/utils/timeout.ts
@@ -4,43 +4,113 @@
  * Full terms: see LICENSE.md.
  */
 
+import { getAbortReason, throwIfAborted } from '../errors';
+
 /**
  * Resolves after the specified duration; useful for retry delays.
  *
  * @param durationMs - Number of milliseconds to wait before resolving.
+ * @param signal - Optional signal used to cancel the wait.
  * @returns A promise that resolves once the duration elapses.
  */
-export const sleep = (durationMs: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, durationMs));
+export const sleep = (
+  durationMs: number,
+  signal?: AbortSignal,
+): Promise<void> => {
+  if (!signal) {
+    return new Promise((resolve) => setTimeout(resolve, durationMs));
+  }
+
+  throwIfAborted(signal);
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, durationMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(getAbortReason(signal));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+};
 
 /**
  * Wraps a promise and rejects if it does not settle within the timeout.
  *
  * @param promise - Operation that may take longer than the allowed timeout.
  * @param timeoutMs - Maximum time in milliseconds to wait before rejecting.
+ * @param signal - Optional signal used to cancel the operation.
  * @returns The result of the original promise when it resolves in time.
  * @throws Error when the timeout is exceeded.
  */
 export async function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs?: number,
+  signal?: AbortSignal,
 ): Promise<T> {
-  if (!timeoutMs) {
+  if (!timeoutMs && !signal) {
     return promise;
   }
 
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error(`Step execution exceeded timeout of ${timeoutMs}ms`));
-    }, timeoutMs);
+    let settled = false;
+    const timer = timeoutMs
+      ? setTimeout(() => {
+          settled = true;
+          signal?.removeEventListener('abort', onAbort);
+          reject(
+            new Error(`Step execution exceeded timeout of ${timeoutMs}ms`),
+          );
+        }, timeoutMs)
+      : undefined;
+    const onAbort = () => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      reject(getAbortReason(signal as AbortSignal));
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+
+        return;
+      }
+
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
 
     promise.then(
       (value) => {
-        clearTimeout(timer);
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+        }
+        signal?.removeEventListener('abort', onAbort);
         resolve(value);
       },
       (error) => {
-        clearTimeout(timer);
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+        }
+        signal?.removeEventListener('abort', onAbort);
         reject(error);
       },
     );

--- a/packages/agentic/src/workflow-event-emitter.ts
+++ b/packages/agentic/src/workflow-event-emitter.ts
@@ -38,6 +38,7 @@ export type WorkflowEventMap = {
   'hook:step:start': StepWorkflowEventPayload;
   'hook:step:success': StepWorkflowEventPayload;
   'hook:step:error': StepWorkflowEventPayload & { error: unknown };
+  'hook:step:cancelled': StepWorkflowEventPayload & { error: unknown };
   'hook:step:suspended': StepWorkflowEventPayload & {
     reason?: string;
     data?: unknown;

--- a/packages/agentic/src/workflow-runner.ts
+++ b/packages/agentic/src/workflow-runner.ts
@@ -13,13 +13,17 @@ import {
   type WorkflowRunStatus,
   type WorkflowSnapshot,
 } from './context';
+import { throwIfAborted } from './errors';
 import { RunnerRuntimeControl } from './runner-runtime-control';
 import { executeConditional as runConditionalExecutor } from './step-executors/conditional-executor';
 import { executeLoop as runLoopExecutor } from './step-executors/loop-executor';
 import { executeParallel as runParallelExecutor } from './step-executors/parallel-executor';
 import { wrapSuspensionContinuation } from './step-executors/suspension-continuation';
 import { executeTaskStep as runTaskExecutor } from './step-executors/task-executor';
-import type { StepExecutorEnv } from './step-executors/types';
+import type {
+  StepExecutorEnv,
+  StepExecutorEnvForkOverrides,
+} from './step-executors/types';
 import {
   rebuildSuspension,
   type SuspensionRebuilderDeps,
@@ -190,8 +194,10 @@ export class WorkflowRunner {
       throw new Error('Workflow state not initialized.');
     }
 
+    const env = this.createExecutorEnv();
+
     return this.runExecution(() =>
-      this.executeFlow(this.compiled.flow, state, []),
+      this.executeFlow(this.compiled.flow, state, [], 0, env),
     );
   }
 
@@ -462,14 +468,28 @@ export class WorkflowRunner {
    * @returns A step executor environment bound to this runner.
    * @throws When the workflow context is missing.
    */
-  private createExecutorEnv(): StepExecutorEnv {
-    if (!this.context) {
+  private createExecutorEnv(
+    overrides: StepExecutorEnvForkOverrides = {},
+  ): StepExecutorEnv {
+    const context = overrides.context ?? this.context;
+    if (!context) {
       throw new Error('Workflow context is not attached.');
     }
 
-    return {
+    const signal = overrides.signal ?? new AbortController().signal;
+    const setCurrentStep =
+      overrides.setCurrentStep ??
+      ((step?: StepInfo) => {
+        this.currentStep = step;
+      });
+    const captureTaskOutput =
+      overrides.captureTaskOutput ??
+      ((task: CompiledTask, state: ExecutionState, result: unknown) =>
+        this.captureTaskOutput(task, state, result));
+    const executorEnv: StepExecutorEnv = {
       compiled: this.compiled,
-      context: this.context,
+      context,
+      signal,
       runId: this.runId,
       buildInstanceStepInfo: (step, iterationStack) =>
         this.buildInstanceStepInfo(step, iterationStack),
@@ -478,9 +498,7 @@ export class WorkflowRunner {
       recordStepExecution: (step, update) =>
         this.recordStepExecution(step, update),
       emit: (event, payload) => this.emit(event, payload),
-      setCurrentStep: (step?: StepInfo) => {
-        this.currentStep = step;
-      },
+      setCurrentStep,
       beginStepExecution: (stepId) => {
         if (!this.runtimeControl) {
           return `${stepId}#1`;
@@ -507,12 +525,22 @@ export class WorkflowRunner {
       recordStepSuspendResult: (params) => {
         this.runtimeControl?.recordStepSuspendResult(params);
       },
-      captureTaskOutput: (task, state, result) =>
-        this.captureTaskOutput(task, state, result),
+      captureTaskOutput,
       executeFlow: (steps, state, path, startIndex) =>
-        this.executeFlow(steps, state, path, startIndex),
-      executeStep: (step, state, path) => this.executeStep(step, state, path),
+        this.executeFlow(steps, state, path, startIndex, executorEnv),
+      executeStep: (step, state, path) =>
+        this.executeStep(step, state, path, executorEnv),
+      fork: (forkOverrides) =>
+        this.createExecutorEnv({
+          context: forkOverrides.context ?? context,
+          signal: forkOverrides.signal ?? signal,
+          setCurrentStep: forkOverrides.setCurrentStep ?? setCurrentStep,
+          captureTaskOutput:
+            forkOverrides.captureTaskOutput ?? captureTaskOutput,
+        }),
     };
+
+    return executorEnv;
   }
 
   /**
@@ -552,16 +580,19 @@ export class WorkflowRunner {
     state: ExecutionState,
     path: Array<number | string>,
     startIndex = 0,
+    env = this.createExecutorEnv(),
   ): Promise<Suspension | void> {
     // Walk the flow sequentially; if a step suspends, wrap its continuation so we resume at the same index.
     for (let index = startIndex; index < steps.length; index += 1) {
+      throwIfAborted(env.signal);
+
       const step = steps[index];
       const stepPath = [...path, index];
-      const suspension = await this.executeStep(step, state, stepPath);
+      const suspension = await this.executeStep(step, state, stepPath, env);
 
       if (suspension) {
         return wrapSuspensionContinuation(suspension, () =>
-          this.executeFlow(steps, state, path, index + 1),
+          this.executeFlow(steps, state, path, index + 1, env),
         );
       }
     }
@@ -581,8 +612,10 @@ export class WorkflowRunner {
     step: CompiledStep,
     state: ExecutionState,
     path: Array<number | string>,
+    env = this.createExecutorEnv(),
   ): Promise<Suspension | void> {
-    const env = this.createExecutorEnv();
+    throwIfAborted(env.signal);
+
     switch (step.type) {
       case StepType.Task:
         return runTaskExecutor(env, step, state, path);

--- a/packages/api/src/actions/types.ts
+++ b/packages/api/src/actions/types.ts
@@ -56,8 +56,9 @@ export type ActionRegistry<
   A extends Action<unknown, unknown, BaseWorkflowContext, unknown> = AnyAction,
 > = Map<ActionName, A>;
 
-export type ExecArgs<
-  I,
-  C extends BaseWorkflowContext,
-  S = unknown,
-> = ActionExecutionArgs<I, C, S, RuntimeBindings>;
+export type ExecArgs<I, C extends BaseWorkflowContext, S = unknown> = Omit<
+  ActionExecutionArgs<I, C, S, RuntimeBindings>,
+  'signal'
+> & {
+  signal?: AbortSignal;
+};

--- a/packages/api/src/extensions/actions/ai/agent.action.ts
+++ b/packages/api/src/extensions/actions/ai/agent.action.ts
@@ -47,6 +47,7 @@ export class AiAgentAction extends AiBaseAction<
     settings,
     context,
     bindings,
+    signal,
   }: ExecArgs<AiAgentInput, WorkflowRuntimeContext, AiAgentSettings>) {
     const logger = context.services.logger;
     const modelBinding = bindings.model;
@@ -77,6 +78,7 @@ export class AiAgentAction extends AiBaseAction<
       bindings.tools,
       bindings.mcp,
       selectedMemorySlugs,
+      signal,
     )) as ToolSet | undefined;
     const toolNames = [
       ...Object.keys(bindings.tools ?? {}),
@@ -115,7 +117,10 @@ export class AiAgentAction extends AiBaseAction<
       throw new Error('Prompt is required to call the agent.');
     }
 
-    const result = await agent.generate({ prompt: agentPrompt });
+    const result = await agent.generate({
+      prompt: agentPrompt,
+      abortSignal: signal,
+    });
 
     return {
       text: result.text,

--- a/packages/api/src/extensions/actions/ai/ai-base.action.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.ts
@@ -656,6 +656,7 @@ export abstract class AiBaseAction<
     toolBindings?: RuntimeBindings['tools'],
     mcpToolBindings?: RuntimeBindings['mcp'],
     selectedMemorySlugs: string[] = [],
+    signal?: AbortSignal,
   ): Promise<ToolSet | undefined> {
     const actionService = context.services.actions;
     const logger = context.services.logger;
@@ -691,15 +692,36 @@ export abstract class AiBaseAction<
           description: action.description,
           inputSchema: action.inputSchema,
           outputSchema: action.outputSchema,
-          execute: async (input) =>
-            nestedBindings
+          execute: async (input, options) => {
+            const toolSignal = options?.abortSignal ?? signal;
+
+            if (nestedBindings) {
+              return toolSignal
+                ? action.run(
+                    input,
+                    context,
+                    toolDefinition.settings as any,
+                    nestedBindings as RuntimeBindings,
+                    toolSignal,
+                  )
+                : action.run(
+                    input,
+                    context,
+                    toolDefinition.settings as any,
+                    nestedBindings as RuntimeBindings,
+                  );
+            }
+
+            return toolSignal
               ? action.run(
                   input,
                   context,
                   toolDefinition.settings as any,
-                  nestedBindings as RuntimeBindings,
+                  undefined,
+                  toolSignal,
                 )
-              : action.run(input, context, toolDefinition.settings as any),
+              : action.run(input, context, toolDefinition.settings as any);
+          },
         } as ToolSet[string];
       }
     }
@@ -746,7 +768,19 @@ export abstract class AiBaseAction<
           description: updateMemoryAction.description,
           inputSchema: memorySchema,
           outputSchema: memorySchema,
-          execute: async (input) => updateMemoryAction.run(input, context),
+          execute: async (input, options) => {
+            const toolSignal = options?.abortSignal ?? signal;
+
+            return toolSignal
+              ? updateMemoryAction.run(
+                  input,
+                  context,
+                  undefined,
+                  undefined,
+                  toolSignal,
+                )
+              : updateMemoryAction.run(input, context);
+          },
         } as ToolSet[string];
       }
     }

--- a/packages/api/src/extensions/actions/ai/generate-object.base.action.ts
+++ b/packages/api/src/extensions/actions/ai/generate-object.base.action.ts
@@ -35,6 +35,7 @@ export abstract class AiGenerateObjectBaseAction<
     settings,
     context,
     bindings,
+    signal,
   }: ExecArgs<I, C, AiGenerateObjectSettings>) {
     const logger = context.services.logger;
     const modelBinding = bindings.model;
@@ -68,6 +69,7 @@ export abstract class AiGenerateObjectBaseAction<
       bindings.tools,
       bindings.mcp,
       selectedMemorySlugs,
+      signal,
     )) as ToolSet | undefined;
     const toolNames = [
       ...Object.keys(bindings.tools ?? {}),
@@ -101,6 +103,7 @@ export abstract class AiGenerateObjectBaseAction<
       ...callSettingsWithoutStops,
       model,
       output,
+      abortSignal: signal,
       ...(tools ? { tools } : {}),
       ...(stopWhen ? { stopWhen } : {}),
     });

--- a/packages/api/src/extensions/actions/ai/generate-text.base.action.ts
+++ b/packages/api/src/extensions/actions/ai/generate-text.base.action.ts
@@ -31,6 +31,7 @@ export abstract class AiGenerateTextBaseAction<
     settings,
     context,
     bindings,
+    signal,
   }: ExecArgs<I, C, AiGenerateTextSettings>) {
     const logger = context.services.logger;
     const modelBinding = bindings.model;
@@ -61,6 +62,7 @@ export abstract class AiGenerateTextBaseAction<
       bindings.tools,
       bindings.mcp,
       selectedMemorySlugs,
+      signal,
     )) as ToolSet | undefined;
     const toolNames = [
       ...Object.keys(bindings.tools ?? {}),
@@ -86,6 +88,7 @@ export abstract class AiGenerateTextBaseAction<
       ...promptPayload,
       ...callSettings,
       model,
+      abortSignal: signal,
       ...(tools ? { tools } : {}),
       ...(stopWhen ? { stopWhen } : {}),
     });

--- a/packages/api/src/extensions/actions/web/http-request.action.ts
+++ b/packages/api/src/extensions/actions/web/http-request.action.ts
@@ -136,6 +136,17 @@ function resolveFinalUrl(response: {
   return response.request?.res?.responseUrl ?? response.request?.responseUrl;
 }
 
+function isAxiosCancellation(error: unknown) {
+  if (typeof axios.isCancel === 'function' && axios.isCancel(error)) {
+    return true;
+  }
+
+  return (
+    error instanceof Error &&
+    (error as Error & { code?: string }).code === 'ERR_CANCELED'
+  );
+}
+
 function parseRequestBody(
   body: string,
 ): string | Record<string, unknown> | unknown[] {
@@ -171,7 +182,7 @@ export const HttpRequestAction = createAction<
   inputSchema: httpRequestInputSchema,
   outputSchema: httpRequestOutputSchema,
   settingsSchema: httpRequestSettingsSchema,
-  async execute({ input, context, settings }) {
+  async execute({ input, context, settings, signal }) {
     const logger = context.services.logger;
     const timeoutMs = settings.timeout_ms ?? 10000;
     const method = settings.method ?? 'GET';
@@ -192,6 +203,7 @@ export const HttpRequestAction = createAction<
         method,
         headers,
         timeout: timeoutMs,
+        signal,
         validateStatus: () => true,
         ...(requestData !== undefined ? { data: requestData } : {}),
       });
@@ -240,6 +252,10 @@ export const HttpRequestAction = createAction<
         truncated: false,
       };
     } catch (error) {
+      if (signal?.aborted || isAxiosCancellation(error)) {
+        throw error;
+      }
+
       const message =
         error instanceof Error ? error.message : 'Unknown network error';
 

--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -360,6 +360,48 @@ describe('WorkflowService (TypeORM)', () => {
       },
     );
 
+    it('broadcasts cancelled step events', async () => {
+      const targetWorkflow = await createWorkflowForType(WorkflowType.manual);
+      const run = await createWorkflowRun(targetWorkflow);
+      const step = {
+        id: '0:slow_branch',
+        name: 'slow_branch',
+        type: StepType.Task,
+      };
+      const error = new Error('Parallel wait_any branch lost the race.');
+      const stepExecution: StepExecutionRecord = {
+        ...step,
+        action: 'slow_branch',
+        status: 'cancelled',
+        endedAt: 1700000000000,
+        error: { message: error.message },
+      };
+
+      await workflowService.sendWorkflowStepCancelled({
+        runId: run.id,
+        step,
+        stepExecution,
+        error,
+      });
+
+      expect(gatewayMock.broadcastWorkflowEvent).toHaveBeenCalledTimes(1);
+      expect(gatewayMock.broadcastWorkflowEvent).toHaveBeenCalledWith({
+        runId: run.id,
+        step,
+        stepExecution,
+        error,
+        t: expect.any(Number),
+        workflowRun: expect.objectContaining({
+          id: run.id,
+          workflow: targetWorkflow.id,
+        }),
+        workflowId: targetWorkflow.id,
+        initiatorId: creatorId,
+        threadId: 'thread-1',
+        workflowEvent: 'step:cancelled',
+      });
+    });
+
     it('does not broadcast when the workflow event has no run id', async () => {
       await workflowService.sendWorkflowStart({});
 

--- a/packages/api/src/workflow/services/workflow.service.ts
+++ b/packages/api/src/workflow/services/workflow.service.ts
@@ -289,4 +289,11 @@ export class WorkflowService extends BaseOrmService<WorkflowOrmEntity> {
   ) {
     await this.sendWorkflowEvent('hook:step:error', payload);
   }
+
+  @OnEvent('hook:step:cancelled')
+  async sendWorkflowStepCancelled(
+    payload: WorkflowEventMap[keyof WorkflowEventMap],
+  ) {
+    await this.sendWorkflowEvent('hook:step:cancelled', payload);
+  }
 }

--- a/packages/api/types/event-emitter.d.ts
+++ b/packages/api/types/event-emitter.d.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { StepInfo } from '@hexabot-ai/agentic';
+import type { StepExecutionRecord, StepInfo } from '@hexabot-ai/agentic';
 import type { HttpException } from '@nestjs/common';
 import type { OnEventType } from '@nestjs/event-emitter';
 import type { OnEventOptions } from '@nestjs/event-emitter/dist/interfaces';
@@ -135,6 +135,12 @@ type HookEventPayload<
 
 type HookWildcardPayload<Entity> = [OrmLifecycleEvent<Entity>];
 
+type StepWorkflowEventPayload = {
+  runId?: string;
+  step: StepInfo;
+  stepExecution?: StepExecutionRecord;
+};
+
 declare module '@nestjs/event-emitter' {
   interface IHookSettingsGroupLabelOperationMap
     extends DefaultHookSettingsMap {}
@@ -239,11 +245,12 @@ declare module '@nestjs/event-emitter' {
     'hook:workflow:suspended': [
       { runId?: string; step: StepInfo; reason?: string; data?: unknown },
     ];
-    'hook:step:start': [{ runId?: string; step: StepInfo }];
-    'hook:step:success': [{ runId?: string; step: StepInfo }];
-    'hook:step:error': [{ runId?: string; step: StepInfo; error: unknown }];
+    'hook:step:start': [StepWorkflowEventPayload];
+    'hook:step:success': [StepWorkflowEventPayload];
+    'hook:step:error': [StepWorkflowEventPayload & { error: unknown }];
+    'hook:step:cancelled': [StepWorkflowEventPayload & { error: unknown }];
     'hook:step:suspended': [
-      { runId?: string; step: StepInfo; reason?: string; data?: unknown },
+      StepWorkflowEventPayload & { reason?: string; data?: unknown },
     ];
     'hook:step:skipped': [{ runId?: string; step: StepInfo; reason?: string }];
   }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -570,6 +570,7 @@
       "status_failed": "Failed",
       "status_skipped": "Skipped",
       "status_suspended": "Suspended",
+      "status_cancelled": "Cancelled",
       "status_pending": "Pending",
       "type_llm": "LLM",
       "type_http": "HTTP",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -571,6 +571,7 @@
       "status_failed": "Échouée",
       "status_skipped": "Ignorée",
       "status_suspended": "Suspendue",
+      "status_cancelled": "Annulée",
       "status_pending": "En attente",
       "type_llm": "LLM",
       "type_http": "HTTP",

--- a/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
+++ b/packages/frontend/src/components/visual-editor/v4/types/workflow.types.ts
@@ -98,4 +98,5 @@ export type NodeExecutionState =
   | "start"
   | "finish"
   | "suspended"
+  | "cancelled"
   | "error";

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-execution-events.utils.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-execution-events.utils.test.ts
@@ -43,6 +43,11 @@ const stepSuccessEvent: SubscribeWorkflowProps = {
   workflowEvent: "step:success",
   t: 120,
 };
+const stepCancelledEvent: SubscribeWorkflowProps = {
+  ...stepStartEvent,
+  workflowEvent: "step:cancelled",
+  t: 125,
+};
 const loopStepStartEvent: SubscribeWorkflowProps = {
   ...stepStartEvent,
   t: 130,
@@ -106,6 +111,23 @@ describe("workflow-execution-events.utils", () => {
         key: "0:send_message",
         state: "finish",
         delayMs: STEP_SUCCESS_FINISH_DELAY_MS,
+      },
+    ]);
+  });
+
+  it("maps step cancellation to a cancelled state", () => {
+    expect(mapWorkflowEventToExecutionActions(stepCancelledEvent)).toEqual([
+      {
+        type: "append",
+        key: EIndicatorType.WORKFLOW_START,
+        state: "finish",
+        delayMs: START_INDICATOR_FINISH_DELAY_MS,
+      },
+      {
+        type: "append",
+        key: "0:send_message",
+        state: "cancelled",
+        t: 125,
       },
     ]);
   });

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-execution-events.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-execution-events.utils.ts
@@ -151,5 +151,14 @@ export const mapWorkflowEventToExecutionActions = (
     });
   }
 
+  if (event.workflowEvent === "step:cancelled") {
+    stepActions.push({
+      type: "append",
+      key: stepExecutionKey,
+      state: "cancelled",
+      t: event.t,
+    });
+  }
+
   return stepActions;
 };

--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/inspector-panel/InspectorTabs.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/inspector-panel/InspectorTabs.tsx
@@ -151,6 +151,7 @@ export const InspectorTabs = ({ run, step }: InspectorTabsProps) => {
       failed: t("label.step_trace.status_failed"),
       skipped: t("label.step_trace.status_skipped"),
       suspended: t("label.step_trace.status_suspended"),
+      cancelled: t("label.step_trace.status_cancelled"),
       pending: t("label.step_trace.status_pending"),
     }),
     [t],

--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/ActionStatusIndicator.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/ActionStatusIndicator.tsx
@@ -10,6 +10,7 @@ import type { LucideIcon } from "lucide-react";
 import {
   CheckCircle2,
   Circle,
+  Ban,
   Loader2,
   PauseCircle,
   SkipForward,
@@ -59,6 +60,12 @@ const getStatusIndicator = (
         color: "warning.main",
         label: labels.suspended,
       };
+    case "cancelled":
+      return {
+        Icon: Ban,
+        color: "text.secondary",
+        label: labels.cancelled,
+      };
     default:
       return { Icon: Circle, color: "text.secondary", label: labels.pending };
   }
@@ -76,6 +83,7 @@ export const ActionStatusIndicator = ({
       failed: t("label.step_trace.status_failed"),
       skipped: t("label.step_trace.status_skipped"),
       suspended: t("label.step_trace.status_suspended"),
+      cancelled: t("label.step_trace.status_cancelled"),
       pending: t("label.step_trace.status_pending"),
     }),
     [t],

--- a/packages/frontend/src/components/workflow-run-debugger/live-workflow-run.utils.test.ts
+++ b/packages/frontend/src/components/workflow-run-debugger/live-workflow-run.utils.test.ts
@@ -156,6 +156,43 @@ describe("live workflow run utils", () => {
     );
   });
 
+  it("merges cancelled step events without marking the run terminal", () => {
+    const runningRun = buildRun({
+      status: EWorkflowRunStatus.RUNNING,
+      stepLog: {
+        "0:slow_branch": buildStepExecution({
+          id: "0:slow_branch",
+          name: "slow_branch",
+          status: "running",
+        }),
+      },
+    });
+    const updated = mergeWorkflowRunLiveEvent(
+      runningRun,
+      buildEvent({
+        workflowRun: runningRun,
+        workflowEvent: "step:cancelled",
+        t: 3200,
+        step: { id: "0:slow_branch", name: "slow_branch", type: StepType.Task },
+        stepExecution: buildStepExecution({
+          id: "0:slow_branch",
+          name: "slow_branch",
+          status: "cancelled",
+          endedAt: 3200,
+          error: { message: "Parallel wait_any branch lost the race." },
+        }),
+      }),
+    );
+
+    expect(updated?.status).toBe(EWorkflowRunStatus.RUNNING);
+    expect(updated?.stepLog?.["0:slow_branch"]).toEqual(
+      expect.objectContaining({
+        status: "cancelled",
+        error: { message: "Parallel wait_any branch lost the race." },
+      }),
+    );
+  });
+
   it("filters and touches only matching debugger workflow run collections", () => {
     const event = buildEvent({ workflowEvent: "step:start" });
 

--- a/packages/graph/src/workflow/providers/WorkflowNodeProvider.tsx
+++ b/packages/graph/src/workflow/providers/WorkflowNodeProvider.tsx
@@ -28,6 +28,8 @@ const toActionStatus = (
       return "running";
     case "suspended":
       return "suspended";
+    case "cancelled":
+      return "cancelled";
     case "error":
       return "failed";
     case "finish":

--- a/packages/graph/src/workflow/types/workflow-node.types.ts
+++ b/packages/graph/src/workflow/types/workflow-node.types.ts
@@ -52,6 +52,7 @@ export type NodeExecutionState =
   | "start"
   | "finish"
   | "suspended"
+  | "cancelled"
   | "error";
 
 export type WorkflowExecutionState = {

--- a/packages/graph/src/workflow/utils/execution-state.utils.test.ts
+++ b/packages/graph/src/workflow/utils/execution-state.utils.test.ts
@@ -76,6 +76,21 @@ describe("execution-state.utils", () => {
     ).toBe("suspended");
   });
 
+  it("prefers cancelled over completed when events share the same timestamp", () => {
+    expect(
+      resolveNodeExecutionState({
+        executionStates: {
+          "0:send_message": [
+            { state: "finish", t: 10 },
+            { state: "cancelled", t: 10 },
+          ],
+        },
+        nodeId: "node-1",
+        stepId: "0:send_message",
+      }),
+    ).toBe("cancelled");
+  });
+
   it("keeps the later equal-priority event when events share the same timestamp", () => {
     expect(
       resolveNodeExecutionState({

--- a/packages/graph/src/workflow/utils/execution-state.utils.ts
+++ b/packages/graph/src/workflow/utils/execution-state.utils.ts
@@ -21,8 +21,9 @@ const EXECUTION_STATE_PRIORITY: Record<NodeExecutionState, number> = {
   running: 1,
   start: 1,
   finish: 2,
-  suspended: 3,
-  error: 4,
+  cancelled: 3,
+  suspended: 4,
+  error: 5,
 };
 
 export const resolveNodeExecutionState = ({

--- a/packages/graph/src/workflow/utils/workflow-theme.utils.ts
+++ b/packages/graph/src/workflow/utils/workflow-theme.utils.ts
@@ -48,9 +48,11 @@ const WORKFLOW_STATE_ICONS: Partial<Record<ActionStatus, WorkflowIcon>> = {
   running: WorkflowRunningIcon,
   failed: Icons.TriangleAlert,
   suspended: Icons.SquarePause,
+  cancelled: Icons.Ban,
 };
 const WORKFLOW_STATE_COLOR_OVERRIDES: Partial<Record<ActionStatus, string>> = {
   failed: "#FF0000",
+  cancelled: "#64748B",
 };
 
 export const getWorkflowStateConfig = (


### PR DESCRIPTION
## Summary

- Implement true concurrent `parallel` execution in `@hexabot-ai/agentic`, with `wait_all`/`wait_any` cancellation and isolated branch output handling.
- Add workflow cancellation support via `AbortSignal`, `cancelled` step status, `hook:step:cancelled`, and exported cancellation/parallel suspension errors.
- Reject suspensions inside parallel branches and remove parallel suspension continuation behavior.
- Update API event forwarding, AI/HTTP action cancellation handling, frontend debugger state, graph execution state, docs, and tests.
