### PR TITLE
Feat/mcp compact payload

### DIFF
--- a/packages/api/src/mcp/README.md
+++ b/packages/api/src/mcp/README.md
@@ -13,11 +13,11 @@ Claude Code.
 
 All routes are mounted under the existing API prefix.
 
-| Route | Purpose |
-| --- | --- |
-| `/api/mcp` | Streamable HTTP MCP endpoint. |
-| `/api/mcp-token` | List and create MCP personal access tokens for the current Hexabot user. |
-| `/api/mcp-token/:id/revoke` | Revoke one MCP personal access token owned by the current Hexabot user. |
+| Route                       | Purpose                                                                  |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `/api/mcp`                  | Streamable HTTP MCP endpoint.                                            |
+| `/api/mcp-token`            | List and create MCP personal access tokens for the current Hexabot user. |
+| `/api/mcp-token/:id/revoke` | Revoke one MCP personal access token owned by the current Hexabot user.  |
 
 The MCP endpoint is stateful and uses `mcp-session-id` headers for sessions.
 
@@ -141,19 +141,20 @@ client, but the effective configuration should be equivalent to:
 
 ### Workflows
 
-| Tool | Permission | Purpose |
-| --- | --- | --- |
-| `hexabot_workflow_search` | `workflow:read` | Search workflows by metadata. |
-| `hexabot_workflow_get` | `workflow:read` | Read one workflow with populated version metadata. |
-| `hexabot_workflow_version_status` | `workflow:read` | Check current and published version pointers for one workflow. |
-| `hexabot_workflow_create` | `workflow:create` | Create a workflow and optionally commit initial YAML. |
-| `hexabot_workflow_update` | `workflow:update` | Update workflow metadata and optionally commit YAML. |
-| `hexabot_workflow_yaml_validate` | `workflow:read` | Validate workflow definition YAML without creating a version. |
-| `hexabot_workflow_yaml_commit` | `workflowversion:create` | Validate and commit workflow definition YAML. |
-| `hexabot_workflow_rollback` | `workflowversion:create` | Roll back to a previous version by creating a new restore snapshot. |
-| `hexabot_workflow_publish` | `workflow:update` | Publish the current workflow version. |
-| `hexabot_workflow_unpublish` | `workflow:update` | Clear the published workflow version. |
-| `hexabot_workflow_run` | `workflowrun:create` | Run a manual or scheduled workflow and return the run summary. |
+| Tool                              | Permission               | Purpose                                                                                      |
+| --------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------- |
+| `hexabot_workflow_search`         | `workflow:read`          | Search workflows by metadata.                                                                |
+| `hexabot_workflow_get`            | `workflow:read`          | Read one workflow with compact version metadata.                                             |
+| `hexabot_workflow_version_status` | `workflow:read`          | Check current and published version pointers for one workflow.                               |
+| `hexabot_workflow_create`         | `workflow:create`        | Create a workflow and optionally commit initial YAML.                                        |
+| `hexabot_workflow_update`         | `workflow:update`        | Update workflow metadata and optionally commit YAML.                                         |
+| `hexabot_workflow_yaml_validate`  | `workflow:read`          | Validate workflow definition YAML without creating a version.                                |
+| `hexabot_workflow_yaml_get`       | `workflowversion:read`   | Read exact workflow YAML by current workflow version or version ID with byte-range chunking. |
+| `hexabot_workflow_yaml_commit`    | `workflowversion:create` | Validate and commit workflow definition YAML.                                                |
+| `hexabot_workflow_rollback`       | `workflowversion:create` | Roll back to a previous version by creating a new restore snapshot.                          |
+| `hexabot_workflow_publish`        | `workflow:update`        | Publish the current workflow version.                                                        |
+| `hexabot_workflow_unpublish`      | `workflow:update`        | Clear the published workflow version.                                                        |
+| `hexabot_workflow_run`            | `workflowrun:create`     | Run a manual or scheduled workflow and return the run summary.                               |
 
 Workflow YAML is validated with `parseWorkflowDefinition()` before a version is
 created. Coding agents can call `hexabot_workflow_yaml_validate` first to get
@@ -164,42 +165,53 @@ explicitly supplied. `hexabot_workflow_rollback` and
 publish that snapshot with `hexabot_workflow_publish` when it should become the
 published version.
 
+Large YAML definitions are intentionally omitted from workflow and version list
+or metadata tools. Use `hexabot_workflow_yaml_get` with `workflowId` or
+`versionId` to retrieve the exact YAML. Its `offset`, `limit`, `endOffset`, and
+`nextOffset` fields use UTF-8 byte offsets; the response also includes the
+version checksum and total byte length so clients can verify reconstruction.
+
 ### Workflow versions and runs
 
-| Tool | Permission | Purpose |
-| --- | --- | --- |
-| `hexabot_workflow_version_search` | `workflowversion:read` | List YAML versions for a workflow. |
-| `hexabot_workflow_version_get` | `workflowversion:read` | Read one workflow YAML version. |
-| `hexabot_workflow_version_update` | `workflowversion:update` | Update workflow version metadata. |
-| `hexabot_workflow_version_restore` | `workflowversion:create` | Restore a previous version by creating a new snapshot. |
-| `hexabot_workflow_run_search` | `workflowrun:read` | Search workflow runs by workflow and status. |
-| `hexabot_workflow_run_get` | `workflowrun:read` | Read one workflow run with populated workflow metadata. |
-| `hexabot_workflow_run_debug` | `workflowrun:read` | Inspect one workflow run with execution state, workflow YAML, and parent/child run context for troubleshooting. |
+| Tool                               | Permission               | Purpose                                                                                         |
+| ---------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `hexabot_workflow_version_search`  | `workflowversion:read`   | List compact version metadata for a workflow.                                                   |
+| `hexabot_workflow_version_get`     | `workflowversion:read`   | Read compact version metadata.                                                                  |
+| `hexabot_workflow_version_update`  | `workflowversion:update` | Update workflow version metadata.                                                               |
+| `hexabot_workflow_version_restore` | `workflowversion:create` | Restore a previous version by creating a new snapshot.                                          |
+| `hexabot_workflow_run_search`      | `workflowrun:read`       | Search workflow runs by workflow and status.                                                    |
+| `hexabot_workflow_run_get`         | `workflowrun:read`       | Read one workflow run with populated workflow metadata but no nested YAML body.                 |
+| `hexabot_workflow_run_debug`       | `workflowrun:read`       | Inspect one workflow run with execution state and parent/child run context for troubleshooting. |
+
+Workflow run search/get responses strip nested `definitionYml` fields from
+populated workflow-version relations. `hexabot_workflow_run_debug` returns the
+executed YAML once as top-level `workflowDefinitionYml` only when
+`includeWorkflowDefinition=true`.
 
 ### Memory definitions
 
-| Tool | Permission | Purpose |
-| --- | --- | --- |
-| `hexabot_memory_definition_search` | `memorydefinition:read` | Search memory definitions. |
-| `hexabot_memory_definition_get` | `memorydefinition:read` | Read one memory definition. |
+| Tool                               | Permission                | Purpose                     |
+| ---------------------------------- | ------------------------- | --------------------------- |
+| `hexabot_memory_definition_search` | `memorydefinition:read`   | Search memory definitions.  |
+| `hexabot_memory_definition_get`    | `memorydefinition:read`   | Read one memory definition. |
 | `hexabot_memory_definition_create` | `memorydefinition:create` | Create a memory definition. |
 | `hexabot_memory_definition_update` | `memorydefinition:update` | Update a memory definition. |
 
 ### Actions and runtime bindings
 
-| Tool | Permission | Purpose |
-| --- | --- | --- |
-| `hexabot_action_search` | `workflow:read` | Search available workflow actions and schemas. |
-| `hexabot_action_get` | `workflow:read` | Read one workflow action schema. |
-| `hexabot_binding_search` | `workflow:read` | Search runtime binding kind schemas. |
-| `hexabot_binding_get` | `workflow:read` | Read one runtime binding schema. |
+| Tool                     | Permission      | Purpose                                        |
+| ------------------------ | --------------- | ---------------------------------------------- |
+| `hexabot_action_search`  | `workflow:read` | Search available workflow actions and schemas. |
+| `hexabot_action_get`     | `workflow:read` | Read one workflow action schema.               |
+| `hexabot_binding_search` | `workflow:read` | Search runtime binding kind schemas.           |
+| `hexabot_binding_get`    | `workflow:read` | Read one runtime binding schema.               |
 
 ### Credentials
 
-| Tool | Permission | Purpose |
-| --- | --- | --- |
+| Tool                        | Permission        | Purpose                                      |
+| --------------------------- | ----------------- | -------------------------------------------- |
 | `hexabot_credential_search` | `credential:read` | Search credential metadata by name or owner. |
-| `hexabot_credential_get` | `credential:read` | Read credential metadata. |
+| `hexabot_credential_get`    | `credential:read` | Read credential metadata.                    |
 
 Credential secret values are never returned. The MCP tools remove the `value`
 field from all credential responses and do not support searching by secret
@@ -207,26 +219,26 @@ value.
 
 ### MCP servers
 
-| Tool | Permission | Purpose |
-| --- | --- | --- |
-| `hexabot_mcp_server_search` | `mcpserver:read` | Search configured MCP servers. |
-| `hexabot_mcp_server_get` | `mcpserver:read` | Read one configured MCP server. |
+| Tool                        | Permission         | Purpose                             |
+| --------------------------- | ------------------ | ----------------------------------- |
+| `hexabot_mcp_server_search` | `mcpserver:read`   | Search configured MCP servers.      |
+| `hexabot_mcp_server_get`    | `mcpserver:read`   | Read one configured MCP server.     |
 | `hexabot_mcp_server_create` | `mcpserver:create` | Create an MCP server configuration. |
 | `hexabot_mcp_server_update` | `mcpserver:update` | Update an MCP server configuration. |
 
 ### CMS and RAG content
 
-| Tool | Permission | Purpose |
-| --- | --- | --- |
-| `hexabot_content_type_search` | `contenttype:read` | Search CMS content types. |
-| `hexabot_content_type_get` | `contenttype:read` | Read one content type. |
-| `hexabot_content_type_create` | `contenttype:create` | Create a content type. |
-| `hexabot_content_type_update` | `contenttype:update` | Update a content type. |
-| `hexabot_content_search` | `content:read` | Search CMS content records. |
-| `hexabot_content_get` | `content:read` | Read one content record. |
-| `hexabot_content_create` | `content:create` | Create a content record. |
-| `hexabot_content_update` | `content:update` | Update a content record. |
-| `hexabot_rag_content_search` | `content:read` | Search indexed CMS content through RAG retrieval. |
+| Tool                          | Permission           | Purpose                                           |
+| ----------------------------- | -------------------- | ------------------------------------------------- |
+| `hexabot_content_type_search` | `contenttype:read`   | Search CMS content types.                         |
+| `hexabot_content_type_get`    | `contenttype:read`   | Read one content type.                            |
+| `hexabot_content_type_create` | `contenttype:create` | Create a content type.                            |
+| `hexabot_content_type_update` | `contenttype:update` | Update a content type.                            |
+| `hexabot_content_search`      | `content:read`       | Search CMS content records.                       |
+| `hexabot_content_get`         | `content:read`       | Read one content record.                          |
+| `hexabot_content_create`      | `content:create`     | Create a content record.                          |
+| `hexabot_content_update`      | `content:update`     | Update a content record.                          |
+| `hexabot_rag_content_search`  | `content:read`       | Search indexed CMS content through RAG retrieval. |
 
 ## Extending the MCP module
 

--- a/packages/api/src/mcp/guards/hexabot-mcp-token.guard.spec.ts
+++ b/packages/api/src/mcp/guards/hexabot-mcp-token.guard.spec.ts
@@ -54,6 +54,28 @@ describe('HexabotMcpTokenGuard', () => {
     expect(request.mcpTokenId).toBe('token-id');
   });
 
+  it('accepts bearer auth scheme case-insensitively', async () => {
+    const mcpTokenService = {
+      authenticateBearerToken: jest.fn().mockResolvedValue({
+        user: activeUser,
+        tokenId: 'token-id',
+      }),
+    } as unknown as McpTokenService;
+    const moduleRef = {
+      get: jest.fn().mockReturnValue(mcpTokenService),
+    } as unknown as ModuleRef;
+    const request = {
+      headers: { authorization: 'bearer   hbt_mcp_secret' },
+    } as HexabotMcpRequest;
+    const guard = new HexabotMcpTokenGuard(moduleRef);
+
+    await expect(guard.canActivate(buildContext(request))).resolves.toBe(true);
+
+    expect(mcpTokenService.authenticateBearerToken).toHaveBeenCalledWith(
+      'hbt_mcp_secret',
+    );
+  });
+
   it('rejects requests without bearer tokens', async () => {
     const moduleRef = {
       get: jest.fn(),

--- a/packages/api/src/mcp/guards/hexabot-mcp-token.guard.ts
+++ b/packages/api/src/mcp/guards/hexabot-mcp-token.guard.ts
@@ -44,9 +44,9 @@ export class HexabotMcpTokenGuard implements CanActivate {
       return undefined;
     }
 
-    const [type, token] = authHeader.split(' ');
+    const match = authHeader.trim().match(/^Bearer\s+(\S+)$/i);
 
-    return type === 'Bearer' ? token : undefined;
+    return match?.[1];
   }
 
   private getMcpTokenService(): McpTokenService {

--- a/packages/api/src/mcp/tools/credential-mcp.tools.spec.ts
+++ b/packages/api/src/mcp/tools/credential-mcp.tools.spec.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { sanitizeCredential } from './hexabot-mcp.utils';
+import { omitKeysDeep, sanitizeCredential } from './hexabot-mcp.utils';
 
 describe('sanitizeCredential', () => {
   it('masks credential values from MCP output', () => {
@@ -17,5 +17,27 @@ describe('sanitizeCredential', () => {
 
     expect(credential).not.toHaveProperty('value');
     expect(JSON.stringify(credential)).not.toContain('secret-token');
+  });
+
+  it('omits selected keys recursively from MCP output', () => {
+    const output = omitKeysDeep(
+      {
+        id: 'run-id',
+        workflowVersion: {
+          id: 'version-id',
+          definitionYml: 'large-yaml',
+        },
+        children: [{ definitionYml: 'child-yaml', status: 'finished' }],
+      },
+      ['definitionYml'],
+    );
+
+    expect(output).toEqual({
+      id: 'run-id',
+      workflowVersion: {
+        id: 'version-id',
+      },
+      children: [{ status: 'finished' }],
+    });
   });
 });

--- a/packages/api/src/mcp/tools/hexabot-mcp.utils.ts
+++ b/packages/api/src/mcp/tools/hexabot-mcp.utils.ts
@@ -6,8 +6,24 @@
 
 export const sanitizeCredential = <T extends Record<string, unknown>>(
   credential: T,
-): T => {
+): Omit<T, 'value'> => {
   const { value: _value, ...safeCredential } = credential;
 
-  return safeCredential as T;
+  return safeCredential;
+};
+
+export const omitKeysDeep = <T>(value: T, keys: readonly string[]): T => {
+  if (Array.isArray(value)) {
+    return value.map((item) => omitKeysDeep(item, keys)) as T;
+  }
+
+  if (value === null || typeof value !== 'object' || value instanceof Date) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !keys.includes(key))
+      .map(([key, nestedValue]) => [key, omitKeysDeep(nestedValue, keys)]),
+  ) as T;
 };

--- a/packages/api/src/mcp/tools/workflow-mcp.helper.ts
+++ b/packages/api/src/mcp/tools/workflow-mcp.helper.ts
@@ -4,7 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import { type WorkflowFull, type WorkflowVersion } from '@hexabot-ai/types';
+import {
+  type WorkflowFull,
+  type WorkflowVersion,
+  type WorkflowVersionFull,
+} from '@hexabot-ai/types';
 import {
   BadRequestException,
   Injectable,
@@ -17,6 +21,8 @@ import { WorkflowVersionService } from '@/workflow/services/workflow-version.ser
 import { WorkflowService } from '@/workflow/services/workflow.service';
 import { WorkflowVersionAction } from '@/workflow/types';
 
+type WorkflowVersionLike = WorkflowVersion | WorkflowVersionFull;
+
 type WorkflowVersionSummary = Pick<
   WorkflowVersion,
   | 'id'
@@ -24,12 +30,26 @@ type WorkflowVersionSummary = Pick<
   | 'checksum'
   | 'message'
   | 'action'
-  | 'parentVersion'
-  | 'workflow'
-  | 'createdBy'
   | 'createdAt'
   | 'updatedAt'
->;
+> & {
+  parentVersion:
+    | WorkflowVersion['parentVersion']
+    | WorkflowVersionFull['parentVersion'];
+  workflow: WorkflowVersion['workflow'] | WorkflowVersionFull['workflow'];
+  createdBy: WorkflowVersion['createdBy'] | WorkflowVersionFull['createdBy'];
+  definitionYmlByteLength?: number;
+};
+
+type WorkflowSummary = Omit<
+  WorkflowFull,
+  'currentVersion' | 'publishedVersion' | 'definitionYml' | 'definition'
+> & {
+  currentVersion: WorkflowVersionSummary | null;
+  publishedVersion: WorkflowVersionSummary | null;
+  currentVersionId: string | null;
+  publishedVersionId: string | null;
+};
 
 @Injectable()
 export class HexabotWorkflowMcpHelper {
@@ -121,8 +141,30 @@ export class HexabotWorkflowMcpHelper {
     };
   }
 
-  private summarizeWorkflowVersion(
-    version: WorkflowVersion | null | undefined,
+  summarizeWorkflow(workflow: WorkflowFull): WorkflowSummary {
+    const {
+      currentVersion,
+      publishedVersion,
+      definitionYml: _definitionYml,
+      definition: _definition,
+      ...metadata
+    } = workflow;
+    const currentVersionSummary = this.summarizeWorkflowVersion(currentVersion);
+    const publishedVersionSummary =
+      this.summarizeWorkflowVersion(publishedVersion);
+
+    return {
+      ...metadata,
+      currentVersion: currentVersionSummary,
+      publishedVersion: publishedVersionSummary,
+      currentVersionId: currentVersionSummary?.id ?? null,
+      publishedVersionId: publishedVersionSummary?.id ?? null,
+    };
+  }
+
+  summarizeWorkflowVersion(
+    version: WorkflowVersionLike | null | undefined,
+    options?: { includeDefinitionYmlByteLength?: boolean },
   ): WorkflowVersionSummary | null {
     if (!version) {
       return null;
@@ -139,8 +181,7 @@ export class HexabotWorkflowMcpHelper {
       createdAt,
       updatedAt,
     } = version;
-
-    return {
+    const summary = {
       id,
       version: versionNumber,
       checksum,
@@ -151,7 +192,19 @@ export class HexabotWorkflowMcpHelper {
       createdBy,
       createdAt,
       updatedAt,
+      ...(options?.includeDefinitionYmlByteLength
+        ? {
+            definitionYmlByteLength:
+              typeof version.definitionYml === 'string'
+                ? Buffer.byteLength(version.definitionYml, 'utf8')
+                : undefined,
+          }
+        : {}),
     };
+
+    return Object.fromEntries(
+      Object.entries(summary).filter(([, value]) => value !== undefined),
+    ) as WorkflowVersionSummary;
   }
 
   private resolveRelationId(

--- a/packages/api/src/mcp/tools/workflow-mcp.tools.spec.ts
+++ b/packages/api/src/mcp/tools/workflow-mcp.tools.spec.ts
@@ -43,6 +43,68 @@ const buildWorkflowTools = (overrides: Record<string, unknown> = {}) => {
 };
 
 describe('HexabotWorkflowMcpTools', () => {
+  it('searches workflows with compact version summaries', async () => {
+    const workflow = {
+      id: 'workflow-id',
+      name: 'Support triage',
+      description: null,
+      type: WorkflowType.manual,
+      schedule: null,
+      inputSchema: {},
+      builtin: false,
+      x: 0,
+      y: 0,
+      zoom: 1,
+      direction: 'horizontal',
+      currentVersion: {
+        id: 'current-version-id',
+        version: 3,
+        definitionYml: 'defs: {}\nflow: []\noutputs: {}\n',
+        checksum: 'current-checksum',
+        message: 'Draft update',
+        action: WorkflowVersionAction.update,
+        parentVersion: null,
+        workflow: 'workflow-id',
+        createdBy: actor.id,
+        createdAt: new Date('2026-05-08T10:00:00.000Z'),
+        updatedAt: new Date('2026-05-08T10:00:00.000Z'),
+      },
+      publishedVersion: null,
+      createdBy: null,
+      createdAt: new Date('2026-05-08T09:00:00.000Z'),
+      updatedAt: new Date('2026-05-08T10:00:00.000Z'),
+    };
+    const workflowService = {
+      findAndPopulate: jest.fn().mockResolvedValue([workflow]),
+      count: jest.fn().mockResolvedValue(1),
+    };
+    const tools = buildWorkflowTools({ workflowService });
+    const result = await tools.searchWorkflows({
+      limit: 20,
+      skip: 0,
+      sortBy: 'createdAt',
+      sortDirection: 'DESC',
+    });
+
+    expect(result).toEqual({
+      items: [
+        expect.objectContaining({
+          id: 'workflow-id',
+          currentVersion: expect.objectContaining({
+            id: 'current-version-id',
+            checksum: 'current-checksum',
+          }),
+          currentVersionId: 'current-version-id',
+          publishedVersionId: null,
+        }),
+      ],
+      total: 1,
+      limit: 20,
+      skip: 0,
+    });
+    expect(result.items[0].currentVersion).not.toHaveProperty('definitionYml');
+  });
+
   it('returns current and published workflow version status without YAML payloads', async () => {
     const currentVersion = {
       id: 'current-version-id',
@@ -145,7 +207,13 @@ describe('HexabotWorkflowMcpTools', () => {
     const tools = buildWorkflowTools({ workflowService });
 
     await expect(tools.publishWorkflow({ id: 'workflow-id' })).resolves.toEqual(
-      publishedWorkflow,
+      expect.objectContaining({
+        id: 'workflow-id',
+        currentVersion: { id: 'current-version-id' },
+        publishedVersion: { id: 'current-version-id' },
+        currentVersionId: 'current-version-id',
+        publishedVersionId: 'current-version-id',
+      }),
     );
     expect(workflowService.updateOne).toHaveBeenCalledWith('workflow-id', {
       publishedVersion: 'current-version-id',
@@ -177,7 +245,15 @@ describe('HexabotWorkflowMcpTools', () => {
 
     await expect(
       tools.unpublishWorkflow({ id: 'workflow-id' }),
-    ).resolves.toEqual(unpublishedWorkflow);
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: 'workflow-id',
+        currentVersion: { id: 'current-version-id' },
+        publishedVersion: null,
+        currentVersionId: 'current-version-id',
+        publishedVersionId: null,
+      }),
+    );
     expect(workflowService.updateOne).toHaveBeenCalledWith('workflow-id', {
       publishedVersion: null,
     });

--- a/packages/api/src/mcp/tools/workflow-mcp.tools.ts
+++ b/packages/api/src/mcp/tools/workflow-mcp.tools.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Action } from '@hexabot-ai/types';
+import { Action, type WorkflowFull } from '@hexabot-ai/types';
 import {
   BadRequestException,
   Injectable,
@@ -64,21 +64,30 @@ export class HexabotWorkflowMcpTools extends HexabotMcpToolBase {
   ) {
     const where = this.buildWorkflowWhere(args);
     const options = this.findOptions<WorkflowOrmEntity>(args, where);
+    const result = await this.listWithCount(this.workflowService, options);
 
-    return await this.listWithCount(this.workflowService, options);
+    return {
+      ...result,
+      items: result.items.map((workflow) =>
+        this.workflowHelper.summarizeWorkflow(workflow as WorkflowFull),
+      ),
+    };
   }
 
   @McpPermission('workflow', Action.READ)
   @ToolGuards([McpPermissionGuard])
   @Tool({
     name: 'hexabot_workflow_get',
-    description: 'Read a Hexabot workflow with populated version metadata.',
+    description:
+      'Read a Hexabot workflow with compact version metadata, excluding YAML definition bodies.',
     parameters: z.object({
       id: uuidSchema,
     }),
   })
   async getWorkflow(args: { id: string }) {
-    return await this.workflowHelper.requireWorkflow(args.id);
+    const workflow = await this.workflowHelper.requireWorkflow(args.id);
+
+    return this.workflowHelper.summarizeWorkflow(workflow);
   }
 
   @McpPermission('workflow', Action.READ)
@@ -145,7 +154,9 @@ export class HexabotWorkflowMcpTools extends HexabotMcpToolBase {
       });
     }
 
-    return await this.workflowHelper.requireWorkflow(workflow.id);
+    return this.workflowHelper.summarizeWorkflow(
+      await this.workflowHelper.requireWorkflow(workflow.id),
+    );
   }
 
   @McpPermission('workflow', Action.UPDATE)
@@ -188,7 +199,9 @@ export class HexabotWorkflowMcpTools extends HexabotMcpToolBase {
       });
     }
 
-    return await this.workflowHelper.requireWorkflow(id);
+    return this.workflowHelper.summarizeWorkflow(
+      await this.workflowHelper.requireWorkflow(id),
+    );
   }
 
   @McpPermission('workflow', Action.UPDATE)
@@ -215,7 +228,9 @@ export class HexabotWorkflowMcpTools extends HexabotMcpToolBase {
       publishedVersion: workflow.currentVersion,
     });
 
-    return await this.workflowHelper.requireWorkflow(args.id);
+    return this.workflowHelper.summarizeWorkflow(
+      await this.workflowHelper.requireWorkflow(args.id),
+    );
   }
 
   @McpPermission('workflow', Action.UPDATE)
@@ -231,7 +246,9 @@ export class HexabotWorkflowMcpTools extends HexabotMcpToolBase {
     await this.workflowHelper.requireWorkflow(args.id);
     await this.workflowService.updateOne(args.id, { publishedVersion: null });
 
-    return await this.workflowHelper.requireWorkflow(args.id);
+    return this.workflowHelper.summarizeWorkflow(
+      await this.workflowHelper.requireWorkflow(args.id),
+    );
   }
 
   private buildWorkflowWhere(args: {

--- a/packages/api/src/mcp/tools/workflow-run-mcp.tools.spec.ts
+++ b/packages/api/src/mcp/tools/workflow-run-mcp.tools.spec.ts
@@ -186,7 +186,12 @@ describe('HexabotWorkflowRunMcpTools', () => {
         name: 'Manual workflow',
         type: WorkflowType.manual,
       },
-      workflowVersion: null,
+      workflowVersion: {
+        id: 'version-id',
+        version: 2,
+        checksum: 'checksum',
+        definitionYml: 'defs: {}\nflow: []\noutputs: {}\n',
+      },
       parentRun: null,
       stepLog: null,
       suspendedStep: 'await_reply',
@@ -208,9 +213,21 @@ describe('HexabotWorkflowRunMcpTools', () => {
     });
 
     expect(result).not.toHaveProperty('workflowDefinitionYml');
+    expect((result.run as any).workflowVersion).toEqual({
+      id: 'version-id',
+      version: 2,
+      checksum: 'checksum',
+    });
     expect(result).toEqual(
       expect.objectContaining({
-        run,
+        run: expect.objectContaining({
+          id: 'run-id',
+          workflowVersion: {
+            id: 'version-id',
+            version: 2,
+            checksum: 'checksum',
+          },
+        }),
         relatedRuns: {
           parent: null,
           children: [],

--- a/packages/api/src/mcp/tools/workflow-run-mcp.tools.spec.ts
+++ b/packages/api/src/mcp/tools/workflow-run-mcp.tools.spec.ts
@@ -75,6 +75,75 @@ describe('HexabotWorkflowRunMcpTools', () => {
     );
   });
 
+  it('searches workflow runs without nested workflow YAML definitions', async () => {
+    const run = {
+      id: 'run-id',
+      status: 'finished',
+      workflowVersion: {
+        id: 'version-id',
+        version: 3,
+        checksum: 'checksum',
+        definitionYml: 'defs: {}\nflow: []\noutputs: {}\n',
+      },
+    };
+    const workflowRunService = {
+      findAndPopulate: jest.fn().mockResolvedValue([run]),
+      count: jest.fn().mockResolvedValue(1),
+    };
+    const tools = buildWorkflowRunTools({ workflowRunService });
+    const result = await tools.searchWorkflowRuns({
+      workflowId: '11111111-1111-4111-8111-111111111111',
+      limit: 20,
+      skip: 0,
+      sortBy: 'createdAt',
+      sortDirection: 'DESC',
+    });
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: 'run-id',
+          status: 'finished',
+          workflowVersion: {
+            id: 'version-id',
+            version: 3,
+            checksum: 'checksum',
+          },
+        },
+      ],
+      total: 1,
+      limit: 20,
+      skip: 0,
+    });
+  });
+
+  it('reads a workflow run without nested workflow YAML definitions', async () => {
+    const run = {
+      id: 'run-id',
+      status: 'finished',
+      workflowVersion: {
+        id: 'version-id',
+        version: 3,
+        checksum: 'checksum',
+        definitionYml: 'defs: {}\nflow: []\noutputs: {}\n',
+      },
+    };
+    const workflowRunService = {
+      findOneAndPopulate: jest.fn().mockResolvedValue(run),
+    };
+    const tools = buildWorkflowRunTools({ workflowRunService });
+
+    await expect(tools.getWorkflowRun({ id: 'run-id' })).resolves.toEqual({
+      id: 'run-id',
+      status: 'finished',
+      workflowVersion: {
+        id: 'version-id',
+        version: 3,
+        checksum: 'checksum',
+      },
+    });
+  });
+
   it('returns workflow run debugging context with related runs and YAML', async () => {
     const run = {
       id: 'run-id',
@@ -105,8 +174,22 @@ describe('HexabotWorkflowRunMcpTools', () => {
       createdAt: '2026-05-08T10:00:00.000Z',
       updatedAt: '2026-05-08T10:00:01.000Z',
     };
-    const parentRun = { id: 'parent-run-id', status: 'suspended' };
-    const childRun = { id: 'child-run-id', status: 'finished' };
+    const parentRun = {
+      id: 'parent-run-id',
+      status: 'suspended',
+      workflowVersion: {
+        id: 'parent-version-id',
+        definitionYml: 'parent-yaml',
+      },
+    };
+    const childRun = {
+      id: 'child-run-id',
+      status: 'finished',
+      workflowVersion: {
+        id: 'child-version-id',
+        definitionYml: 'child-yaml',
+      },
+    };
     const workflowRunService = {
       findOneAndPopulate: jest.fn().mockImplementation((id: string) => {
         if (id === 'run-id') {
@@ -129,11 +212,32 @@ describe('HexabotWorkflowRunMcpTools', () => {
         childRunsLimit: 5,
       }),
     ).resolves.toEqual({
-      run,
+      run: {
+        ...run,
+        workflowVersion: {
+          id: 'version-id',
+          version: 3,
+          checksum: 'checksum',
+        },
+      },
       workflowDefinitionYml: run.workflowVersion.definitionYml,
       relatedRuns: {
-        parent: parentRun,
-        children: [childRun],
+        parent: {
+          id: 'parent-run-id',
+          status: 'suspended',
+          workflowVersion: {
+            id: 'parent-version-id',
+          },
+        },
+        children: [
+          {
+            id: 'child-run-id',
+            status: 'finished',
+            workflowVersion: {
+              id: 'child-version-id',
+            },
+          },
+        ],
         childRunTotal: 1,
         childRunsLimit: 5,
       },

--- a/packages/api/src/mcp/tools/workflow-run-mcp.tools.ts
+++ b/packages/api/src/mcp/tools/workflow-run-mcp.tools.ts
@@ -39,6 +39,9 @@ import {
   paginationSchema,
   uuidSchema,
 } from './hexabot-mcp.schemas';
+import { omitKeysDeep } from './hexabot-mcp.utils';
+
+const WORKFLOW_DEFINITION_RESPONSE_KEYS = ['definitionYml'] as const;
 
 @Injectable()
 export class HexabotWorkflowRunMcpTools extends HexabotMcpToolBase {
@@ -120,11 +123,12 @@ export class HexabotWorkflowRunMcpTools extends HexabotMcpToolBase {
       ...(args.workflowId ? { workflow: { id: args.workflowId } } : {}),
       ...(args.status ? { status: args.status } : {}),
     } as any;
-
-    return await this.listWithCount(
+    const result = await this.listWithCount(
       this.workflowRunService,
       this.findOptions<WorkflowRunOrmEntity>(args, where),
     );
+
+    return this.sanitizeWorkflowRunResponse(result);
   }
 
   @McpPermission('workflowrun', Action.READ)
@@ -142,7 +146,7 @@ export class HexabotWorkflowRunMcpTools extends HexabotMcpToolBase {
       throw new NotFoundException(`Workflow run ${args.id} not found`);
     }
 
-    return run;
+    return this.withoutWorkflowDefinition(run);
   }
 
   @McpPermission('workflowrun', Action.READ)
@@ -188,16 +192,10 @@ export class HexabotWorkflowRunMcpTools extends HexabotMcpToolBase {
       : ([null, [], 0] as const);
     const includeWorkflowDefinition = args.includeWorkflowDefinition ?? true;
     const response: Record<string, unknown> = {
-      run: includeWorkflowDefinition
-        ? run
-        : this.stripWorkflowDefinitionYml(run),
+      run: this.withoutWorkflowDefinition(run),
       relatedRuns: {
-        parent: includeWorkflowDefinition
-          ? parentRun
-          : this.stripWorkflowDefinitionYml(parentRun),
-        children: includeWorkflowDefinition
-          ? childRuns
-          : this.stripWorkflowDefinitionYml(childRuns),
+        parent: this.withoutWorkflowDefinition(parentRun),
+        children: this.withoutWorkflowDefinition(childRuns),
         childRunTotal,
         childRunsLimit: includeRelatedRuns ? childRunsLimit : 0,
       },
@@ -279,22 +277,16 @@ export class HexabotWorkflowRunMcpTools extends HexabotMcpToolBase {
     };
   }
 
-  private stripWorkflowDefinitionYml<T>(value: T): T {
-    if (Array.isArray(value)) {
-      return value.map((item) => this.stripWorkflowDefinitionYml(item)) as T;
-    }
+  private sanitizeWorkflowRunResponse<T extends { items: unknown[] }>(
+    response: T,
+  ): T {
+    return {
+      ...response,
+      items: this.withoutWorkflowDefinition(response.items),
+    };
+  }
 
-    if (value === null || typeof value !== 'object' || value instanceof Date) {
-      return value;
-    }
-
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .filter(([key]) => key !== 'definitionYml')
-        .map(([key, nestedValue]) => [
-          key,
-          this.stripWorkflowDefinitionYml(nestedValue),
-        ]),
-    ) as T;
+  private withoutWorkflowDefinition<T>(value: T): T {
+    return omitKeysDeep(value, WORKFLOW_DEFINITION_RESPONSE_KEYS);
   }
 }

--- a/packages/api/src/mcp/tools/workflow-run-mcp.tools.ts
+++ b/packages/api/src/mcp/tools/workflow-run-mcp.tools.ts
@@ -186,18 +186,25 @@ export class HexabotWorkflowRunMcpTools extends HexabotMcpToolBase {
           this.workflowRunService.count({ where: childWhere }),
         ])
       : ([null, [], 0] as const);
+    const includeWorkflowDefinition = args.includeWorkflowDefinition ?? true;
     const response: Record<string, unknown> = {
-      run,
+      run: includeWorkflowDefinition
+        ? run
+        : this.stripWorkflowDefinitionYml(run),
       relatedRuns: {
-        parent: parentRun,
-        children: childRuns,
+        parent: includeWorkflowDefinition
+          ? parentRun
+          : this.stripWorkflowDefinitionYml(parentRun),
+        children: includeWorkflowDefinition
+          ? childRuns
+          : this.stripWorkflowDefinitionYml(childRuns),
         childRunTotal,
         childRunsLimit: includeRelatedRuns ? childRunsLimit : 0,
       },
       summary: this.buildWorkflowRunDebugSummary(run, childRunTotal),
     };
 
-    if (args.includeWorkflowDefinition ?? true) {
+    if (includeWorkflowDefinition) {
       response.workflowDefinitionYml =
         run.workflowVersion?.definitionYml ?? null;
     }
@@ -270,5 +277,24 @@ export class HexabotWorkflowRunMcpTools extends HexabotMcpToolBase {
       failedSteps,
       childRunTotal,
     };
+  }
+
+  private stripWorkflowDefinitionYml<T>(value: T): T {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.stripWorkflowDefinitionYml(item)) as T;
+    }
+
+    if (value === null || typeof value !== 'object' || value instanceof Date) {
+      return value;
+    }
+
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => key !== 'definitionYml')
+        .map(([key, nestedValue]) => [
+          key,
+          this.stripWorkflowDefinitionYml(nestedValue),
+        ]),
+    ) as T;
   }
 }

--- a/packages/api/src/mcp/tools/workflow-version-mcp.tools.spec.ts
+++ b/packages/api/src/mcp/tools/workflow-version-mcp.tools.spec.ts
@@ -200,6 +200,103 @@ describe('HexabotWorkflowVersionMcpTools', () => {
     });
   });
 
+  it('lists workflow versions as compact summaries without YAML bodies', async () => {
+    const version = {
+      id: 'version-id',
+      version: 3,
+      definitionYml: 'defs: {}\nflow: []\noutputs: {}\n',
+      checksum: 'checksum',
+      message: 'Draft update',
+      action: WorkflowVersionAction.update,
+      parentVersion: null,
+      workflow: 'workflow-id',
+      createdBy: actor.id,
+      createdAt: new Date('2026-05-08T10:00:00.000Z'),
+      updatedAt: new Date('2026-05-08T10:00:00.000Z'),
+    };
+    const workflowVersionService = {
+      findAndPopulate: jest.fn().mockResolvedValue([version]),
+      count: jest.fn().mockResolvedValue(1),
+    };
+    const tools = buildWorkflowVersionTools({ workflowVersionService });
+    const result = await tools.searchWorkflowVersions({
+      workflowId: 'workflow-id',
+      limit: 20,
+      skip: 0,
+      sortBy: 'version',
+      sortDirection: 'DESC',
+    });
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: 'version-id',
+          version: 3,
+          checksum: 'checksum',
+          message: 'Draft update',
+          action: WorkflowVersionAction.update,
+          parentVersion: null,
+          workflow: 'workflow-id',
+          createdBy: actor.id,
+          createdAt: version.createdAt,
+          updatedAt: version.updatedAt,
+          definitionYmlByteLength: Buffer.byteLength(
+            version.definitionYml,
+            'utf8',
+          ),
+        },
+      ],
+      total: 1,
+      limit: 20,
+      skip: 0,
+    });
+    expect(result.items[0]).not.toHaveProperty('definitionYml');
+  });
+
+  it('returns exact workflow YAML chunks with checksum metadata', async () => {
+    const version = {
+      id: 'version-id',
+      version: 3,
+      definitionYml: '0123456789',
+      checksum: 'checksum',
+      workflow: 'workflow-id',
+    };
+    const workflowVersionService = {
+      findOneAndPopulate: jest.fn().mockResolvedValue(version),
+    };
+    const tools = buildWorkflowVersionTools({ workflowVersionService });
+
+    await expect(
+      tools.getWorkflowYaml({
+        versionId: 'version-id',
+        offset: 3,
+        limit: 4,
+      }),
+    ).resolves.toEqual({
+      workflowId: 'workflow-id',
+      versionId: 'version-id',
+      version: 3,
+      checksum: 'checksum',
+      definitionYmlByteLength: 10,
+      definitionYmlLength: 10,
+      chunk: {
+        offset: 3,
+        limit: 4,
+        endOffset: 7,
+        length: 4,
+        byteLength: 4,
+        hasMore: true,
+        nextOffset: 7,
+      },
+      definitionYml: '3456',
+    });
+    expect(workflowVersionService.findOneAndPopulate).toHaveBeenCalledWith({
+      where: {
+        id: 'version-id',
+      },
+    });
+  });
+
   it('returns structured workflow YAML validation errors', async () => {
     const tools = buildWorkflowVersionTools();
 

--- a/packages/api/src/mcp/tools/workflow-version-mcp.tools.spec.ts
+++ b/packages/api/src/mcp/tools/workflow-version-mcp.tools.spec.ts
@@ -282,6 +282,7 @@ describe('HexabotWorkflowVersionMcpTools', () => {
       chunk: {
         offset: 3,
         limit: 4,
+        unit: 'utf8Bytes',
         endOffset: 7,
         length: 4,
         byteLength: 4,
@@ -294,6 +295,46 @@ describe('HexabotWorkflowVersionMcpTools', () => {
       where: {
         id: 'version-id',
       },
+    });
+  });
+
+  it('chunks workflow YAML on UTF-8 byte offsets without splitting characters', async () => {
+    const version = {
+      id: 'version-id',
+      version: 3,
+      definitionYml: 'aé🙂z',
+      checksum: 'checksum',
+      workflow: 'workflow-id',
+    };
+    const workflowVersionService = {
+      findOneAndPopulate: jest.fn().mockResolvedValue(version),
+    };
+    const tools = buildWorkflowVersionTools({ workflowVersionService });
+
+    await expect(
+      tools.getWorkflowYaml({
+        versionId: 'version-id',
+        offset: 1,
+        limit: 2,
+      }),
+    ).resolves.toEqual({
+      workflowId: 'workflow-id',
+      versionId: 'version-id',
+      version: 3,
+      checksum: 'checksum',
+      definitionYmlByteLength: 8,
+      definitionYmlLength: 5,
+      chunk: {
+        offset: 1,
+        limit: 2,
+        unit: 'utf8Bytes',
+        endOffset: 3,
+        length: 1,
+        byteLength: 2,
+        hasMore: true,
+        nextOffset: 3,
+      },
+      definitionYml: 'é',
     });
   });
 

--- a/packages/api/src/mcp/tools/workflow-version-mcp.tools.ts
+++ b/packages/api/src/mcp/tools/workflow-version-mcp.tools.ts
@@ -5,8 +5,16 @@
  */
 
 import { validateWorkflow } from '@hexabot-ai/agentic';
-import { Action } from '@hexabot-ai/types';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Action,
+  type WorkflowVersion,
+  type WorkflowVersionFull,
+} from '@hexabot-ai/types';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { Tool, ToolGuards } from '@rekog/mcp-nest';
 import { z } from 'zod';
 
@@ -67,10 +75,13 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
     request?: HexabotMcpRequest,
   ) {
     const actorId = this.getActorId(request);
-
-    return await this.workflowHelper.commitWorkflowDefinition({
+    const version = await this.workflowHelper.commitWorkflowDefinition({
       ...args,
       createdBy: actorId,
+    });
+
+    return this.workflowHelper.summarizeWorkflowVersion(version, {
+      includeDefinitionYmlByteLength: true,
     });
   }
 
@@ -108,7 +119,8 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
   @ToolGuards([McpPermissionGuard])
   @Tool({
     name: 'hexabot_workflow_version_search',
-    description: 'List workflow definition YAML versions for a workflow.',
+    description:
+      'List compact workflow definition version metadata for a workflow, excluding YAML bodies.',
     parameters: z.object({
       workflowId: uuidSchema,
       ...paginationSchema,
@@ -118,18 +130,28 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
   })
   async searchWorkflowVersions(args: { workflowId: string } & PaginationArgs) {
     const where = { workflow: { id: args.workflowId } } as any;
-
-    return await this.listWithCount(
+    const result = await this.listWithCount(
       this.workflowVersionService,
       this.findOptions<WorkflowVersionOrmEntity>(args, where),
     );
+
+    return {
+      ...result,
+      items: result.items.map((version) =>
+        this.workflowHelper.summarizeWorkflowVersion(
+          version as WorkflowVersion,
+          { includeDefinitionYmlByteLength: true },
+        ),
+      ),
+    };
   }
 
   @McpPermission('workflowversion', Action.READ)
   @ToolGuards([McpPermissionGuard])
   @Tool({
     name: 'hexabot_workflow_version_get',
-    description: 'Read one workflow definition YAML version.',
+    description:
+      'Read compact workflow definition version metadata, excluding the YAML body.',
     parameters: z.object({
       id: uuidSchema,
       workflowId: uuidSchema.optional(),
@@ -147,7 +169,63 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
       throw new NotFoundException(`Workflow version ${args.id} not found`);
     }
 
-    return version;
+    return this.workflowHelper.summarizeWorkflowVersion(version, {
+      includeDefinitionYmlByteLength: true,
+    });
+  }
+
+  @McpPermission('workflowversion', Action.READ)
+  @ToolGuards([McpPermissionGuard])
+  @Tool({
+    name: 'hexabot_workflow_yaml_get',
+    description:
+      'Read workflow definition YAML by workflowId/current version or versionId, with checksum, byte length, and offset/limit chunking.',
+    parameters: z.object({
+      workflowId: uuidSchema.optional(),
+      versionId: uuidSchema.optional(),
+      offset: z.number().int().min(0).default(0),
+      limit: z.number().int().min(1).max(64000).default(16000),
+    }),
+  })
+  async getWorkflowYaml(args: {
+    workflowId?: string;
+    versionId?: string;
+    offset?: number;
+    limit?: number;
+  }) {
+    const version = await this.requireWorkflowVersionForYaml(args);
+    const definitionYml = version.definitionYml;
+    const offset = args.offset ?? 0;
+    const limit = args.limit ?? 16000;
+
+    if (offset > definitionYml.length) {
+      throw new BadRequestException(
+        `Offset ${offset} exceeds workflow YAML length ${definitionYml.length}`,
+      );
+    }
+
+    const endOffset = Math.min(offset + limit, definitionYml.length);
+    const chunk = definitionYml.slice(offset, endOffset);
+    const workflowId = this.resolveRelationId(version.workflow);
+
+    return {
+      workflowId,
+      versionId: version.id,
+      version: version.version,
+      checksum: version.checksum,
+      definitionYmlByteLength: Buffer.byteLength(definitionYml, 'utf8'),
+      definitionYmlLength: definitionYml.length,
+      chunk: {
+        offset,
+        limit,
+        endOffset,
+        length: chunk.length,
+        byteLength: Buffer.byteLength(chunk, 'utf8'),
+        hasMore: endOffset < definitionYml.length,
+        nextOffset: endOffset < definitionYml.length ? endOffset : null,
+      },
+      definitionYml: chunk,
+    };
   }
 
   @McpPermission('workflowversion', Action.UPDATE)
@@ -162,8 +240,12 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
     }),
   })
   async updateWorkflowVersion(args: { id: string; message?: string | null }) {
-    return await this.workflowVersionService.updateOne(args.id, {
+    const version = await this.workflowVersionService.updateOne(args.id, {
       message: args.message ?? undefined,
+    });
+
+    return this.workflowHelper.summarizeWorkflowVersion(version, {
+      includeDefinitionYmlByteLength: true,
     });
   }
 
@@ -184,10 +266,14 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
     _context: unknown,
     request?: HexabotMcpRequest,
   ) {
-    return await this.workflowHelper.restoreWorkflowVersionSnapshot(
+    const version = await this.workflowHelper.restoreWorkflowVersionSnapshot(
       args,
       this.getActorId(request),
     );
+
+    return this.workflowHelper.summarizeWorkflowVersion(version, {
+      includeDefinitionYmlByteLength: true,
+    });
   }
 
   @McpPermission('workflowversion', Action.CREATE)
@@ -207,10 +293,14 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
     _context: unknown,
     request?: HexabotMcpRequest,
   ) {
-    return await this.workflowHelper.restoreWorkflowVersionSnapshot(
+    const version = await this.workflowHelper.restoreWorkflowVersionSnapshot(
       args,
       this.getActorId(request),
     );
+
+    return this.workflowHelper.summarizeWorkflowVersion(version, {
+      includeDefinitionYmlByteLength: true,
+    });
   }
 
   private getWorkflowValidationActions() {
@@ -222,5 +312,62 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
         ],
       ),
     );
+  }
+
+  private async requireWorkflowVersionForYaml(args: {
+    workflowId?: string;
+    versionId?: string;
+  }): Promise<WorkflowVersion | WorkflowVersionFull> {
+    if (!args.workflowId && !args.versionId) {
+      throw new BadRequestException(
+        'workflowId or versionId is required to read workflow YAML',
+      );
+    }
+
+    if (args.versionId) {
+      const version = await this.workflowVersionService.findOneAndPopulate({
+        where: {
+          id: args.versionId,
+          ...(args.workflowId ? { workflow: { id: args.workflowId } } : {}),
+        } as any,
+      });
+
+      if (!version) {
+        throw new NotFoundException(
+          `Workflow version ${args.versionId} not found`,
+        );
+      }
+
+      return version;
+    }
+
+    const workflowId = args.workflowId;
+    if (!workflowId) {
+      throw new BadRequestException(
+        'workflowId is required when versionId is not provided',
+      );
+    }
+    const workflow = await this.workflowHelper.requireWorkflow(workflowId);
+    const currentVersionId = this.resolveRelationId(workflow.currentVersion);
+    if (!currentVersionId) {
+      throw new NotFoundException(
+        `Workflow ${workflowId} has no current version`,
+      );
+    }
+
+    const version = await this.workflowVersionService.findOneAndPopulate({
+      where: {
+        id: currentVersionId,
+        workflow: { id: workflowId },
+      } as any,
+    });
+
+    if (!version) {
+      throw new NotFoundException(
+        `Workflow version ${currentVersionId} not found`,
+      );
+    }
+
+    return version;
   }
 }

--- a/packages/api/src/mcp/tools/workflow-version-mcp.tools.ts
+++ b/packages/api/src/mcp/tools/workflow-version-mcp.tools.ts
@@ -179,7 +179,7 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
   @Tool({
     name: 'hexabot_workflow_yaml_get',
     description:
-      'Read workflow definition YAML by workflowId/current version or versionId, with checksum, byte length, and offset/limit chunking.',
+      'Read workflow definition YAML by workflowId/current version or versionId, with checksum, byte length, and UTF-8 byte offset/limit chunking.',
     parameters: z.object({
       workflowId: uuidSchema.optional(),
       versionId: uuidSchema.optional(),
@@ -197,15 +197,8 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
     const definitionYml = version.definitionYml;
     const offset = args.offset ?? 0;
     const limit = args.limit ?? 16000;
-
-    if (offset > definitionYml.length) {
-      throw new BadRequestException(
-        `Offset ${offset} exceeds workflow YAML length ${definitionYml.length}`,
-      );
-    }
-
-    const endOffset = Math.min(offset + limit, definitionYml.length);
-    const chunk = definitionYml.slice(offset, endOffset);
+    const { chunk, chunkByteLength, endOffset, totalByteLength } =
+      this.sliceUtf8Chunk(definitionYml, offset, limit);
     const workflowId = this.resolveRelationId(version.workflow);
 
     return {
@@ -213,16 +206,17 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
       versionId: version.id,
       version: version.version,
       checksum: version.checksum,
-      definitionYmlByteLength: Buffer.byteLength(definitionYml, 'utf8'),
+      definitionYmlByteLength: totalByteLength,
       definitionYmlLength: definitionYml.length,
       chunk: {
         offset,
         limit,
+        unit: 'utf8Bytes',
         endOffset,
         length: chunk.length,
-        byteLength: Buffer.byteLength(chunk, 'utf8'),
-        hasMore: endOffset < definitionYml.length,
-        nextOffset: endOffset < definitionYml.length ? endOffset : null,
+        byteLength: chunkByteLength,
+        hasMore: endOffset < totalByteLength,
+        nextOffset: endOffset < totalByteLength ? endOffset : null,
       },
       definitionYml: chunk,
     };
@@ -369,5 +363,97 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
     }
 
     return version;
+  }
+
+  private sliceUtf8Chunk(
+    value: string,
+    offset: number,
+    limit: number,
+  ): {
+    chunk: string;
+    chunkByteLength: number;
+    endOffset: number;
+    totalByteLength: number;
+  } {
+    const totalByteLength = Buffer.byteLength(value, 'utf8');
+    if (offset > totalByteLength) {
+      throw new BadRequestException(
+        `Offset ${offset} exceeds workflow YAML byte length ${totalByteLength}`,
+      );
+    }
+
+    const startIndex = this.findUtf8IndexForOffset(value, offset);
+    let endIndex = value.length;
+    let byteOffset = offset;
+
+    for (let index = startIndex; index < value.length; ) {
+      const char = this.readCodePoint(value, index);
+      const nextByteOffset = byteOffset + Buffer.byteLength(char, 'utf8');
+
+      if (nextByteOffset > offset + limit) {
+        if (index === startIndex) {
+          throw new BadRequestException(
+            `Limit ${limit} is too small to include the next UTF-8 character at offset ${offset}`,
+          );
+        }
+        endIndex = index;
+        break;
+      }
+
+      byteOffset = nextByteOffset;
+      index += char.length;
+    }
+
+    const chunk = value.slice(startIndex, endIndex);
+    const chunkByteLength = Buffer.byteLength(chunk, 'utf8');
+
+    return {
+      chunk,
+      chunkByteLength,
+      endOffset: offset + chunkByteLength,
+      totalByteLength,
+    };
+  }
+
+  private findUtf8IndexForOffset(value: string, offset: number): number {
+    if (offset === 0) {
+      return 0;
+    }
+
+    let byteOffset = 0;
+    for (let index = 0; index < value.length; ) {
+      const char = this.readCodePoint(value, index);
+      const nextByteOffset = byteOffset + Buffer.byteLength(char, 'utf8');
+
+      if (offset === nextByteOffset) {
+        return index + char.length;
+      }
+
+      if (offset < nextByteOffset) {
+        throw new BadRequestException(
+          `Offset ${offset} is not aligned to a UTF-8 character boundary`,
+        );
+      }
+
+      byteOffset = nextByteOffset;
+      index += char.length;
+    }
+
+    if (offset === byteOffset) {
+      return value.length;
+    }
+
+    throw new BadRequestException(
+      `Offset ${offset} exceeds workflow YAML byte length ${byteOffset}`,
+    );
+  }
+
+  private readCodePoint(value: string, index: number): string {
+    const codePoint = value.codePointAt(index);
+    if (codePoint === undefined) {
+      return '';
+    }
+
+    return String.fromCodePoint(codePoint);
   }
 }


### PR DESCRIPTION
**Summary**
- Added compact MCP workflow/version responses that omit large `definitionYml` payloads.
- Added `hexabot_workflow_yaml_get` for exact workflow YAML retrieval with checksum, byte length, and UTF-8 byte chunking.
- Sanitized workflow-run MCP responses to avoid nested YAML leaks, and documented the updated MCP workflow contracts.
