### PR TITLE
fix(graph): workflow graph edges disappearing

### DIFF
--- a/packages/graph/src/workflow/utils/graph-builder/project.ts
+++ b/packages/graph/src/workflow/utils/graph-builder/project.ts
@@ -38,6 +38,8 @@ export const projectSemanticGraph = (
       type: node.type,
       selectable: Boolean(node.selectable),
       position: { x: 0, y: 0 },
+      // Preserve xyflow handle bounds when controlled nodes are replaced for runtime styling.
+      measured: dimensions,
       data: node.data as GraphNode["data"],
       style,
     } as GraphNode;

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -327,6 +327,9 @@ describe("buildNodesAndEdges", () => {
     expect(taskNode?.height).toBe(
       defaultConfig.dimensions?.[ENodeType.TASK]?.height,
     );
+    expect(taskNode?.measured).toEqual(
+      defaultConfig.dimensions?.[ENodeType.TASK],
+    );
     expect(taskNode?.style).toBeUndefined();
   });
 


### PR DESCRIPTION
## What changed?

Fix workflow graph edges disappearing during workflow execution.

## Details

Execution-state updates replace controlled xyflow node objects for runtime styling. Projected graph nodes now include their known `measured` dimensions so xyflow preserves handle bounds across those updates and can keep rendering edge positions reliably.

