### PR TITLE
feat(frontend): intial guided tour

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -59,6 +59,7 @@
     "react-hook-form": "^7.51.5",
     "react-i18next": "^14.1.1",
     "react-is": "^18.3.1",
+    "react-joyride": "^2.9.3",
     "react-router-dom": "^6.30.2",
     "socket.io-client": "^4.7.5",
     "yaml": "^2.8.3",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -675,7 +675,10 @@
     "not_now": "Not now",
     "view_plans": "View plans",
     "enter_license_key": "Enter license key",
-    "manage_users": "Manage users"
+    "manage_users": "Manage users",
+    "next": "Next",
+    "skip": "Skip",
+    "done": "Done"
   },
   "input": {
     "search": "Search",
@@ -907,6 +910,33 @@
       "show": "Show YAML editor",
       "hide": "Hide YAML editor",
       "validation_title": "Workflow definition has errors"
+    },
+    "guided_tour": {
+      "workflow_name_prefix": "My first workflow",
+      "dashboard_create": {
+        "title": "Create your first workflow",
+        "content": "Start by creating a conversational workflow. Use the highlighted Create Workflow button and Hexabot will open a fresh visual editor for you."
+      },
+      "empty_insert": {
+        "title": "Add the first block",
+        "content": "Your canvas is ready. Click the highlighted plus button to drop in the first building block."
+      },
+      "insert_step": {
+        "title": "Choose a step",
+        "content": "Pick Step from the insert menu. This gives the workflow a real action to run when the conversation starts."
+      },
+      "send_text_action": {
+        "title": "Send a text message",
+        "content": "Choose Send Text Message. It is the quickest way to make your bot answer with a clear, friendly reply."
+      },
+      "action_save": {
+        "title": "Save the action",
+        "content": "Save the action with the default values. That locks the first reply into the workflow so you can try it right away."
+      },
+      "chat_widget": {
+        "title": "Test the conversation",
+        "content": "Now test the flow from the chat widget. Send a message and watch your first workflow answer back."
+      }
     },
     "workflow_versions": {
       "show": "Show workflow versions",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -675,7 +675,10 @@
     "not_now": "Plus tard",
     "view_plans": "Voir les offres",
     "enter_license_key": "Saisir une clé de licence",
-    "manage_users": "Gérer les utilisateurs"
+    "manage_users": "Gérer les utilisateurs",
+    "next": "Suivant",
+    "skip": "Ignorer",
+    "done": "Terminé"
   },
   "input": {
     "search": "Recherche",
@@ -907,6 +910,33 @@
       "show": "Afficher l'éditeur YAML",
       "hide": "Masquer l'éditeur YAML",
       "validation_title": "La définition du workflow contient des erreurs"
+    },
+    "guided_tour": {
+      "workflow_name_prefix": "Mon premier workflow",
+      "dashboard_create": {
+        "title": "Créez votre premier workflow",
+        "content": "Commencez par créer un workflow conversationnel. Utilisez le bouton Créer un workflow mis en évidence et Hexabot ouvrira un éditeur visuel tout neuf."
+      },
+      "empty_insert": {
+        "title": "Ajoutez le premier bloc",
+        "content": "Votre canevas est prêt. Cliquez sur le bouton plus mis en évidence pour déposer le premier bloc."
+      },
+      "insert_step": {
+        "title": "Choisissez une étape",
+        "content": "Choisissez Étape dans le menu d'insertion. Le workflow aura ainsi une vraie action à exécuter au début de la conversation."
+      },
+      "send_text_action": {
+        "title": "Envoyez un message texte",
+        "content": "Choisissez Envoyer un message texte. C'est le moyen le plus rapide de faire répondre votre bot avec un message clair et sympa."
+      },
+      "action_save": {
+        "title": "Enregistrez l'action",
+        "content": "Enregistrez l'action avec les valeurs par défaut. La première réponse est alors ajoutée au workflow et vous pouvez l'essayer tout de suite."
+      },
+      "chat_widget": {
+        "title": "Testez la conversation",
+        "content": "Testez maintenant la conversation depuis le widget de chat. Envoyez un message et regardez votre premier workflow répondre."
+      }
     },
     "workflow_versions": {
       "show": "Afficher les versions du workflow",

--- a/packages/frontend/src/app-components/drawers/DrawerPrimaryFooterAction.tsx
+++ b/packages/frontend/src/app-components/drawers/DrawerPrimaryFooterAction.tsx
@@ -12,6 +12,7 @@ type DrawerPrimaryFooterActionProps = {
   onClick: () => void;
   disabled?: boolean;
   ariaLabel?: string;
+  dataTourId?: string;
   startIcon?: ReactNode;
   minWidth?: number;
 };
@@ -21,6 +22,7 @@ export const DrawerPrimaryFooterAction = ({
   onClick,
   disabled,
   ariaLabel,
+  dataTourId,
   startIcon,
   minWidth = 200,
 }: DrawerPrimaryFooterActionProps) => {
@@ -32,6 +34,7 @@ export const DrawerPrimaryFooterAction = ({
         onClick={onClick}
         disabled={disabled}
         aria-label={ariaLabel}
+        data-tour-id={dataTourId}
         startIcon={startIcon}
         sx={{ minWidth }}
       >

--- a/packages/frontend/src/components/dashboard/widgets/QuickActions.tsx
+++ b/packages/frontend/src/components/dashboard/widgets/QuickActions.tsx
@@ -35,6 +35,9 @@ export const QuickActions = () => {
             variant="outlined"
             startIcon={<Icon size={18} color={theme.palette.primary.main} />}
             onClick={() => url && router.push(url)}
+            data-tour-id={
+              id === "create" ? "admin-workflow-tour-create" : undefined
+            }
           >
             {t(label)}
           </Button>

--- a/packages/frontend/src/components/guided-tour/AdminWorkflowTour.tsx
+++ b/packages/frontend/src/components/guided-tour/AdminWorkflowTour.tsx
@@ -1,0 +1,636 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { Workflow as WorkflowHelper } from "@hexabot-ai/agentic";
+import { Action } from "@hexabot-ai/types";
+import AutoAwesomeRoundedIcon from "@mui/icons-material/AutoAwesomeRounded";
+import {
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { alpha, useTheme } from "@mui/material/styles";
+import { X } from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Joyride, {
+  type CallBackProps,
+  type Step,
+  type TooltipRenderProps,
+} from "react-joyride";
+
+import { isLicenseQuotaReached } from "@/components/license/license-quotas";
+import { useCreate } from "@/hooks/crud/useCreate";
+import { useAppRouter } from "@/hooks/useAppRouter";
+import { useAuth } from "@/hooks/useAuth";
+import { useHasPermission } from "@/hooks/useHasPermission";
+import { useToast } from "@/hooks/useToast";
+import { useTranslate } from "@/hooks/useTranslate";
+import { EntityType, RouterType } from "@/services/types";
+
+import { createBaseDefinition } from "../visual-editor/v4/utils/workflow-definition.utils";
+
+import {
+  ADMIN_WORKFLOW_TOUR_CLICK_THROUGH_SELECTORS,
+  ADMIN_WORKFLOW_TOUR_SELECTORS,
+  buildAdminWorkflowTourWorkflowPayload,
+  getAdminWorkflowTourTransition,
+  isAdminWorkflowTourCompleted,
+  isAdminWorkflowTourContinuationAllowed,
+  isAdminWorkflowTourDashboardRoute,
+  isAdminWorkflowTourEligible,
+  isAdminWorkflowTourWorkflowEditorRoute,
+  markAdminWorkflowTourCompleted,
+  removeAdminWorkflowTourSpotlightProxy,
+  waitForAdminWorkflowTourTarget,
+} from "./admin-workflow-tour.utils";
+
+type TourWorkflowCreatePayload = ReturnType<
+  typeof buildAdminWorkflowTourWorkflowPayload
+>;
+
+type JoyrideTooltipActionProps = TooltipRenderProps["primaryProps"] & {
+  children?: ReactNode;
+};
+
+const getTooltipLabel = (title: ReactNode, content: ReactNode) => {
+  if (typeof title === "string") {
+    return title;
+  }
+
+  if (typeof content === "string") {
+    return content;
+  }
+
+  return undefined;
+};
+const getJoyrideActionContent = (props: JoyrideTooltipActionProps) =>
+  props.children ?? props.title;
+const AdminWorkflowTourTooltip = ({
+  backProps,
+  closeProps,
+  index,
+  isLastStep,
+  primaryProps,
+  skipProps,
+  step,
+  size,
+  tooltipProps,
+}: TooltipRenderProps) => {
+  const {
+    content,
+    hideBackButton,
+    hideCloseButton,
+    hideFooter,
+    showSkipButton,
+    styles,
+    title,
+  } = step;
+  const theme = useTheme();
+  const tooltipLabel = getTooltipLabel(title, content);
+  const showBack = !hideBackButton && index > 0;
+  const showSkip = showSkipButton && !isLastStep;
+  const backActionProps = backProps as JoyrideTooltipActionProps;
+  const closeActionProps = closeProps as JoyrideTooltipActionProps;
+  const primaryActionProps = primaryProps as JoyrideTooltipActionProps;
+  const skipActionProps = skipProps as JoyrideTooltipActionProps;
+
+  return (
+    <Paper
+      aria-label={tooltipLabel}
+      className="react-joyride__tooltip"
+      elevation={0}
+      style={{
+        ...styles.tooltip,
+        backgroundColor: theme.palette.background.paper,
+        backgroundImage: `linear-gradient(135deg, ${alpha(
+          theme.palette.primary.main,
+          0.1,
+        )} 0%, ${theme.palette.background.paper} 44%)`,
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: theme.shape.borderRadius,
+        boxShadow: theme.shadows[8],
+        color: theme.palette.text.primary,
+        padding: 0,
+      }}
+      {...tooltipProps}
+    >
+      <Box sx={{ p: 2.25, position: "relative" }}>
+        {!hideCloseButton ? (
+          <IconButton
+            size="small"
+            sx={{
+              color: "text.secondary",
+              position: "absolute",
+              right: 12,
+              top: 12,
+              "&:hover": {
+                bgcolor: alpha(theme.palette.primary.main, 0.08),
+                color: "text.primary",
+              },
+            }}
+            type="button"
+            {...closeActionProps}
+          >
+            <X aria-hidden="true" size={18} strokeWidth={2.25} />
+            <Box
+              component="span"
+              sx={{
+                border: 0,
+                clip: "rect(0 0 0 0)",
+                height: 1,
+                m: -1,
+                overflow: "hidden",
+                p: 0,
+                position: "absolute",
+                whiteSpace: "nowrap",
+                width: 1,
+              }}
+            >
+              {getJoyrideActionContent(closeActionProps)}
+            </Box>
+          </IconButton>
+        ) : null}
+        <Stack spacing={2}>
+          <Stack
+            alignItems="flex-start"
+            direction="row"
+            spacing={1.5}
+            sx={{ pr: hideCloseButton ? 0 : 3.5 }}
+          >
+            <Box
+              aria-hidden="true"
+              sx={{
+                alignItems: "center",
+                bgcolor: alpha(theme.palette.primary.main, 0.12),
+                borderRadius: 1,
+                color: "primary.main",
+                display: "flex",
+                flexShrink: 0,
+                height: 36,
+                justifyContent: "center",
+                width: 36,
+              }}
+            >
+              <AutoAwesomeRoundedIcon fontSize="small" />
+            </Box>
+            <Stack spacing={0.75} sx={{ flex: 1, minWidth: 0 }}>
+              <Stack
+                alignItems="center"
+                direction="row"
+                justifyContent="space-between"
+                spacing={1}
+              >
+                {title ? (
+                  <Typography
+                    component="h2"
+                    sx={{ fontWeight: 700, lineHeight: 1.3 }}
+                    variant="subtitle1"
+                  >
+                    {title}
+                  </Typography>
+                ) : null}
+                <Chip
+                  color="primary"
+                  label={`${index + 1}/${size}`}
+                  size="small"
+                  sx={{
+                    flexShrink: 0,
+                    fontWeight: 700,
+                    height: 24,
+                  }}
+                  variant="outlined"
+                />
+              </Stack>
+              <Typography
+                color="text.secondary"
+                component="div"
+                sx={{ lineHeight: 1.55 }}
+                variant="body2"
+              >
+                {content}
+              </Typography>
+            </Stack>
+          </Stack>
+          {!hideFooter ? (
+            <Stack
+              alignItems="center"
+              direction="row"
+              justifyContent="space-between"
+              spacing={1}
+            >
+              <Box>
+                {showSkip ? (
+                  <Button
+                    color="inherit"
+                    size="small"
+                    type="button"
+                    variant="text"
+                    {...skipActionProps}
+                  >
+                    {getJoyrideActionContent(skipActionProps)}
+                  </Button>
+                ) : null}
+              </Box>
+              <Stack direction="row" spacing={1}>
+                {showBack ? (
+                  <Button
+                    color="primary"
+                    size="small"
+                    type="button"
+                    variant="outlined"
+                    {...backActionProps}
+                  >
+                    {getJoyrideActionContent(backActionProps)}
+                  </Button>
+                ) : null}
+                <Button
+                  color="primary"
+                  size="small"
+                  type="button"
+                  variant="contained"
+                  {...primaryActionProps}
+                >
+                  {getJoyrideActionContent(primaryActionProps)}
+                </Button>
+              </Stack>
+            </Stack>
+          ) : null}
+        </Stack>
+      </Box>
+    </Paper>
+  );
+};
+
+export const AdminWorkflowTour = () => {
+  const router = useAppRouter();
+  const theme = useTheme();
+  const { user, isAuthenticated, refetchUser } = useAuth();
+  const hasPermission = useHasPermission();
+  const { toast } = useToast();
+  const { t } = useTranslate();
+  const userId = user?.id;
+  const [run, setRun] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [pendingStepIndex, setPendingStepIndex] = useState<number | null>(null);
+  const [hasStarted, setHasStarted] = useState(false);
+  const [isStopped, setIsStopped] = useState(false);
+  const [createRequested, setCreateRequested] = useState(false);
+  const [createdWorkflowId, setCreatedWorkflowId] = useState<string | null>(
+    null,
+  );
+  const [isCompleted, setIsCompleted] = useState(() =>
+    isAdminWorkflowTourCompleted(userId),
+  );
+  const createInFlightRef = useRef(false);
+  const clickThroughTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const canReadWorkflow = hasPermission(EntityType.WORKFLOW, Action.READ);
+  const canCreateWorkflow = hasPermission(EntityType.WORKFLOW, Action.CREATE);
+  const workflowQuotaReached = isLicenseQuotaReached(
+    user?.license,
+    "workflows",
+  );
+  const isEligible = isAdminWorkflowTourEligible({
+    canCreateWorkflow,
+    canReadWorkflow,
+    isAuthenticated,
+    isCompleted,
+    userId,
+    workflowQuotaReached,
+  });
+  const canContinueTour = isAdminWorkflowTourContinuationAllowed({
+    canCreateWorkflow,
+    canReadWorkflow,
+    hasStarted,
+    isAuthenticated,
+    isCompleted,
+    isStopped,
+    userId,
+  });
+  const isDashboardRoute = isAdminWorkflowTourDashboardRoute(router.pathname);
+  const isWorkflowEditorRoute = isAdminWorkflowTourWorkflowEditorRoute(
+    router.pathname,
+  );
+  const blankDefinitionYml = useMemo(
+    () => WorkflowHelper.stringifyDefinition(createBaseDefinition()),
+    [],
+  );
+  const workflowNamePrefix = t(
+    "visual_editor.guided_tour.workflow_name_prefix",
+  );
+  const steps = useMemo<Step[]>(
+    () => [
+      {
+        target: ADMIN_WORKFLOW_TOUR_SELECTORS.dashboardCreate,
+        title: t("visual_editor.guided_tour.dashboard_create.title"),
+        content: t("visual_editor.guided_tour.dashboard_create.content"),
+        disableBeacon: true,
+        hideFooter: true,
+        placement: "bottom",
+        spotlightClicks: true,
+      },
+      {
+        target: ADMIN_WORKFLOW_TOUR_SELECTORS.emptyInsert,
+        title: t("visual_editor.guided_tour.empty_insert.title"),
+        content: t("visual_editor.guided_tour.empty_insert.content"),
+        disableBeacon: true,
+        hideFooter: true,
+        placement: "right",
+        spotlightClicks: true,
+      },
+      {
+        target: ADMIN_WORKFLOW_TOUR_SELECTORS.insertStep,
+        title: t("visual_editor.guided_tour.insert_step.title"),
+        content: t("visual_editor.guided_tour.insert_step.content"),
+        disableBeacon: true,
+        hideFooter: true,
+        placement: "right",
+        spotlightClicks: true,
+      },
+      {
+        target: ADMIN_WORKFLOW_TOUR_SELECTORS.sendTextActionSpotlight,
+        title: t("visual_editor.guided_tour.send_text_action.title"),
+        content: t("visual_editor.guided_tour.send_text_action.content"),
+        disableBeacon: true,
+        disableScrolling: true,
+        hideFooter: true,
+        isFixed: true,
+        placement: "left",
+        spotlightClicks: true,
+      },
+      {
+        target: ADMIN_WORKFLOW_TOUR_SELECTORS.actionSave,
+        title: t("visual_editor.guided_tour.action_save.title"),
+        content: t("visual_editor.guided_tour.action_save.content"),
+        disableBeacon: true,
+        hideFooter: true,
+        placement: "left",
+        spotlightClicks: true,
+      },
+      {
+        target: ADMIN_WORKFLOW_TOUR_SELECTORS.chatWidget,
+        title: t("visual_editor.guided_tour.chat_widget.title"),
+        content: t("visual_editor.guided_tour.chat_widget.content"),
+        disableBeacon: true,
+        placement: "top",
+      },
+    ],
+    [t],
+  );
+  const stopTour = useCallback(() => {
+    removeAdminWorkflowTourSpotlightProxy();
+    setRun(false);
+    setPendingStepIndex(null);
+    setIsStopped(true);
+  }, []);
+  const completeTour = useCallback(() => {
+    removeAdminWorkflowTourSpotlightProxy();
+    setRun(false);
+    setPendingStepIndex(null);
+    setIsStopped(true);
+    setIsCompleted(true);
+    markAdminWorkflowTourCompleted(userId);
+  }, [userId]);
+  const { mutate: createWorkflow } = useCreate<
+    EntityType.WORKFLOW,
+    TourWorkflowCreatePayload
+  >(EntityType.WORKFLOW, {
+    onError: (error) => {
+      createInFlightRef.current = false;
+      setCreateRequested(false);
+      stopTour();
+      toast.error(error);
+    },
+  });
+
+  useEffect(() => {
+    setIsCompleted(isAdminWorkflowTourCompleted(userId));
+    setHasStarted(false);
+    setIsStopped(false);
+    setCreateRequested(false);
+    setCreatedWorkflowId(null);
+    createInFlightRef.current = false;
+  }, [userId]);
+
+  useEffect(() => {
+    if (!isEligible || !isDashboardRoute || hasStarted || isStopped) {
+      return;
+    }
+
+    setHasStarted(true);
+    setPendingStepIndex(0);
+  }, [hasStarted, isDashboardRoute, isEligible, isStopped]);
+
+  useEffect(() => {
+    if (
+      !createRequested ||
+      !canContinueTour ||
+      !isWorkflowEditorRoute ||
+      createdWorkflowId ||
+      createInFlightRef.current
+    ) {
+      return;
+    }
+
+    createInFlightRef.current = true;
+    setRun(false);
+    createWorkflow(
+      buildAdminWorkflowTourWorkflowPayload({
+        definitionYml: blankDefinitionYml,
+        workflowNamePrefix,
+      }),
+      {
+        onSuccess: (workflow) => {
+          setCreatedWorkflowId(workflow.id);
+          void refetchUser();
+          void router
+            .push(`/${RouterType.WORKFLOW_EDITOR}/${workflow.id}`)
+            .then(() => {
+              setPendingStepIndex(1);
+            });
+        },
+      },
+    );
+  }, [
+    blankDefinitionYml,
+    canContinueTour,
+    createRequested,
+    createWorkflow,
+    createdWorkflowId,
+    isWorkflowEditorRoute,
+    refetchUser,
+    router,
+    workflowNamePrefix,
+  ]);
+
+  useEffect(() => {
+    if (pendingStepIndex === null || !canContinueTour) {
+      return;
+    }
+
+    const target = steps[pendingStepIndex]?.target;
+
+    if (typeof target !== "string") {
+      return;
+    }
+
+    let cancelled = false;
+
+    setRun(false);
+    waitForAdminWorkflowTourTarget(target)
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+
+        setStepIndex(pendingStepIndex);
+        setPendingStepIndex(null);
+        setRun(true);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          stopTour();
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canContinueTour, pendingStepIndex, steps, stopTour]);
+
+  useEffect(() => {
+    const clickThroughSelector =
+      ADMIN_WORKFLOW_TOUR_CLICK_THROUGH_SELECTORS[stepIndex];
+
+    if (!run || !clickThroughSelector) {
+      return;
+    }
+
+    const handleClickThrough = (event: MouseEvent) => {
+      const target = event.target;
+
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      if (!target.closest(clickThroughSelector)) {
+        return;
+      }
+
+      if (clickThroughTimerRef.current) {
+        clearTimeout(clickThroughTimerRef.current);
+      }
+
+      clickThroughTimerRef.current = setTimeout(() => {
+        clickThroughTimerRef.current = null;
+        setRun(false);
+        if (stepIndex === 0) {
+          setCreateRequested(true);
+
+          return;
+        }
+
+        setPendingStepIndex(stepIndex + 1);
+      }, 0);
+    };
+
+    document.addEventListener("click", handleClickThrough, true);
+
+    return () => {
+      document.removeEventListener("click", handleClickThrough, true);
+      if (clickThroughTimerRef.current) {
+        clearTimeout(clickThroughTimerRef.current);
+        clickThroughTimerRef.current = null;
+      }
+    };
+  }, [run, stepIndex]);
+
+  const handleJoyrideCallback = useCallback(
+    (data: CallBackProps) => {
+      const transition = getAdminWorkflowTourTransition({
+        action: data.action,
+        index: data.index,
+        size: data.size,
+        status: data.status,
+        type: data.type,
+      });
+
+      if (transition.complete) {
+        completeTour();
+
+        return;
+      }
+
+      if (transition.stop) {
+        stopTour();
+
+        return;
+      }
+
+      if (transition.retryStepIndex !== undefined) {
+        setRun(false);
+        setPendingStepIndex(transition.retryStepIndex);
+
+        return;
+      }
+
+      if (transition.nextStepIndex !== undefined) {
+        setRun(false);
+        setPendingStepIndex(transition.nextStepIndex);
+      }
+    },
+    [completeTour, stopTour],
+  );
+
+  if (!hasStarted && !run) {
+    return null;
+  }
+
+  return (
+    <Joyride
+      callback={handleJoyrideCallback}
+      continuous
+      disableOverlayClose
+      disableScrolling
+      hideBackButton
+      locale={{
+        back: t("button.back"),
+        close: t("button.close"),
+        last: t("button.done"),
+        next: t("button.next"),
+        skip: t("button.skip"),
+      }}
+      run={run}
+      showSkipButton
+      spotlightPadding={8}
+      stepIndex={stepIndex}
+      steps={steps}
+      tooltipComponent={AdminWorkflowTourTooltip}
+      styles={{
+        options: {
+          arrowColor: theme.palette.background.paper,
+          backgroundColor: theme.palette.background.paper,
+          overlayColor: "rgba(15, 23, 42, 0.58)",
+          primaryColor: theme.palette.primary.main,
+          textColor: theme.palette.text.primary,
+          zIndex: theme.zIndex.modal + 100,
+        },
+      }}
+    />
+  );
+};

--- a/packages/frontend/src/components/guided-tour/admin-workflow-tour.utils.test.ts
+++ b/packages/frontend/src/components/guided-tour/admin-workflow-tour.utils.test.ts
@@ -1,0 +1,386 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { WorkflowType } from "@hexabot-ai/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildAdminWorkflowTourWorkflowPayload,
+  formatAdminWorkflowTourTimestamp,
+  getAdminWorkflowTourStorageKey,
+  getAdminWorkflowTourTransition,
+  isAdminWorkflowTourCompleted,
+  isAdminWorkflowTourContinuationAllowed,
+  isAdminWorkflowTourDashboardRoute,
+  isAdminWorkflowTourEligible,
+  isAdminWorkflowTourTargetReady,
+  isAdminWorkflowTourWorkflowEditorRoute,
+  markAdminWorkflowTourCompleted,
+  waitForAdminWorkflowTourTarget,
+} from "./admin-workflow-tour.utils";
+
+class FakeStorage implements Pick<Storage, "getItem" | "setItem"> {
+  private readonly items = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.items.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.items.set(key, value);
+  }
+}
+
+const createRect = (rect: Partial<DOMRect> = {}) =>
+  ({
+    bottom: 60,
+    height: 50,
+    left: 10,
+    right: 110,
+    top: 10,
+    width: 100,
+    x: 10,
+    y: 10,
+    toJSON: () => ({}),
+    ...rect,
+  }) as DOMRect;
+const createTarget = (
+  rect: DOMRect = createRect(),
+  parentElement: Element | null = null,
+) =>
+  ({
+    getBoundingClientRect: () => rect,
+    parentElement,
+  }) as Element;
+const createViewport = (
+  style: Partial<CSSStyleDeclaration> = {},
+): Pick<Window, "getComputedStyle" | "innerHeight" | "innerWidth"> => ({
+  getComputedStyle: () =>
+    ({
+      display: "block",
+      visibility: "visible",
+      ...style,
+    }) as CSSStyleDeclaration,
+  innerHeight: 240,
+  innerWidth: 320,
+});
+
+describe("admin-workflow-tour.utils", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("builds user-scoped completion keys and stores completion", () => {
+    const storage = new FakeStorage();
+    const userId = "user-1";
+
+    expect(getAdminWorkflowTourStorageKey(userId)).toBe(
+      "hexabot.admin_workflow_editor_tour.v1.user-1",
+    );
+    expect(isAdminWorkflowTourCompleted(userId, storage)).toBe(false);
+    expect(markAdminWorkflowTourCompleted(userId, storage)).toBe(true);
+    expect(isAdminWorkflowTourCompleted(userId, storage)).toBe(true);
+  });
+
+  it("does not complete without a user id or storage", () => {
+    expect(isAdminWorkflowTourCompleted(undefined, new FakeStorage())).toBe(
+      false,
+    );
+    expect(markAdminWorkflowTourCompleted(undefined, new FakeStorage())).toBe(
+      false,
+    );
+    expect(isAdminWorkflowTourCompleted("user-1", null)).toBe(false);
+    expect(markAdminWorkflowTourCompleted("user-1", null)).toBe(false);
+  });
+
+  it("requires auth, workflow permissions, quota availability, and no completion", () => {
+    const eligible = {
+      canCreateWorkflow: true,
+      canReadWorkflow: true,
+      isAuthenticated: true,
+      isCompleted: false,
+      userId: "user-1",
+      workflowQuotaReached: false,
+    };
+
+    expect(isAdminWorkflowTourEligible(eligible)).toBe(true);
+    expect(
+      isAdminWorkflowTourEligible({ ...eligible, canCreateWorkflow: false }),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourEligible({ ...eligible, canReadWorkflow: false }),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourEligible({ ...eligible, isAuthenticated: false }),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourEligible({ ...eligible, isCompleted: true }),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourEligible({ ...eligible, userId: undefined }),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourEligible({ ...eligible, workflowQuotaReached: true }),
+    ).toBe(false);
+  });
+
+  it("allows an already-started tour to continue after workflow quota changes", () => {
+    const continuation = {
+      canCreateWorkflow: true,
+      canReadWorkflow: true,
+      hasStarted: true,
+      isAuthenticated: true,
+      isCompleted: false,
+      isStopped: false,
+      userId: "user-1",
+    };
+
+    expect(isAdminWorkflowTourContinuationAllowed(continuation)).toBe(true);
+    expect(
+      isAdminWorkflowTourContinuationAllowed({
+        ...continuation,
+        hasStarted: false,
+      }),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourContinuationAllowed({
+        ...continuation,
+        isStopped: true,
+      }),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourContinuationAllowed({
+        ...continuation,
+        isCompleted: true,
+      }),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourContinuationAllowed({
+        ...continuation,
+        userId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("builds a conversational workflow payload with a stable generated name", () => {
+    const now = new Date(2026, 4, 15, 9, 8, 7);
+
+    expect(formatAdminWorkflowTourTimestamp(now)).toBe("20260515-090807");
+    expect(
+      buildAdminWorkflowTourWorkflowPayload({
+        definitionYml: "flow: []",
+        now,
+        workflowNamePrefix: "First bot",
+      }),
+    ).toEqual({
+      definitionYml: "flow: []",
+      description: null,
+      name: "First bot - 20260515-090807",
+      schedule: null,
+      type: WorkflowType.conversational,
+    });
+  });
+
+  it("recognizes dashboard and workflow editor tour routes", () => {
+    expect(isAdminWorkflowTourDashboardRoute("/")).toBe(true);
+    expect(isAdminWorkflowTourDashboardRoute("/workflow-editor")).toBe(false);
+    expect(isAdminWorkflowTourWorkflowEditorRoute("/workflow-editor")).toBe(
+      true,
+    );
+    expect(
+      isAdminWorkflowTourWorkflowEditorRoute("/workflow-editor/workflow-1"),
+    ).toBe(true);
+    expect(isAdminWorkflowTourWorkflowEditorRoute("/workflow/runs")).toBe(
+      false,
+    );
+  });
+
+  it("maps Joyride callback events to controlled tour transitions", () => {
+    expect(
+      getAdminWorkflowTourTransition({
+        action: "next",
+        index: 0,
+        size: 6,
+        status: "running",
+        type: "step:after",
+      }),
+    ).toEqual({ nextStepIndex: 1 });
+    expect(
+      getAdminWorkflowTourTransition({
+        action: "prev",
+        index: 2,
+        size: 6,
+        status: "running",
+        type: "step:after",
+      }),
+    ).toEqual({ nextStepIndex: 1 });
+    expect(
+      getAdminWorkflowTourTransition({
+        action: "next",
+        index: 5,
+        size: 6,
+        status: "running",
+        type: "step:after",
+      }),
+    ).toEqual({ complete: true });
+    expect(
+      getAdminWorkflowTourTransition({
+        action: "close",
+        index: 1,
+        size: 6,
+        status: "running",
+        type: "step:after",
+      }),
+    ).toEqual({ complete: true });
+    expect(
+      getAdminWorkflowTourTransition({
+        action: "next",
+        index: 3,
+        size: 6,
+        status: "running",
+        type: "error:target_not_found",
+      }),
+    ).toEqual({ retryStepIndex: 3 });
+    expect(
+      getAdminWorkflowTourTransition({
+        action: "skip",
+        index: 2,
+        size: 6,
+        status: "skipped",
+        type: "tour:end",
+      }),
+    ).toEqual({ complete: true });
+    expect(
+      getAdminWorkflowTourTransition({
+        action: "close",
+        index: 5,
+        size: 6,
+        status: "finished",
+        type: "tour:end",
+      }),
+    ).toEqual({ complete: true });
+  });
+
+  it("checks that targets are rendered and horizontally reachable before starting a step", () => {
+    const viewport = createViewport();
+
+    expect(isAdminWorkflowTourTargetReady(createTarget(), viewport)).toBe(true);
+    expect(
+      isAdminWorkflowTourTargetReady(
+        createTarget(createRect({ bottom: 420, top: 370 })),
+        viewport,
+      ),
+    ).toBe(true);
+    expect(
+      isAdminWorkflowTourTargetReady(
+        createTarget(createRect({ right: 0 })),
+        viewport,
+      ),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourTargetReady(
+        createTarget(createRect({ width: 0 })),
+        viewport,
+      ),
+    ).toBe(false);
+    expect(
+      isAdminWorkflowTourTargetReady(
+        createTarget(),
+        createViewport({ visibility: "hidden" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("resolves target waiting when the target appears later", async () => {
+    vi.useFakeTimers();
+
+    const target = {} as Element;
+    let activeTarget: Element | null = null;
+    const promise = waitForAdminWorkflowTourTarget("[data-tour-id='target']", {
+      intervalMs: 10,
+      queryTarget: () => activeTarget,
+      timeoutMs: 100,
+    });
+    const assertion = expect(promise).resolves.toBe(target);
+
+    await vi.advanceTimersByTimeAsync(20);
+    activeTarget = target;
+    await vi.advanceTimersByTimeAsync(10);
+    await assertion;
+  });
+
+  it("waits until the target is ready and its measured position is stable", async () => {
+    vi.useFakeTimers();
+
+    let rect = createRect({ left: 500, right: 600 });
+    const target = {
+      getBoundingClientRect: () => rect,
+    } as Element;
+    let activeTarget: Element | null = null;
+    let ready = false;
+    let resolved = false;
+    const promise = waitForAdminWorkflowTourTarget("[data-tour-id='target']", {
+      intervalMs: 10,
+      isTargetReady: () => ready,
+      queryTarget: () => activeTarget,
+      requiredStableChecks: 2,
+      timeoutMs: 100,
+    }).then((value) => {
+      resolved = true;
+
+      return value;
+    });
+
+    activeTarget = target;
+    await vi.advanceTimersByTimeAsync(10);
+    expect(resolved).toBe(false);
+
+    ready = true;
+    await vi.advanceTimersByTimeAsync(10);
+    expect(resolved).toBe(false);
+
+    rect = createRect({ left: 460, right: 560 });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(promise).resolves.toBe(target);
+  });
+
+  it("scrolls ready targets into view before resolving", async () => {
+    vi.useFakeTimers();
+
+    const scrollTargetIntoView = vi.fn();
+    const target = createTarget();
+    const promise = waitForAdminWorkflowTourTarget("[data-tour-id='target']", {
+      intervalMs: 10,
+      isTargetReady: () => true,
+      queryTarget: () => target,
+      requiredStableChecks: 1,
+      scrollTargetIntoView,
+      timeoutMs: 100,
+    });
+
+    await expect(promise).resolves.toBe(target);
+    expect(scrollTargetIntoView).toHaveBeenCalledWith(target);
+  });
+
+  it("rejects target waiting after the timeout", async () => {
+    vi.useFakeTimers();
+
+    const promise = waitForAdminWorkflowTourTarget("[data-tour-id='missing']", {
+      intervalMs: 10,
+      queryTarget: () => null,
+      timeoutMs: 30,
+    });
+    const assertion = expect(promise).rejects.toThrow(
+      "Tour target was not found: [data-tour-id='missing']",
+    );
+
+    await vi.advanceTimersByTimeAsync(30);
+    await assertion;
+  });
+});

--- a/packages/frontend/src/components/guided-tour/admin-workflow-tour.utils.ts
+++ b/packages/frontend/src/components/guided-tour/admin-workflow-tour.utils.ts
@@ -1,0 +1,448 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { WorkflowType } from "@hexabot-ai/types";
+
+import { RouterType } from "@/services/types";
+
+export const ADMIN_WORKFLOW_TOUR_STORAGE_PREFIX =
+  "hexabot.admin_workflow_editor_tour.v1";
+
+export const ADMIN_WORKFLOW_TOUR_SELECTORS = {
+  dashboardCreate: '[data-tour-id="admin-workflow-tour-create"]',
+  emptyInsert: '[data-tour-id="admin-workflow-tour-empty-insert"]',
+  insertStep: '[data-tour-id="admin-workflow-tour-insert-step"]',
+  sendTextAction: '[data-tour-id="admin-workflow-tour-send-text-action"]',
+  sendTextActionSpotlight:
+    '[data-tour-id="admin-workflow-tour-send-text-action-spotlight"]',
+  actionSave: '[data-tour-id="admin-workflow-tour-action-save"]',
+  chatWidget: '[data-tour-id="admin-workflow-tour-chat-widget"]',
+} as const;
+
+export const ADMIN_WORKFLOW_TOUR_CLICK_THROUGH_SELECTORS: Record<
+  number,
+  string
+> = {
+  0: ADMIN_WORKFLOW_TOUR_SELECTORS.dashboardCreate,
+  1: ADMIN_WORKFLOW_TOUR_SELECTORS.emptyInsert,
+  2: ADMIN_WORKFLOW_TOUR_SELECTORS.insertStep,
+  3: ADMIN_WORKFLOW_TOUR_SELECTORS.sendTextAction,
+  4: ADMIN_WORKFLOW_TOUR_SELECTORS.actionSave,
+};
+
+type TourStorage = Pick<Storage, "getItem" | "setItem">;
+
+type AdminWorkflowTourEligibility = {
+  canCreateWorkflow: boolean;
+  canReadWorkflow: boolean;
+  isAuthenticated: boolean;
+  isCompleted: boolean;
+  userId?: string;
+  workflowQuotaReached: boolean;
+};
+
+type AdminWorkflowTourContinuation = Omit<
+  AdminWorkflowTourEligibility,
+  "workflowQuotaReached"
+> & {
+  hasStarted: boolean;
+  isStopped: boolean;
+};
+
+type AdminWorkflowTourWorkflowPayloadOptions = {
+  definitionYml: string;
+  now?: Date;
+  workflowNamePrefix?: string;
+};
+
+type AdminWorkflowTourCallbackEvent = {
+  action: string;
+  index: number;
+  size: number;
+  status: string;
+  type: string;
+};
+
+export type AdminWorkflowTourTransition = {
+  complete?: boolean;
+  nextStepIndex?: number;
+  retryStepIndex?: number;
+  stop?: boolean;
+};
+
+type WaitForTargetOptions = {
+  intervalMs?: number;
+  isTargetReady?: (target: Element) => boolean;
+  queryTarget?: (selector: string) => Element | null;
+  requiredStableChecks?: number;
+  scrollTargetIntoView?: (target: Element) => void;
+  timeoutMs?: number;
+};
+
+type TourTargetViewport = Pick<
+  Window,
+  "getComputedStyle" | "innerHeight" | "innerWidth"
+>;
+
+const ADMIN_WORKFLOW_TOUR_SPOTLIGHT_PROXY_ATTR =
+  "data-admin-workflow-tour-spotlight-proxy";
+const ADMIN_WORKFLOW_TOUR_SPOTLIGHT_SOURCES: Record<string, string> = {
+  [ADMIN_WORKFLOW_TOUR_SELECTORS.sendTextActionSpotlight]:
+    ADMIN_WORKFLOW_TOUR_SELECTORS.sendTextAction,
+};
+const padDatePart = (value: number) => String(value).padStart(2, "0");
+const getAdminWorkflowTourViewport = (): TourTargetViewport | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window;
+};
+const getAdminWorkflowTourTargetRectSnapshot = (target: Element) => {
+  const getBoundingClientRect = target.getBoundingClientRect;
+
+  if (typeof getBoundingClientRect !== "function") {
+    return null;
+  }
+
+  const rect = getBoundingClientRect.call(target);
+
+  return [rect.top, rect.right, rect.bottom, rect.left, rect.width, rect.height]
+    .map((value) => Math.round(value))
+    .join(":");
+};
+const getAdminWorkflowTourSpotlightSourceSelector = (selector: string) =>
+  ADMIN_WORKFLOW_TOUR_SPOTLIGHT_SOURCES[selector] ?? selector;
+const updateAdminWorkflowTourSpotlightProxy = (
+  selector: string,
+  sourceTarget: Element,
+) => {
+  if (
+    !ADMIN_WORKFLOW_TOUR_SPOTLIGHT_SOURCES[selector] ||
+    typeof document === "undefined"
+  ) {
+    return;
+  }
+
+  const proxy =
+    document.querySelector<HTMLElement>(selector) ??
+    document.createElement("div");
+  const rect = sourceTarget.getBoundingClientRect();
+
+  if (!proxy.parentElement) {
+    proxy.setAttribute(
+      "data-tour-id",
+      "admin-workflow-tour-send-text-action-spotlight",
+    );
+    proxy.setAttribute(ADMIN_WORKFLOW_TOUR_SPOTLIGHT_PROXY_ATTR, "true");
+    proxy.setAttribute("aria-hidden", "true");
+    document.body.appendChild(proxy);
+  }
+
+  Object.assign(proxy.style, {
+    height: `${Math.round(rect.height)}px`,
+    left: `${Math.round(rect.left)}px`,
+    opacity: "0",
+    pointerEvents: "none",
+    position: "fixed",
+    top: `${Math.round(rect.top)}px`,
+    width: `${Math.round(rect.width)}px`,
+  });
+};
+const scrollAdminWorkflowTourTargetIntoView = (target: Element) => {
+  const viewport = getAdminWorkflowTourViewport();
+
+  if (!viewport || typeof target.scrollIntoView !== "function") {
+    return;
+  }
+
+  const rect = target.getBoundingClientRect();
+
+  if (rect.top >= 0 && rect.bottom <= viewport.innerHeight) {
+    return;
+  }
+
+  target.scrollIntoView({
+    block: "center",
+    inline: "nearest",
+  });
+};
+
+export const removeAdminWorkflowTourSpotlightProxy = () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document
+    .querySelectorAll(`[${ADMIN_WORKFLOW_TOUR_SPOTLIGHT_PROXY_ATTR}="true"]`)
+    .forEach((proxy) => proxy.remove());
+};
+
+export const isAdminWorkflowTourTargetReady = (
+  target: Element,
+  viewport: TourTargetViewport | null = getAdminWorkflowTourViewport(),
+) => {
+  if (!viewport) {
+    return true;
+  }
+
+  const rect = target.getBoundingClientRect();
+
+  if (
+    rect.width <= 0 ||
+    rect.height <= 0 ||
+    rect.right <= 0 ||
+    rect.left >= viewport.innerWidth
+  ) {
+    return false;
+  }
+
+  let currentTarget: Element | null = target;
+
+  while (currentTarget) {
+    const { display, visibility } = viewport.getComputedStyle(currentTarget);
+
+    if (display === "none" || visibility === "hidden") {
+      return false;
+    }
+
+    currentTarget = currentTarget.parentElement;
+  }
+
+  return true;
+};
+
+export const getAdminWorkflowTourStorageKey = (userId: string) =>
+  `${ADMIN_WORKFLOW_TOUR_STORAGE_PREFIX}.${userId}`;
+
+export const getAdminWorkflowTourStorage = (): TourStorage | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+export const isAdminWorkflowTourCompleted = (
+  userId: string | undefined,
+  storage: TourStorage | null = getAdminWorkflowTourStorage(),
+) => {
+  if (!userId || !storage) {
+    return false;
+  }
+
+  try {
+    return storage.getItem(getAdminWorkflowTourStorageKey(userId)) === "done";
+  } catch {
+    return false;
+  }
+};
+
+export const markAdminWorkflowTourCompleted = (
+  userId: string | undefined,
+  storage: TourStorage | null = getAdminWorkflowTourStorage(),
+) => {
+  if (!userId || !storage) {
+    return false;
+  }
+
+  try {
+    storage.setItem(getAdminWorkflowTourStorageKey(userId), "done");
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const isAdminWorkflowTourEligible = ({
+  canCreateWorkflow,
+  canReadWorkflow,
+  isAuthenticated,
+  isCompleted,
+  userId,
+  workflowQuotaReached,
+}: AdminWorkflowTourEligibility) =>
+  Boolean(
+    isAuthenticated &&
+      userId &&
+      canReadWorkflow &&
+      canCreateWorkflow &&
+      !workflowQuotaReached &&
+      !isCompleted,
+  );
+
+export const isAdminWorkflowTourContinuationAllowed = ({
+  canCreateWorkflow,
+  canReadWorkflow,
+  hasStarted,
+  isAuthenticated,
+  isCompleted,
+  isStopped,
+  userId,
+}: AdminWorkflowTourContinuation) =>
+  Boolean(
+    hasStarted &&
+      !isStopped &&
+      !isCompleted &&
+      isAuthenticated &&
+      userId &&
+      canReadWorkflow &&
+      canCreateWorkflow,
+  );
+
+export const isAdminWorkflowTourDashboardRoute = (pathname: string) =>
+  pathname === RouterType.HOME;
+
+export const isAdminWorkflowTourWorkflowEditorRoute = (pathname: string) =>
+  pathname.startsWith(`/${RouterType.WORKFLOW_EDITOR}`);
+
+export const formatAdminWorkflowTourTimestamp = (date: Date) => {
+  const year = date.getFullYear();
+  const month = padDatePart(date.getMonth() + 1);
+  const day = padDatePart(date.getDate());
+  const hour = padDatePart(date.getHours());
+  const minute = padDatePart(date.getMinutes());
+  const second = padDatePart(date.getSeconds());
+
+  return `${year}${month}${day}-${hour}${minute}${second}`;
+};
+
+export const buildAdminWorkflowTourWorkflowPayload = ({
+  definitionYml,
+  now = new Date(),
+  workflowNamePrefix = "My first workflow",
+}: AdminWorkflowTourWorkflowPayloadOptions) => ({
+  definitionYml,
+  description: null,
+  name: `${workflowNamePrefix} - ${formatAdminWorkflowTourTimestamp(now)}`,
+  schedule: null,
+  type: WorkflowType.conversational,
+});
+
+export const getAdminWorkflowTourTransition = ({
+  action,
+  index,
+  size,
+  status,
+  type,
+}: AdminWorkflowTourCallbackEvent): AdminWorkflowTourTransition => {
+  if (status === "finished" || status === "skipped") {
+    return { complete: true };
+  }
+
+  if (status === "error") {
+    return { stop: true };
+  }
+
+  if (type === "error:target_not_found") {
+    return { retryStepIndex: index };
+  }
+
+  if (type !== "step:after") {
+    return {};
+  }
+
+  if (action === "close") {
+    return { complete: true };
+  }
+
+  const nextStepIndex = action === "prev" ? index - 1 : index + 1;
+
+  if (nextStepIndex >= size) {
+    return { complete: true };
+  }
+
+  return { nextStepIndex: Math.max(0, nextStepIndex) };
+};
+
+export const waitForAdminWorkflowTourTarget = (
+  selector: string,
+  {
+    intervalMs = 100,
+    isTargetReady = isAdminWorkflowTourTargetReady,
+    queryTarget = (targetSelector) =>
+      typeof document === "undefined"
+        ? null
+        : document.querySelector(targetSelector),
+    requiredStableChecks = 2,
+    scrollTargetIntoView = scrollAdminWorkflowTourTargetIntoView,
+    timeoutMs = 12000,
+  }: WaitForTargetOptions = {},
+) =>
+  new Promise<Element>((resolve, reject) => {
+    const startedAt = Date.now();
+    let lastRectSnapshot: string | null = null;
+    let settled = false;
+    let stableChecks = 0;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const clearTimer = () => {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+    const checkTarget = () => {
+      const sourceSelector =
+        getAdminWorkflowTourSpotlightSourceSelector(selector);
+      const sourceTarget = queryTarget(sourceSelector);
+
+      if (sourceTarget && isTargetReady(sourceTarget)) {
+        scrollTargetIntoView(sourceTarget);
+        updateAdminWorkflowTourSpotlightProxy(selector, sourceTarget);
+      }
+
+      const target =
+        sourceSelector === selector ? sourceTarget : queryTarget(selector);
+
+      if (target && isTargetReady(target)) {
+        const rectSnapshot = getAdminWorkflowTourTargetRectSnapshot(target);
+
+        if (
+          rectSnapshot &&
+          requiredStableChecks > 1 &&
+          lastRectSnapshot !== rectSnapshot
+        ) {
+          lastRectSnapshot = rectSnapshot;
+          stableChecks = 1;
+
+          return;
+        }
+
+        stableChecks += 1;
+
+        if (rectSnapshot && stableChecks < requiredStableChecks) {
+          return;
+        }
+
+        settled = true;
+        clearTimer();
+        resolve(target);
+
+        return;
+      }
+
+      lastRectSnapshot = null;
+      stableChecks = 0;
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        settled = true;
+        clearTimer();
+        reject(new Error(`Tour target was not found: ${selector}`));
+      }
+    };
+
+    checkTarget();
+
+    if (!settled) {
+      timer = setInterval(checkTarget, intervalMs);
+    }
+  });

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerFooter.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerFooter.tsx
@@ -27,6 +27,7 @@ export const ActionFormDrawerFooter = ({
       ariaLabel={saveLabel}
       onClick={onSave}
       disabled={saveDisabled}
+      dataTourId="admin-workflow-tour-action-save"
       startIcon={<Save size={18} />}
     />
   );

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionListDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionListDrawer.tsx
@@ -160,6 +160,11 @@ const ActionListDrawerContent = ({
                   return (
                     <ActionItem
                       key={actionKey}
+                      data-tour-id={
+                        action.name === "send_text_message"
+                          ? "admin-workflow-tour-send-text-action"
+                          : undefined
+                      }
                       onClick={() => onActionSelect?.(action)}
                     >
                       <ListItemIcon

--- a/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowBottomDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowBottomDrawer.tsx
@@ -404,6 +404,7 @@ export const WorkflowBottomDrawer = () => {
         {isConversationalWorkflow ? (
           <ChatWidgetColumn
             variant="spaced"
+            data-tour-id="admin-workflow-tour-chat-widget"
             onWheelCapture={(event) => {
               event.stopPropagation();
             }}

--- a/packages/frontend/src/layout/AuthenticatedLayout.tsx
+++ b/packages/frontend/src/layout/AuthenticatedLayout.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { HexabotLogo } from "@/app-components/logos/HexabotLogo";
 import { DashboardHeader } from "@/app-components/menus/DashboardSidebar/DashboardHeader";
 import { DashboardSidebar } from "@/app-components/menus/DashboardSidebar/DashboardSidebar";
+import { AdminWorkflowTour } from "@/components/guided-tour/AdminWorkflowTour";
 import { useAuthRedirection } from "@/hooks/auth/useAuthRedirection";
 import useAvailableMenuItems from "@/hooks/useAvailableMenuItems";
 import { useConfig } from "@/hooks/useConfig";
@@ -86,6 +87,7 @@ export const AuthenticatedLayout: React.FC<
           {children}
         </Grid>
       </Box>
+      <AdminWorkflowTour />
     </WorkflowEventProvider>
   );
 };

--- a/packages/graph/src/workflow/components/WorkflowEmptyState.tsx
+++ b/packages/graph/src/workflow/components/WorkflowEmptyState.tsx
@@ -55,6 +55,7 @@ export const WorkflowEmptyState = ({
             aria-controls={isMenuOpen ? menuId : undefined}
             aria-haspopup="menu"
             aria-expanded={isMenuOpen ? "true" : undefined}
+            data-tour-id="admin-workflow-tour-empty-insert"
             onClick={handleOpenInsertMenu}
           >
             <Plus size={24} />

--- a/packages/graph/src/workflow/components/WorkflowInsertContextMenu.tsx
+++ b/packages/graph/src/workflow/components/WorkflowInsertContextMenu.tsx
@@ -173,6 +173,11 @@ export const WorkflowInsertContextMenu = ({
               role="menuitem"
               className="workflow-insert-menu__item nodrag nopan"
               data-item-id={item.id}
+              data-tour-id={
+                item.id === "step"
+                  ? "admin-workflow-tour-insert-step"
+                  : undefined
+              }
               onClick={(event) => {
                 handleMenuItemClick(event, item.type);
               }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         version: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.37.0(jiti@2.6.1))
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)
+        version: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
       lint-staged:
         specifier: ^15.3.0
         version: 15.5.2
@@ -109,7 +109,7 @@ importers:
         version: 3.6.2
       ts-jest:
         specifier: ^29.4.5
-        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.3.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.3.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
@@ -559,7 +559,7 @@ importers:
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))(prettier@3.6.2)
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)
+        version: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
       lint-staged:
         specifier: ^15.3.0
         version: 15.5.2
@@ -568,7 +568,7 @@ importers:
         version: 3.6.2
       ts-jest:
         specifier: ^29.4.5
-        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.3.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.3.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsx:
         specifier: ^4.19.2
         version: 4.20.6
@@ -686,6 +686,9 @@ importers:
       react-is:
         specifier: 18.3.1
         version: 18.3.1
+      react-joyride:
+        specifier: ^2.9.3
+        version: 2.9.3(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^6.30.2
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -865,7 +868,7 @@ importers:
         version: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.37.0(jiti@2.6.1))
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)
+        version: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
       lint-staged:
         specifier: ^15.3.0
         version: 15.5.2
@@ -874,7 +877,7 @@ importers:
         version: 3.6.2
       ts-jest:
         specifier: ^29.4.5
-        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.3.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.3.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -2272,6 +2275,12 @@ packages:
 
   '@fontsource/roboto@5.2.8':
     resolution: {integrity: sha512-oh9g4Cg3loVMz9MWeKWfDI+ooxxG1aRVetkiKIb2ESS2rrryGecQ/y4pAj4z5A5ebyw450dYRi/c4k/I3UBhHA==}
+
+  '@gilbarbara/deep-equal@0.1.2':
+    resolution: {integrity: sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA==}
+
+  '@gilbarbara/deep-equal@0.3.1':
+    resolution: {integrity: sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw==}
 
   '@golevelup/nestjs-discovery@5.0.0':
     resolution: {integrity: sha512-NaIWLCLI+XvneUK05LH2idHLmLNITYT88YnpOuUQmllKtiJNIS3woSt7QXrMZ5k3qUWuZpehEVz1JtlX4I1KyA==}
@@ -5844,6 +5853,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-diff@1.0.2:
+    resolution: {integrity: sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -6937,10 +6950,6 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
-    engines: {node: '>= 12'}
-
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -7038,6 +7047,12 @@ packages:
 
   is-json@2.0.1:
     resolution: {integrity: sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==}
+
+  is-lite@0.8.2:
+    resolution: {integrity: sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw==}
+
+  is-lite@1.2.1:
+    resolution: {integrity: sha512-pgF+L5bxC+10hLBgf6R2P4ZZUBOQIIacbdo8YvuCP8/JvsWxG7aZ9p10DYuLtifFci4l3VITphhMlMV4Y+urPw==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -8481,6 +8496,10 @@ packages:
   polka@0.5.2:
     resolution: {integrity: sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==}
 
+  popper.js@1.16.1:
+    resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
+    deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
+
   portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
     engines: {node: '>= 10.12'}
@@ -8800,6 +8819,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-floater@0.7.9:
+    resolution: {integrity: sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==}
+    peerDependencies:
+      react: 15 - 18
+      react-dom: 15 - 18
+
   react-hook-form@7.65.0:
     resolution: {integrity: sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==}
     engines: {node: '>=18.0.0'}
@@ -8819,8 +8844,20 @@ packages:
       react-native:
         optional: true
 
+  react-innertext@1.1.5:
+    resolution: {integrity: sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==}
+    peerDependencies:
+      '@types/react': '>=0.0.0 <=99'
+      react: '>=0.0.0 <=99'
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-joyride@2.9.3:
+    resolution: {integrity: sha512-1+Mg34XK5zaqJ63eeBhqdbk7dlGCFp36FXwsEvgpjqrtyywX2C6h9vr3jgxP0bGHCw8Ilsp/nRDzNVq6HJ3rNw==}
+    peerDependencies:
+      react: 15 - 18
+      react-dom: 15 - 18
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -9038,6 +9075,12 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  scroll@3.0.1:
+    resolution: {integrity: sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==}
+
+  scrollparent@2.1.0:
+    resolution: {integrity: sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==}
 
   secure-compare@3.0.1:
     resolution: {integrity: sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==}
@@ -9536,6 +9579,12 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  tree-changes@0.11.3:
+    resolution: {integrity: sha512-r14mvDZ6tqz8PRQmlFKjhUVngu4VZ9d92ON3tp0EGpFBE6PAHOq8Bx8m8ahbNoGE3uI/npjYcJiqVydyOiYXag==}
+
+  tree-changes@0.9.3:
+    resolution: {integrity: sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -11793,6 +11842,10 @@ snapshots:
 
   '@fontsource/roboto@5.2.8': {}
 
+  '@gilbarbara/deep-equal@0.1.2': {}
+
+  '@gilbarbara/deep-equal@0.3.1': {}
+
   '@golevelup/nestjs-discovery@5.0.0(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
     dependencies:
       '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -12129,6 +12182,42 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
       jest-config: 30.2.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@20.12.12)(typescript@5.9.3))
+      jest-haste-map: 30.2.0
+      jest-message-util: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-resolve-dependencies: 30.2.0
+      jest-runner: 30.2.0
+      jest-runtime: 30.2.0
+      jest-snapshot: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      jest-watcher: 30.2.0
+      micromatch: 4.0.8
+      pretty-format: 30.2.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.2.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.2.0
+      '@jest/test-result': 30.2.0
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      '@types/node': 20.12.12
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.2.0
+      jest-config: 30.2.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -15938,6 +16027,8 @@ snapshots:
     optionalDependencies:
       babel-plugin-macros: 3.1.0
 
+  deep-diff@1.0.2: {}
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -17291,9 +17382,6 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.0.1:
-    optional: true
-
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -17383,6 +17471,10 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-json@2.0.1: {}
+
+  is-lite@0.8.2: {}
+
+  is-lite@1.2.1: {}
 
   is-map@2.0.3: {}
 
@@ -17563,15 +17655,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0):
+  jest-cli@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@20.12.12)(typescript@5.9.3))
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)
+      jest-config: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -17615,7 +17707,40 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0):
+  jest-config@30.2.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.4)
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      deepmerge: 4.3.1
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      jest-circus: 30.2.0(babel-plugin-macros@3.1.0)
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-runner: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.2.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.12.12
+      ts-node: 10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.4
       '@jest/get-type': 30.1.0
@@ -17643,6 +17768,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.1
+      ts-node: 10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17881,12 +18007,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0):
+  jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@20.12.12)(typescript@5.9.3))
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)
+      jest-cli: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -19406,6 +19532,8 @@ snapshots:
       '@polka/url': 0.5.0
       trouter: 2.0.1
 
+  popper.js@1.16.1: {}
+
   portfinder@1.0.38:
     dependencies:
       async: 3.2.6
@@ -19722,6 +19850,16 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-floater@0.7.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      deepmerge: 4.3.1
+      is-lite: 0.8.2
+      popper.js: 1.16.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tree-changes: 0.9.3
+
   react-hook-form@7.65.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -19735,7 +19873,30 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
+  react-innertext@1.1.5(@types/react@18.3.2)(react@18.3.1):
+    dependencies:
+      '@types/react': 18.3.2
+      react: 18.3.1
+
   react-is@18.3.1: {}
+
+  react-joyride@2.9.3(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@gilbarbara/deep-equal': 0.3.1
+      deep-diff: 1.0.2
+      deepmerge: 4.3.1
+      is-lite: 1.2.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-floater: 0.7.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-innertext: 1.1.5(@types/react@18.3.2)(react@18.3.1)
+      react-is: 18.3.1
+      scroll: 3.0.1
+      scrollparent: 2.1.0
+      tree-changes: 0.11.3
+      type-fest: 4.41.0
+    transitivePeerDependencies:
+      - '@types/react'
 
   react-refresh@0.17.0: {}
 
@@ -20013,6 +20174,10 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
+  scroll@3.0.1: {}
+
+  scrollparent@2.1.0: {}
+
   secure-compare@3.0.1: {}
 
   seek-bzip@1.0.6:
@@ -20220,7 +20385,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.0.1
+      ip-address: 10.1.0
       smart-buffer: 4.2.0
     optional: true
 
@@ -20573,6 +20738,16 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-changes@0.11.3:
+    dependencies:
+      '@gilbarbara/deep-equal': 0.3.1
+      is-lite: 1.2.1
+
+  tree-changes@0.9.3:
+    dependencies:
+      '@gilbarbara/deep-equal': 0.1.2
+      is-lite: 0.8.2
+
   tree-kill@1.2.2: {}
 
   tree-sitter@0.22.4:
@@ -20592,12 +20767,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.3.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.3.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)
+      jest: 30.2.0(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -20646,6 +20821,27 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.32
+
+  ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.1)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 9.0.0
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.32
+    optional: true
 
   tsconfig-paths-jest@0.0.1: {}
 


### PR DESCRIPTION
## What changed?

- Add an admin workflow guided tour that helps eligible users create and test their first conversational workflow.
- Automatically starts from the dashboard, creates a starter workflow, and continues through the visual editor.
- Guides users through inserting a step, choosing Send Text Message, saving the action, and testing it in the chat widget.
- Tracks tour completion per user so the tour does not restart after it is finished or skipped.
- Adds improved tooltip UI and friendlier English/French tour copy.
