### PR TITLE
feat(frontend): jsonata assist

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -682,7 +682,23 @@
   },
   "input": {
     "search": "Search",
-    "jsonata_formula_mode": "JSONata mode (starts with '=')"
+    "jsonata_formula_mode": "Dynamic value",
+    "dynamic_value": {
+      "active": "Dynamic value",
+      "use_dynamic": "Use dynamic value",
+      "menu": {
+        "replace": "Replace with dynamic value",
+        "replace_description": "Clear this static value and start an expression.",
+        "convert": "Convert current text to dynamic string",
+        "convert_description": "Keep this text as a quoted JSONata string.",
+        "cancel": "Cancel"
+      },
+      "errors": {
+        "disabled": "Values starting with '=' are dynamic values. This field does not support dynamic values.",
+        "empty": "Enter a dynamic value expression.",
+        "invalid_jsonata": "Invalid JSONata expression."
+      }
+    }
   },
   "link": {
     "reset": "Forgot your password?"
@@ -750,6 +766,15 @@
           "mode": {
             "override_global_settings": "Override global settings"
           }
+        },
+        "dynamic_values_help": {
+          "open": "About dynamic values",
+          "title": "Dynamic values",
+          "static": "Static values are kept exactly as entered.",
+          "dynamic": "Type '=' or click the function icon to use a dynamic value from $input, $output, or $context.",
+          "technical": "Dynamic values use JSONata expressions. In settings, only supported fields can use them.",
+          "docs": "Hexabot docs",
+          "jsonata_docs": "JSONata docs"
         },
         "description": {
           "placeholder": "Optional step description."

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -682,7 +682,23 @@
   },
   "input": {
     "search": "Recherche",
-    "jsonata_formula_mode": "Mode JSONata (commence par '=')"
+    "jsonata_formula_mode": "Valeur dynamique",
+    "dynamic_value": {
+      "active": "Valeur dynamique",
+      "use_dynamic": "Utiliser une valeur dynamique",
+      "menu": {
+        "replace": "Remplacer par une valeur dynamique",
+        "replace_description": "Effacer cette valeur statique et commencer une expression.",
+        "convert": "Convertir le texte en chaîne dynamique",
+        "convert_description": "Conserver ce texte comme chaîne JSONata entre guillemets.",
+        "cancel": "Annuler"
+      },
+      "errors": {
+        "disabled": "Les valeurs qui commencent par '=' sont des valeurs dynamiques. Ce champ ne prend pas en charge les valeurs dynamiques.",
+        "empty": "Saisissez une expression de valeur dynamique.",
+        "invalid_jsonata": "Expression JSONata invalide."
+      }
+    }
   },
   "link": {
     "reset": "Mot de passe oublié?"
@@ -750,6 +766,15 @@
           "mode": {
             "override_global_settings": "Remplacer les paramètres globaux"
           }
+        },
+        "dynamic_values_help": {
+          "open": "À propos des valeurs dynamiques",
+          "title": "Valeurs dynamiques",
+          "static": "Les valeurs statiques sont conservées exactement comme elles sont saisies.",
+          "dynamic": "Saisissez '=' ou cliquez sur l'icône de fonction pour utiliser une valeur dynamique depuis $input, $output ou $context.",
+          "technical": "Les valeurs dynamiques utilisent des expressions JSONata. Dans les paramètres, seuls les champs compatibles peuvent les utiliser.",
+          "docs": "Documentation Hexabot",
+          "jsonata_docs": "Documentation JSONata"
         },
         "description": {
           "placeholder": "Description optionnelle de l'étape."

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/JsonSchemaForm.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/JsonSchemaForm.tsx
@@ -16,6 +16,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isRecord } from "@/utils/object";
 import validator from "@/utils/rjsf-zod-validator";
 
+import type {
+  ExpressionFieldState,
+  ExpressionPolicy,
+} from "./expression.types";
 import { FORM_FIELDS } from "./fields";
 import { FORM_TEMPLATES } from "./templates";
 import { getFormWidgets } from "./widgets";
@@ -57,6 +61,7 @@ type JsonSchemaFormProps<
   uiSchema?: UiSchema;
   liveValidate?: "onChange" | "onBlur" | boolean;
   enableJsonataTextWidget?: boolean;
+  expressionPolicy?: ExpressionPolicy;
   formContext?: Record<string, unknown>;
   onVisibleErrorsChange?: (hasVisibleErrors: boolean) => void;
   validateOnMount?: boolean;
@@ -72,6 +77,7 @@ export const JsonSchemaForm = <
   uiSchema,
   liveValidate = "onChange",
   enableJsonataTextWidget = true,
+  expressionPolicy = "input-default",
   formContext,
   onVisibleErrorsChange,
   validateOnMount = false,
@@ -81,6 +87,9 @@ export const JsonSchemaForm = <
   );
   const visibleErrorFieldIdsRef = useRef<Set<string>>(new Set());
   const [hasVisibleErrors, setHasVisibleErrors] = useState(false);
+  const [expressionFieldStates, setExpressionFieldStates] = useState<
+    Record<string, ExpressionFieldState>
+  >({});
   const normalizedFormData = useMemo(
     () => withSchemaDefaults(schema, formData),
     [formData, schema],
@@ -106,6 +115,40 @@ export const JsonSchemaForm = <
       setHasVisibleErrors((previous) =>
         previous === nextHasVisibleErrors ? previous : nextHasVisibleErrors,
       );
+    },
+    [],
+  );
+  const reportExpressionFieldState = useCallback(
+    (fieldId: string, state?: ExpressionFieldState) => {
+      if (!fieldId) {
+        return;
+      }
+
+      setExpressionFieldStates((current) => {
+        const previous = current[fieldId];
+
+        if (!state) {
+          if (!previous) {
+            return current;
+          }
+
+          const { [fieldId]: _, ...next } = current;
+
+          return next;
+        }
+
+        if (
+          previous?.hasError === state.hasError &&
+          previous?.suppressSchemaErrors === state.suppressSchemaErrors
+        ) {
+          return current;
+        }
+
+        return {
+          ...current,
+          [fieldId]: state,
+        };
+      });
     },
     [],
   );
@@ -140,7 +183,10 @@ export const JsonSchemaForm = <
       formData={liveFormData}
       formContext={{
         ...(formContext ?? {}),
+        expressionFieldStates,
+        expressionPolicy,
         formData: liveFormData,
+        reportExpressionFieldState,
         reportFieldVisibleError,
       }}
       onChange={(event) => {

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/expression.types.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/expression.types.ts
@@ -1,0 +1,21 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+export type ExpressionPolicy = "input-default" | "opt-in" | "disabled";
+
+export type ExpressionFieldState = {
+  hasError: boolean;
+  suppressSchemaErrors: boolean;
+};
+
+export type ExpressionFormContext = {
+  expressionFieldStates?: Record<string, ExpressionFieldState | undefined>;
+  expressionPolicy?: ExpressionPolicy;
+  reportExpressionFieldState?: (
+    fieldId: string,
+    state?: ExpressionFieldState,
+  ) => void;
+};

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/index.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/index.ts
@@ -8,3 +8,8 @@ export { FORM_FIELDS } from "./fields";
 export { JsonSchemaForm } from "./JsonSchemaForm";
 export { FORM_TEMPLATES } from "./templates";
 export { FORM_WIDGETS, FORM_WIDGETS_BASE, getFormWidgets } from "./widgets";
+export type {
+  ExpressionFieldState,
+  ExpressionFormContext,
+  ExpressionPolicy,
+} from "./expression.types";

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/templates/ActionFieldTemplate.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/templates/ActionFieldTemplate.tsx
@@ -12,6 +12,8 @@ import {
 } from "@rjsf/utils";
 import { useEffect } from "react";
 
+import type { ExpressionFormContext } from "../expression.types";
+
 import { isActionFieldHidden } from "./action-field-template.utils";
 
 export const ActionFieldTemplate = (props: FieldTemplateProps) => {
@@ -36,16 +38,17 @@ export const ActionFieldTemplate = (props: FieldTemplateProps) => {
     schema,
     uiSchema,
     registry,
-    formData,
   } = props;
   const uiOptions = getUiOptions(uiSchema);
   const rootFormData = registry.formContext?.formData as
     | Record<string, unknown>
     | undefined;
+  const expressionFieldState = (
+    registry.formContext as ExpressionFormContext | undefined
+  )?.expressionFieldStates?.[id];
   const shouldIgnoreErrors =
-    id.startsWith("action-") &&
-    typeof formData === "string" &&
-    formData.startsWith("=");
+    expressionFieldState?.suppressSchemaErrors === true &&
+    expressionFieldState?.hasError !== true;
   const reportFieldVisibleError = registry.formContext
     ?.reportFieldVisibleError as
     | ((fieldId: string, hasVisibleError: boolean) => void)
@@ -55,8 +58,11 @@ export const ActionFieldTemplate = (props: FieldTemplateProps) => {
     uiOptions,
     formData: rootFormData,
   });
-  const hasVisibleError =
+  const hasSchemaVisibleError =
     !isHidden && !shouldIgnoreErrors && rawErrors.length > 0;
+  const hasExpressionVisibleError =
+    !isHidden && expressionFieldState?.hasError === true;
+  const hasVisibleError = hasSchemaVisibleError || hasExpressionVisibleError;
   const WrapIfAdditionalTemplate = getTemplate(
     "WrapIfAdditionalTemplate",
     registry,
@@ -95,7 +101,7 @@ export const ActionFieldTemplate = (props: FieldTemplateProps) => {
     >
       <FormControl fullWidth error={hasVisibleError} required={required}>
         {children}
-        {hasVisibleError ? errors : null}
+        {hasSchemaVisibleError ? errors : null}
         {help}
       </FormControl>
     </WrapIfAdditionalTemplate>

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/JsonataTextWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/JsonataTextWidget.tsx
@@ -4,17 +4,29 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { RJSFSchema, WidgetProps } from "@rjsf/utils";
+import { FormHelperText } from "@mui/material";
+import {
+  getTemplate,
+  type BaseInputTemplateProps,
+  type RJSFSchema,
+  type WidgetProps,
+} from "@rjsf/utils";
+import { useCallback, useEffect } from "react";
 import type { ReactNode } from "react";
 
 import {
   JsonataFormulaField,
   type GlobalsSchema,
 } from "@/app-components/inputs/JsonataFormulaField";
+import { isExpressionValue } from "@/app-components/inputs/JsonataFormulaField/dynamicValueUtils";
+import { useTranslate } from "@/hooks/useTranslate";
 
+import type { ExpressionFormContext } from "../expression.types";
+
+import { resolveAllowExpression } from "./expression-policy.utils";
 import { getDescription, LabelWithTooltip } from "./shared";
 
-type JsonataFormContext = {
+type JsonataFormContext = ExpressionFormContext & {
   globalsSchema?: GlobalsSchema;
 };
 type JsonataWidgetOptions = {
@@ -36,10 +48,18 @@ export const JsonataTextWidget = ({
   options,
   schema,
   registry,
+  ...props
 }: WidgetProps) => {
+  const { t } = useTranslate();
   const widgetOptions = options as JsonataWidgetOptions;
   const context = registry.formContext as JsonataFormContext | undefined;
+  const reportExpressionFieldState = context?.reportExpressionFieldState;
   const globalsSchema = widgetOptions?.globalsSchema ?? context?.globalsSchema;
+  const allowExpression = resolveAllowExpression({
+    schema: schema as RJSFSchema,
+    options: widgetOptions,
+    policy: context?.expressionPolicy,
+  });
   const hasCustomEmptyValue =
     widgetOptions !== undefined &&
     Object.prototype.hasOwnProperty.call(widgetOptions, "emptyValue");
@@ -52,6 +72,94 @@ export const JsonataTextWidget = ({
   const labelWithTooltip = (
     <LabelWithTooltip label={fieldLabel} description={description} />
   );
+  const hasDisallowedExpressionValue =
+    !allowExpression && isExpressionValue(safeValue);
+
+  useEffect(() => {
+    if (allowExpression) {
+      reportExpressionFieldState?.(id, undefined);
+
+      return;
+    }
+
+    reportExpressionFieldState?.(
+      id,
+      hasDisallowedExpressionValue
+        ? { hasError: true, suppressSchemaErrors: false }
+        : undefined,
+    );
+  }, [
+    allowExpression,
+    hasDisallowedExpressionValue,
+    id,
+    reportExpressionFieldState,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      reportExpressionFieldState?.(id, undefined);
+    };
+  }, [id, reportExpressionFieldState]);
+
+  const reportAllowedExpressionState = useCallback(
+    (state: { hasError: boolean; suppressSchemaErrors: boolean }) => {
+      reportExpressionFieldState?.(
+        id,
+        state.hasError || state.suppressSchemaErrors
+          ? {
+              hasError: state.hasError,
+              suppressSchemaErrors: state.suppressSchemaErrors,
+            }
+          : undefined,
+      );
+    },
+    [id, reportExpressionFieldState],
+  );
+
+  if (!allowExpression) {
+    const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+      "BaseInputTemplate",
+      registry,
+      options,
+    );
+
+    return (
+      <>
+        <BaseInputTemplate
+          {...(props as BaseInputTemplateProps)}
+          id={id}
+          label={fieldLabel ?? ""}
+          required={required}
+          disabled={disabled}
+          readonly={readonly}
+          value={safeValue}
+          schema={schema}
+          registry={registry}
+          options={options}
+          onChange={(nextValue) =>
+            onChange(normalizeValue(nextValue == null ? "" : String(nextValue)))
+          }
+          onBlur={(fieldId, nextValue) =>
+            onBlur?.(
+              fieldId,
+              normalizeValue(nextValue == null ? "" : String(nextValue)),
+            )
+          }
+          onFocus={(fieldId, nextValue) =>
+            onFocus?.(
+              fieldId,
+              normalizeValue(nextValue == null ? "" : String(nextValue)),
+            )
+          }
+        />
+        {hasDisallowedExpressionValue ? (
+          <FormHelperText error sx={{ mt: 0.5 }}>
+            {t("input.dynamic_value.errors.disabled")}
+          </FormHelperText>
+        ) : null}
+      </>
+    );
+  }
 
   return (
     <JsonataFormulaField
@@ -63,6 +171,8 @@ export const JsonataTextWidget = ({
       onFocus={(next) => onFocus?.(id, normalizeValue(next))}
       globalsSchema={globalsSchema}
       disabled={disabled || readonly}
+      enableExpressionAssist
+      onExpressionStateChange={reportAllowedExpressionState}
       fullWidth
     />
   );

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/expression-policy.utils.test.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/expression-policy.utils.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { resolveAllowExpression } from "./expression-policy.utils";
+
+describe("expression policy utils", () => {
+  it("allows expressions by default for action input forms", () => {
+    expect(
+      resolveAllowExpression({
+        schema: { type: "string" },
+        options: {},
+        policy: "input-default",
+      }),
+    ).toBe(true);
+  });
+
+  it("requires explicit opt-in for settings-style forms", () => {
+    expect(
+      resolveAllowExpression({
+        schema: { type: "string" },
+        options: {},
+        policy: "opt-in",
+      }),
+    ).toBe(false);
+    expect(
+      resolveAllowExpression({
+        schema: { type: "string" },
+        options: { allowExpression: true },
+        policy: "opt-in",
+      }),
+    ).toBe(true);
+  });
+
+  it("respects explicit opt-out on input fields", () => {
+    expect(
+      resolveAllowExpression({
+        schema: { type: "string" },
+        options: { allowExpression: false },
+        policy: "input-default",
+      }),
+    ).toBe(false);
+  });
+
+  it("never allows expressions for unsafe field shapes", () => {
+    expect(
+      resolveAllowExpression({
+        schema: { type: "string", writeOnly: true },
+        options: { allowExpression: true },
+        policy: "input-default",
+      }),
+    ).toBe(false);
+    expect(
+      resolveAllowExpression({
+        schema: { type: "string" },
+        options: { entity: "Credential", allowExpression: true },
+        policy: "input-default",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/expression-policy.utils.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/expression-policy.utils.ts
@@ -1,0 +1,56 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type { RJSFSchema } from "@rjsf/utils";
+
+import type { ExpressionPolicy } from "../expression.types";
+
+export type { ExpressionPolicy } from "../expression.types";
+
+type ExpressionPolicyOptions = {
+  allowExpression?: unknown;
+  entity?: unknown;
+  inputType?: unknown;
+  [key: string]: unknown;
+};
+
+const isUnsafeExpressionSchema = (
+  schema: RJSFSchema | undefined,
+  options: ExpressionPolicyOptions | undefined,
+) => {
+  const schemaRecord = schema as Record<string, unknown> | undefined;
+  const widget = schemaRecord?.["ui:widget"] ?? options?.["ui:widget"];
+  const format = schemaRecord?.format;
+
+  return (
+    schemaRecord?.writeOnly === true ||
+    widget === "PasswordWidget" ||
+    widget === "AutoCompleteWidget" ||
+    format === "password" ||
+    options?.inputType === "password" ||
+    typeof options?.entity === "string"
+  );
+};
+
+export const resolveAllowExpression = ({
+  schema,
+  options,
+  policy,
+}: {
+  schema?: RJSFSchema;
+  options?: ExpressionPolicyOptions;
+  policy?: ExpressionPolicy;
+}) => {
+  if (policy === "disabled" || isUnsafeExpressionSchema(schema, options)) {
+    return false;
+  }
+
+  if (typeof options?.allowExpression === "boolean") {
+    return options.allowExpression;
+  }
+
+  return (policy ?? "input-default") === "input-default";
+};

--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/ExpressionAssist.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/ExpressionAssist.tsx
@@ -1,0 +1,105 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import FunctionsRoundedIcon from "@mui/icons-material/FunctionsRounded";
+import {
+  Box,
+  IconButton,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from "@mui/material";
+
+import { useTranslate } from "@/hooks/useTranslate";
+
+type ExpressionAssistProps = {
+  disabled?: boolean;
+  isExpression: boolean;
+  menuAnchor: HTMLElement | null;
+  onConvertStaticText: () => void;
+  onMenuClose: () => void;
+  onOpen: (anchor: HTMLElement) => void;
+  onReplaceWithExpression: () => void;
+};
+
+export const ExpressionAssist = ({
+  disabled,
+  isExpression,
+  menuAnchor,
+  onConvertStaticText,
+  onMenuClose,
+  onOpen,
+  onReplaceWithExpression,
+}: ExpressionAssistProps) => {
+  const { t } = useTranslate();
+  const label = isExpression
+    ? t("input.dynamic_value.active")
+    : t("input.dynamic_value.use_dynamic");
+
+  return (
+    <>
+      <Tooltip title={label} arrow>
+        <Box
+          component="span"
+          sx={{
+            position: "absolute",
+            right: 4,
+            top: "50%",
+            transform: "translateY(-50%)",
+            display: "inline-flex",
+            alignItems: "center",
+            zIndex: 1,
+          }}
+        >
+          <IconButton
+            aria-label={label}
+            disabled={disabled}
+            size="small"
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpen(event.currentTarget);
+            }}
+            sx={{
+              color: isExpression ? "primary.main" : "text.secondary",
+            }}
+          >
+            <FunctionsRoundedIcon sx={{ fontSize: 16 }} />
+          </IconButton>
+        </Box>
+      </Tooltip>
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={onMenuClose}
+        onClick={(event) => event.stopPropagation()}
+        slotProps={{
+          paper: {
+            sx: {
+              maxWidth: 320,
+            },
+          },
+        }}
+      >
+        <MenuItem onClick={onReplaceWithExpression}>
+          <ListItemText
+            primary={t("input.dynamic_value.menu.replace")}
+            secondary={t("input.dynamic_value.menu.replace_description")}
+          />
+        </MenuItem>
+        <MenuItem onClick={onConvertStaticText}>
+          <ListItemText
+            primary={t("input.dynamic_value.menu.convert")}
+            secondary={t("input.dynamic_value.menu.convert_description")}
+          />
+        </MenuItem>
+        <MenuItem onClick={onMenuClose}>
+          <ListItemText primary={t("input.dynamic_value.menu.cancel")} />
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};

--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/JsonataFormulaField.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/JsonataFormulaField.tsx
@@ -19,6 +19,16 @@ import * as React from "react";
 
 import { useTranslate } from "@/hooks/useTranslate";
 
+import {
+  ensureExpressionPrefix,
+  isExpressionValue,
+  looksLikeDynamicValueExpressionBody,
+  shouldAppendCompletionDot,
+  stripExpressionPrefix,
+  toJsonataStringLiteral,
+  validateDynamicValue,
+} from "./dynamicValueUtils";
+import { ExpressionAssist } from "./ExpressionAssist";
 import { useJsonataGlobalsSchema } from "./globals-schema.context";
 import { indexToLineCol } from "./jsonataUtils";
 import {
@@ -28,6 +38,23 @@ import {
 } from "./monaco";
 import { extractGlobals } from "./schema";
 import type { JsonataFormulaFieldProps } from "./types";
+
+const getValidationMessage = (
+  validation: ReturnType<typeof validateDynamicValue>,
+  t: ReturnType<typeof useTranslate>["t"],
+) => {
+  if (validation.code === "empty_dynamic") {
+    return t("input.dynamic_value.errors.empty");
+  }
+
+  if (validation.code === "invalid_dynamic") {
+    return (
+      validation.errorMessage ?? t("input.dynamic_value.errors.invalid_jsonata")
+    );
+  }
+
+  return null;
+};
 
 export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
   const {
@@ -43,6 +70,8 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
     fullWidth,
     minHeightPx = 36,
     maxHeightPx = 220,
+    enableExpressionAssist = false,
+    onExpressionStateChange,
     sx,
   } = props;
   const { t } = useTranslate();
@@ -53,7 +82,7 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
     () => extractGlobals(resolvedGlobalsSchema),
     [resolvedGlobalsSchema],
   );
-  const isJsonataMode = value.startsWith("=");
+  const isJsonataMode = isExpressionValue(value);
   const monacoRef = React.useRef<typeof import("monaco-editor") | null>(null);
   const editorRef = React.useRef<
     import("monaco-editor").editor.IStandaloneCodeEditor | null
@@ -61,15 +90,12 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
   const completionDisposableRef = React.useRef<
     import("monaco-editor").IDisposable | null
   >(null);
-  const [internalError, setInternalError] = React.useState<string | null>(null);
   const [height, setHeight] = React.useState<number>(minHeightPx);
+  const [assistMenuAnchor, setAssistMenuAnchor] =
+    React.useState<HTMLElement | null>(null);
   const prevIsJsonataMode = React.useRef<boolean>(isJsonataMode);
   const onBlurRef = React.useRef(onBlur);
   const onFocusRef = React.useRef(onFocus);
-
-  React.useEffect(() => {
-    prevIsJsonataMode.current = isJsonataMode;
-  }, [isJsonataMode]);
 
   React.useEffect(() => {
     onBlurRef.current = onBlur;
@@ -181,7 +207,22 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
       editor.focus();
       editor.trigger("jsonata", "editor.action.triggerSuggest", null);
     }
+
+    prevIsJsonataMode.current = isJsonataMode;
   }, [isJsonataMode]);
+
+  const validationResult = React.useMemo(() => {
+    return validateDynamicValue(value);
+  }, [value]);
+  const validationMessage = getValidationMessage(validationResult, t);
+
+  React.useEffect(() => {
+    onExpressionStateChange?.({
+      hasError: Boolean(validationMessage),
+      isExpression: validationResult.isExpression,
+      suppressSchemaErrors: validationResult.suppressSchemaErrors,
+    });
+  }, [onExpressionStateChange, validationMessage, validationResult]);
 
   // Syntax validation (debounced)
   React.useEffect(() => {
@@ -195,8 +236,6 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
     if (!model) return;
 
     const handle = window.setTimeout(() => {
-      setInternalError(null);
-
       // Clear markers in plain mode
       if (!isJsonataMode) {
         monaco.editor.setModelMarkers(model, "jsonata", []);
@@ -204,7 +243,22 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
         return;
       }
 
-      const expr = value.slice(1); // strip leading '='
+      const expr = stripExpressionPrefix(value);
+
+      if (validationResult.code === "empty_dynamic") {
+        monaco.editor.setModelMarkers(model, "jsonata", [
+          {
+            severity: monaco.MarkerSeverity.Error,
+            message: validationMessage ?? t("input.dynamic_value.errors.empty"),
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 2,
+          },
+        ]);
+
+        return;
+      }
 
       if (!expr.trim()) {
         monaco.editor.setModelMarkers(model, "jsonata", []);
@@ -217,14 +271,10 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
         jsonata(expr);
 
         monaco.editor.setModelMarkers(model, "jsonata", []);
-        setInternalError(null);
       } catch (e: any) {
         const message = e?.message
           ? String(e.message)
-          : "Invalid JSONata expression";
-
-        setInternalError(message);
-
+          : t("input.dynamic_value.errors.invalid_jsonata");
         const posIndex: number =
           typeof e?.position === "number"
             ? e.position
@@ -232,7 +282,6 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
               ? e.offset
               : 0;
         const { line, col } = indexToLineCol(expr, Math.max(0, posIndex));
-        // +1 column shift on first line due to the leading '=' in the editor content
         const lineNumber = line + 1;
         const startColumn = col + 1 + (line === 0 ? 1 : 0);
         const endColumn = startColumn + 1;
@@ -251,13 +300,147 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
     }, 200);
 
     return () => window.clearTimeout(handle);
-  }, [value, isJsonataMode]);
+  }, [isJsonataMode, t, validationMessage, validationResult.code, value]);
 
-  const showError = Boolean(internalError);
+  const handleEditorChange = (nextEditorValue?: string) => {
+    onChange(nextEditorValue ?? "");
+  };
+  const appendDotForPathCompletion = (
+    editor: import("monaco-editor").editor.IStandaloneCodeEditor,
+    monaco: typeof import("monaco-editor"),
+  ) => {
+    const model = editor.getModel();
+    const position = editor.getPosition();
+
+    if (!model || !position) {
+      return;
+    }
+
+    const textBeforeCursor = model.getValueInRange({
+      startLineNumber: position.lineNumber,
+      startColumn: 1,
+      endLineNumber: position.lineNumber,
+      endColumn: position.column,
+    });
+
+    if (!shouldAppendCompletionDot(textBeforeCursor)) {
+      return;
+    }
+
+    editor.executeEdits("dynamic-value", [
+      {
+        range: new monaco.Range(
+          position.lineNumber,
+          position.column,
+          position.lineNumber,
+          position.column,
+        ),
+        text: ".",
+        forceMoveMarkers: true,
+      },
+    ]);
+    editor.setPosition({
+      lineNumber: position.lineNumber,
+      column: position.column + 1,
+    });
+  };
+  const focusDynamicValueEditor = (
+    editor: import("monaco-editor").editor.IStandaloneCodeEditor,
+    monaco: typeof import("monaco-editor"),
+    options: { triggerSuggestions?: boolean } = { triggerSuggestions: true },
+  ) => {
+    const model = editor.getModel();
+
+    if (model) {
+      monaco.editor.setModelLanguage(model, "jsonata");
+    }
+
+    if (options.triggerSuggestions) {
+      appendDotForPathCompletion(editor, monaco);
+    }
+
+    editor.focus();
+
+    if (options.triggerSuggestions) {
+      editor.trigger("dynamic-value", "editor.action.triggerSuggest", null);
+    }
+  };
+  const replaceEditorValue = (
+    nextValue: string,
+    options: { triggerSuggestions?: boolean } = { triggerSuggestions: true },
+  ) => {
+    const editor = editorRef.current;
+    const monaco = monacoRef.current;
+
+    if (!editor || !monaco) {
+      onChange(nextValue);
+
+      return;
+    }
+
+    editor.setValue(nextValue);
+    editor.setPosition({ lineNumber: 1, column: nextValue.length + 1 });
+    focusDynamicValueEditor(editor, monaco, options);
+  };
+  const handleExpressionAssist = (anchor: HTMLElement) => {
+    const editor = editorRef.current;
+    const monaco = monacoRef.current;
+
+    if (!editor || !monaco) {
+      if (
+        !value.trim() ||
+        isExpressionValue(value) ||
+        looksLikeDynamicValueExpressionBody(value)
+      ) {
+        onChange(ensureExpressionPrefix(value));
+      } else {
+        setAssistMenuAnchor(anchor);
+      }
+
+      return;
+    }
+
+    const editorCurrentValue = editor.getValue();
+
+    if (isExpressionValue(editorCurrentValue)) {
+      focusDynamicValueEditor(editor, monaco);
+
+      return;
+    }
+
+    if (!editorCurrentValue.trim()) {
+      replaceEditorValue("=");
+
+      return;
+    }
+
+    if (looksLikeDynamicValueExpressionBody(editorCurrentValue)) {
+      replaceEditorValue(ensureExpressionPrefix(editorCurrentValue));
+
+      return;
+    }
+
+    setAssistMenuAnchor(anchor);
+  };
+  const closeAssistMenu = () => setAssistMenuAnchor(null);
+  const replaceWithDynamicValue = () => {
+    closeAssistMenu();
+    replaceEditorValue("=");
+  };
+  const convertStaticTextToDynamicString = () => {
+    const currentValue = editorRef.current?.getValue() ?? value;
+
+    closeAssistMenu();
+    replaceEditorValue(toJsonataStringLiteral(currentValue), {
+      triggerSuggestions: false,
+    });
+  };
+  const showError = Boolean(validationMessage);
   const { mode } = useColorScheme();
-  const showModeIcon = isJsonataMode;
+  const showAssistIcon = enableExpressionAssist;
+  const showModeIcon = !showAssistIcon && isJsonataMode;
   const modeLabel = t("input.jsonata_formula_mode");
-  const resolvedHelperText = showError ? internalError : helperText;
+  const resolvedHelperText = showError ? validationMessage : helperText;
 
   return (
     <FormControl
@@ -314,7 +497,10 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
             borderRadius: resolvedTheme.shape.borderRadius,
             border: "1px solid",
             paddingLeft: theme.spacing(1),
-            paddingRight: showModeIcon ? theme.spacing(4.5) : theme.spacing(1),
+            paddingRight:
+              showModeIcon || showAssistIcon
+                ? theme.spacing(4.5)
+                : theme.spacing(1),
             borderColor,
             backgroundColor: disabled
               ? disabledBackground
@@ -380,9 +566,20 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
             </Box>
           </Tooltip>
         ) : null}
+        {showAssistIcon ? (
+          <ExpressionAssist
+            disabled={disabled}
+            isExpression={isJsonataMode}
+            menuAnchor={assistMenuAnchor}
+            onConvertStaticText={convertStaticTextToDynamicString}
+            onMenuClose={closeAssistMenu}
+            onOpen={handleExpressionAssist}
+            onReplaceWithExpression={replaceWithDynamicValue}
+          />
+        ) : null}
         <Editor
           value={value}
-          onChange={(v) => onChange(v ?? "")}
+          onChange={handleEditorChange}
           onMount={onMount}
           theme={mode}
           beforeMount={handleEditorWillMount}

--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/dynamicValueUtils.test.ts
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/dynamicValueUtils.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ensureExpressionPrefix,
+  isExpressionValue,
+  looksLikeDynamicValueExpressionBody,
+  shouldAppendCompletionDot,
+  stripExpressionPrefix,
+  toJsonataStringLiteral,
+  validateDynamicValue,
+} from "./dynamicValueUtils";
+
+describe("dynamic value utils", () => {
+  it("detects and normalizes expression prefixes", () => {
+    expect(isExpressionValue("plain text")).toBe(false);
+    expect(isExpressionValue("=$input.text")).toBe(true);
+    expect(stripExpressionPrefix("=$input.text")).toBe("$input.text");
+    expect(ensureExpressionPrefix("$input.text")).toBe("=$input.text");
+    expect(ensureExpressionPrefix("=$input.text")).toBe("=$input.text");
+  });
+
+  it("validates static, valid, empty, and invalid expressions", () => {
+    expect(validateDynamicValue("plain text")).toMatchObject({
+      code: null,
+      isExpression: false,
+      suppressSchemaErrors: false,
+    });
+    expect(validateDynamicValue("=$input.text")).toMatchObject({
+      code: null,
+      isExpression: true,
+      suppressSchemaErrors: true,
+    });
+    expect(validateDynamicValue("=").code).toBe("empty_dynamic");
+    expect(validateDynamicValue("=$input.").code).toBe("invalid_dynamic");
+  });
+
+  it("detects scope paths that can continue with property completion", () => {
+    expect(shouldAppendCompletionDot("=$input")).toBe(true);
+    expect(shouldAppendCompletionDot("=$output.step")).toBe(true);
+    expect(shouldAppendCompletionDot("=$context.memory")).toBe(true);
+    expect(shouldAppendCompletionDot('=$input."display-name"')).toBe(true);
+    expect(shouldAppendCompletionDot("=$input.")).toBe(false);
+    expect(shouldAppendCompletionDot("=$count($input.items)")).toBe(false);
+    expect(shouldAppendCompletionDot("plain text")).toBe(false);
+  });
+
+  it("detects expression-looking static text and escapes literal conversion", () => {
+    expect(looksLikeDynamicValueExpressionBody("$input.user.name")).toBe(true);
+    expect(looksLikeDynamicValueExpressionBody("$output.step")).toBe(true);
+    expect(looksLikeDynamicValueExpressionBody("$count($input.items)")).toBe(
+      true,
+    );
+    expect(looksLikeDynamicValueExpressionBody("hello")).toBe(false);
+    expect(looksLikeDynamicValueExpressionBody("user.name")).toBe(false);
+    expect(toJsonataStringLiteral('hello "there"')).toBe(
+      '="hello \\"there\\""',
+    );
+  });
+});

--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/dynamicValueUtils.ts
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/dynamicValueUtils.ts
@@ -1,0 +1,84 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import jsonata from "jsonata";
+
+export type DynamicValueValidationCode = "empty_dynamic" | "invalid_dynamic";
+
+export type DynamicValueValidationResult = {
+  code: DynamicValueValidationCode | null;
+  errorMessage?: string;
+  isExpression: boolean;
+  suppressSchemaErrors: boolean;
+};
+
+export const isExpressionValue = (value: string) => value.startsWith("=");
+
+export const stripExpressionPrefix = (value: string) =>
+  isExpressionValue(value) ? value.slice(1) : value;
+
+export const ensureExpressionPrefix = (value: string) =>
+  isExpressionValue(value) ? value : `=${value}`;
+
+const ROOTED_SCOPE_PATH_PATTERN =
+  /(?:^|[^\w$])(?:\$input|\$output|\$context)(?:\.(?:[A-Za-z_$][A-Za-z0-9_$]*|"[^"\\]*(?:\\.[^"\\]*)*"))*$/;
+const EXPRESSION_BODY_HINT_PATTERN =
+  /^(?:(?:\$input|\$output|\$context)(?:$|[\s.[({])|\$[A-Za-z_][A-Za-z0-9_]*\s*\()/;
+
+export const shouldAppendCompletionDot = (textBeforeCursor: string) => {
+  const trimmedText = textBeforeCursor.trimEnd();
+
+  return (
+    trimmedText.length > 0 &&
+    !trimmedText.endsWith(".") &&
+    ROOTED_SCOPE_PATH_PATTERN.test(trimmedText)
+  );
+};
+
+export const looksLikeDynamicValueExpressionBody = (value: string) =>
+  EXPRESSION_BODY_HINT_PATTERN.test(value.trim());
+
+export const toJsonataStringLiteral = (value: string) =>
+  `=${JSON.stringify(value)}`;
+
+export const validateDynamicValue = (
+  value: string,
+): DynamicValueValidationResult => {
+  if (!isExpressionValue(value)) {
+    return {
+      code: null,
+      isExpression: false,
+      suppressSchemaErrors: false,
+    };
+  }
+
+  const expressionBody = stripExpressionPrefix(value);
+
+  if (!expressionBody.trim()) {
+    return {
+      code: "empty_dynamic",
+      isExpression: true,
+      suppressSchemaErrors: false,
+    };
+  }
+
+  try {
+    jsonata(expressionBody);
+
+    return {
+      code: null,
+      isExpression: true,
+      suppressSchemaErrors: true,
+    };
+  } catch (error) {
+    return {
+      code: "invalid_dynamic",
+      errorMessage: error instanceof Error ? error.message : undefined,
+      isExpression: true,
+      suppressSchemaErrors: false,
+    };
+  }
+};

--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/monaco.ts
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/monaco.ts
@@ -108,36 +108,53 @@ export function createCompletionProvider(
   },
   targetModel?: import("monaco-editor").editor.ITextModel | null,
 ) {
-  const varItems: import("monaco-editor").languages.CompletionItem[] = [
-    {
-      label: "$input",
-      kind: monaco.languages.CompletionItemKind.Variable,
-      insertText: "$input",
-      detail: "Global variable",
-      documentation: "Incoming payload / current input",
-    },
-    {
-      label: "$output",
-      kind: monaco.languages.CompletionItemKind.Variable,
-      insertText: "$output",
-      detail: "Global variable",
-      documentation: "Output produced so far",
-    },
-    {
-      label: "$context",
-      kind: monaco.languages.CompletionItemKind.Variable,
-      insertText: "$context",
-      detail: "Global variable",
-      documentation: "Execution context / workflow context",
-    },
-  ] as any;
-
   function schemaForVar(v: "$input" | "$output" | "$context") {
     if (v === "$input") return globals.input;
     if (v === "$output") return globals.output;
 
     return globals.context;
   }
+
+  const triggerSuggestCommand = {
+    id: "editor.action.triggerSuggest",
+    title: "Show suggestions",
+  };
+  const getCompletionNode = (schema: JsonSchemaLike | undefined) => {
+    let node = deref(rootSchema, schema);
+
+    if (node && schemaTypeHas(node, "array")) {
+      node = deref(rootSchema, getItemsSchema(rootSchema, node));
+    }
+
+    return node;
+  };
+  const hasChildCompletions = (schema: JsonSchemaLike | undefined) => {
+    const node = getCompletionNode(schema);
+
+    return node ? getPropertyKeys(rootSchema, node).length > 0 : false;
+  };
+  const buildInsertBehavior = (
+    insertText: string,
+    schema: JsonSchemaLike | undefined,
+  ) =>
+    hasChildCompletions(schema)
+      ? {
+          insertText: `${insertText}.`,
+          command: triggerSuggestCommand,
+        }
+      : { insertText };
+  const buildVarItem = (
+    label: "$input" | "$output" | "$context",
+    documentation: string,
+    range: import("monaco-editor").IRange,
+  ): import("monaco-editor").languages.CompletionItem => ({
+    label,
+    kind: monaco.languages.CompletionItemKind.Variable,
+    detail: "Global variable",
+    documentation,
+    range,
+    ...buildInsertBehavior(label, deref(rootSchema, schemaForVar(label))),
+  });
 
   return monaco.languages.registerCompletionItemProvider("jsonata", {
     triggerCharacters: [".", "$", '"', "'"],
@@ -174,15 +191,32 @@ export function createCompletionProvider(
           : baseRange;
       const suggestions: import("monaco-editor").languages.CompletionItem[] =
         [];
+      const normalizedTextUntilCursor = textUntilCursor.trim();
 
       // Always allow vars when user is typing `$...`
       if (
+        normalizedTextUntilCursor === "" ||
+        normalizedTextUntilCursor === "=" ||
         textUntilCursor.endsWith("$") ||
         charBeforeWord === "$" ||
         word.word.startsWith("$")
       ) {
         suggestions.push(
-          ...varItems.map((i) => ({ ...i, range: rangeIncludingDollar })),
+          buildVarItem(
+            "$input",
+            "Incoming payload / current input",
+            rangeIncludingDollar,
+          ),
+          buildVarItem(
+            "$output",
+            "Output produced so far",
+            rangeIncludingDollar,
+          ),
+          buildVarItem(
+            "$context",
+            "Execution context / workflow context",
+            rangeIncludingDollar,
+          ),
         );
       }
 
@@ -234,6 +268,14 @@ export function createCompletionProvider(
       const keys = getPropertyKeys(rootSchema, node);
       // If user is right after `$input` with no dot yet, insert a dot automatically
       const needsDot = /(\$input|\$output|\$context)$/.test(textUntilCursor);
+      const propertyRange = needsDot
+        ? new monaco.Range(
+            position.lineNumber,
+            position.column,
+            position.lineNumber,
+            position.column,
+          )
+        : baseRange;
       const propertyItems = keys.map((k) => {
         const propSchema = deref(
           rootSchema,
@@ -241,16 +283,17 @@ export function createCompletionProvider(
         );
         const insert = formatSegmentForJsonata(k);
         const insertText = needsDot ? `.${insert}` : insert;
+        const insertBehavior = buildInsertBehavior(insertText, propSchema);
 
         return {
           label: k,
           kind: monaco.languages.CompletionItemKind.Field,
-          insertText,
-          range: baseRange,
+          range: propertyRange,
           detail: propSchema?.type
             ? `(${Array.isArray(propSchema.type) ? propSchema.type.join(" | ") : propSchema.type})`
             : "field",
           documentation: propSchema?.description,
+          ...insertBehavior,
         } as import("monaco-editor").languages.CompletionItem;
       });
 

--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/types.ts
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/types.ts
@@ -82,5 +82,14 @@ export type JsonataFormulaFieldProps = {
   minHeightPx?: number;
   maxHeightPx?: number;
 
+  /** Shows a compact affordance that focuses JSONata autocomplete. */
+  enableExpressionAssist?: boolean;
+
+  onExpressionStateChange?: (state: {
+    hasError: boolean;
+    isExpression: boolean;
+    suppressSchemaErrors: boolean;
+  }) => void;
+
   sx?: SxProps<Theme>;
 };

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerContent.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerContent.tsx
@@ -17,6 +17,7 @@ import {
 import { buildSettingsUiSchema } from "../../../../utils/settings-ui-schema.utils";
 import { ActionSchemaPanel } from "../ActionSchemaPanel";
 
+import { DynamicValueHelp } from "./DynamicValueHelp";
 import { ExecutionSettingsPanel } from "./ExecutionSettingsPanel";
 
 export type ActionFormDrawerContentProps = {
@@ -83,6 +84,8 @@ export const ActionFormDrawerContent = ({
           panelKey={`${panelKeyBase}-input`}
           emptyLabel={t("visual_editor.actions_drawer.form.empty_schema.input")}
           uiSchema={extractUiSchema(actionSchema.inputSchema as RJSFSchema)}
+          expressionPolicy="input-default"
+          headerAction={<DynamicValueHelp />}
         />
       ) : null}
       {hasSettingsSchema ? (
@@ -100,6 +103,8 @@ export const ActionFormDrawerContent = ({
             actionSchema.settingSchema as RJSFSchema | undefined,
             actionSettingsData,
           )}
+          expressionPolicy="opt-in"
+          headerAction={<DynamicValueHelp />}
         />
       ) : null}
       <ExecutionSettingsPanel

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/DynamicValueHelp.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/DynamicValueHelp.tsx
@@ -1,0 +1,133 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import {
+  Box,
+  IconButton,
+  Link,
+  Popover,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { CircleQuestionMark } from "lucide-react";
+import { useState } from "react";
+
+import { useTranslate } from "@/hooks/useTranslate";
+
+const JSONATA_DOCUMENTATION_URL = "https://docs.jsonata.org/overview";
+const HEXABOT_EXPRESSIONS_DOCUMENTATION_URL =
+  "https://docs.hexabot.ai/workflow-editor/expressions-and-jsonata-scopes";
+
+export const DynamicValueHelp = () => {
+  const { t } = useTranslate();
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const closePopover = (event?: { stopPropagation?: () => void }) => {
+    event?.stopPropagation?.();
+    setAnchor(null);
+  };
+
+  return (
+    <>
+      <Tooltip
+        title={t("visual_editor.actions_drawer.form.dynamic_values_help.open")}
+      >
+        <IconButton
+          size="small"
+          onClick={(event) => {
+            event.stopPropagation();
+            setAnchor(event.currentTarget);
+          }}
+          aria-label={t(
+            "visual_editor.actions_drawer.form.dynamic_values_help.open",
+          )}
+        >
+          <CircleQuestionMark size={16} />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={(event) =>
+          closePopover(event as { stopPropagation?: () => void })
+        }
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        slotProps={{
+          backdrop: {
+            onClick: (event) => event.stopPropagation(),
+            onMouseDown: (event) => event.stopPropagation(),
+            sx: { zIndex: 0 },
+          },
+          paper: {
+            onClick: (event) => event.stopPropagation(),
+            onMouseDown: (event) => event.stopPropagation(),
+            sx: {
+              width: 320,
+              maxWidth: "calc(100vw - 32px)",
+              p: 2,
+              zIndex: 1,
+            },
+          },
+        }}
+      >
+        <Stack spacing={1}>
+          <Typography variant="subtitle2">
+            {t("visual_editor.actions_drawer.form.dynamic_values_help.title")}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t("visual_editor.actions_drawer.form.dynamic_values_help.static")}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t("visual_editor.actions_drawer.form.dynamic_values_help.dynamic")}
+          </Typography>
+          <Box>
+            {["$input", "$output", "$context"].map((source) => (
+              <Typography
+                key={source}
+                variant="body2"
+                component="span"
+                sx={{
+                  display: "inline-block",
+                  mr: 1,
+                  fontFamily: "monospace",
+                  color: "text.primary",
+                }}
+              >
+                {source}
+              </Typography>
+            ))}
+          </Box>
+          <Typography variant="caption" color="text.secondary">
+            {t(
+              "visual_editor.actions_drawer.form.dynamic_values_help.technical",
+            )}
+          </Typography>
+          <Stack direction="row" gap={1.5} flexWrap="wrap">
+            <Link
+              href={HEXABOT_EXPRESSIONS_DOCUMENTATION_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="caption"
+            >
+              {t("visual_editor.actions_drawer.form.dynamic_values_help.docs")}
+            </Link>
+            <Link
+              href={JSONATA_DOCUMENTATION_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="caption"
+            >
+              {t(
+                "visual_editor.actions_drawer.form.dynamic_values_help.jsonata_docs",
+              )}
+            </Link>
+          </Stack>
+        </Stack>
+      </Popover>
+    </>
+  );
+};

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionSchemaPanel.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionSchemaPanel.tsx
@@ -8,11 +8,17 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Box,
+  Stack,
   Typography,
 } from "@mui/material";
 import type { RJSFSchema, UiSchema } from "@rjsf/utils";
+import type { ReactNode } from "react";
 
-import { JsonSchemaForm } from "@/app-components/inputs/JsonSchemaForm";
+import {
+  JsonSchemaForm,
+  type ExpressionPolicy,
+} from "@/app-components/inputs/JsonSchemaForm";
 
 export type ActionSchemaPanelProps = {
   title: string;
@@ -23,6 +29,8 @@ export type ActionSchemaPanelProps = {
   panelKey: string;
   emptyLabel: string;
   uiSchema?: UiSchema;
+  expressionPolicy?: ExpressionPolicy;
+  headerAction?: ReactNode;
 };
 
 export const ActionSchemaPanel = ({
@@ -34,10 +42,31 @@ export const ActionSchemaPanel = ({
   panelKey,
   emptyLabel,
   uiSchema,
+  expressionPolicy = "input-default",
+  headerAction,
 }: ActionSchemaPanelProps) => (
   <Accordion variant="elevation" defaultExpanded>
     <AccordionSummary>
-      <Typography variant="subtitle2">{title}</Typography>
+      {headerAction ? (
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          width="100%"
+          gap={1}
+        >
+          <Typography variant="subtitle2">{title}</Typography>
+          <Box
+            component="span"
+            onClick={(event) => event.stopPropagation()}
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            {headerAction}
+          </Box>
+        </Stack>
+      ) : (
+        <Typography variant="subtitle2">{title}</Typography>
+      )}
     </AccordionSummary>
     <AccordionDetails>
       {schema ? (
@@ -48,6 +77,7 @@ export const ActionSchemaPanel = ({
           onVisibleErrorsChange={onVisibleErrorsChange}
           uiSchema={uiSchema}
           idPrefix={`action-${panelKey}`}
+          expressionPolicy={expressionPolicy}
         />
       ) : (
         <Typography variant="body2" color="text.secondary">

--- a/packages/frontend/src/components/visual-editor/v4/components/main/BindingDrawer/BindingSelectionDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/BindingDrawer/BindingSelectionDrawer.tsx
@@ -221,6 +221,7 @@ const BindingSelectionDrawerContent = ({
             onVisibleErrorsChange={onVisibleErrorsChange}
             uiSchema={bindingUiSchema}
             idPrefix="single-binding-selection-drawer"
+            expressionPolicy="opt-in"
           />
         ) : (
           <Typography variant="body2" color="text.secondary" px={1}>

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ToolDrawer/ToolFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ToolDrawer/ToolFormDrawer.tsx
@@ -114,6 +114,7 @@ const ToolFormDrawerContent = ({
             actionSettingSchema as RJSFSchema | undefined,
             actionSettingsData,
           )}
+          expressionPolicy="opt-in"
         />
       ) : (
         <Typography variant="body2" color="text.secondary" px={1}>


### PR DESCRIPTION
## What changed?

Improves the Jsonata dynamic value input UX across action, binding, and tool forms.

- Adds a function-icon assist flow for dynamic values, including expression conversion/replacement actions and improved autocomplete behavior.
- Adds expression policy handling so action inputs can allow dynamic values by default while settings-style fields require opt-in.
- Suppresses schema errors when valid dynamic expressions are used, while surfacing Jsonata-specific validation errors.
- Extracts reusable UI/types into separate components and utilities, including `ExpressionAssist`, `DynamicValueHelp`, and shared expression form types.
- Adds EN/FR translations and unit tests for dynamic value utilities and expression policy rules.
