### PR TITLE
fix(frontend): resolve dashboard title overflow in Latest dashboard cards

### DIFF
--- a/packages/frontend/src/components/dashboard/components/LatestWorkflowsCard.tsx
+++ b/packages/frontend/src/components/dashboard/components/LatestWorkflowsCard.tsx
@@ -71,7 +71,7 @@ export const LatestWorkflowsCard = ({ workflow }: { workflow: Workflow }) => {
         />
 
         {/* Content */}
-        <Box>
+        <Box minWidth={0}>
           <Box display="flex" alignItems="center" gap={1} mb={0.5}>
             <Typography variant="subtitle2" fontWeight="bold" noWrap>
               {workflow.name}


### PR DESCRIPTION
## Summary
Fixes a UI issue in the Home Dashboard “Latest” section where long workflow titles overflow and overlap adjacent cards.

## Changes
* Prevent workflow titles from rendering outside card boundaries
* Ensure long titles wrap or truncate correctly
* Preserve consistent card spacing and alignment

## Impact
Improves dashboard readability and prevents broken card layouts for workflows with long names.

## Screenshots
- Before the fix
<img width="784" height="152" alt="image" src="https://github.com/user-attachments/assets/42f06361-139c-4f3f-b23a-808fb180be1a" />
- After the fix
<img width="784" height="152" alt="image" src="https://github.com/user-attachments/assets/77043cd3-646c-4db2-b612-385f31002956" />
