### PR TITLE
fix(api): add @resvg/resvg-js-win32-x64-msvc dependency

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -179,7 +179,8 @@
   "optionalDependencies": {
     "@css-inline/css-inline-linux-arm64-musl": "^0.14.1",
     "@resvg/resvg-js-darwin-arm64": "^2.6.2",
-    "@resvg/resvg-js-linux-arm64-musl": "^2.6.2"
+    "@resvg/resvg-js-linux-arm64-musl": "^2.6.2",
+    "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
   },
   "jest": {
     "globalSetup": "<rootDir>/../test/global-setup.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
       '@resvg/resvg-js-linux-arm64-musl':
         specifier: ^2.6.2
         version: 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc':
+        specifier: 2.6.2
+        version: 2.6.2
     devDependencies:
       '@compodoc/compodoc':
         specifier: ^1.2.1


### PR DESCRIPTION
## What changed?

Summary: Added a fix/workaround for Windows 10 dependency installation issues related to `@resvg/resvg-js`. The update ensures the required platform-specific package (`@resvg/resvg-js-win32-x64-msvc`) is properly installed/resolved so the API can start successfully on Windows environments.

Why: Developers on Windows were unable to run the project locally due to a `MODULE_NOT_FOUND` error during application startup.

How to review: Focus on dependency installation logic/package configuration changes and verify the application startup flow on Windows.

Validation:

* Ran dependency installation on Windows 10
* Started the API successfully without missing module errors
* Confirmed `@resvg/resvg-js-win32-x64-msvc` is available after install