### PR TITLE
fix(graph): resolve graph rotation arrows alignment

### DIFF
--- a/packages/graph/src/workflow/components/workflow-nodes/GenericNodePorts.tsx
+++ b/packages/graph/src/workflow/components/workflow-nodes/GenericNodePorts.tsx
@@ -4,6 +4,10 @@
  * Full terms: see LICENSE.md.
  */
 
+import { useUpdateNodeInternals } from "@xyflow/react";
+import { useLayoutEffect } from "react";
+
+import { useWorkflowGraphHost } from "../../contexts/workflow-graph-host.context";
 import { useWorkflowNode } from "../../hooks/useWorkflowNode";
 import {
   ENodeType,
@@ -24,7 +28,13 @@ export const GenericNodePorts = <T extends ENodeType = ENodeType>({
     node: IWorkflowNodeContext<T>;
   }) => boolean;
 }) => {
+  const { direction } = useWorkflowGraphHost();
   const workflowNode = useWorkflowNode<T>();
+  const updateNodeInternals = useUpdateNodeInternals();
+
+  useLayoutEffect(() => {
+    updateNodeInternals(workflowNode.id);
+  }, [direction, updateNodeInternals, workflowNode.id]);
 
   return (workflowNode.ports as WorkflowNodePort<T>[])?.map((portDef, idx) => {
     const port = getWorkflowPortId(portDef);


### PR DESCRIPTION
Summary: Fixed an issue in the visual flow editor where node connectors became diagonally misaligned after using the rotation/reorientation action. Connectors now remain properly attached and vertically aligned after layout rotation.

Why: Rotating workflows caused connector paths to render incorrectly, making flows visually confusing and harder to edit.

How to review: Create a simple flow (Start → Send Text Message → Stop), rotate the layout using the toolbar button, and verify connector alignment before and after rotation.

Validation: Tested rotation behavior on existing connected workflows and confirmed connector paths remain correctly aligned after reorientation.

Screenshots :
- After the fix
<img width="1702" height="267" alt="image" src="https://github.com/user-attachments/assets/d6811801-1930-42ae-bf6b-403e144ee083" />

- Before the fix
<img width="1702" height="267" alt="image" src="https://github.com/user-attachments/assets/24bbd533-fc72-48d1-b8e2-83c0c87d8f0f" />
