### PR TITLE
fix(agentic): resolve evaluation of nested dynamic object values

### DIFF
--- a/packages/agentic/src/__tests__/workflow-values.test.ts
+++ b/packages/agentic/src/__tests__/workflow-values.test.ts
@@ -73,6 +73,25 @@ describe('workflow values', () => {
     });
   });
 
+  it('evaluates nested expressions inside literal objects', async () => {
+    const mapping = {
+      headers: compileValue({
+        nestedFiled: '=$input.headerValue',
+      }),
+    };
+    const values = await evaluateMapping(mapping, {
+      input: { headerValue: 'Bearer token-value' },
+      context: new TestContext().state,
+      output: {},
+    });
+
+    expect(values).toEqual({
+      headers: {
+        nestedFiled: 'Bearer token-value',
+      },
+    });
+  });
+
   it('handles missing mappings and deep merges settings', async () => {
     await expect(
       evaluateMapping(undefined, {

--- a/packages/agentic/src/workflow-values.ts
+++ b/packages/agentic/src/workflow-values.ts
@@ -35,6 +35,44 @@ export type CompileValueOptions = {
 /** Basic object guard that rejects arrays and null. */
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
+const resolveNestedExpressions = async (
+  value: unknown,
+  scope: EvaluationScope,
+  seen: WeakSet<object> = new WeakSet(),
+): Promise<unknown> => {
+  if (typeof value === 'string' && value.startsWith('=')) {
+    return evaluateValue(compileValue(value), scope);
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return value;
+    }
+    seen.add(value);
+
+    return Promise.all(
+      value.map((entry) => resolveNestedExpressions(entry, scope, seen)),
+    );
+  }
+
+  if (isPlainObject(value)) {
+    if (seen.has(value)) {
+      return value;
+    }
+    seen.add(value);
+
+    const entries = await Promise.all(
+      Object.entries(value).map(async ([key, entry]) => [
+        key,
+        await resolveNestedExpressions(entry, scope, seen),
+      ]),
+    );
+
+    return Object.fromEntries(entries);
+  }
+
+  return value;
+};
 const registerJsonataFunctions = (
   expression: Expression,
   registry?: JsonataFunctionRegistry,
@@ -118,11 +156,16 @@ export const evaluateMapping = async (
     return {};
   }
 
-  const result: Record<string, unknown> = {};
-
-  for (const [key, compiled] of Object.entries(mapping)) {
-    result[key] = await evaluateValue(compiled, scope);
-  }
+  const entries = await Promise.all(
+    Object.entries(mapping).map(async ([key, compiled]) => [
+      key,
+      await resolveNestedExpressions(
+        await evaluateValue(compiled, scope),
+        scope,
+      ),
+    ]),
+  );
+  const result: Record<string, unknown> = Object.fromEntries(entries);
 
   return result;
 };


### PR DESCRIPTION
Summary: Added recursive input evaluation for nested objects and arrays. This fixes cases where dynamic values inside nested structures were treated as raw strings.

Why: In actions like http_request, nested headers containing expressions such as $input.text were not being evaluated at runtime.

How to review: Test http_request actions with dynamic values inside nested headers and confirm expressions resolve correctly.

Validation: Verified nested object and array values are now evaluated recursively without affecting existing top-level behavior.