### PR TITLE
fix(frontend): add a RJSF email widget component

### DIFF
--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/EmailWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/EmailWidget.tsx
@@ -1,0 +1,26 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { TextField } from "@mui/material";
+import { WidgetProps } from "@rjsf/utils";
+
+import { createReadOnlyInputProps } from "../../readOnlyInput.util";
+
+export const EmailWidget = (props: WidgetProps) => {
+  return (
+    <TextField
+      label={props.label}
+      type="email"
+      value={props.value}
+      onChange={(e) => props.onChange(e.target.value)}
+      variant="outlined"
+      fullWidth
+      slotProps={{
+        htmlInput: createReadOnlyInputProps(),
+      }}
+    />
+  );
+};

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/index.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/index.ts
@@ -10,6 +10,7 @@ import { ActionRadioWidget } from "./ActionRadioWidget";
 import { ActionRangeWidget } from "./ActionRangeWidget";
 import { ActionSelectWidget } from "./ActionSelectWidget";
 import { AutoCompleteWidget } from "./AutoCompleteWidget";
+import { EmailWidget } from "./EmailWidget";
 import { JsonataTextWidget } from "./JsonataTextWidget";
 import { PasswordWidget } from "./PasswordWidget";
 import { TextWidget } from "./TextWidget";
@@ -22,6 +23,7 @@ export const FORM_WIDGETS_BASE = {
   RangeWidget: ActionRangeWidget,
   AutoCompleteWidget,
   TextWidget,
+  EmailWidget,
   PasswordWidget,
 } as const;
 
@@ -30,6 +32,7 @@ export const FORM_WIDGETS = {
   TextWidget: JsonataTextWidget,
   TextareaWidget: JsonataTextWidget,
   URLWidget: JsonataTextWidget,
+  EmailWidget: JsonataTextWidget,
   UpDownWidget: JsonataTextWidget,
 } as const;
 


### PR DESCRIPTION
**Summary:**
Adds a new RJSF email widget component to improve email field handling and provide a more consistent form experience.

**Why:**
This is needed to support dedicated email input behavior and validation within RJSF-based forms.

**How to review:**
Focus on the new email widget component implementation and its integration within the RJSF field/widget registry.

**Validation:**
Tested rendering, input behavior, and email validation in forms using the new widget.

