### PR TITLE
fix(frontend): resolve redirection to workflowRunDebugger run issue

### DIFF
--- a/packages/frontend/src/components/dashboard/widgets/AttentionRequired.tsx
+++ b/packages/frontend/src/components/dashboard/widgets/AttentionRequired.tsx
@@ -45,12 +45,13 @@ export const AttentionRequired = () => {
   const handleViewRun = (run: WorkflowRunFull) => {
     const workflowId = resolveEntityId(run.workflow);
     const initiatorId = resolveEntityId(run.triggeredBy);
+    const runId = resolveEntityId(run.id);
 
     if (!workflowId || !initiatorId) {
       return;
     }
 
-    router.push(`/workflow/${workflowId}/runs/${initiatorId}`);
+    router.push(`/workflow/${workflowId}/runs/${initiatorId}/${runId}`);
   };
 
   return (

--- a/packages/frontend/src/components/dashboard/widgets/RecentRuns.tsx
+++ b/packages/frontend/src/components/dashboard/widgets/RecentRuns.tsx
@@ -51,9 +51,10 @@ export const RecentRuns = () => {
   const openRun = (run: WorkflowRun) => {
     const workflowId = resolveEntityId(run.workflow);
     const initiatorId = resolveEntityId(run.triggeredBy);
+    const runId = resolveEntityId(run.id);
 
-    if (workflowId && initiatorId) {
-      router.push(`/workflow/${workflowId}/runs/${initiatorId}`);
+    if (workflowId && initiatorId && runId) {
+      router.push(`/workflow/${workflowId}/runs/${initiatorId}/${runId}`);
     }
   };
   const resolveWorkflow = (run: WorkflowRun): Workflow | null => {

--- a/packages/frontend/src/components/workflow-run-debugger/components/WorkflowRunDebugger.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/WorkflowRunDebugger.tsx
@@ -21,12 +21,14 @@ import { StepTracePanel } from "./panels/step-trace-panel";
 
 type WorkflowRunDebuggerProps = {
   initiatorId?: string;
+  runId?: string;
   workflow?: Workflow;
   workflowInput?: Record<string, unknown>;
 };
 
 export const WorkflowRunDebugger: FC<WorkflowRunDebuggerProps> = ({
   initiatorId,
+  runId,
   workflow,
   workflowInput,
 }) => {
@@ -60,16 +62,16 @@ export const WorkflowRunDebugger: FC<WorkflowRunDebuggerProps> = ({
     },
   );
   const latestRun = workflowRuns[0];
-  const [selectedRunId, setSelectedRunId] = useState<string | undefined>(
-    undefined,
-  );
+  const [selectedRunId, setSelectedRunId] = useState<string | undefined>(runId);
   const [selectedStepId, setSelectedStepId] = useState<string | undefined>(
     undefined,
   );
 
   useEffect(() => {
     if (!workflowRuns.length) {
-      setSelectedRunId(undefined);
+      if (!runId) {
+        setSelectedRunId(undefined);
+      }
 
       return;
     }
@@ -78,10 +80,17 @@ export const WorkflowRunDebugger: FC<WorkflowRunDebuggerProps> = ({
       (run) => run.id === selectedRunId,
     );
 
-    if (!isSelectedStillAvailable) {
+    if (!isSelectedStillAvailable && !runId) {
       setSelectedRunId(workflowRuns[0]?.id);
     }
-  }, [selectedRunId, workflowRuns]);
+  }, [runId, selectedRunId, workflowRuns]);
+
+  useEffect(() => {
+    if (runId) {
+      setSelectedRunId(runId);
+      setSelectedStepId(undefined);
+    }
+  }, [runId]);
 
   const selectedRun = useMemo(
     () => workflowRuns.find((run) => run.id === selectedRunId) ?? latestRun,
@@ -94,10 +103,11 @@ export const WorkflowRunDebugger: FC<WorkflowRunDebuggerProps> = ({
   }, [selectedRun?.stepLog, selectedStepId]);
 
   useEffect(() => {
+    if (runId) return;
     // New run
     setSelectedRunId(latestRun?.id);
     setSelectedStepId(undefined);
-  }, [workflowRuns.length]);
+  }, [latestRun?.id, runId]);
 
   useEffect(() => {
     setSelectedStepId(undefined);

--- a/packages/frontend/src/components/workflow-run-debugger/index.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/index.tsx
@@ -19,18 +19,19 @@ import { WorkflowRunDebugger } from "./components/WorkflowRunDebugger";
 
 export const WorkflowRunDebuggerPage = () => {
   const { t } = useTranslate();
-  const { workflowId, initiatorId: initiatorId } = useParams<{
+  const params = useParams<{
     workflowId?: string;
     initiatorId?: string;
+    runId?: string;
   }>();
   const { data: workflow } = useGet(
-    workflowId || "",
+    params.workflowId || "",
     {
       entity: EntityType.WORKFLOW,
       format: Format.FULL,
     },
     {
-      enabled: Boolean(workflowId),
+      enabled: Boolean(params.workflowId),
     },
   );
 
@@ -47,7 +48,7 @@ export const WorkflowRunDebuggerPage = () => {
         minHeight="calc(100dvh - 182px)"
         maxHeight="calc(100dvh - 182px)"
       >
-        <WorkflowRunDebugger initiatorId={initiatorId} workflow={workflow} />
+        <WorkflowRunDebugger {...params} />
       </Box>
     </WorkflowActionsProvider>
   );

--- a/packages/frontend/src/components/workflow-runs/index.tsx
+++ b/packages/frontend/src/components/workflow-runs/index.tsx
@@ -45,7 +45,9 @@ export const WorkflowRuns = ({
       {
         action: ColumnActionType.View,
         onClick: (row) =>
-          router.push(`/workflow/${row.workflow}/runs/${row.triggeredBy}`),
+          router.push(
+            `/workflow/${row.workflow}/runs/${row.triggeredBy}/${row.id}`,
+          ),
       },
     ],
     t("label.operations"),

--- a/packages/frontend/src/routes/routeConfig.tsx
+++ b/packages/frontend/src/routes/routeConfig.tsx
@@ -98,7 +98,7 @@ export const routes: RouteObjectItem[] = [
     },
   },
   {
-    path: "/workflow/:workflowId/runs/:initiatorId",
+    path: "/workflow/:workflowId/runs/:initiatorId/:runId?",
     Component: WorkflowRunDebuggerPage,
     handle: {
       requiredPermissions: [[EntityType.WORKFLOW_RUN, Action.READ]],


### PR DESCRIPTION
* **Summary:**
  Fixed an issue on the workflow runs page where opening a run’s details always displayed the first workflow run instead of the selected one. The selected workflow run is now correctly mapped and rendered in the details view.

* **Why:**
  Users were unable to inspect the correct workflow execution details, which made workflow debugging and monitoring unreliable.

* **How to review:**
  Focus on the workflow run selection logic and the details view rendering/state management on the `workflowRuns` page.

* **Validation:**

  * Verified that selecting different workflow runs displays the correct corresponding details.
  * Tested navigation between multiple runs to ensure the selected state updates correctly.
  * Confirmed no regression for the first workflow run display behavior.
