### PR TITLE
fix(api): add @resvg/resvg-js-linux-x64-gnu dependency

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -180,6 +180,7 @@
     "@css-inline/css-inline-linux-arm64-musl": "^0.14.1",
     "@resvg/resvg-js-darwin-arm64": "^2.6.2",
     "@resvg/resvg-js-linux-arm64-musl": "^2.6.2",
+    "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
     "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
   },
   "jest": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
       '@resvg/resvg-js-linux-arm64-musl':
         specifier: ^2.6.2
         version: 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu':
+        specifier: 2.6.2
+        version: 2.6.2
       '@resvg/resvg-js-win32-x64-msvc':
         specifier: 2.6.2
         version: 2.6.2


### PR DESCRIPTION
## What changed?

**Summary:**
Added a fix/workaround for Ubuntu 24 dependency installation issues related to `@resvg/resvg-js`. The update ensures the required platform-specific package (`@resvg/resvg-js-linux-x64-gnu`) is properly installed/resolved so the API can start successfully on Ubuntu environments.

**Why:** 
Developers on Ubuntu 24 were unable to run the project locally due to a `MODULE_NOT_FOUND` error during application startup.

**How to review:** 
Focus on dependency installation logic/package configuration changes and verify the application startup flow on Ubuntu 24.

**Validation:**
* Ran dependency installation on Ubuntu 24
* Started the API successfully without missing module errors
* Confirmed `@resvg/resvg-js-linux-x64-gnu` is available after install
