### PR TITLE
fix(frontend): resolve conditional node edges re-render issue

### DIFF
--- a/packages/graph/src/workflow/components/workflow-nodes/GenericNodePorts.tsx
+++ b/packages/graph/src/workflow/components/workflow-nodes/GenericNodePorts.tsx
@@ -34,7 +34,7 @@ export const GenericNodePorts = <T extends ENodeType = ENodeType>({
 
   useLayoutEffect(() => {
     updateNodeInternals(workflowNode.id);
-  }, [direction, updateNodeInternals, workflowNode.id]);
+  }, [direction, updateNodeInternals, workflowNode.id, workflowNode.ports]);
 
   return (workflowNode.ports as WorkflowNodePort<T>[])?.map((portDef, idx) => {
     const port = getWorkflowPortId(portDef);


### PR DESCRIPTION
## What changed?
Updated the Conditional node to re-render its edges/arrows when a new condition expression is added.

## Summary
Fixed an issue where Conditional node edges/arrows were not updated when adding a new condition expression.

## Why
Without updating the graph connections, the workflow visualization could become out of sync with the node configuration.

## How to review
Focus on the Conditional node logic responsible for creating/updating dynamic handles and graph edges when conditions are added.

## Validation
* Added a new condition expression and verified that edges/arrows update correctly.
* Confirmed existing Conditional node behavior remains unchanged.


