### PR TITLE
fix(graph): add loop operator tooltip

### DIFF
--- a/packages/graph/src/workflow/utils/graph-builder/traverse.ts
+++ b/packages/graph/src/workflow/utils/graph-builder/traverse.ts
@@ -970,7 +970,32 @@ const walkStep = ({
 
             return portDef;
           })
-        : operatorBaseData.ports;
+        : operatorType === StepType.Loop
+          ? operatorBaseData.ports.map((portDef) => {
+              if (portDef === ELinkType.OPERATOR_OUT) {
+                return {
+                  id: ELinkType.OPERATOR_OUT,
+                  label: `visual_editor.loop_drawer.form.type.${
+                    (step as CompiledLoopStep).loopType
+                  }.label`,
+                };
+              }
+
+              if (
+                typeof portDef !== "string" &&
+                portDef.id === ELinkType.OPERATOR_OUT
+              ) {
+                return {
+                  ...portDef,
+                  label: `visual_editor.loop_drawer.form.type.${
+                    (step as CompiledLoopStep).loopType
+                  }.label`,
+                };
+              }
+
+              return portDef;
+            })
+          : operatorBaseData.ports;
   const resolvedPorts: WorkflowNodePort<ENodeType.OPERATOR>[] =
     operatorType === StepType.Conditional
       ? [ELinkType.OPERATOR_IN, ...ports]


### PR DESCRIPTION
## What changed?

Added the missing type tooltip to loop nodes in the visual editor so they behave consistently with other node types and provide clearer node identification.

## Summary

Added the missing type tooltip for loop nodes in the visual editor, aligning their behavior with other node types.

## Why

Loop nodes currently do not display a type tooltip, creating an inconsistent user experience and making node identification less clear.

## How to review

Verify the loop node UI in the visual editor and confirm that the type tooltip is displayed correctly and matches the behavior of other nodes.

## Validation

* Confirmed the tooltip appears on loop nodes.
* Verified existing node tooltips remain unaffected.

## Extra 
<img width="433" height="218" alt="image" src="https://github.com/user-attachments/assets/3dc378c4-bd61-4725-be75-f6d2f22156fb" />
<img width="433" height="218" alt="image" src="https://github.com/user-attachments/assets/cab46326-ae64-48f9-90cf-19a4422f87d2" />

