### PR TITLE
fix(graph): resolve cropped attachment nodes inside a group

### DIFF
--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -1410,6 +1410,88 @@ describe("buildNodesAndEdges", () => {
     expect(placeholderToAfter?.hidden).toBe(true);
   });
 
+  it("expands the loop group bounds to enclose AI agent binding attachments", async () => {
+    const loopStep: CompiledLoopStep = {
+      id: "0:loop",
+      label: "loop",
+      type: StepType.Loop,
+      loopType: "for_each",
+      forEach: {
+        item: "item",
+        in: { kind: "literal", value: [] },
+      },
+      steps: [taskStep("0.loop.0:agent", "agent")],
+    };
+    const flow: CompiledStep[] = [
+      loopStep,
+      taskStep("1:after_loop", "after_loop"),
+    ];
+    const tasks: TestTaskDefinitions = {
+      agent: {
+        action: "agent_action",
+        bindings: {
+          tools: ["search_tool"],
+          memory: ["profile_memory"],
+          model: "openai_model",
+          mcp: ["mcp_server"],
+        },
+        settings: {},
+      },
+      after_loop: { action: "after_action", settings: {} },
+    };
+    const graph = await buildGraph({
+      flow,
+      tasks,
+      defs: {
+        search_tool: { kind: "tools", settings: {} },
+        profile_memory: { kind: "memory", settings: {} },
+        openai_model: { kind: "model", settings: {} },
+        mcp_server: { kind: "mcp", settings: {} },
+      },
+      actionCatalog: createActionCatalog({
+        agent_action: ["tools", "memory", "model", "mcp"],
+      }),
+      bindingCatalog: createBindingCatalog([
+        { kind: "tools", multiple: true },
+        { kind: "memory", multiple: true },
+        { kind: "model", multiple: false },
+        { kind: "mcp", multiple: true },
+      ]),
+    });
+    const loopGroup = graph.nodes.find(
+      (node) => node.id === createGroupId(loopStep.id),
+    );
+    const agentAttachments = graph.nodes.filter(
+      (node) =>
+        node.type === ENodeType.BINDING_SINGLE ||
+        node.type === ENodeType.BINDING_MULTI,
+    );
+
+    expect(loopGroup).toBeDefined();
+    expect(agentAttachments.length).toBeGreaterThan(0);
+
+    const groupStyle = loopGroup?.style as
+      | { width: number; height: number }
+      | undefined;
+    const groupPosition = loopGroup?.position as
+      | { x: number; y: number }
+      | undefined;
+
+    expect(groupStyle).toBeDefined();
+    expect(groupPosition).toBeDefined();
+
+    const groupBottom = groupPosition!.y + groupStyle!.height;
+    const attachmentBottom = Math.max(
+      ...agentAttachments.map(
+        (node) =>
+          node.position.y +
+          (NODE_METRICS[node.type as ENodeType]?.dimensions.height ?? 0),
+      ),
+    );
+
+    expect(groupBottom).toBeGreaterThanOrEqual(attachmentBottom);
+  });
+
   it("attaches end-indicator edges with next insert path metadata", async () => {
     const flow: CompiledStep[] = [taskStep("0:single", "single")];
     const graph = await buildGraph({ flow, tasks: baseTasks(["single"]) });

--- a/packages/graph/src/workflow/utils/workflow-node.utils.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.ts
@@ -498,24 +498,70 @@ const getGroupNodes = (
   nodes: GraphNode[],
   groups: Map<string, GroupMeta>,
   config: INodeConfig,
+  attachmentEdges: Edge[],
 ) => {
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
-  const groupNodes: GraphNode<ENodeType.GROUP>[] = [];
+  const attachmentChildrenByParent = new Map<string, Set<string>>();
 
-  groups.forEach((group) => {
-    const groupMembers = [...group.memberNodeIds]
-      .map((nodeId) => nodesById.get(nodeId))
-      .filter((node): node is GraphNode => Boolean(node));
-
-    if (!groupMembers.length) {
+  attachmentEdges.forEach(({ source, target }) => {
+    if (!nodesById.has(source) || !nodesById.has(target)) {
       return;
     }
 
+    if (!attachmentChildrenByParent.has(source)) {
+      attachmentChildrenByParent.set(source, new Set());
+    }
+
+    attachmentChildrenByParent.get(source)!.add(target);
+  });
+
+  const collectAttachmentDescendants = (rootId: string): string[] => {
+    const result: string[] = [];
+    const stack = [rootId];
+
+    while (stack.length) {
+      const current = stack.pop()!;
+      const children = attachmentChildrenByParent.get(current);
+
+      if (!children) {
+        continue;
+      }
+
+      children.forEach((childId) => {
+        if (!nodesById.has(childId)) {
+          return;
+        }
+
+        result.push(childId);
+        stack.push(childId);
+      });
+    }
+
+    return result;
+  };
+  const groupNodes: GraphNode<ENodeType.GROUP>[] = [];
+
+  groups.forEach((group) => {
+    const groupMemberIds = [...group.memberNodeIds].filter((nodeId) =>
+      nodesById.has(nodeId),
+    );
+
+    if (!groupMemberIds.length) {
+      return;
+    }
+
+    const boundsMemberIds = [
+      ...groupMemberIds,
+      ...groupMemberIds.flatMap(collectAttachmentDescendants),
+    ];
+    const boundsMembers = boundsMemberIds
+      .map((nodeId) => nodesById.get(nodeId))
+      .filter((node): node is GraphNode => Boolean(node));
     const color = config.highlights?.[group.operatorType]?.color;
     const basePadding = config.highlights?.[group.operatorType]?.padding || 0;
     const padding = getGroupPadding(basePadding, group.level);
     const backgroundAlpha = getGroupBackgroundAlpha(group.level);
-    const bounds = getNodesBounds(groupMembers);
+    const bounds = getNodesBounds(boundsMembers);
 
     groupNodes.push({
       ...DEFAULT_NODE_PROPS,
@@ -574,7 +620,12 @@ export const buildNodesAndEdges = async ({
       config,
     },
   );
-  const groupNodes = getGroupNodes(positionedNodes, traversal.groups, config);
+  const groupNodes = getGroupNodes(
+    positionedNodes,
+    traversal.groups,
+    config,
+    projected.edges.filter(isAttachmentEdge),
+  );
 
   return {
     edges: projected.edges,


### PR DESCRIPTION
### What changed?

* Fixed the Visual Editor layout so attachment nodes are no longer clipped when placed inside a group.
* Updated group rendering/overflow handling to ensure attachment nodes remain fully visible.
* Preserved existing group and node behavior while correcting the visual cropping issue.

### Summary
Fixes an issue where attachment nodes were cropped when placed inside a group in the Visual Editor. Attachment nodes now render correctly within group containers.

### Why

Grouped workflows containing attachment nodes were difficult to view and interact with because portions of the nodes were clipped.

### What changed?

* Updated the Visual Editor rendering/layout logic to prevent attachment nodes from being clipped inside groups.
* Ensured attachment nodes are fully visible when added to or moved within a group.

### How to review

* Create a group in the Visual Editor.
* Add or move an attachment node into the group.
* Verify that the attachment node is fully visible and not cropped.

### Validation

* Tested attachment nodes inside existing and newly created groups.
* Verified that attachment nodes render correctly after moving them in and out of groups.
* Confirmed no regressions in group rendering behavior.

### Extra
<img width="1661" height="428" alt="image" src="https://github.com/user-attachments/assets/4d7b433b-67ff-4a15-b4f8-6db0998a18e7" />
