### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
@@ -230,6 +230,7 @@ describe('AiBaseAction', () => {
     it('enforces api key for hosted providers', () => {
       expect(action.shouldRequireApiKeyPublic('openai')).toBe(true);
       expect(action.shouldRequireApiKeyPublic('gateway')).toBe(true);
+      expect(action.shouldRequireApiKeyPublic('litellm')).toBe(true);
     });
 
     it('allows local providers without api key', () => {
@@ -261,6 +262,21 @@ describe('AiBaseAction', () => {
       const result = await action.loadProviderPublic('gateway', options);
 
       expect(createGatewayProvider).toHaveBeenCalledWith(options);
+      expect(result).toBe(provider);
+    });
+
+    it('loads litellm provider via createOpenAI with compatible mode', async () => {
+      const provider = createProviderStub();
+      const options: ProviderInitOptions = {
+        apiKey: 'sk-litellm-key',
+        baseURL: 'http://localhost:4000/v1',
+      };
+
+      (createOpenAI as jest.Mock).mockReturnValue(provider);
+
+      const result = await action.loadProviderPublic('litellm', options);
+
+      expect(createOpenAI).toHaveBeenCalledWith(options);
       expect(result).toBe(provider);
     });
 

--- a/packages/api/src/extensions/actions/ai/ai-base.action.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.ts
@@ -123,7 +123,11 @@ export abstract class AiBaseAction<
     // Most hosted providers need an API key; skip strict enforcement for custom/local providers.
     const providerId = this.getProviderId(provider);
 
-    return providerId === 'openai' || providerId === 'gateway';
+    return (
+      providerId === 'openai' ||
+      providerId === 'gateway' ||
+      providerId === 'litellm'
+    );
   }
 
   protected async loadProvider(
@@ -141,6 +145,10 @@ export abstract class AiBaseAction<
       const { createGatewayProvider } = await import('@ai-sdk/gateway');
 
       return createGatewayProvider(options);
+    }
+
+    if (providerId === 'litellm') {
+      return createOpenAI(options);
     }
 
     const moduleCandidates = new Set<string>([

--- a/packages/api/src/extensions/actions/ai/model.binding.ts
+++ b/packages/api/src/extensions/actions/ai/model.binding.ts
@@ -36,6 +36,7 @@ export const vercelAiSdkProviders = [
   'huggingface',
   'hume',
   'klingai',
+  'litellm',
   'lmnt',
   'luma',
   'mistral',
@@ -85,7 +86,7 @@ export const aiModelBindingSchema = z.strictObject({
       'ui:options': {
         showWhen: {
           field: 'provider',
-          equals: 'gateway',
+          equals: ['gateway', 'litellm'],
         },
       },
     }),


### PR DESCRIPTION
## What changed?

**Summary:** Adds `'litellm'` as a provider option in the AI model binding. Users select `litellm` in the provider dropdown, set their LiteLLM proxy URL as the base URL, and get access to 100+ LLM providers (Anthropic, Google, Bedrock, Azure, Ollama, etc.) through a single OpenAI-compatible gateway.

**Why:** For better provider management in the AI action dropdown. LiteLLM lets users consolidate multiple provider keys, enable fallback routing, and access models not natively bundled with Hexabot - all through a self-hosted proxy they control.

**How to review:** Three files, 27 lines added:
- `model.binding.ts` - added `'litellm'` to `vercelAiSdkProviders`, show `base_url` field when litellm is selected
- `ai-base.action.ts` - handle `'litellm'` in `loadProvider` (uses `createOpenAI` since litellm proxy is OpenAI-compatible), require API key
- `ai-base.action.spec.ts` - added `shouldRequireApiKey` assertion for litellm + `loadProvider` test verifying it routes through `createOpenAI`

**Validation:**
- Build passes (`pnpm build` - 7/7 tasks)
- All 1133 tests pass (`pnpm --filter @hexabot-ai/api test`)
- Pre-commit hooks (eslint + typecheck) clean
- Live E2E against a real LiteLLM proxy (routing to Claude via Azure Foundry):

```text
$ litellm --config config.yaml --port 4000
# proxy healthy, model: anthropic/claude-sonnet-4-6

$ node -e "
const provider = createOpenAI({ apiKey: 'sk-test', baseURL: 'http://localhost:4000/v1' });
const { text, finishReason, usage } = await generateText({
  model: provider('anthropic/claude-sonnet-4-6'),
  prompt: 'Say OK and nothing else.',
});
"

content: "OK"
finishReason: stop
usage: { inputTokens: 13, outputTokens: 4, totalTokens: 17 }
```

**Usage:**
1. Run a LiteLLM proxy: `litellm --config config.yaml --port 4000`
2. In Hexabot AI action settings, select provider: `litellm`
3. Set base URL: `http://localhost:4000/v1`
4. Set model: `anthropic/claude-sonnet-4-6` (or any model configured on the proxy)
5. Set API key: your LiteLLM proxy master key

Zero new dependencies - reuses the existing `@ai-sdk/openai` package.
