### PR TITLE
fix(api): make base_url compatible with multiple values

### DIFF
--- a/packages/api/src/extensions/actions/ai/model.binding.ts
+++ b/packages/api/src/extensions/actions/ai/model.binding.ts
@@ -86,7 +86,7 @@ export const aiModelBindingSchema = z.strictObject({
       'ui:options': {
         showWhen: {
           field: 'provider',
-          equals: ['gateway', 'litellm'],
+          in: ['gateway', 'litellm'],
         },
       },
     }),


### PR DESCRIPTION
## Summary

Display the configured Base URL in the model configuration UI. This ensures users can verify the endpoint associated with a model after saving or editing its settings.

## Why

The Base URL was not visible in the model configuration view, making it difficult to confirm endpoint settings and troubleshoot configuration issues.

## How to Review

Focus on the model configuration UI and verify that the Base URL is correctly displayed when viewing and editing models with custom endpoints.

## Validation

* Created a model with a custom Base URL.
* Saved and reopened the configuration.
* Confirmed the Base URL is displayed correctly.
* Verified existing model configuration behavior remains unchanged.
