### PR TITLE
fix(api): make LiteLLM provider using chat completions

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -57,6 +57,7 @@
     "@ai-sdk/gateway": "^3.0.9",
     "@ai-sdk/mcp": "^1.0.25",
     "@ai-sdk/openai": "^3.0.7",
+    "@ai-sdk/openai-compatible": "^2.0.48",
     "@ai-sdk/provider": "^3.0.2",
     "@hexabot-ai/agentic": "workspace:*",
     "@hexabot-ai/types": "workspace:*",

--- a/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.spec.ts
@@ -6,6 +6,7 @@
 
 import { createGatewayProvider } from '@ai-sdk/gateway';
 import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { Message, OutgoingMessageType } from '@hexabot-ai/types';
 import { LanguageModelUsage } from 'ai';
 import { z } from 'zod';
@@ -24,6 +25,10 @@ import {
 
 jest.mock('@ai-sdk/openai', () => ({
   createOpenAI: jest.fn(),
+}));
+
+jest.mock('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: jest.fn(),
 }));
 
 jest.mock('@ai-sdk/gateway', () => ({
@@ -265,18 +270,22 @@ describe('AiBaseAction', () => {
       expect(result).toBe(provider);
     });
 
-    it('loads litellm provider via createOpenAI with compatible mode', async () => {
+    it('loads litellm provider via createOpenAICompatible with compatible mode', async () => {
       const provider = createProviderStub();
       const options: ProviderInitOptions = {
         apiKey: 'sk-litellm-key',
         baseURL: 'http://localhost:4000/v1',
       };
 
-      (createOpenAI as jest.Mock).mockReturnValue(provider);
+      (createOpenAICompatible as jest.Mock).mockReturnValue(provider);
 
       const result = await action.loadProviderPublic('litellm', options);
 
-      expect(createOpenAI).toHaveBeenCalledWith(options);
+      expect(createOpenAICompatible).toHaveBeenCalledWith({
+        ...options,
+        name: 'litellm',
+        baseURL: options.baseURL,
+      });
       expect(result).toBe(provider);
     });
 

--- a/packages/api/src/extensions/actions/ai/ai-base.action.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.ts
@@ -5,13 +5,14 @@
  */
 
 import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { ProviderV2, ProviderV3 } from '@ai-sdk/provider';
 import {
   IncomingMessageType,
   Message,
-  Thread,
   StdIncomingMessage,
   StdOutgoingMessage,
+  Thread,
 } from '@hexabot-ai/types';
 import {
   LanguageModel,
@@ -148,7 +149,11 @@ export abstract class AiBaseAction<
     }
 
     if (providerId === 'litellm') {
-      return createOpenAI(options);
+      return createOpenAICompatible({
+        ...options,
+        name: 'litellm',
+        baseURL: options.baseURL || '',
+      });
     }
 
     const moduleCandidates = new Set<string>([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.7
         version: 3.0.7(zod@4.3.6)
+      '@ai-sdk/openai-compatible':
+        specifier: ^2.0.48
+        version: 2.0.48(zod@4.3.6)
       '@ai-sdk/provider':
         specifier: ^3.0.2
         version: 3.0.2
@@ -1024,6 +1027,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@2.0.48':
+    resolution: {integrity: sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.7':
     resolution: {integrity: sha512-CBoYn1U59Lop8yBL9KuVjHCKc/B06q9Qo0SasRwHoyMEq+X4I8LQZu3a8Ck1jwwcZTTxfyiExB70LtIRSynBDA==}
     engines: {node: '>=18'}
@@ -1036,11 +1045,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.4':
     resolution: {integrity: sha512-VxhX0B/dWGbpNHxrKCWUAJKXIXV015J4e7qYjdIU9lLWeptk0KMLGcqkB4wFxff5Njqur8dt8wRi1MN9lZtDqg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.2':
     resolution: {integrity: sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==}
@@ -6571,6 +6590,10 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
@@ -10651,6 +10674,12 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.3.6
 
+  '@ai-sdk/openai-compatible@2.0.48(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/openai@3.0.7(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
@@ -10664,12 +10693,23 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.4(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.2':
     dependencies:
@@ -17340,6 +17380,8 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:


### PR DESCRIPTION
## Problem

The LiteLLM integration currently relies on the OpenAI Responses API endpoint. This creates compatibility issues with providers and models that support the Chat Completions API but do not fully support the Responses API.

## Context

This occurs when configuring models through LiteLLM, especially for providers that expose OpenAI-compatible Chat Completions endpoints but lack support for the newer Responses API.

## Steps to Reproduce

1. Configure a model through LiteLLM.
2. Send a request using the current integration.
3. Observe that requests are routed through the Responses API endpoint.
4. Attempt to use a provider/model that only supports Chat Completions.
5. Requests fail or exhibit unexpected behavior.

## Expected

LiteLLM should use the Chat Completions API endpoint by default (or provide a configuration option to do so) instead of relying on the Responses API endpoint.

## Impact

* Affects users integrating providers that are OpenAI-compatible but only implement Chat Completions.
* Reduces compatibility across supported LiteLLM providers.
* Can prevent certain models from working entirely.