### PR TITLE
fix: ws web channel cors

### DIFF
--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -13,7 +13,8 @@ SSL_EMAIL=hello@hexabot.ai
 API_ORIGIN=http://localhost:3000/api
 # Public origin for the web UI that nginx should proxy.
 FRONTEND_BASE_URL=http://localhost:8080
-# Comma-separated list of origins allowed by CORS and Socket.IO.
+# Comma-separated admin/frontend origins allowed by CORS and console Socket.IO.
+# Public web widget embed origins are configured per web channel source.
 FRONTEND_ORIGIN=http://localhost:8080,http://localhost:3000,http://localhost:5173
 # Enables optional single-sign-on integrations.
 SSO_ENABLED=false

--- a/packages/api/src/channel/source.controller.spec.ts
+++ b/packages/api/src/channel/source.controller.spec.ts
@@ -14,6 +14,8 @@ import { ThreadOrmEntity } from '@/chat/entities/thread.entity';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
+import type { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import { SourceOrmEntity } from './entities/source.entity';
 import { SourceService } from './services/source.service';
@@ -118,11 +120,23 @@ describe('SourceController (TypeORM cascade)', () => {
   let sourceRepository: Repository<SourceOrmEntity>;
   let threadRepository: Repository<ThreadOrmEntity>;
   let messageRepository: Repository<MessageOrmEntity>;
+  const websocketGatewayMock = {
+    joinSockets: jest.fn(),
+    broadcastWorkflowEvent: jest.fn(),
+  } as jest.Mocked<
+    Pick<WebsocketGateway, 'joinSockets' | 'broadcastWorkflowEvent'>
+  >;
 
   beforeAll(async () => {
     const testing = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [SourceController],
+      providers: [
+        {
+          provide: WEBSOCKET_GATEWAY,
+          useValue: websocketGatewayMock,
+        },
+      ],
       typeorm: {
         fixtures: installMessageFixturesTypeOrm,
       },

--- a/packages/api/src/chat/controllers/message.controller.spec.ts
+++ b/packages/api/src/chat/controllers/message.controller.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '@/utils/test/fixtures/message';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 
 import { MessageController } from './message.controller';
 
@@ -37,6 +38,10 @@ describe('MessageController (TypeORM)', () => {
     findChannel: jest.fn(),
     getChannelHandler: jest.fn(),
   };
+  const websocketGatewayMock = {
+    joinSockets: jest.fn(),
+    broadcastWorkflowEvent: jest.fn(),
+  };
   const defaultOrder = { order: { createdAt: 'ASC' as const } };
 
   beforeAll(async () => {
@@ -51,6 +56,10 @@ describe('MessageController (TypeORM)', () => {
         {
           provide: ChannelService,
           useValue: channelServiceMock,
+        },
+        {
+          provide: WEBSOCKET_GATEWAY,
+          useValue: websocketGatewayMock,
         },
       ],
       typeorm: {

--- a/packages/api/src/config/index.ts
+++ b/packages/api/src/config/index.ts
@@ -6,6 +6,13 @@
 
 import { join } from 'path';
 
+import {
+  parseAuditHeaders,
+  parseCsv,
+  parseIntWithFallback,
+  parseOptionalInt,
+} from '@/utils/helpers/parse';
+
 import { Config } from './types';
 
 const isProduction = (process.env.NODE_ENV || 'development')
@@ -16,59 +23,6 @@ const shouldAutoMigrate =
   (autoMigrateToggle === 'true' &&
     (process.env.API_IS_PRIMARY_NODE || 'true') === 'true') ||
   !isProduction;
-const parseIntWithFallback = (
-  value: string | undefined,
-  fallback: number,
-): number => {
-  if (!value) {
-    return fallback;
-  }
-  const parsed = Number.parseInt(value, 10);
-
-  return Number.isNaN(parsed) ? fallback : parsed;
-};
-const parseOptionalInt = (value: string | undefined): number | undefined => {
-  if (value === undefined) {
-    return undefined;
-  }
-  const parsed = Number.parseInt(value, 10);
-
-  return Number.isNaN(parsed) ? undefined : parsed;
-};
-const parseCsv = (value: string | undefined, fallback: string[]): string[] => {
-  if (!value) {
-    return fallback;
-  }
-
-  return value
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
-};
-const parseAuditHeaders = (
-  value: string | undefined,
-): Record<string, string> => {
-  if (!value) {
-    return {};
-  }
-
-  try {
-    const parsed = JSON.parse(value) as unknown;
-
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return {};
-    }
-
-    return Object.fromEntries(
-      Object.entries(parsed).map(([key, headerValue]) => [
-        key,
-        String(headerValue),
-      ]),
-    );
-  } catch {
-    return {};
-  }
-};
 const sessionMaxAge = parseIntWithFallback(
   process.env.SESSION_MAX_AGE,
   24 * 60 * 60 * 1000,
@@ -114,9 +68,7 @@ export const config: Config = {
       headers:
         'content-type,x-xsrf-token,x-csrf-token,authorization,mcp-session-id,last-event-id',
       methods: ['GET', 'PATCH', 'POST', 'DELETE', 'OPTIONS', 'HEAD'],
-      allowOrigins: process.env.FRONTEND_ORIGIN
-        ? process.env.FRONTEND_ORIGIN.split(',').map((origin) => origin.trim())
-        : ['*'],
+      allowOrigins: parseCsv(process.env.FRONTEND_ORIGIN, ['*']),
       allowCredentials: true,
     },
     csrf: true,
@@ -174,9 +126,9 @@ export const config: Config = {
     // that sets a cookie (this is used by the sails.io.js socket client
     // to get access to a 3rd party cookie and to enable sessions).
     grant3rdPartyCookie: true,
-    onlyAllowOrigins: process.env.FRONTEND_ORIGIN
-      ? process.env.FRONTEND_ORIGIN.split(',').map((origin) => origin.trim())
-      : [], // ['http://example.com', 'https://example.com'],
+    // Admin/frontend origins for Socket.IO connections without a web source.
+    // Web widget origins are controlled by each web source's allowed_domains.
+    onlyAllowOrigins: parseCsv(process.env.FRONTEND_ORIGIN, []), // ['http://example.com', 'https://example.com'],
   },
   session: {
     secret: process.env.SESSION_SECRET || 'changeme',

--- a/packages/api/src/extensions/channels/web/base-web-channel.ts
+++ b/packages/api/src/extensions/channels/web/base-web-channel.ts
@@ -50,6 +50,7 @@ import { MessageService } from '@/chat/services/message.service';
 import type { SubscriberChannelData } from '@/chat/types/channel';
 import { MenuService } from '@/cms/services/menu.service';
 import { config } from '@/config';
+import { getAllowedDomains } from '@/utils/helpers/origin';
 import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
 
@@ -303,12 +304,11 @@ export default abstract class BaseWebChannelHandler<N extends ChannelName>
     res: Response | SocketResponse,
     source: Source,
   ): Promise<void> {
-    const allowedDomains =
-      typeof source.settings.allowed_domains === 'string'
-        ? source.settings.allowed_domains
-        : '*';
-
-    await this.sessionService.validateCors(req, res, allowedDomains);
+    await this.sessionService.validateCors(
+      req,
+      res,
+      getAllowedDomains(source.settings),
+    );
   }
 
   protected async getOrCreateSession(

--- a/packages/api/src/extensions/channels/web/services/web-session.service.ts
+++ b/packages/api/src/extensions/channels/web/services/web-session.service.ts
@@ -12,6 +12,7 @@ import { SubscriberCreateDto } from '@/chat/dto/subscriber.dto';
 import { SubscriberService } from '@/chat/services/subscriber.service';
 import { ThreadService } from '@/chat/services/thread.service';
 import { LoggerService } from '@/logger/logger.service';
+import { isAllowedOrigin, normalizeOrigin } from '@/utils/helpers/origin';
 import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
 
@@ -62,38 +63,26 @@ export class WebSessionService {
     res: Response | SocketResponse,
     allowedDomains: string,
   ): Promise<void> {
-    if (!req.headers?.origin) {
+    const origin = req.headers?.origin;
+
+    if (!origin) {
       this.logger.debug('No origin ', req.headers);
       throw new Error('CORS - No origin provided!');
     }
 
-    const originUrl = new URL(req.headers.origin);
-    if (!['http:', 'https:'].includes(originUrl.protocol)) {
+    const normalizedOrigin = normalizeOrigin(origin);
+
+    if (!normalizedOrigin) {
       throw new Error('CORS - Invalid origin!');
     }
 
-    const origins = allowedDomains.split(',');
-    const foundOrigin = origins
-      .filter((o) => o.trim() !== '*')
-      .map((o) => {
-        try {
-          return new URL(o.trim()).origin;
-        } catch {
-          this.logger.error(`Invalid URL in allowed domains: ${o}`);
-
-          return null;
-        }
-      })
-      .filter((o): o is string => o !== null)
-      .some((o) => o === originUrl.origin);
-
-    if (!foundOrigin && !origins.includes('*')) {
+    if (!isAllowedOrigin(normalizedOrigin, allowedDomains)) {
       res.set('Access-Control-Allow-Origin', '');
-      this.logger.debug('No origin found ', req.headers.origin);
+      this.logger.debug('No origin found ', origin);
       throw new Error('CORS - Domain not allowed!');
     }
 
-    res.set('Access-Control-Allow-Origin', originUrl.origin);
+    res.set('Access-Control-Allow-Origin', normalizedOrigin);
     res.set('Access-Control-Allow-Credentials', 'true');
     res.set('Access-Control-Expose-Headers', '');
     if (req.method === 'OPTIONS') {

--- a/packages/api/src/setting/services/setting.service.spec.ts
+++ b/packages/api/src/setting/services/setting.service.spec.ts
@@ -173,7 +173,7 @@ describe('SettingService', () => {
         }),
         makeSetting({
           label: 'allowed_domains',
-          value: 'https://example.com,https://another.com',
+          value: ' https://example.com, https://another.com ',
         }),
       ];
 

--- a/packages/api/src/setting/services/setting.service.ts
+++ b/packages/api/src/setting/services/setting.service.ts
@@ -28,6 +28,7 @@ import {
 import { Cacheable } from '@/utils/decorators/cacheable.decorator';
 import { UpdateOneOptions } from '@/utils/generics/base-orm.repository';
 import { BaseOrmService } from '@/utils/generics/base-orm.service';
+import { splitAllowedOrigins } from '@/utils/helpers/origin';
 import { UpdateEntityEvent } from '@/utils/types/entity-event.types';
 
 import { SettingCreateDto, SettingUpdateDto } from '../dto/setting.dto';
@@ -272,9 +273,9 @@ export class SettingService extends BaseOrmService<SettingOrmEntity> {
       where: { label: 'allowed_domains' },
     })) as Setting[];
     const allowedDomains = settings.flatMap((setting) =>
-      (typeof setting.value === 'string' ? setting.value : '')
-        .split(',')
-        .filter((origin) => origin),
+      typeof setting.value === 'string'
+        ? splitAllowedOrigins(setting.value)
+        : [],
     );
     const uniqueOrigins = new Set([
       ...config.security.cors.allowOrigins,

--- a/packages/api/src/transfer/workflow-transfer.service.spec.ts
+++ b/packages/api/src/transfer/workflow-transfer.service.spec.ts
@@ -36,7 +36,8 @@ import {
 } from '@/utils/test/fixtures/user';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
+import type { WebsocketGateway } from '@/websocket/websocket.gateway';
 import { workflowResourceRef } from '@/workflow/resource-refs';
 import { McpClientPoolService } from '@/workflow/services/mcp-client-pool.service';
 import { McpServerService } from '@/workflow/services/mcp-server.service';
@@ -168,7 +169,7 @@ describe('WorkflowTransferService', () => {
         McpServerTransferAdapter,
         KnowledgeBaseTransferAdapter,
         {
-          provide: WebsocketGateway,
+          provide: WEBSOCKET_GATEWAY,
           useValue: websocketGatewayMock,
         },
         {

--- a/packages/api/src/utils/helpers/origin.spec.ts
+++ b/packages/api/src/utils/helpers/origin.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import {
+  getAllowedDomains,
+  isAllowedOrigin,
+  normalizeOrigin,
+  splitAllowedOrigins,
+} from './origin';
+
+describe('origin helpers', () => {
+  describe('splitAllowedOrigins', () => {
+    it('splits comma-separated origins and trims empty values', () => {
+      expect(
+        splitAllowedOrigins(' https://example.com, ,https://test.com/path '),
+      ).toEqual(['https://example.com', 'https://test.com/path']);
+    });
+  });
+
+  describe('getAllowedDomains', () => {
+    it('returns source allowed domains or wildcard fallback', () => {
+      expect(
+        getAllowedDomains({ allowed_domains: 'https://example.com' }),
+      ).toBe('https://example.com');
+      expect(getAllowedDomains({ allowed_domains: 123 })).toBe('*');
+    });
+  });
+
+  describe('normalizeOrigin', () => {
+    it('normalizes http origins and rejects invalid origins', () => {
+      expect(normalizeOrigin('https://example.com/path')).toBe(
+        'https://example.com',
+      );
+      expect(normalizeOrigin('not-a-url')).toBeNull();
+      expect(normalizeOrigin('chrome-extension://abc')).toBeNull();
+      expect(normalizeOrigin(undefined)).toBeNull();
+    });
+  });
+
+  describe('isAllowedOrigin', () => {
+    it('allows exact normalized origins', () => {
+      expect(
+        isAllowedOrigin('https://example.com', [
+          'https://example.com',
+          'https://other.com',
+        ]),
+      ).toBe(true);
+    });
+
+    it('normalizes allowed origins before comparison', () => {
+      expect(
+        isAllowedOrigin(
+          'https://example.com',
+          ' https://example.com/some/path ',
+        ),
+      ).toBe(true);
+    });
+
+    it('allows wildcard origins', () => {
+      expect(isAllowedOrigin('https://example.com', ' * ')).toBe(true);
+    });
+
+    it('rejects unmatched origins', () => {
+      expect(
+        isAllowedOrigin('https://example.com', 'https://allowed.example.com'),
+      ).toBe(false);
+    });
+
+    it('reports invalid request origins', () => {
+      expect(isAllowedOrigin('not-a-url', '*')).toBe(false);
+    });
+
+    it('rejects non-http request origins', () => {
+      expect(isAllowedOrigin('chrome-extension://abc', '*')).toBe(false);
+    });
+
+    it('ignores invalid allowed origins', () => {
+      expect(
+        isAllowedOrigin('https://example.com', 'not-a-url,https://example.com'),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/api/src/utils/helpers/origin.ts
+++ b/packages/api/src/utils/helpers/origin.ts
@@ -1,0 +1,50 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { parseCsv } from './parse';
+
+export const normalizeOrigin = (value: string | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value.trim());
+
+    return ['http:', 'https:'].includes(url.protocol) ? url.origin : null;
+  } catch {
+    return null;
+  }
+};
+
+export const splitAllowedOrigins = (
+  allowedOrigins: string | string[],
+): string[] => parseCsv(allowedOrigins, []);
+
+export const getAllowedDomains = (settings: Record<string, unknown>): string =>
+  typeof settings.allowed_domains === 'string' ? settings.allowed_domains : '*';
+
+export const isAllowedOrigin = (
+  origin: string | undefined,
+  allowedOrigins: string | string[],
+): boolean => {
+  const normalizedOrigin = normalizeOrigin(origin);
+  const allowedOriginValues = splitAllowedOrigins(allowedOrigins);
+
+  if (!normalizedOrigin) {
+    return false;
+  }
+
+  if (allowedOriginValues.includes('*')) {
+    return true;
+  }
+
+  const normalizedAllowedOrigins = allowedOriginValues
+    .map(normalizeOrigin)
+    .filter((allowedOrigin): allowedOrigin is string => allowedOrigin !== null);
+
+  return normalizedAllowedOrigins.includes(normalizedOrigin);
+};

--- a/packages/api/src/utils/helpers/parse.spec.ts
+++ b/packages/api/src/utils/helpers/parse.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import {
+  parseAuditHeaders,
+  parseCsv,
+  parseIntWithFallback,
+  parseOptionalInt,
+} from './parse';
+
+describe('parse helpers', () => {
+  describe('parseIntWithFallback', () => {
+    it('parses integers and falls back for empty or invalid values', () => {
+      expect(parseIntWithFallback('42', 1)).toBe(42);
+      expect(parseIntWithFallback(undefined, 1)).toBe(1);
+      expect(parseIntWithFallback('invalid', 1)).toBe(1);
+    });
+  });
+
+  describe('parseOptionalInt', () => {
+    it('parses integers and returns undefined for missing or invalid values', () => {
+      expect(parseOptionalInt('42')).toBe(42);
+      expect(parseOptionalInt(undefined)).toBeUndefined();
+      expect(parseOptionalInt('invalid')).toBeUndefined();
+    });
+  });
+
+  describe('parseCsv', () => {
+    it('splits comma-separated values and trims empty entries', () => {
+      expect(parseCsv(' first, ,second ', [])).toEqual(['first', 'second']);
+    });
+
+    it('trims array values without splitting them again', () => {
+      expect(parseCsv([' first ', '', 'second,third'], [])).toEqual([
+        'first',
+        'second,third',
+      ]);
+    });
+
+    it('uses the fallback for missing values', () => {
+      expect(parseCsv(undefined, ['fallback'])).toEqual(['fallback']);
+    });
+  });
+
+  describe('parseAuditHeaders', () => {
+    it('parses JSON object values into string headers', () => {
+      expect(parseAuditHeaders('{"x-api-key":"secret","retry":3}')).toEqual({
+        'x-api-key': 'secret',
+        retry: '3',
+      });
+    });
+
+    it('returns an empty object for invalid or non-object values', () => {
+      expect(parseAuditHeaders(undefined)).toEqual({});
+      expect(parseAuditHeaders('not-json')).toEqual({});
+      expect(parseAuditHeaders('[]')).toEqual({});
+    });
+  });
+});

--- a/packages/api/src/utils/helpers/parse.ts
+++ b/packages/api/src/utils/helpers/parse.ts
@@ -1,0 +1,68 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+export const parseIntWithFallback = (
+  value: string | undefined,
+  fallback: number,
+): number => {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+export const parseOptionalInt = (
+  value: string | undefined,
+): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+export const parseCsv = (
+  value: string | string[] | undefined,
+  fallback: string[],
+): string[] => {
+  if (!value) {
+    return fallback;
+  }
+
+  const values = Array.isArray(value) ? value : value.split(',');
+
+  return values
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+export const parseAuditHeaders = (
+  value: string | undefined,
+): Record<string, string> => {
+  if (!value) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed).map(([key, headerValue]) => [
+        key,
+        String(headerValue),
+      ]),
+    );
+  } catch {
+    return {};
+  }
+};

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -46,6 +46,8 @@ export * from './helpers/misc';
 
 export * from './helpers/object';
 
+export * from './helpers/parse';
+
 export * from './helpers/safeRandom';
 
 export * from './helpers/svg';

--- a/packages/api/src/websocket/tokens.ts
+++ b/packages/api/src/websocket/tokens.ts
@@ -1,0 +1,7 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+export const WEBSOCKET_GATEWAY = Symbol('WEBSOCKET_GATEWAY');

--- a/packages/api/src/websocket/utils/gateway-options.spec.ts
+++ b/packages/api/src/websocket/utils/gateway-options.spec.ts
@@ -4,12 +4,168 @@
  * Full terms: see LICENSE.md.
  */
 
+import type { IncomingMessage } from 'http';
+
+import { config } from '@/config';
+import { CONSOLE_CHANNEL_NAME } from '@/extensions/channels/console/settings.schema';
+import { WEB_CHANNEL_NAME } from '@/extensions/channels/web/settings.schema';
+
 import { buildWebSocketGatewayOptions } from './gateway-options';
+import type { SocketOriginDependencies } from './gateway-options';
+
+type SocketCorsSource = NonNullable<
+  Awaited<ReturnType<SocketOriginDependencies['findActiveSourceById']>>
+>;
 
 describe('buildWebSocketGatewayOptions', () => {
+  const originalEnv = config.env;
+  const originalBeforeConnect = config.sockets.beforeConnect;
+  const webSourceId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const consoleSourceId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const sources: Record<string, SocketCorsSource> = {
+    [webSourceId]: {
+      channel: WEB_CHANNEL_NAME,
+      settings: { allowed_domains: 'https://embed.example.com' },
+    },
+    [consoleSourceId]: {
+      channel: CONSOLE_CHANNEL_NAME,
+      settings: { allowed_domains: 'https://embed.example.com' },
+    },
+  };
+  const makeHandshake = (origin?: string, sourceId?: string): IncomingMessage =>
+    ({
+      headers: origin ? { origin } : {},
+      url: `/socket.io/?EIO=4&transport=websocket${
+        sourceId ? `&source_id=${sourceId}` : ''
+      }`,
+    }) as unknown as IncomingMessage;
+  const makeDependencies = (): jest.Mocked<SocketOriginDependencies> => ({
+    getAllowedOrigins: jest
+      .fn()
+      .mockResolvedValue(['https://admin.example.com']),
+    findActiveSourceById: jest.fn(
+      async (sourceId) => sources[sourceId] ?? null,
+    ),
+  });
+  const runAllowRequest = async (
+    dependencies: SocketOriginDependencies,
+    origin?: string,
+    sourceId?: string,
+  ): Promise<{ err: string | null | undefined; success: boolean }> => {
+    const options = buildWebSocketGatewayOptions(dependencies);
+
+    return await new Promise((resolve) => {
+      options.allowRequest?.(
+        makeHandshake(origin, sourceId),
+        (err, success) => {
+          resolve({
+            err,
+            success,
+          });
+        },
+      );
+    });
+  };
+
+  beforeEach(() => {
+    config.env = 'production';
+    config.sockets.beforeConnect = () => true;
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    config.env = originalEnv;
+    config.sockets.beforeConnect = originalBeforeConnect;
+    jest.restoreAllMocks();
+  });
+
   it('enables CORS credentials for socket transports', () => {
     const options = buildWebSocketGatewayOptions();
 
     expect(options.cors).toMatchObject({ credentials: true });
+  });
+
+  it('allows a web source socket when the origin matches source allowed domains', async () => {
+    const dependencies = makeDependencies();
+
+    await expect(
+      runAllowRequest(dependencies, 'https://embed.example.com', webSourceId),
+    ).resolves.toEqual({ err: null, success: true });
+
+    expect(dependencies.findActiveSourceById).toHaveBeenCalledWith(webSourceId);
+    expect(dependencies.getAllowedOrigins).not.toHaveBeenCalled();
+  });
+
+  it('rejects a web source socket when the origin is not in source allowed domains', async () => {
+    const dependencies = makeDependencies();
+
+    await expect(
+      runAllowRequest(
+        dependencies,
+        'https://not-allowed.example.com',
+        webSourceId,
+      ),
+    ).resolves.toMatchObject({
+      err: 'Origin not allowed',
+      success: false,
+    });
+  });
+
+  it('allows a web source socket when source allowed domains is wildcard', async () => {
+    const dependencies = makeDependencies();
+    dependencies.findActiveSourceById.mockResolvedValue({
+      channel: WEB_CHANNEL_NAME,
+      settings: {
+        allowed_domains: '*',
+      },
+    });
+
+    await expect(
+      runAllowRequest(
+        dependencies,
+        'https://anywhere.example.com',
+        webSourceId,
+      ),
+    ).resolves.toEqual({ err: null, success: true });
+  });
+
+  it('does not let console source allowed domains bypass global origins', async () => {
+    const dependencies = makeDependencies();
+
+    await expect(
+      runAllowRequest(
+        dependencies,
+        'https://embed.example.com',
+        consoleSourceId,
+      ),
+    ).resolves.toMatchObject({
+      err: 'Origin not allowed',
+      success: false,
+    });
+
+    expect(dependencies.getAllowedOrigins).toHaveBeenCalled();
+  });
+
+  it('uses global origins for sockets without source_id', async () => {
+    const dependencies = makeDependencies();
+
+    await expect(
+      runAllowRequest(dependencies, 'https://admin.example.com'),
+    ).resolves.toEqual({ err: null, success: true });
+
+    expect(dependencies.getAllowedOrigins).toHaveBeenCalled();
+    expect(dependencies.findActiveSourceById).not.toHaveBeenCalled();
+  });
+
+  it('honors beforeConnect before evaluating socket origin policy', async () => {
+    const dependencies = makeDependencies();
+    config.sockets.beforeConnect = () => false;
+
+    await expect(
+      runAllowRequest(dependencies, 'https://embed.example.com', webSourceId),
+    ).resolves.toEqual({ err: null, success: false });
+
+    expect(dependencies.findActiveSourceById).not.toHaveBeenCalled();
+    expect(dependencies.getAllowedOrigins).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/websocket/utils/gateway-options.ts
+++ b/packages/api/src/websocket/utils/gateway-options.ts
@@ -4,40 +4,154 @@
  * Full terms: see LICENSE.md.
  */
 
+import type { IncomingMessage } from 'http';
 import util from 'util';
 
+import type { Source } from '@hexabot-ai/types';
+import { NotFoundException } from '@nestjs/common';
+import { isUUID } from 'class-validator';
 import type { ServerOptions } from 'socket.io';
 
 import { AppInstance } from '@/app.instance';
+import { SourceService } from '@/channel/services/source.service';
 import { config } from '@/config';
+import { CONSOLE_CHANNEL_NAME } from '@/extensions/channels/console/settings.schema';
+import { WEB_CHANNEL_NAME } from '@/extensions/channels/web/settings.schema';
 import { SettingService } from '@/setting/services/setting.service';
+import { getAllowedDomains, isAllowedOrigin } from '@/utils/helpers/origin';
 
-export const buildWebSocketGatewayOptions = (): Partial<ServerOptions> => {
+type SocketCorsSource = Pick<Source, 'channel' | 'settings'>;
+type AllowRequestCallback = (
+  err: string | null | undefined,
+  success: boolean,
+) => void;
+
+export type SocketOriginDependencies = {
+  getAllowedOrigins: () => Promise<string[]>;
+  findActiveSourceById: (sourceId: string) => Promise<SocketCorsSource | null>;
+};
+
+const getDefaultSocketOriginDependencies = (): SocketOriginDependencies => {
+  const app = AppInstance.getApp();
+  const settingService = app.get<SettingService>(SettingService);
+  const sourceService = app.get<SourceService>(SourceService);
+
+  return {
+    getAllowedOrigins: () => settingService.getAllowedOrigins(),
+    findActiveSourceById: (sourceId) => sourceService.findActiveById(sourceId),
+  };
+};
+
+export const isSocketRequestOriginAllowed = async (
+  handshake: IncomingMessage,
+  dependencies: SocketOriginDependencies = getDefaultSocketOriginDependencies(),
+): Promise<boolean> => {
+  const { origin: rawOrigin } = handshake.headers;
+  const origin = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
+  const rawSourceId = handshake.url
+    ? new URL(handshake.url, 'ws://localhost').searchParams.get('source_id')
+    : null;
+
+  if (!rawSourceId) {
+    return isAllowedOrigin(origin, await dependencies.getAllowedOrigins());
+  }
+
+  if (!isUUID(rawSourceId)) {
+    return false;
+  }
+
+  let source: SocketCorsSource | null;
+  try {
+    source = await dependencies.findActiveSourceById(rawSourceId);
+  } catch (error) {
+    if (error instanceof NotFoundException) {
+      return false;
+    }
+    throw error;
+  }
+  if (!source) {
+    return false;
+  }
+
+  if (source.channel === WEB_CHANNEL_NAME) {
+    return isAllowedOrigin(origin, getAllowedDomains(source.settings));
+  }
+
+  if (source.channel === CONSOLE_CHANNEL_NAME) {
+    return isAllowedOrigin(origin, await dependencies.getAllowedOrigins());
+  }
+
+  return false;
+};
+
+const runBeforeConnect = (
+  handshake: IncomingMessage,
+  cb: AllowRequestCallback,
+): boolean => {
+  try {
+    const result = config.sockets.beforeConnect(handshake);
+
+    if (!result) {
+      cb(null, false);
+
+      return false;
+    }
+
+    return true;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `A socket was rejected via the config.sockets.beforeConnect function.\n` +
+        `It attempted to connect with headers:\n` +
+        `${util.inspect(handshake.headers, { depth: null })}\n` +
+        `Details: ${e}`,
+    );
+
+    cb(e instanceof Error ? e.message : `${e}`, false);
+
+    return false;
+  }
+};
+
+export const buildWebSocketGatewayOptions = (
+  dependencies?: SocketOriginDependencies,
+): Partial<ServerOptions> => {
   const opts: Partial<ServerOptions> = {
     allowEIO3: true, // Allows support for Engine.io v3 clients.
     path: config.sockets.path,
     ...(typeof config.sockets.serveClient !== 'undefined' && {
       serveClient: config.sockets.serveClient,
     }),
-    ...(config.sockets.beforeConnect && {
-      allowRequest: (handshake, cb) => {
-        try {
-          const result = config.sockets.beforeConnect(handshake);
+    allowRequest: (handshake, cb) => {
+      if (!runBeforeConnect(handshake, cb)) {
+        return;
+      }
 
-          return cb(null, result);
-        } catch (e) {
+      if (config.env === 'test') {
+        cb(null, true);
+
+        return;
+      }
+
+      isSocketRequestOriginAllowed(handshake, dependencies)
+        .then((allowed) => {
+          if (allowed) {
+            cb(null, true);
+
+            return;
+          }
+
           // eslint-disable-next-line no-console
           console.log(
-            `A socket was rejected via the config.sockets.beforeConnect function.\n` +
-              `It attempted to connect with headers:\n` +
-              `${util.inspect(handshake.headers, { depth: null })}\n` +
-              `Details: ${e}`,
+            `A socket was rejected by the Socket.IO origin policy.\n` +
+              `It attempted to connect with origin: ${handshake.headers.origin}`,
           );
-
-          return cb(e, false);
-        }
-      },
-    }),
+          cb('Origin not allowed', false);
+        })
+        .catch((error) => {
+          cb(error instanceof Error ? error.message : `${error}`, false);
+        });
+    },
     ...(config.sockets.pingTimeout && {
       pingTimeout: config.sockets.pingTimeout,
     }),
@@ -54,31 +168,7 @@ export const buildWebSocketGatewayOptions = (): Partial<ServerOptions> => {
     ...(config.sockets.cookie && { cookie: config.sockets.cookie }),
     cors: {
       credentials: true,
-      origin: async (origin, cb) => {
-        if (config.env === 'test') {
-          cb(null, true);
-        } else {
-          // Retrieve the allowed origins from the settings
-          const app = AppInstance.getApp();
-          const settingService = app.get<SettingService>(SettingService);
-
-          await settingService
-            .getAllowedOrigins()
-            .then((allowedOrigins) => {
-              if (origin && allowedOrigins.includes(origin)) {
-                cb(null, true);
-              } else {
-                // eslint-disable-next-line no-console
-                console.log(
-                  `A socket was rejected via the config.sockets.onlyAllowOrigins array.\n` +
-                    `It attempted to connect with origin: ${origin}`,
-                );
-                cb(new Error('Origin not allowed'), false);
-              }
-            })
-            .catch(cb);
-        }
-      },
+      origin: true,
     },
   };
 

--- a/packages/api/src/websocket/websocket.module.ts
+++ b/packages/api/src/websocket/websocket.module.ts
@@ -9,12 +9,17 @@ import { Global, Module } from '@nestjs/common';
 import { UserModule } from '@/user/user.module';
 
 import { SocketEventDispatcherService } from './services/socket-event-dispatcher.service';
+import { WEBSOCKET_GATEWAY } from './tokens';
 import { WebsocketGateway } from './websocket.gateway';
 
 @Global()
 @Module({
   imports: [UserModule],
-  providers: [WebsocketGateway, SocketEventDispatcherService],
-  exports: [WebsocketGateway],
+  providers: [
+    WebsocketGateway,
+    { provide: WEBSOCKET_GATEWAY, useExisting: WebsocketGateway },
+    SocketEventDispatcherService,
+  ],
+  exports: [WebsocketGateway, WEBSOCKET_GATEWAY],
 })
 export class WebsocketModule {}

--- a/packages/api/src/workflow/controllers/workflow-version.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow-version.controller.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '@/utils/test/fixtures/workflow';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 
 import { WorkflowVersionService } from '../services/workflow-version.service';
 import { WorkflowService } from '../services/workflow.service';
@@ -33,6 +34,10 @@ describe('WorkflowVersionController (TypeORM)', () => {
   let workflowVersionService: WorkflowVersionService;
   let logger: LoggerService;
   const createdWorkflowIds = new Set<string>();
+  const websocketGatewayMock = {
+    joinSockets: jest.fn(),
+    broadcastWorkflowEvent: jest.fn(),
+  };
   let counter = 0;
 
   const buildWorkflowPayload = () => {
@@ -65,6 +70,12 @@ describe('WorkflowVersionController (TypeORM)', () => {
     const { module: testingModule, getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [WorkflowVersionController],
+      providers: [
+        {
+          provide: WEBSOCKET_GATEWAY,
+          useValue: websocketGatewayMock,
+        },
+      ],
       typeorm: {
         fixtures: [
           installMessagingWorkflowFixturesTypeOrm,

--- a/packages/api/src/workflow/controllers/workflow.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow.controller.spec.ts
@@ -38,7 +38,8 @@ import {
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
+import type { WebsocketGateway } from '@/websocket/websocket.gateway';
 import {
   conversationalWorkflowInputJsonSchema,
   scheduledWorkflowInputJsonSchema,
@@ -151,7 +152,7 @@ describe('WorkflowController (TypeORM)', () => {
           useValue: workflowRunServiceMock,
         },
         {
-          provide: WebsocketGateway,
+          provide: WEBSOCKET_GATEWAY,
           useValue: websocketGatewayMock,
         },
       ],

--- a/packages/api/src/workflow/services/agentic.service.spec.ts
+++ b/packages/api/src/workflow/services/agentic.service.spec.ts
@@ -25,6 +25,7 @@ import {
 } from '@/utils/test/fixtures/workflow';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 import { WorkflowContextFactory } from '@/workflow/contexts/workflow-context-factory';
 import { WorkflowRunOrmEntity } from '@/workflow/entities/workflow-run.entity';
 import { WorkflowVersionOrmEntity } from '@/workflow/entities/workflow-version.entity';
@@ -56,6 +57,10 @@ const i18nServiceMock = {
   ),
 };
 const moduleRefMock: Partial<ModuleRef> = {};
+const websocketGatewayMock = {
+  joinSockets: jest.fn(),
+  broadcastWorkflowEvent: jest.fn(),
+};
 const buildRunnerMock = ({
   startResult,
   resumeResult,
@@ -180,6 +185,7 @@ describe('AgenticService (TypeORM)', () => {
         },
         { provide: I18nService, useValue: i18nServiceMock },
         { provide: ModuleRef, useValue: moduleRefMock },
+        { provide: WEBSOCKET_GATEWAY, useValue: websocketGatewayMock },
       ],
       typeorm: {
         entities: [

--- a/packages/api/src/workflow/services/workflow-run.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-run.service.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '@/utils/test/fixtures/user';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 
 import { WorkflowRunOrmEntity } from '../entities/workflow-run.entity';
 import { WorkflowVersionOrmEntity } from '../entities/workflow-version.entity';
@@ -43,7 +44,10 @@ describe('WorkflowRunService (TypeORM)', () => {
   let workflowVersionId: string | null;
   let counter = 0;
   let creatorId: string;
-
+  const websocketGatewayMock = {
+    joinSockets: jest.fn(),
+    broadcastWorkflowEvent: jest.fn(),
+  };
   const buildWorkflowDefinition = (): WorkflowDefinition => ({
     defs: {
       greet: { kind: 'task', action: 'greet' },
@@ -71,6 +75,7 @@ describe('WorkflowRunService (TypeORM)', () => {
         WorkflowRunService,
         WorkflowRunRepository,
         WorkflowVersionService,
+        { provide: WEBSOCKET_GATEWAY, useValue: websocketGatewayMock },
       ],
       typeorm: {
         entities: [

--- a/packages/api/src/workflow/services/workflow-scheduler.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-scheduler.service.spec.ts
@@ -27,7 +27,8 @@ import {
   InsertEntityEvent,
   UpdateEntityEvent,
 } from '@/utils/types/entity-event.types';
-import { WebsocketGateway } from '@/websocket/websocket.gateway';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
+import type { WebsocketGateway } from '@/websocket/websocket.gateway';
 import { WorkflowType } from '@/workflow/types';
 
 import { WorkflowOrmEntity } from '../entities/workflow.entity';
@@ -102,7 +103,7 @@ describe('WorkflowSchedulerService (TypeORM)', () => {
           useValue: workflowRunServiceMock,
         },
         {
-          provide: WebsocketGateway,
+          provide: WEBSOCKET_GATEWAY,
           useValue: websocketGatewayMock,
         },
         I18nServiceProvider,

--- a/packages/api/src/workflow/services/workflow-version.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-version.service.spec.ts
@@ -23,6 +23,7 @@ import {
   getLastTypeOrmDataSource,
 } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 
 import { WorkflowVersionOrmEntity } from '../entities/workflow-version.entity';
 import { WorkflowOrmEntity } from '../entities/workflow.entity';
@@ -34,7 +35,10 @@ describe('WorkflowVersionService (TypeORM)', () => {
   let module: TestingModule;
   let workflowVersionService: WorkflowVersionService;
   let workflowRepository: Repository<WorkflowOrmEntity>;
-
+  const websocketGatewayMock = {
+    joinSockets: jest.fn(),
+    broadcastWorkflowEvent: jest.fn(),
+  };
   const createWorkflow = async (
     overrides: Partial<WorkflowOrmEntity> = {},
   ): Promise<WorkflowOrmEntity> => {
@@ -52,7 +56,10 @@ describe('WorkflowVersionService (TypeORM)', () => {
   beforeAll(async () => {
     const testing = await buildTestingMocks({
       autoInjectFrom: ['providers'],
-      providers: [WorkflowVersionService],
+      providers: [
+        WorkflowVersionService,
+        { provide: WEBSOCKET_GATEWAY, useValue: websocketGatewayMock },
+      ],
       typeorm: {
         fixtures: [installUserFixturesTypeOrm],
       },

--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -21,7 +21,7 @@ import {
 } from '@/utils/test/fixtures/user';
 import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
-import { WebsocketGateway } from '@/websocket';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 import {
   conversationalWorkflowInputJsonSchema,
   scheduledWorkflowInputJsonSchema,
@@ -107,7 +107,7 @@ describe('WorkflowService (TypeORM)', () => {
         WorkflowVersionService,
         WorkflowRunService,
         WorkflowRunRepository,
-        { provide: WebsocketGateway, useValue: gatewayMock },
+        { provide: WEBSOCKET_GATEWAY, useValue: gatewayMock },
       ],
       typeorm: {
         fixtures: installUserFixturesTypeOrm,

--- a/packages/api/src/workflow/services/workflow.service.ts
+++ b/packages/api/src/workflow/services/workflow.service.ts
@@ -8,6 +8,7 @@ import type { WorkflowEventMap } from '@hexabot-ai/agentic';
 import { WorkflowFull, Workflow } from '@hexabot-ai/types';
 import {
   BadRequestException,
+  Inject,
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common';
@@ -19,15 +20,16 @@ import { UpdateOneOptions } from '@/utils/generics/base-orm.repository';
 import { BaseOrmService } from '@/utils/generics/base-orm.service';
 import { InferCreateDto } from '@/utils/types/dto.types';
 import {
-  Room,
   SocketGet,
   SocketPost,
-  SocketReq,
-  SocketRequest,
-  SocketRes,
-  SocketResponse,
-  WebsocketGateway,
-} from '@/websocket';
+} from '@/websocket/decorators/socket-method.decorator';
+import { SocketReq } from '@/websocket/decorators/socket-req.decorator';
+import { SocketRes } from '@/websocket/decorators/socket-res.decorator';
+import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
+import { Room } from '@/websocket/types';
+import { SocketRequest } from '@/websocket/utils/socket-request';
+import { SocketResponse } from '@/websocket/utils/socket-response';
+import type { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import { WorkflowUpdateDto } from '../dto/workflow.dto';
 import { WorkflowOrmEntity } from '../entities/workflow.entity';
@@ -35,6 +37,11 @@ import { WorkflowRepository } from '../repositories/workflow.repository';
 import { WorkflowType } from '../types';
 
 import { WorkflowRunService } from './workflow-run.service';
+
+type WorkflowSocketGateway = Pick<
+  WebsocketGateway,
+  'joinSockets' | 'broadcastWorkflowEvent'
+>;
 
 @Injectable()
 export class WorkflowService extends BaseOrmService<WorkflowOrmEntity> {
@@ -51,7 +58,8 @@ export class WorkflowService extends BaseOrmService<WorkflowOrmEntity> {
    */
   constructor(
     readonly repository: WorkflowRepository,
-    private readonly gateway: WebsocketGateway,
+    @Inject(WEBSOCKET_GATEWAY)
+    private readonly gateway: WorkflowSocketGateway,
     private readonly workflowRunService: WorkflowRunService,
   ) {
     super(repository);


### PR DESCRIPTION
## What changed?
- Refactors API config parsing into shared helpers and adds reusable origin utilities.
- Tightens Socket.IO origin checks so web widget sockets use each web source’s allowed_domains, while console/admin - sockets use global allowed origins.
- Updates web channel CORS validation to normalize origins consistently and trims allowed domain settings.
- Adds a WEBSOCKET_GATEWAY injection token and updates workflow tests/services to use it.
- Adds unit coverage for parsing, origin matching, and Socket.IO origin policy behavior.
