### PR TITLE
fix: optional avatar url

### DIFF
--- a/packages/api/src/extensions/channels/web/settings.schema.spec.ts
+++ b/packages/api/src/extensions/channels/web/settings.schema.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { toDraft07JsonSchema } from '@/utils/helpers/zod';
+
+import { WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA } from './settings.schema';
+
+describe('WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA', () => {
+  it('normalizes missing and blank avatar URLs to an empty string', () => {
+    expect(WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA.parse({})).toMatchObject({
+      avatar_url: '',
+    });
+    expect(
+      WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA.parse({ avatar_url: undefined }),
+    ).toMatchObject({
+      avatar_url: '',
+    });
+    expect(
+      WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA.parse({ avatar_url: '' }),
+    ).toMatchObject({
+      avatar_url: '',
+    });
+    expect(
+      WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA.parse({ avatar_url: '   ' }),
+    ).toMatchObject({
+      avatar_url: '',
+    });
+  });
+
+  it('preserves valid avatar URLs and rejects invalid non-empty values', () => {
+    expect(
+      WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA.parse({
+        avatar_url: 'https://example.com/avatar.png',
+      }),
+    ).toMatchObject({
+      avatar_url: 'https://example.com/avatar.png',
+    });
+
+    expect(() =>
+      WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA.parse({ avatar_url: 'not-a-url' }),
+    ).toThrow();
+  });
+
+  it('keeps avatar_url as an optional URI string in generated JSON schema', () => {
+    const jsonSchema = toDraft07JsonSchema(WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA);
+    const avatarUrlSchema = jsonSchema.properties?.avatar_url;
+
+    expect(avatarUrlSchema).toMatchObject({
+      default: '',
+      type: 'string',
+      format: 'uri',
+    });
+    expect(jsonSchema.required ?? []).not.toContain('avatar_url');
+  });
+});

--- a/packages/api/src/extensions/channels/web/settings.schema.ts
+++ b/packages/api/src/extensions/channels/web/settings.schema.ts
@@ -12,6 +12,8 @@ export const WEB_CHANNEL_NAME = 'web' as const;
 
 const WEB_ALLOWED_UPLOAD_TYPES =
   'audio/mpeg,audio/x-ms-wma,audio/vnd.rn-realaudio,audio/x-wav,image/gif,image/jpeg,image/png,image/tiff,image/vnd.microsoft.icon,image/vnd.djvu,image/svg+xml,text/css,text/csv,text/html,text/plain,text/xml,video/mpeg,video/mp4,video/quicktime,video/x-ms-wmv,video/x-msvideo,video/x-flv,video/web,application/msword,application/vnd.ms-powerpoint,application/pdf,application/vnd.ms-excel,application/vnd.oasis.opendocument.presentation,application/vnd.oasis.opendocument.tex,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.graphics,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+const emptyStringToUndefined = (value: unknown) =>
+  typeof value === 'string' && value.trim() === '' ? undefined : value;
 
 export const WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA = z
   .strictObject({
@@ -46,10 +48,14 @@ export const WEB_CHANNEL_SOURCE_SETTINGS_SCHEMA = z
       title: 'Window title',
       description: 'Title displayed in the web widget header.',
     }),
-    avatar_url: z.url().default('').optional().meta({
-      title: 'Avatar URL',
-      description: 'URL of the chatbot avatar image.',
-    }),
+    avatar_url: z
+      .preprocess(emptyStringToUndefined, z.url().optional())
+      .default('')
+      .optional()
+      .meta({
+        title: 'Avatar URL',
+        description: 'URL of the chatbot avatar image.',
+      }),
     show_emoji: z.boolean().default(true).meta({
       title: 'Show emoji',
       description: 'Enable emoji picker in the chat interface.',

--- a/packages/frontend/src/app-components/widget/ChatWidget.tsx
+++ b/packages/frontend/src/app-components/widget/ChatWidget.tsx
@@ -5,10 +5,9 @@
  */
 
 import UiChatWidget from "@hexabot-ai/widget/src/UiChatWidget";
-import { Avatar, Box, useColorScheme, useTheme } from "@mui/material";
+import { Box, useColorScheme, useTheme } from "@mui/material";
 import { memo, useCallback, useMemo } from "react";
 
-import { getAvatarSrc } from "@/components/inbox/helpers/mapMessages";
 import { useFind } from "@/hooks/crud/useFind";
 import { useAppRouter } from "@/hooks/useAppRouter";
 import { useAuth } from "@/hooks/useAuth";
@@ -115,15 +114,6 @@ const ChatWidgetComponent = ({
       workflowId,
     ],
   );
-  const avatarSrc = useMemo(
-    () =>
-      `${getAvatarSrc(apiUrl, EntityType.USER, "bot")}?color=${encodeURIComponent(primaryColor)}`,
-    [apiUrl, primaryColor],
-  );
-  const renderAvatar = useCallback(
-    () => <Avatar sx={{ width: "32px", height: "32px" }} src={avatarSrc} />,
-    [avatarSrc],
-  );
   const handleUnauthorized = useCallback(() => {
     reload();
   }, [reload]);
@@ -142,7 +132,6 @@ const ChatWidgetComponent = ({
     <Box sx={containerSx}>
       <UiChatWidget
         config={widgetConfig}
-        CustomAvatar={renderAvatar}
         CustomHeader={isEmbedded ? HiddenHeader : undefined}
         CustomLauncher={isEmbedded ? HiddenLauncher : undefined}
         defaultIsOpen={isEmbedded}

--- a/packages/widget/src/components/Message.scss
+++ b/packages/widget/src/components/Message.scss
@@ -43,6 +43,10 @@
     max-width: calc(100% - 2.5rem);
     width: 100%;
 
+    &.no-avatar {
+      max-width: 100%;
+    }
+
     .hb-message--avatar {
       width: 28px;
       height: 28px;

--- a/packages/widget/src/components/Message.test.tsx
+++ b/packages/widget/src/components/Message.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Direction, UiMessage, Web } from "../types/message.types";
+
+import Message from "./Message";
+
+const mockUseChat = vi.fn();
+
+vi.mock("../providers/ChatProvider", () => ({
+  useChat: () => mockUseChat(),
+}));
+
+const createMessage = (): UiMessage => ({
+  type: Web.OutboundMessageType.text,
+  data: {
+    text: "Hello",
+  },
+  mid: "message-1",
+  author: "chatbot",
+  read: true,
+  delivery: true,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  direction: Direction.received,
+  handover: false,
+});
+
+describe("Message", () => {
+  let container: HTMLDivElement;
+  let root: Root | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    mockUseChat.mockReturnValue({
+      participants: [
+        {
+          id: "chatbot",
+          name: "Hexabot",
+        },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+      root = undefined;
+    }
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("does not render the default avatar when the participant has no image URL", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Message message={createMessage()} />);
+    });
+
+    expect(container.querySelector(".hb-message--avatar")).toBeNull();
+  });
+
+  it("renders an avatar with background image when the participant has an image URL", async () => {
+    mockUseChat.mockReturnValue({
+      participants: [
+        {
+          id: "chatbot",
+          name: "Hexabot",
+          imageUrl: "https://example.com/avatar.png",
+        },
+      ],
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Message message={createMessage()} />);
+    });
+
+    const avatarNode = container.querySelector<HTMLElement>(
+      ".hb-message--avatar",
+    );
+
+    expect(avatarNode).not.toBeNull();
+    expect(avatarNode?.style.backgroundImage).toContain(
+      "https://example.com/avatar.png",
+    );
+  });
+
+  it("renders an explicit custom avatar even when no image URL is configured", async () => {
+    const CustomAvatar = () => <span data-custom-avatar="1" />;
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Message message={createMessage()} Avatar={CustomAvatar} />);
+    });
+
+    expect(container.querySelector(".hb-message--avatar")).not.toBeNull();
+    expect(container.querySelector("[data-custom-avatar='1']")).not.toBeNull();
+  });
+});

--- a/packages/widget/src/components/Message.test.tsx
+++ b/packages/widget/src/components/Message.test.tsx
@@ -67,6 +67,11 @@ describe("Message", () => {
     });
 
     expect(container.querySelector(".hb-message--avatar")).toBeNull();
+    expect(
+      container
+        .querySelector(".hb-message--content")
+        ?.classList.contains("no-avatar"),
+    ).toBe(true);
   });
 
   it("renders an avatar with background image when the participant has an image URL", async () => {
@@ -90,6 +95,11 @@ describe("Message", () => {
     );
 
     expect(avatarNode).not.toBeNull();
+    expect(
+      container
+        .querySelector(".hb-message--content")
+        ?.classList.contains("with-avatar"),
+    ).toBe(true);
     expect(avatarNode?.style.backgroundImage).toContain(
       "https://example.com/avatar.png",
     );

--- a/packages/widget/src/components/Message.tsx
+++ b/packages/widget/src/components/Message.tsx
@@ -8,11 +8,10 @@ import dayjs from "dayjs";
 import "dayjs/locale/en";
 import "dayjs/locale/fr";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { MessageCircle } from "lucide-react";
 import React, { PropsWithChildren, useState } from "react";
 
 import { useChat } from "../providers/ChatProvider";
-import { UiMessage, Web } from "../types/message.types";
+import { Direction, UiMessage, Web } from "../types/message.types";
 
 import "./Message.scss";
 import ButtonsMessage from "./messages/ButtonMessage";
@@ -45,27 +44,28 @@ const Message: React.FC<MessageProps> = ({ message, Avatar }) => {
   const fromNow = (time: Date) => {
     return dayjs(time).fromNow();
   };
+  const shouldShowAvatar =
+    message.direction === Direction.received &&
+    (Boolean(user.imageUrl) || Boolean(Avatar));
 
   return (
     <div className={`hb-message ${message.direction}`}>
       <div className={`hb-message--content ${message.direction}`}>
-        <div
-          title={user.name}
-          className="hb-message--avatar"
-          style={
-            user.imageUrl
-              ? {
-                  backgroundImage: `url(${user.imageUrl})`,
-                }
-              : undefined
-          }
-        >
-          {Avatar ? (
-            <Avatar />
-          ) : !user.imageUrl ? (
-            <MessageCircle width="32px" height="32px" />
-          ) : null}
-        </div>
+        {shouldShowAvatar && (
+          <div
+            title={user.name}
+            className="hb-message--avatar"
+            style={
+              user.imageUrl
+                ? {
+                    backgroundImage: `url(${user.imageUrl})`,
+                  }
+                : undefined
+            }
+          >
+            {Avatar ? <Avatar /> : null}
+          </div>
+        )}
         <div className="hb-message--wrapper" onClick={handleTime}>
           {message.data && "text" in message.data && (
             <TextMessage message={message} />

--- a/packages/widget/src/components/Message.tsx
+++ b/packages/widget/src/components/Message.tsx
@@ -50,7 +50,11 @@ const Message: React.FC<MessageProps> = ({ message, Avatar }) => {
 
   return (
     <div className={`hb-message ${message.direction}`}>
-      <div className={`hb-message--content ${message.direction}`}>
+      <div
+        className={`hb-message--content ${message.direction} ${
+          shouldShowAvatar ? "with-avatar" : "no-avatar"
+        }`}
+      >
         {shouldShowAvatar && (
           <div
             title={user.name}

--- a/packages/widget/src/providers/SettingsProvider.tsx
+++ b/packages/widget/src/providers/SettingsProvider.tsx
@@ -47,7 +47,7 @@ export type ChannelSettings = {
   persistent_menu: boolean;
   theme?: ThemeOverrides;
   window_title: string;
-  avatar_url: string;
+  avatar_url?: string;
   show_emoji: boolean;
   show_file: boolean;
   show_location: boolean;
@@ -139,13 +139,15 @@ export const SettingsProvider: React.FC<ChatSettingsProviderProps> = ({
   }, [scopedSettings, legacySettings, settingsStorageKey]);
 
   useSubscribe("settings", (settings: ChannelSettings) => {
+    const avatarUrl = settings.avatar_url?.trim() || "";
+
     setSettings({
       ...defaultSettings,
       showEmoji: settings.show_emoji,
       showFile: settings.show_file,
       showLocation: settings.show_location,
       title: settings.window_title,
-      titleImageUrl: settings.avatar_url,
+      titleImageUrl: avatarUrl,
       menu: settings.menu,
       allowedUploadTypes: settings.allowed_upload_types
         ? settings.allowed_upload_types.split(",")
@@ -154,7 +156,7 @@ export const SettingsProvider: React.FC<ChatSettingsProviderProps> = ({
       theme: settings.theme,
       greetingMessage: settings.greeting_message,
       placeholder: t("settings.placeholder"),
-      avatarUrl: settings.avatar_url,
+      avatarUrl,
     });
   });
 


### PR DESCRIPTION
## What changed?

Makes the web channel avatar_url optional end to end.

- API now accepts missing, empty, or whitespace-only avatar_url values and normalizes them to ""
- Invalid non-empty avatar URLs are still rejected
- Widget settings now tolerate a missing avatar_url
- Chat messages no longer render the default avatar slot/icon when no avatar URL is configured
- Explicit CustomAvatar rendering remains supported
