### PR TITLE
feat: chat widget messaging visual effects

### DIFF
--- a/packages/widget/src/components/Message.scss
+++ b/packages/widget/src/components/Message.scss
@@ -2,6 +2,10 @@
   margin: 0 0.625rem 0.375rem;
   display: flex;
 
+  &.hb-message--new {
+    animation: hb-message-enter 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
   &:first-child {
     margin-top: 50%;
   }
@@ -97,6 +101,24 @@
         }
       }
     }
+  }
+}
+
+@keyframes hb-message-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hb-message.hb-message--new {
+    animation: none;
   }
 }
 

--- a/packages/widget/src/components/Message.test.tsx
+++ b/packages/widget/src/components/Message.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../providers/ChatProvider", () => ({
   useChat: () => mockUseChat(),
 }));
 
-const createMessage = (): UiMessage => ({
+const createMessage = (overrides: Partial<UiMessage> = {}): UiMessage => ({
   type: Web.OutboundMessageType.text,
   data: {
     text: "Hello",
@@ -30,6 +30,7 @@ const createMessage = (): UiMessage => ({
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   direction: Direction.received,
   handover: false,
+  ...overrides,
 });
 
 describe("Message", () => {
@@ -115,5 +116,41 @@ describe("Message", () => {
 
     expect(container.querySelector(".hb-message--avatar")).not.toBeNull();
     expect(container.querySelector("[data-custom-avatar='1']")).not.toBeNull();
+  });
+
+  it("marks the message for entry animation when requested", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Message message={createMessage()} animate />);
+    });
+
+    expect(
+      container
+        .querySelector(".hb-message")
+        ?.classList.contains("hb-message--new"),
+    ).toBe(true);
+    expect(
+      container
+        .querySelector(".hb-message--text-content")
+        ?.classList.contains("typewriter"),
+    ).toBe(true);
+  });
+
+  it("does not typewrite sent messages when animating", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Message
+          message={createMessage({ direction: Direction.sent })}
+          animate
+        />,
+      );
+    });
+
+    expect(
+      container
+        .querySelector(".hb-message--text-content")
+        ?.classList.contains("typewriter"),
+    ).toBe(false);
   });
 });

--- a/packages/widget/src/components/Message.tsx
+++ b/packages/widget/src/components/Message.tsx
@@ -25,11 +25,16 @@ import MessageStatus from "./MessageStatus";
 dayjs.extend(relativeTime);
 
 type MessageProps = PropsWithChildren<{
+  animate?: boolean;
   Avatar?: () => JSX.Element;
   message: UiMessage;
 }>;
 
-const Message: React.FC<MessageProps> = ({ message, Avatar }) => {
+const Message: React.FC<MessageProps> = ({
+  message,
+  animate = false,
+  Avatar,
+}) => {
   const { participants } = useChat();
   const [isTimeVisible, setIsTimeVisible] = useState(false);
   const user = participants.find(
@@ -47,9 +52,14 @@ const Message: React.FC<MessageProps> = ({ message, Avatar }) => {
   const shouldShowAvatar =
     message.direction === Direction.received &&
     (Boolean(user.imageUrl) || Boolean(Avatar));
+  const shouldTypewrite = animate && message.direction === Direction.received;
 
   return (
-    <div className={`hb-message ${message.direction}`}>
+    <div
+      className={`hb-message ${message.direction}${
+        animate ? " hb-message--new" : ""
+      }`}
+    >
       <div
         className={`hb-message--content ${message.direction} ${
           shouldShowAvatar ? "with-avatar" : "no-avatar"
@@ -72,7 +82,7 @@ const Message: React.FC<MessageProps> = ({ message, Avatar }) => {
         )}
         <div className="hb-message--wrapper" onClick={handleTime}>
           {message.data && "text" in message.data && (
-            <TextMessage message={message} />
+            <TextMessage message={message} typewriter={shouldTypewrite} />
           )}
           {message.type === Web.InboundMessageType.file && (
             <FileMessage message={message} />

--- a/packages/widget/src/components/Messages.tsx
+++ b/packages/widget/src/components/Messages.tsx
@@ -20,7 +20,7 @@ type MessagesProps = PropsWithChildren<{
 
 const Messages: React.FC<MessagesProps> = ({ Avatar }) => {
   const { scroll, setScroll, isOpen } = useWidget();
-  const { messages, showTypingIndicator, setNewIOMessage } = useChat();
+  const { messages, newIOMessage, showTypingIndicator } = useChat();
   const scrollListRef = useRef<HTMLDivElement>(null);
   const [lastReceivedMessage, setLastReceivedMessage] = useState<
     UiMessage | undefined
@@ -58,11 +58,6 @@ const Messages: React.FC<MessagesProps> = ({ Avatar }) => {
   }, [scroll, isOpen, messages.length]);
 
   useEffect(() => {
-    setNewIOMessage(messages[messages.length - 1]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
     const newestReceivedMessage = messages[messages.length - 1];
 
     if (lastReceivedMessage !== newestReceivedMessage) {
@@ -85,7 +80,12 @@ const Messages: React.FC<MessagesProps> = ({ Avatar }) => {
       }}
     >
       {messages.map((message) => (
-        <Message key={message.mid} message={message} Avatar={Avatar} />
+        <Message
+          key={message.mid}
+          message={message}
+          Avatar={Avatar}
+          animate={message.mid === newIOMessage?.mid}
+        />
       ))}
       {showTypingIndicator && <TypingMessage />}
     </div>

--- a/packages/widget/src/components/messages/TextMessage.tsx
+++ b/packages/widget/src/components/messages/TextMessage.tsx
@@ -8,19 +8,29 @@ import DOMPurify from "dompurify";
 import { marked } from "marked";
 import React, { useMemo } from "react";
 
+import { useTypewriter } from "../../hooks/useTypewriter";
 import { Direction, UiMessage } from "../../types/message.types";
 
 import "./TextMessage.scss";
 
 interface TextMessageProps {
   message: UiMessage;
+  typewriter?: boolean;
 }
 
-const TextMessage: React.FC<TextMessageProps> = ({ message }) => {
+const TextMessage: React.FC<TextMessageProps> = ({
+  message,
+  typewriter = false,
+}) => {
   if (!("text" in message.data)) {
     throw new Error("Unable to find text.");
   }
   const text = message.data.text;
+  const shouldTypewrite =
+    typewriter && message.direction === Direction.received;
+  const { isTypewriting, visibleText } = useTypewriter(text, {
+    enabled: shouldTypewrite,
+  });
   const safeHtml = useMemo(() => {
     if (message.direction !== Direction.received) {
       return "";
@@ -43,10 +53,16 @@ const TextMessage: React.FC<TextMessageProps> = ({ message }) => {
   return (
     <div className="hb-message--text">
       {message.direction === Direction.received ? (
-        <div
-          className="hb-message--text-content markdown"
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
-        />
+        isTypewriting ? (
+          <p className="hb-message--text-content plain typewriter">
+            {visibleText}
+          </p>
+        ) : (
+          <div
+            className="hb-message--text-content markdown"
+            dangerouslySetInnerHTML={{ __html: safeHtml }}
+          />
+        )
       ) : (
         <p className="hb-message--text-content plain">{text}</p>
       )}

--- a/packages/widget/src/hooks/useTypewriter.ts
+++ b/packages/widget/src/hooks/useTypewriter.ts
@@ -1,0 +1,106 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+interface UseTypewriterOptions {
+  enabled?: boolean;
+  maxDuration?: number;
+  minDuration?: number;
+  msPerCharacter?: number;
+}
+
+interface UseTypewriterResult {
+  isTypewriting: boolean;
+  visibleText: string;
+}
+
+const TYPEWRITER_MIN_DURATION_MS = 500;
+const TYPEWRITER_MAX_DURATION_MS = 2200;
+const TYPEWRITER_MS_PER_CHARACTER = 24;
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+export const useTypewriter = (
+  text: string,
+  {
+    enabled = false,
+    maxDuration = TYPEWRITER_MAX_DURATION_MS,
+    minDuration = TYPEWRITER_MIN_DURATION_MS,
+    msPerCharacter = TYPEWRITER_MS_PER_CHARACTER,
+  }: UseTypewriterOptions = {},
+): UseTypewriterResult => {
+  const characters = useMemo(() => Array.from(text), [text]);
+  const shouldTypewrite = enabled && !prefersReducedMotion();
+  const [visibleLength, setVisibleLength] = useState(() =>
+    shouldTypewrite ? 0 : characters.length,
+  );
+  const visibleText = useMemo(
+    () =>
+      shouldTypewrite ? characters.slice(0, visibleLength).join("") : text,
+    [characters, shouldTypewrite, text, visibleLength],
+  );
+  const isTypewriting = shouldTypewrite && visibleLength < characters.length;
+
+  useEffect(() => {
+    if (!shouldTypewrite || characters.length === 0) {
+      setVisibleLength(characters.length);
+
+      return undefined;
+    }
+
+    let frameId: number | undefined;
+    let startTime: number | undefined;
+    let lastVisibleLength = 0;
+    const duration = Math.min(
+      maxDuration,
+      Math.max(minDuration, characters.length * msPerCharacter),
+    );
+    const updateFrame = (timestamp: number) => {
+      if (startTime === undefined) {
+        startTime = timestamp;
+      }
+
+      const progress = Math.min((timestamp - startTime) / duration, 1);
+      const nextVisibleLength = Math.min(
+        characters.length,
+        Math.floor(progress * characters.length),
+      );
+
+      if (nextVisibleLength !== lastVisibleLength) {
+        lastVisibleLength = nextVisibleLength;
+        setVisibleLength(nextVisibleLength);
+      }
+
+      if (progress < 1) {
+        frameId = window.requestAnimationFrame(updateFrame);
+      }
+    };
+
+    setVisibleLength(0);
+    frameId = window.requestAnimationFrame(updateFrame);
+
+    return () => {
+      if (frameId !== undefined) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [
+    characters.length,
+    maxDuration,
+    minDuration,
+    msPerCharacter,
+    shouldTypewrite,
+    text,
+  ]);
+
+  return {
+    isTypewriting,
+    visibleText,
+  };
+};

--- a/packages/widget/src/main.tsx
+++ b/packages/widget/src/main.tsx
@@ -17,7 +17,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       {...{
         apiUrl: "http://localhost:3000/api",
         channel: "web",
-        sourceId: "7a59d3c3-b84c-40ac-9263-973bbe5843bc",
+        sourceId: "replace-with-source-id",
         language: "en",
         primaryColor: "#1BA089",
       }}

--- a/packages/widget/src/main.tsx
+++ b/packages/widget/src/main.tsx
@@ -17,7 +17,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       {...{
         apiUrl: "http://localhost:3000/api",
         channel: "web",
-        sourceId: "replace-with-source-id",
+        sourceId: "7a59d3c3-b84c-40ac-9263-973bbe5843bc",
         language: "en",
         primaryColor: "#1BA089",
       }}


### PR DESCRIPTION
## What changed?

- Add a subtle fade-in and slide-up animation for newly appended chat messages.
- Scope the entry animation to new socket messages via `newIOMessage`, so loaded/history messages do not animate on initial render.
- Add a received-message-only typewriter effect for new text messages.
- Move typewriter timing into a reusable `useTypewriter` hook using `requestAnimationFrame()`.
- Respect `prefers-reduced-motion` for both the message entry animation and typewriter reveal.
- Add regression coverage for animated messages and ensure sent messages do not typewrite.
