### PR TITLE
Fix/console prevent disable

### DIFF
--- a/packages/api/src/channel/services/source.service.spec.ts
+++ b/packages/api/src/channel/services/source.service.spec.ts
@@ -8,6 +8,7 @@ import { BadRequestException } from '@nestjs/common';
 import { In, Not } from 'typeorm';
 import z from 'zod';
 
+import { CONSOLE_CHANNEL_NAME } from '@/extensions/channels/console/settings.schema';
 import { WorkflowService } from '@/workflow/services/workflow.service';
 
 import { SourceRepository } from '../repositories/source.repository';
@@ -156,9 +157,98 @@ describe('SourceService', () => {
       sourceId,
       expect.objectContaining({
         channel: 'web',
-        settings: {},
         defaultWorkflow: workflowId,
       }),
+      undefined,
+    );
+  });
+
+  it('rejects disabling console sources', async () => {
+    const sourceId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    jest.spyOn(service, 'findOne').mockResolvedValue({
+      id: sourceId,
+      channel: CONSOLE_CHANNEL_NAME,
+      settings: {},
+      defaultWorkflow: null,
+      state: true,
+    } as any);
+
+    await expect(service.updateOne(sourceId, { state: false })).rejects.toThrow(
+      new BadRequestException('Console source cannot be disabled'),
+    );
+
+    expect(repository.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('allows re-enabling a console source without validating legacy stored settings', async () => {
+    const sourceId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    registerSchema(
+      z.strictObject({
+        input_disabled: z.boolean().default(false),
+      }),
+    );
+    jest.spyOn(service, 'findOne').mockResolvedValue({
+      id: sourceId,
+      channel: CONSOLE_CHANNEL_NAME,
+      settings: {
+        greeting_message: 'legacy',
+        start_button: true,
+      },
+      defaultWorkflow: null,
+      state: false,
+    } as any);
+    repository.updateOne.mockResolvedValue({
+      id: sourceId,
+      channel: CONSOLE_CHANNEL_NAME,
+      state: true,
+    } as any);
+
+    await service.updateOne(sourceId, { state: true });
+
+    expect(repository.updateOne).toHaveBeenCalledWith(
+      sourceId,
+      {
+        state: true,
+        channel: CONSOLE_CHANNEL_NAME,
+      },
+      undefined,
+    );
+  });
+
+  it('allows unrelated console source updates without validating legacy stored settings', async () => {
+    const sourceId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    registerSchema(
+      z.strictObject({
+        input_disabled: z.boolean().default(false),
+      }),
+    );
+    jest.spyOn(service, 'findOne').mockResolvedValue({
+      id: sourceId,
+      channel: CONSOLE_CHANNEL_NAME,
+      settings: {
+        greeting_message: 'legacy',
+        start_button: true,
+      },
+      defaultWorkflow: null,
+      state: true,
+    } as any);
+    repository.updateOne.mockResolvedValue({
+      id: sourceId,
+      channel: CONSOLE_CHANNEL_NAME,
+      name: 'Edited Console',
+    } as any);
+
+    await service.updateOne(sourceId, { name: 'Edited Console' });
+
+    expect(repository.updateOne).toHaveBeenCalledWith(
+      sourceId,
+      {
+        name: 'Edited Console',
+        channel: CONSOLE_CHANNEL_NAME,
+      },
       undefined,
     );
   });

--- a/packages/api/src/channel/services/source.service.ts
+++ b/packages/api/src/channel/services/source.service.ts
@@ -15,6 +15,7 @@ import { FindManyOptions, FindOneOptions, In, Not } from 'typeorm';
 import { DeleteResult } from 'typeorm/driver/mongodb/typings';
 import z from 'zod';
 
+import { CONSOLE_CHANNEL_NAME } from '@/extensions/channels/console/settings.schema';
 import { UpdateOneOptions } from '@/utils/generics/base-orm.repository';
 import { BaseOrmService } from '@/utils/generics/base-orm.service';
 import { WorkflowService } from '@/workflow/services/workflow.service';
@@ -113,9 +114,17 @@ export class SourceService extends BaseOrmService<SourceOrmEntity> {
     return keys.length === 1 && keys[0] === 'state' && payload.state === false;
   }
 
+  private ensureSourceCanBeDisabled(channel: string, state?: boolean): void {
+    if (channel === CONSOLE_CHANNEL_NAME && state === false) {
+      throw new BadRequestException('Console source cannot be disabled');
+    }
+  }
+
   private async buildCreatePayload(
     payload: SourceCreateDto,
   ): Promise<SourceCreateDto> {
+    this.ensureSourceCanBeDisabled(payload.channel, payload.state);
+
     const normalizedSettings = this.normalizeSettings(
       payload.channel,
       payload.settings,
@@ -147,6 +156,9 @@ export class SourceService extends BaseOrmService<SourceOrmEntity> {
       throw new NotFoundException('Source not found');
     }
 
+    const channel = payload.channel ?? existing.channel;
+    this.ensureSourceCanBeDisabled(channel, payload.state);
+
     if (!this.channelRegistry.findChannel(existing.channel)) {
       if (this.isStateOnlyDisablePayload(payload)) {
         return await super.updateOne(idOrOptions, { state: false }, options);
@@ -157,13 +169,16 @@ export class SourceService extends BaseOrmService<SourceOrmEntity> {
       );
     }
 
-    const channel = payload.channel ?? existing.channel;
     const shouldResetSettings =
       payload.channel !== undefined && payload.settings === undefined;
-    const settingsInput = shouldResetSettings
-      ? {}
-      : (payload.settings ?? existing.settings);
-    const normalizedSettings = this.normalizeSettings(channel, settingsInput);
+    const shouldNormalizeSettings =
+      payload.settings !== undefined || shouldResetSettings;
+    const normalizedSettings = shouldNormalizeSettings
+      ? this.normalizeSettings(
+          channel,
+          shouldResetSettings ? {} : payload.settings,
+        )
+      : undefined;
     const normalizedDefaultWorkflow =
       payload.defaultWorkflow !== undefined
         ? await this.normalizeDefaultWorkflow(payload.defaultWorkflow)
@@ -174,7 +189,9 @@ export class SourceService extends BaseOrmService<SourceOrmEntity> {
       {
         ...payload,
         channel,
-        settings: normalizedSettings,
+        ...(normalizedSettings !== undefined
+          ? { settings: normalizedSettings }
+          : {}),
         ...(normalizedDefaultWorkflow !== undefined
           ? { defaultWorkflow: normalizedDefaultWorkflow }
           : {}),

--- a/packages/api/src/extensions/channels/console/i18n/en.translations.json
+++ b/packages/api/src/extensions/channels/console/i18n/en.translations.json
@@ -3,14 +3,10 @@
     "Admin Chat Console": "Admin Chat Console",
     "Allowed domains": "Allowed domains",
     "Comma-separated list of allowed CORS origins.": "Comma-separated list of allowed CORS origins.",
-    "Show start button": "Show start button",
-    "Display the start button before chat begins.": "Display the start button before chat begins.",
     "Disable input": "Disable input",
     "Disable the user input field in the chat widget.": "Disable the user input field in the chat widget.",
     "Persistent menu": "Persistent menu",
     "Keep the menu visible in the chat interface.": "Keep the menu visible in the chat interface.",
-    "Greeting message": "Greeting message",
-    "Greeting shown to users when the conversation starts.": "Greeting shown to users when the conversation starts.",
     "Show emoji": "Show emoji",
     "Enable emoji picker in the chat interface.": "Enable emoji picker in the chat interface.",
     "Show file upload": "Show file upload",
@@ -18,7 +14,6 @@
     "Show location": "Show location",
     "Enable location sharing action in the chat interface.": "Enable location sharing action in the chat interface.",
     "Allowed upload types": "Allowed upload types",
-    "Comma-separated MIME types accepted by the upload input.": "Comma-separated MIME types accepted by the upload input.",
-    "Welcome! Ready to start chatting with our chatbot?": "Welcome! Ready to start chatting with our chatbot?"
+    "Comma-separated MIME types accepted by the upload input.": "Comma-separated MIME types accepted by the upload input."
   }
 }

--- a/packages/api/src/extensions/channels/console/i18n/fr.translations.json
+++ b/packages/api/src/extensions/channels/console/i18n/fr.translations.json
@@ -3,14 +3,10 @@
     "Admin Chat Console": "Testeur Live Chat",
     "Allowed domains": "Domaines autorisés",
     "Comma-separated list of allowed CORS origins.": "Liste séparée par des virgules des origines CORS autorisées.",
-    "Show start button": "Afficher le bouton de démarrage",
-    "Display the start button before chat begins.": "Afficher le bouton de démarrage avant le début de la discussion.",
     "Disable input": "Désactiver la saisie",
     "Disable the user input field in the chat widget.": "Désactiver le champ de saisie utilisateur dans le widget de chat.",
     "Persistent menu": "Menu persistant",
     "Keep the menu visible in the chat interface.": "Garder le menu visible dans l'interface de chat.",
-    "Greeting message": "Message de bienvenue",
-    "Greeting shown to users when the conversation starts.": "Message affiché aux utilisateurs au début de la conversation.",
     "Show emoji": "Afficher les emojis",
     "Enable emoji picker in the chat interface.": "Activer le sélecteur d'emojis dans l'interface de chat.",
     "Show file upload": "Afficher l'envoi de fichier",
@@ -18,7 +14,6 @@
     "Show location": "Afficher la localisation",
     "Enable location sharing action in the chat interface.": "Activer le partage de localisation dans l'interface de chat.",
     "Allowed upload types": "Types de téléversement autorisés",
-    "Comma-separated MIME types accepted by the upload input.": "Types MIME acceptés par le champ d'envoi, séparés par des virgules.",
-    "Welcome! Ready to start chatting with our chatbot?": "Bienvenue ! Prêt à commencer à discuter avec notre chatbot ?"
+    "Comma-separated MIME types accepted by the upload input.": "Types MIME acceptés par le champ d'envoi, séparés par des virgules."
   }
 }

--- a/packages/api/src/extensions/channels/console/settings.schema.spec.ts
+++ b/packages/api/src/extensions/channels/console/settings.schema.spec.ts
@@ -1,0 +1,27 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { toDraft07JsonSchema } from '@/utils/helpers/zod';
+
+import { CONSOLE_CHANNEL_SOURCE_SETTINGS_SCHEMA } from './settings.schema';
+
+describe('CONSOLE_CHANNEL_SOURCE_SETTINGS_SCHEMA', () => {
+  it('does not include pre-chat subscription settings in defaults', () => {
+    const settings = CONSOLE_CHANNEL_SOURCE_SETTINGS_SCHEMA.parse({});
+
+    expect(settings).not.toHaveProperty('greeting_message');
+    expect(settings).not.toHaveProperty('start_button');
+  });
+
+  it('does not expose pre-chat subscription settings in generated JSON schema', () => {
+    const jsonSchema = toDraft07JsonSchema(
+      CONSOLE_CHANNEL_SOURCE_SETTINGS_SCHEMA,
+    );
+
+    expect(jsonSchema.properties ?? {}).not.toHaveProperty('greeting_message');
+    expect(jsonSchema.properties ?? {}).not.toHaveProperty('start_button');
+  });
+});

--- a/packages/api/src/extensions/channels/console/settings.schema.ts
+++ b/packages/api/src/extensions/channels/console/settings.schema.ts
@@ -22,10 +22,6 @@ export const CONSOLE_CHANNEL_SOURCE_SETTINGS_SCHEMA = z
         title: 'Allowed domains',
         description: 'Comma-separated list of allowed CORS origins.',
       }),
-    start_button: z.boolean().default(true).meta({
-      title: 'Show start button',
-      description: 'Display the start button before chat begins.',
-    }),
     input_disabled: z.boolean().default(false).meta({
       title: 'Disable input',
       description: 'Disable the user input field in the chat widget.',
@@ -34,14 +30,6 @@ export const CONSOLE_CHANNEL_SOURCE_SETTINGS_SCHEMA = z
       title: 'Persistent menu',
       description: 'Keep the menu visible in the chat interface.',
     }),
-    greeting_message: z
-      .string()
-      .default('Welcome! Ready to start chatting with our chatbot?')
-      .meta({
-        title: 'Greeting message',
-        description: 'Greeting shown to users when the conversation starts.',
-        'ui:widget': 'textarea',
-      }),
     show_emoji: z.boolean().default(true).meta({
       title: 'Show emoji',
       description: 'Enable emoji picker in the chat interface.',

--- a/packages/frontend/src/components/sources/SourceForm.tsx
+++ b/packages/frontend/src/components/sources/SourceForm.tsx
@@ -32,6 +32,7 @@ import {
   buildSourceSettingsUiSchema,
   getSourceFormDefaults,
   isSourceChannelRegistered,
+  isSourceStateToggleDisabled,
   resolveSourceChannel,
   resolveSourceSettingsSchema,
   shouldDisableSourceFormSubmit,
@@ -142,6 +143,7 @@ export const SourceForm: FC<
       name: params.name,
       state: params.state,
       settings: settingsData,
+      settingsSchema,
       defaultWorkflow: params.defaultWorkflow,
     });
 
@@ -228,7 +230,11 @@ export const SourceForm: FC<
                   control={
                     <Switch
                       checked={field.value}
-                      disabled={isFormDisabled}
+                      disabled={isSourceStateToggleDisabled({
+                        channelName,
+                        state: field.value,
+                        disabled: isFormDisabled,
+                      })}
                       onChange={(_event, checked) => field.onChange(checked)}
                     />
                   }

--- a/packages/frontend/src/components/sources/index.tsx
+++ b/packages/frontend/src/components/sources/index.tsx
@@ -37,7 +37,10 @@ import { IChannel } from "@/types/channel.types";
 import { writeToClipboard } from "@/utils/clipboard";
 import { getDateTimeFormatter } from "@/utils/date";
 
-import { isSourceChannelRegistered } from "./source-form.utils";
+import {
+  isSourceChannelRegistered,
+  isSourceStateToggleDisabled,
+} from "./source-form.utils";
 import { SourceFormDialog } from "./SourceFormDialog";
 
 const SOURCE_REF_ICON_SIZE = 18;
@@ -223,22 +226,30 @@ export const Sources = () => {
       headerName: t("label.enabled"),
       disableColumnMenu: true,
       headerAlign: "left",
-      renderCell: ({ row }) => (
-        <Switch
-          checked={row.state}
-          disabled={
-            !canUpdateSources ||
-            isLoadingChannels ||
-            !isSourceChannelRegistered(row.channel, channelMetadataByName)
-          }
-          onChange={() =>
-            updateSource({
-              id: row.id,
-              params: { state: !row.state },
-            })
-          }
-        />
-      ),
+      renderCell: ({ row }) => {
+        const isRegisteredChannel = isSourceChannelRegistered(
+          row.channel,
+          channelMetadataByName,
+        );
+
+        return (
+          <Switch
+            checked={row.state}
+            disabled={isSourceStateToggleDisabled({
+              channelName: row.channel,
+              state: row.state,
+              disabled:
+                !canUpdateSources || isLoadingChannels || !isRegisteredChannel,
+            })}
+            onChange={() =>
+              updateSource({
+                id: row.id,
+                params: { state: !row.state },
+              })
+            }
+          />
+        );
+      },
     },
     {
       minWidth: 140,

--- a/packages/frontend/src/components/sources/source-form.utils.test.ts
+++ b/packages/frontend/src/components/sources/source-form.utils.test.ts
@@ -11,10 +11,14 @@ import {
   buildSourcePayload,
   buildSourceSettingsUiSchema,
   getSourceFormDefaults,
+  isConsoleSourceChannel,
   isSourceChannelRegistered,
+  isSourceStateToggleDisabled,
+  pruneSourceSettingsBySchema,
   resolveDefaultWorkflowId,
   resolveSourceChannel,
   resolveSourceSettingsSchema,
+  resolveSourceState,
   shouldDisableSourceFormSubmit,
 } from "./source-form.utils";
 
@@ -51,6 +55,51 @@ describe("source form utils", () => {
       expect(isSourceChannelRegistered("custom-channel", {})).toBe(false);
       expect(isSourceChannelRegistered("", {})).toBe(false);
       expect(isSourceChannelRegistered("web", undefined)).toBe(false);
+    });
+  });
+
+  describe("console source helpers", () => {
+    it("detects console channels", () => {
+      expect(isConsoleSourceChannel("console")).toBe(true);
+      expect(isConsoleSourceChannel("web")).toBe(false);
+      expect(isConsoleSourceChannel(undefined)).toBe(false);
+    });
+
+    it("forces console source state to enabled in payloads", () => {
+      expect(resolveSourceState("console", false)).toBe(true);
+      expect(resolveSourceState("console", true)).toBe(true);
+      expect(resolveSourceState("web", false)).toBe(false);
+    });
+
+    it("locks only active console source toggles", () => {
+      expect(
+        isSourceStateToggleDisabled({
+          channelName: "console",
+          state: true,
+          disabled: false,
+        }),
+      ).toBe(true);
+      expect(
+        isSourceStateToggleDisabled({
+          channelName: "console",
+          state: false,
+          disabled: false,
+        }),
+      ).toBe(false);
+      expect(
+        isSourceStateToggleDisabled({
+          channelName: "web",
+          state: true,
+          disabled: false,
+        }),
+      ).toBe(false);
+      expect(
+        isSourceStateToggleDisabled({
+          channelName: "console",
+          state: false,
+          disabled: true,
+        }),
+      ).toBe(true);
     });
   });
 
@@ -147,6 +196,43 @@ describe("source form utils", () => {
     });
   });
 
+  describe("pruneSourceSettingsBySchema", () => {
+    it("keeps only settings declared by the active schema", () => {
+      expect(
+        pruneSourceSettingsBySchema(
+          {
+            greeting_message: "legacy",
+            start_button: true,
+            input_disabled: false,
+            show_file: true,
+          },
+          {
+            type: "object",
+            properties: {
+              input_disabled: { type: "boolean" },
+              show_file: { type: "boolean" },
+            },
+          },
+        ),
+      ).toEqual({
+        input_disabled: false,
+        show_file: true,
+      });
+    });
+
+    it("returns an empty object when the schema has no settings", () => {
+      expect(
+        pruneSourceSettingsBySchema(
+          { input_disabled: false },
+          {
+            type: "object",
+            properties: {},
+          },
+        ),
+      ).toEqual({});
+    });
+  });
+
   describe("resolveDefaultWorkflowId", () => {
     it("normalizes workflow ids from string or populated workflow object", () => {
       expect(resolveDefaultWorkflowId("wf_1")).toBe("wf_1");
@@ -188,6 +274,34 @@ describe("source form utils", () => {
         state: true,
         settings: { greeting_message: "hello" },
         defaultWorkflow: "wf_1",
+      });
+    });
+
+    it("forces console sources enabled and prunes removed settings", () => {
+      expect(
+        buildSourcePayload({
+          channel: "console",
+          name: "Console",
+          state: false,
+          settings: {
+            greeting_message: "legacy",
+            start_button: true,
+            input_disabled: false,
+          },
+          settingsSchema: {
+            type: "object",
+            properties: {
+              input_disabled: { type: "boolean" },
+            },
+          },
+          defaultWorkflow: null,
+        }),
+      ).toEqual({
+        channel: "console",
+        name: "Console",
+        state: true,
+        settings: { input_disabled: false },
+        defaultWorkflow: null,
       });
     });
   });

--- a/packages/frontend/src/components/sources/source-form.utils.ts
+++ b/packages/frontend/src/components/sources/source-form.utils.ts
@@ -12,6 +12,7 @@ import type { IChannel } from "@/types/channel.types";
 import { isRecord } from "@/utils/object";
 
 type SourceLike = Source | SourceFull;
+export const CONSOLE_CHANNEL_NAME = "console";
 
 export const EMPTY_SOURCE_SETTINGS_SCHEMA: RJSFSchema = {
   type: "object",
@@ -33,6 +34,25 @@ export const isSourceChannelRegistered = (
   channelName: string | null | undefined,
   channelsByName: Record<string, IChannel> | null | undefined,
 ): boolean => Boolean(channelName && channelsByName?.[channelName]);
+
+export const isConsoleSourceChannel = (
+  channelName: string | null | undefined,
+): boolean => channelName === CONSOLE_CHANNEL_NAME;
+
+export const resolveSourceState = (
+  channelName: string,
+  state: boolean,
+): boolean => (isConsoleSourceChannel(channelName) ? true : state);
+
+export const isSourceStateToggleDisabled = ({
+  channelName,
+  state,
+  disabled,
+}: {
+  channelName: string;
+  state: boolean;
+  disabled: boolean;
+}): boolean => disabled || (isConsoleSourceChannel(channelName) && state);
 
 export const shouldDisableSourceFormSubmit = ({
   channelName,
@@ -74,6 +94,26 @@ export const buildSourceSettingsUiSchema = (schema: RJSFSchema): UiSchema => {
   };
 };
 
+export const pruneSourceSettingsBySchema = (
+  settings: unknown,
+  schema: RJSFSchema,
+): Record<string, unknown> => {
+  const normalizedSettings = normalizeSourceSettings(settings);
+  const propertyNames = Object.keys(schema.properties || {});
+
+  if (propertyNames.length === 0) {
+    return {};
+  }
+
+  return propertyNames.reduce<Record<string, unknown>>((acc, key) => {
+    if (Object.prototype.hasOwnProperty.call(normalizedSettings, key)) {
+      acc[key] = normalizedSettings[key];
+    }
+
+    return acc;
+  }, {});
+};
+
 export const resolveDefaultWorkflowId = (
   value: SourceLike["defaultWorkflow"] | null | undefined,
 ): string | null => {
@@ -111,17 +151,21 @@ export const buildSourcePayload = ({
   name,
   state,
   settings,
+  settingsSchema,
   defaultWorkflow,
 }: {
   channel: string;
   name: string;
   state: boolean;
   settings: Record<string, unknown>;
+  settingsSchema?: RJSFSchema;
   defaultWorkflow: SourceLike["defaultWorkflow"] | null | undefined;
 }) => ({
   channel,
   name: name.trim(),
-  state,
-  settings: normalizeSourceSettings(settings),
+  state: resolveSourceState(channel, state),
+  settings: settingsSchema
+    ? pruneSourceSettingsBySchema(settings, settingsSchema)
+    : normalizeSourceSettings(settings),
   defaultWorkflow: resolveDefaultWorkflowId(defaultWorkflow),
 });

--- a/packages/widget/src/components/Message.scss
+++ b/packages/widget/src/components/Message.scss
@@ -2,6 +2,10 @@
   margin: 0 0.625rem 0.375rem;
   display: flex;
 
+  &.hb-message--new {
+    animation: hb-message-enter 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
   &:first-child {
     margin-top: 50%;
   }
@@ -97,6 +101,24 @@
         }
       }
     }
+  }
+}
+
+@keyframes hb-message-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hb-message.hb-message--new {
+    animation: none;
   }
 }
 

--- a/packages/widget/src/components/Message.test.tsx
+++ b/packages/widget/src/components/Message.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../providers/ChatProvider", () => ({
   useChat: () => mockUseChat(),
 }));
 
-const createMessage = (): UiMessage => ({
+const createMessage = (overrides: Partial<UiMessage> = {}): UiMessage => ({
   type: Web.OutboundMessageType.text,
   data: {
     text: "Hello",
@@ -30,6 +30,7 @@ const createMessage = (): UiMessage => ({
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   direction: Direction.received,
   handover: false,
+  ...overrides,
 });
 
 describe("Message", () => {
@@ -115,5 +116,41 @@ describe("Message", () => {
 
     expect(container.querySelector(".hb-message--avatar")).not.toBeNull();
     expect(container.querySelector("[data-custom-avatar='1']")).not.toBeNull();
+  });
+
+  it("marks the message for entry animation when requested", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Message message={createMessage()} animate />);
+    });
+
+    expect(
+      container
+        .querySelector(".hb-message")
+        ?.classList.contains("hb-message--new"),
+    ).toBe(true);
+    expect(
+      container
+        .querySelector(".hb-message--text-content")
+        ?.classList.contains("typewriter"),
+    ).toBe(true);
+  });
+
+  it("does not typewrite sent messages when animating", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Message
+          message={createMessage({ direction: Direction.sent })}
+          animate
+        />,
+      );
+    });
+
+    expect(
+      container
+        .querySelector(".hb-message--text-content")
+        ?.classList.contains("typewriter"),
+    ).toBe(false);
   });
 });

--- a/packages/widget/src/components/Message.tsx
+++ b/packages/widget/src/components/Message.tsx
@@ -25,11 +25,16 @@ import MessageStatus from "./MessageStatus";
 dayjs.extend(relativeTime);
 
 type MessageProps = PropsWithChildren<{
+  animate?: boolean;
   Avatar?: () => JSX.Element;
   message: UiMessage;
 }>;
 
-const Message: React.FC<MessageProps> = ({ message, Avatar }) => {
+const Message: React.FC<MessageProps> = ({
+  message,
+  animate = false,
+  Avatar,
+}) => {
   const { participants } = useChat();
   const [isTimeVisible, setIsTimeVisible] = useState(false);
   const user = participants.find(
@@ -47,9 +52,14 @@ const Message: React.FC<MessageProps> = ({ message, Avatar }) => {
   const shouldShowAvatar =
     message.direction === Direction.received &&
     (Boolean(user.imageUrl) || Boolean(Avatar));
+  const shouldTypewrite = animate && message.direction === Direction.received;
 
   return (
-    <div className={`hb-message ${message.direction}`}>
+    <div
+      className={`hb-message ${message.direction}${
+        animate ? " hb-message--new" : ""
+      }`}
+    >
       <div
         className={`hb-message--content ${message.direction} ${
           shouldShowAvatar ? "with-avatar" : "no-avatar"
@@ -72,7 +82,7 @@ const Message: React.FC<MessageProps> = ({ message, Avatar }) => {
         )}
         <div className="hb-message--wrapper" onClick={handleTime}>
           {message.data && "text" in message.data && (
-            <TextMessage message={message} />
+            <TextMessage message={message} typewriter={shouldTypewrite} />
           )}
           {message.type === Web.InboundMessageType.file && (
             <FileMessage message={message} />

--- a/packages/widget/src/components/Messages.tsx
+++ b/packages/widget/src/components/Messages.tsx
@@ -20,7 +20,7 @@ type MessagesProps = PropsWithChildren<{
 
 const Messages: React.FC<MessagesProps> = ({ Avatar }) => {
   const { scroll, setScroll, isOpen } = useWidget();
-  const { messages, showTypingIndicator, setNewIOMessage } = useChat();
+  const { messages, newIOMessage, showTypingIndicator } = useChat();
   const scrollListRef = useRef<HTMLDivElement>(null);
   const [lastReceivedMessage, setLastReceivedMessage] = useState<
     UiMessage | undefined
@@ -58,11 +58,6 @@ const Messages: React.FC<MessagesProps> = ({ Avatar }) => {
   }, [scroll, isOpen, messages.length]);
 
   useEffect(() => {
-    setNewIOMessage(messages[messages.length - 1]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
     const newestReceivedMessage = messages[messages.length - 1];
 
     if (lastReceivedMessage !== newestReceivedMessage) {
@@ -85,7 +80,12 @@ const Messages: React.FC<MessagesProps> = ({ Avatar }) => {
       }}
     >
       {messages.map((message) => (
-        <Message key={message.mid} message={message} Avatar={Avatar} />
+        <Message
+          key={message.mid}
+          message={message}
+          Avatar={Avatar}
+          animate={message.mid === newIOMessage?.mid}
+        />
       ))}
       {showTypingIndicator && <TypingMessage />}
     </div>

--- a/packages/widget/src/components/messages/TextMessage.tsx
+++ b/packages/widget/src/components/messages/TextMessage.tsx
@@ -8,19 +8,29 @@ import DOMPurify from "dompurify";
 import { marked } from "marked";
 import React, { useMemo } from "react";
 
+import { useTypewriter } from "../../hooks/useTypewriter";
 import { Direction, UiMessage } from "../../types/message.types";
 
 import "./TextMessage.scss";
 
 interface TextMessageProps {
   message: UiMessage;
+  typewriter?: boolean;
 }
 
-const TextMessage: React.FC<TextMessageProps> = ({ message }) => {
+const TextMessage: React.FC<TextMessageProps> = ({
+  message,
+  typewriter = false,
+}) => {
   if (!("text" in message.data)) {
     throw new Error("Unable to find text.");
   }
   const text = message.data.text;
+  const shouldTypewrite =
+    typewriter && message.direction === Direction.received;
+  const { isTypewriting, visibleText } = useTypewriter(text, {
+    enabled: shouldTypewrite,
+  });
   const safeHtml = useMemo(() => {
     if (message.direction !== Direction.received) {
       return "";
@@ -43,10 +53,16 @@ const TextMessage: React.FC<TextMessageProps> = ({ message }) => {
   return (
     <div className="hb-message--text">
       {message.direction === Direction.received ? (
-        <div
-          className="hb-message--text-content markdown"
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
-        />
+        isTypewriting ? (
+          <p className="hb-message--text-content plain typewriter">
+            {visibleText}
+          </p>
+        ) : (
+          <div
+            className="hb-message--text-content markdown"
+            dangerouslySetInnerHTML={{ __html: safeHtml }}
+          />
+        )
       ) : (
         <p className="hb-message--text-content plain">{text}</p>
       )}

--- a/packages/widget/src/hooks/useTypewriter.ts
+++ b/packages/widget/src/hooks/useTypewriter.ts
@@ -1,0 +1,106 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+interface UseTypewriterOptions {
+  enabled?: boolean;
+  maxDuration?: number;
+  minDuration?: number;
+  msPerCharacter?: number;
+}
+
+interface UseTypewriterResult {
+  isTypewriting: boolean;
+  visibleText: string;
+}
+
+const TYPEWRITER_MIN_DURATION_MS = 500;
+const TYPEWRITER_MAX_DURATION_MS = 2200;
+const TYPEWRITER_MS_PER_CHARACTER = 24;
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+export const useTypewriter = (
+  text: string,
+  {
+    enabled = false,
+    maxDuration = TYPEWRITER_MAX_DURATION_MS,
+    minDuration = TYPEWRITER_MIN_DURATION_MS,
+    msPerCharacter = TYPEWRITER_MS_PER_CHARACTER,
+  }: UseTypewriterOptions = {},
+): UseTypewriterResult => {
+  const characters = useMemo(() => Array.from(text), [text]);
+  const shouldTypewrite = enabled && !prefersReducedMotion();
+  const [visibleLength, setVisibleLength] = useState(() =>
+    shouldTypewrite ? 0 : characters.length,
+  );
+  const visibleText = useMemo(
+    () =>
+      shouldTypewrite ? characters.slice(0, visibleLength).join("") : text,
+    [characters, shouldTypewrite, text, visibleLength],
+  );
+  const isTypewriting = shouldTypewrite && visibleLength < characters.length;
+
+  useEffect(() => {
+    if (!shouldTypewrite || characters.length === 0) {
+      setVisibleLength(characters.length);
+
+      return undefined;
+    }
+
+    let frameId: number | undefined;
+    let startTime: number | undefined;
+    let lastVisibleLength = 0;
+    const duration = Math.min(
+      maxDuration,
+      Math.max(minDuration, characters.length * msPerCharacter),
+    );
+    const updateFrame = (timestamp: number) => {
+      if (startTime === undefined) {
+        startTime = timestamp;
+      }
+
+      const progress = Math.min((timestamp - startTime) / duration, 1);
+      const nextVisibleLength = Math.min(
+        characters.length,
+        Math.floor(progress * characters.length),
+      );
+
+      if (nextVisibleLength !== lastVisibleLength) {
+        lastVisibleLength = nextVisibleLength;
+        setVisibleLength(nextVisibleLength);
+      }
+
+      if (progress < 1) {
+        frameId = window.requestAnimationFrame(updateFrame);
+      }
+    };
+
+    setVisibleLength(0);
+    frameId = window.requestAnimationFrame(updateFrame);
+
+    return () => {
+      if (frameId !== undefined) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [
+    characters.length,
+    maxDuration,
+    minDuration,
+    msPerCharacter,
+    shouldTypewrite,
+    text,
+  ]);
+
+  return {
+    isTypewriting,
+    visibleText,
+  };
+};

--- a/packages/widget/src/main.tsx
+++ b/packages/widget/src/main.tsx
@@ -17,7 +17,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       {...{
         apiUrl: "http://localhost:3000/api",
         channel: "web",
-        sourceId: "replace-with-source-id",
+        sourceId: "7a59d3c3-b84c-40ac-9263-973bbe5843bc",
         language: "en",
         primaryColor: "#1BA089",
       }}


### PR DESCRIPTION
## What changed?

- Remove console channel pre-chat settings (greeting_message, start_button) from the API schema and i18n.
- Prevent console sources from being disabled in both API and frontend UI.
- Prune source form settings against the active channel schema so removed console fields are not resubmitted.