### PR TITLE
fix(frontend): restrict source target workflow conversational type only

### DIFF
--- a/packages/frontend/src/components/sources/SourceForm.tsx
+++ b/packages/frontend/src/components/sources/SourceForm.tsx
@@ -4,7 +4,12 @@
  * Full terms: see LICENSE.md.
  */
 
-import { type Source, type SourceFull, type Workflow } from "@hexabot-ai/types";
+import {
+  type Source,
+  type SourceFull,
+  type Workflow,
+  WorkflowType,
+} from "@hexabot-ai/types";
 import {
   Alert,
   FormControlLabel,
@@ -234,6 +239,7 @@ export const SourceForm: FC<
                   multiple={false}
                   disabled={isFormDisabled}
                   value={field.value}
+                  where={{ type: WorkflowType.conversational }}
                   onChange={(_event, selected) =>
                     field.onChange(selected?.id || null)
                   }


### PR DESCRIPTION
**Summary:**
Restricted source-target workflow selection in the frontend to only allow workflows with the `conversational` type. This prevents unsupported workflow types from being displayed or selected in source-target workflow configurations.

**Why:**
Source-target workflows are designed to work exclusively with conversational workflows. Allowing other workflow types could lead to invalid configurations, unexpected behavior, or user confusion.

**How to review:**
Focus on the source-target workflow selection and filtering logic in the frontend. Verify that only workflows with the `conversational` type are available for selection and that non-conversational workflows are excluded from the UI.

**Validation:**

* Verified that conversational workflows continue to appear and can be selected.
* Confirmed that non-conversational workflow types are no longer displayed in source-target workflow selectors.
* Checked that existing source-target workflow flows behave as expected after the change.