### PR TITLE
fix(frontend): add a visual editor redirection when id not found

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
@@ -73,7 +73,7 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
   const { refetchUser } = useAuth();
   const queryClient = useTanstackQueryClient();
   const [flowId] = useQueryState("flowId");
-  const { data: workflows } = useFind(
+  const { data: workflows, isSuccess: isWorkflowsSuccess } = useFind(
     {
       entity: EntityType.WORKFLOW,
       format: Format.FULL,
@@ -426,10 +426,14 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
   );
 
   useEffect(() => {
-    if (!flowId && workflows?.length) {
-      updateWorkflowURL(workflows[0].id);
+    if (!isWorkflowsSuccess) return;
+
+    if (!flowId && workflows.length) {
+      updateWorkflowURL(workflows.at(-1)?.id || workflows[0].id);
+    } else if (flowId && !workflows.some((w) => w.id === flowId)) {
+      void router.replace(`/${RouterType.WORKFLOW_EDITOR}/${workflows[0].id}`);
     }
-  }, [flowId, workflows, updateWorkflowURL]);
+  }, [flowId, workflows, isWorkflowsSuccess, updateWorkflowURL, router]);
 
   return (
     <WorkflowContext.Provider


### PR DESCRIPTION
**Summary:**
Added a frontend fallback that automatically redirects users to the Visual Editor when the URL contains an invalid or non-existent editor ID. This prevents users from landing on a broken or empty state.

**Why:**
When users navigate to a URL with an ID that does not exist, the application currently fails to provide a clear recovery path. Redirecting to the Visual Editor improves the user experience and ensures users remain in a functional workflow.

**How to review:**

* Check the routing logic that handles editor/page IDs.
* Verify the behavior when a valid ID is provided (no regression).
* Verify the redirection flow when an invalid or missing ID is detected.
* Review any associated error handling or loading states.

**Validation:**

* Tested navigation with valid editor IDs and confirmed normal behavior.
* Tested navigation with non-existent IDs and confirmed automatic redirection to the Visual Editor.
* Verified no routing regressions in existing editor flows.
