### PR TITLE
fix: replace readme relative github urls by absolute urls

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -46,7 +46,6 @@ The API is divided into several key modules, each responsible for specific funct
 - Channel/helper runtime setting group keys and settings hook namespaces are now the extension `name` (kebab-case).
 - Third-party channel/helper extensions must define settings groups and i18n namespaces with the same kebab-case extension `name`.
 
-
 ## Installation
 
 ```bash
@@ -102,7 +101,7 @@ pnpm --filter @hexabot-ai/api run cli migration migrate down [version]
 
 Auto-migration runs outside production by default, or in production when `DB_AUTO_MIGRATE=true` and `API_IS_PRIMARY_NODE=true`.
 
-Check the Migration README file for more: [Migration Module](./src/migration/README.md)
+Check the Migration README file for more: [Migration Module](https://github.com/hexabot-ai/Hexabot/blob/main/packages/api/src/migration/README.md)
 
 ## Documentation
 
@@ -119,7 +118,6 @@ For detailed information about the API routes and usage, refer to the API docume
 We welcome contributions from the community! Whether you want to report a bug, suggest new features, or submit a pull request, your input is valuable to us.
 
 Feel free to join us on [Discord](https://discord.gg/rNb9t2MFkG)
-
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,6 @@
 
 Hexabot CLI is the command-line entry point for creating, configuring, and operating Hexabot v3 projects. With it, you can scaffold new automation workspaces, initialize environments, start services in local or Docker modes, run database migrations, and manage the project lifecycle.
 
-
 Not yet familiar with [Hexabot](https://hexabot.ai/)? Hexabot v3 is an agentic AI automation platform for building and running workflows across channels with actions, bindings, memory, tools, MCP, and RAG. If you would like to learn more, please visit the [official GitHub repo](https://github.com/hexabot-ai/Hexabot/).
 
 ## Getting Started
@@ -153,21 +152,20 @@ For detailed information on how to get started, as well as in-depth user and dev
 
 You can also find specific documentation for different components of the project in the following locations:
 
-- [API Documentation](../api/README.md)
-- [UI Documentation](../frontend/README.md)
-- [Agentic Package Documentation](../agentic/README.md)
-- [Types Package Documentation](../types/README.md)
-- [Workflow Graph Documentation](../graph/README.md)
-- [Live Chat Widget Documentation](../widget/README.md)
+- [API Documentation](https://github.com/hexabot-ai/Hexabot/blob/main/packages/api/README.md)
+- [UI Documentation](https://github.com/hexabot-ai/Hexabot/blob/main/packages/frontend/README.md)
+- [Agentic Package Documentation](https://github.com/hexabot-ai/Hexabot/blob/main/packages/agentic/README.md)
+- [Types Package Documentation](https://github.com/hexabot-ai/Hexabot/blob/main/packages/types/README.md)
+- [Workflow Graph Documentation](https://github.com/hexabot-ai/Hexabot/blob/main/packages/graph/README.md)
+- [Live Chat Widget Documentation](https://github.com/hexabot-ai/Hexabot/blob/main/packages/widget/README.md)
 
 ## Contributing
 
 We welcome contributions from the community! Whether you want to report a bug, suggest new features, or submit a pull request, your input is valuable to us.
 
-Please refer to our contribution policy first : [How to contribute to Hexabot](./CONTRIBUTING.md)
+Please refer to our contribution policy first : [How to contribute to Hexabot](https://github.com/hexabot-ai/Hexabot/blob/main/CONTRIBUTING.md)
 
-
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](./CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/hexabot-ai/Hexabot/blob/main/CODE_OF_CONDUCT.md)
 
 Feel free to join us on [Discord](https://discord.gg/rNb9t2MFkG)
 


### PR DESCRIPTION
## Summary

Fixes README links displayed on the npm package page by converting relative GitHub links to absolute URLs. This ensures documentation links remain functional when viewed outside of the GitHub repository context.

## Why

Relative links work correctly on GitHub because they are resolved against the repository structure. However, when the README is rendered on npm, those links are not resolved properly, resulting in broken navigation and a degraded developer experience.

## How to review

Focus on:

* README link generation and rendering logic.
* Conversion of relative documentation links to absolute GitHub URLs.
* Any affected documentation files or templates that generate README content.

## Validation

* Verified all README links render correctly on GitHub.
* Verified links resolve correctly when the README is rendered on npm.
* Checked that existing external links remain unchanged.
* Confirmed no regressions in documentation formatting.

## Extra
<img width="1420" height="1295" alt="image" src="https://github.com/user-attachments/assets/cae9d297-8445-4a90-a87c-4567ca1260ca" />
<img width="1420" height="1295" alt="image" src="https://github.com/user-attachments/assets/62b38ada-99aa-4d51-8a0e-01e560f6d7dd" />
