### PR TITLE
fix(frontend): persist WorkflowBottomDrawer sizes

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/main/FlowsDrawer/FlowsDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/FlowsDrawer/FlowsDrawer.tsx
@@ -4,8 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
-import { WorkflowType } from "@hexabot-ai/types";
 import type { Workflow } from "@hexabot-ai/types";
+import { WorkflowType } from "@hexabot-ai/types";
 import {
   Box,
   Button,
@@ -17,12 +17,12 @@ import {
 } from "@mui/material";
 import { Plus, Upload } from "lucide-react";
 import {
-  type ChangeEvent,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 
@@ -47,6 +47,7 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 
+import { useResizableDrawerSize } from "../../../../../../hooks/useResizableDrawerSize";
 import { useWorkflow } from "../../../hooks/useWorkflow";
 import { YamlEditor } from "../../yaml-editor";
 import { WorkflowMenu } from "../WorkflowMenu";
@@ -90,7 +91,6 @@ export const FlowsDrawer = ({ onNew, onEdit }: FlowsDrawerProps) => {
   const formatCron = useCronFormatter();
   const dialogs = useDialogs();
   const { user, refetchUser } = useAuth();
-  const { getLocalStorage, setLocalStorage } = useLocalStorage();
   const {
     workflows,
     selectedFlowId,
@@ -105,18 +105,36 @@ export const FlowsDrawer = ({ onNew, onEdit }: FlowsDrawerProps) => {
   const theme = useTheme();
   const isCompact = useMediaQuery(theme.breakpoints.down("lg"));
   const isSmall = useMediaQuery(theme.breakpoints.down("md"));
-  const [open, setOpen] = useState(false);
+  const minAllowedWidth = isSmall ? 240 : minDrawerWidth;
+  const maxAllowedWidth = isSmall ? 280 : maxDrawerWidth;
+  const collapsedSize = isSmall ? 56 : collapsedWidth;
+  const { getLocalStorage, setLocalStorage } = useLocalStorage();
+  const { size: drawerWidth, handleResizeStart } = useResizableDrawerSize({
+    sizeStorageKey: drawerWidthStorageKey,
+    defaultSize: defaultDrawerWidth,
+    minSize: minAllowedWidth,
+    maxSize: maxAllowedWidth,
+    axis: "horizontal",
+  });
+  const [open, setOpen] = useState(
+    () => !isCompact && Boolean(getLocalStorage(drawerIsOpenStorage)),
+  );
+
+  useEffect(() => {
+    if (isCompact) setOpen(false);
+  }, [isCompact]);
+
+  const toggleOpen = useCallback(() => {
+    setOpen((prev) => {
+      setLocalStorage(drawerIsOpenStorage, prev ? "" : "true");
+
+      return !prev;
+    });
+  }, [setLocalStorage]);
   const [showYaml, setShowYaml] = useState(false);
   const [showVersions, setShowVersions] = useState(false);
-  const [drawerWidth, setDrawerWidth] = useState(() =>
-    Number(getLocalStorage(drawerWidthStorageKey, defaultDrawerWidth)),
-  );
-  const [query, setQuery] = useState("");
-  const resizeStartXRef = useRef(0);
-  const resizeStartWidthRef = useRef(defaultDrawerWidth);
-  const isResizingRef = useRef(false);
-  const latestDrawerWidthRef = useRef(drawerWidth);
   const importInputRef = useRef<HTMLInputElement | null>(null);
+  const [query, setQuery] = useState("");
   const trimmedQuery = query.trim();
   const normalizedQuery = normalizeQuery(trimmedQuery);
   const isSearching = trimmedQuery.length > 0;
@@ -168,73 +186,12 @@ export const FlowsDrawer = ({ onNew, onEdit }: FlowsDrawerProps) => {
       });
   const canCreateWorkflow = Boolean(onNew) && !workflowQuotaReached;
   const workflowsList = isSearching ? searchedWorkflows : workflows;
-  const minAllowedWidth = isSmall ? 240 : minDrawerWidth;
-  const maxAllowedWidth = isSmall ? 280 : maxDrawerWidth;
-  const collapsedSize = isSmall ? 56 : collapsedWidth;
-  const clampDrawerWidth = useCallback(
-    (value: number) =>
-      Math.min(Math.max(value, minAllowedWidth), maxAllowedWidth),
-    [maxAllowedWidth, minAllowedWidth],
-  );
   const yamlToggleLabel = showYaml
     ? t("visual_editor.yaml_editor.hide")
     : t("visual_editor.yaml_editor.show");
   const versionsToggleLabel = showVersions
     ? t("visual_editor.workflow_versions.hide")
     : t("visual_editor.workflow_versions.show");
-
-  useEffect(() => {
-    if (isCompact) {
-      setOpen(false);
-    } else if (getLocalStorage(drawerIsOpenStorage)) {
-      setOpen(true);
-    }
-  }, [isCompact]);
-
-  useEffect(() => {
-    latestDrawerWidthRef.current = drawerWidth;
-  }, [drawerWidth]);
-
-  useEffect(() => {
-    setDrawerWidth((prev) => clampDrawerWidth(prev));
-  }, [clampDrawerWidth]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    const handleMouseMove = (event: MouseEvent) => {
-      if (!isResizingRef.current) return;
-
-      const delta = event.clientX - resizeStartXRef.current;
-      const nextWidth = clampDrawerWidth(resizeStartWidthRef.current + delta);
-
-      latestDrawerWidthRef.current = nextWidth;
-      setDrawerWidth(nextWidth);
-    };
-    const handleMouseUp = () => {
-      if (!isResizingRef.current) return;
-
-      isResizingRef.current = false;
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-
-      setLocalStorage(
-        drawerWidthStorageKey,
-        String(latestDrawerWidthRef.current),
-      );
-    };
-
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
-
-    return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [clampDrawerWidth]);
-
   const hasUnsaved = Boolean(selectedFlowId && (isDefinitionDirty || isSaving));
   const matches = useMemo<FlowMatch[]>(() => {
     const list = workflowsList ?? [];
@@ -390,44 +347,15 @@ export const FlowsDrawer = ({ onNew, onEdit }: FlowsDrawerProps) => {
     });
   }, [isSearching, selectedFlowTypeKey, typeGroups]);
 
-  const handleToggleDrawer = () => {
-    setOpen((prev) => {
-      setLocalStorage(drawerIsOpenStorage, !prev ? "true" : "");
-
-      return !prev;
-    });
-  };
-  const handleResizeStart = useCallback(
-    (event: ReactMouseEvent<HTMLDivElement>) => {
-      if (!open) return;
-
-      isResizingRef.current = true;
-      resizeStartXRef.current = event.clientX;
-      resizeStartWidthRef.current = drawerWidth;
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-      event.preventDefault();
-    },
-    [drawerWidth, open],
-  );
   const handleToggleYaml = () => {
     setShowYaml((prev) => !prev);
     setShowVersions(false);
-    if (!open) {
-      setOpen(true);
-    }
+    if (!open) setOpen(true);
   };
   const handleToggleVersions = () => {
     setShowVersions((prev) => !prev);
     setShowYaml(false);
-    if (!open) {
-      setOpen(true);
-    }
-  };
-  const handleOpenDrawer = () => {
-    setShowYaml(false);
-    setShowVersions(false);
-    setOpen(true);
+    if (!open) setOpen(true);
   };
   const handleToggleType = (key: string) =>
     setOpenTypeKeys((prev) =>
@@ -526,7 +454,7 @@ export const FlowsDrawer = ({ onNew, onEdit }: FlowsDrawerProps) => {
       <FlowsDrawerHeader
         open={open}
         title={t("visual_editor.flows_drawer.title")}
-        onToggle={handleToggleDrawer}
+        onToggle={toggleOpen}
         yamlLabel={yamlToggleLabel}
         onToggleYaml={handleToggleYaml}
         isYamlOpen={showYaml}
@@ -664,7 +592,7 @@ export const FlowsDrawer = ({ onNew, onEdit }: FlowsDrawerProps) => {
             ) : undefined
           }
           yamlLabel={yamlToggleLabel}
-          onOpen={handleOpenDrawer}
+          onOpen={() => setOpen(true)}
           onImport={handleOpenImportPicker}
           onNew={onNew}
           onToggleYaml={handleToggleYaml}

--- a/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowBottomDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowBottomDrawer.tsx
@@ -8,13 +8,7 @@ import { WorkflowType } from "@hexabot-ai/types";
 import { Divider, Drawer, Paper, Stack, useMediaQuery } from "@mui/material";
 import { alpha, styled, useTheme } from "@mui/material/styles";
 import { getDefaultFormState, type RJSFSchema } from "@rjsf/utils";
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type MouseEvent as ReactMouseEvent,
-} from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { ChatWidget } from "@/app-components/widget/ChatWidget";
 import { TriggerSimulatorPanel } from "@/components/workflow-run-debugger/components/panels/trigger-simulator-panel/TriggerSimulatorPanel";
@@ -23,10 +17,12 @@ import { useAuth } from "@/hooks/useAuth";
 import { useTranslate } from "@/hooks/useTranslate";
 import validator from "@/utils/rjsf-zod-validator";
 
+import { useResizableDrawerSize } from "../../../../../hooks/useResizableDrawerSize";
 import { useWorkflow } from "../../hooks/useWorkflow";
 
 const defaultDrawerHeight = 380;
 const minDrawerHeight = 160;
+const drawerHeightStorageKey = "hexabot.visual_editor.bottom_drawer_height";
 const columnDividerWidth = 16;
 const minChatColumnWidth = 280;
 const minDetailsColumnWidth = 240;
@@ -166,6 +162,20 @@ const getDefaultManualInput = (schema?: unknown): Record<string, unknown> => {
     return {};
   }
 };
+const drawerId = "workflow-bottom-drawer";
+const clampChatColumnWidth = (width: number, containerWidth: number) => {
+  const maxWidth = Math.max(
+    minChatColumnWidth,
+    containerWidth - columnDividerWidth - minDetailsColumnWidth,
+  );
+
+  return Math.min(Math.max(width, minChatColumnWidth), maxWidth);
+};
+const getDefaultChatColumnWidth = (containerWidth: number) =>
+  clampChatColumnWidth(
+    Math.round((containerWidth - columnDividerWidth) * defaultChatColumnRatio),
+    containerWidth,
+  );
 
 export const WorkflowBottomDrawer = () => {
   const { t } = useTranslate();
@@ -175,126 +185,46 @@ export const WorkflowBottomDrawer = () => {
   const isConversationalWorkflow =
     workflow?.type === WorkflowType.conversational;
   const isStacked = useMediaQuery(theme.breakpoints.down("md"));
-  const clampDrawerHeight = useCallback(
-    (height: number) => Math.max(height, minDrawerHeight),
-    [],
-  );
-  const [drawerHeight, setDrawerHeight] = useState(defaultDrawerHeight);
+  const { size: drawerHeight, handleResizeStart } = useResizableDrawerSize({
+    sizeStorageKey: drawerHeightStorageKey,
+    defaultSize: defaultDrawerHeight,
+    minSize: minDrawerHeight,
+    axis: "vertical",
+  });
   const [workflowInput, setWorkflowInput] = useState<Record<string, unknown>>(
     {},
   );
-  const [chatColumnWidth, setChatColumnWidth] = useState<number | null>(null);
   const drawerBodyRef = useRef<HTMLDivElement | null>(null);
-  const resizeStateRef = useRef({
-    startY: 0,
-    startHeight: drawerHeight,
-    isResizing: false,
-  });
-  const hasUserResizedColumnsRef = useRef(false);
-  const columnResizeStateRef = useRef({
-    startX: 0,
-    startWidth: 0,
-    isResizing: false,
-  });
-  const drawerId = "workflow-bottom-drawer";
-  const clampChatColumnWidth = useCallback(
-    (width: number, containerWidth: number) => {
-      const maxWidth = Math.max(
+  const {
+    size: chatColumnWidthSize,
+    setSize: setChatColumnWidth,
+    handleResizeStart: handleColumnResizeStart,
+  } = useResizableDrawerSize({
+    sizeStorageKey: "hexabot.visual_editor.bottom_drawer_column_width",
+    // 0 is the sentinel for "fluid / not yet dragged"
+    defaultSize: 0,
+    minSize: minChatColumnWidth,
+    maxSize: () => {
+      const containerWidth = drawerBodyRef.current?.clientWidth ?? 0;
+
+      if (!containerWidth) return undefined;
+
+      return Math.max(
         minChatColumnWidth,
         containerWidth - columnDividerWidth - minDetailsColumnWidth,
       );
-
-      return Math.min(Math.max(width, minChatColumnWidth), maxWidth);
     },
-    [],
-  );
-  const getDefaultChatColumnWidth = useCallback(
-    (containerWidth: number) =>
-      clampChatColumnWidth(
-        Math.round(
-          (containerWidth - columnDividerWidth) * defaultChatColumnRatio,
-        ),
-        containerWidth,
-      ),
-    [clampChatColumnWidth],
-  );
-  const handleResizeMove = useCallback(
-    (event: MouseEvent) => {
-      if (!resizeStateRef.current.isResizing) {
-        return;
+    axis: "horizontal",
+    onResizeStart: (initialSize) => {
+      if (initialSize === 0) {
+        const containerWidth = drawerBodyRef.current?.clientWidth ?? 0;
+
+        setChatColumnWidth(getDefaultChatColumnWidth(containerWidth));
       }
-
-      const delta = resizeStateRef.current.startY - event.clientY;
-
-      setDrawerHeight(
-        clampDrawerHeight(resizeStateRef.current.startHeight + delta),
-      );
     },
-    [clampDrawerHeight],
-  );
-  const handleResizeEnd = useCallback(() => {
-    resizeStateRef.current.isResizing = false;
-    document.removeEventListener("mousemove", handleResizeMove);
-    document.removeEventListener("mouseup", handleResizeEnd);
-  }, [handleResizeMove]);
-  const handleResizeStart = (event: ReactMouseEvent<HTMLElement>) => {
-    event.preventDefault();
-    resizeStateRef.current = {
-      startY: event.clientY,
-      startHeight: drawerHeight,
-      isResizing: true,
-    };
-    document.addEventListener("mousemove", handleResizeMove);
-    document.addEventListener("mouseup", handleResizeEnd);
-  };
-  const handleColumnResizeMove = useCallback(
-    (event: MouseEvent) => {
-      if (!columnResizeStateRef.current.isResizing || !drawerBodyRef.current) {
-        return;
-      }
-
-      const containerWidth = drawerBodyRef.current.clientWidth;
-      const delta = event.clientX - columnResizeStateRef.current.startX;
-
-      setChatColumnWidth(
-        clampChatColumnWidth(
-          columnResizeStateRef.current.startWidth + delta,
-          containerWidth,
-        ),
-      );
-    },
-    [clampChatColumnWidth],
-  );
-  const handleColumnResizeEnd = useCallback(() => {
-    columnResizeStateRef.current.isResizing = false;
-    document.body.style.cursor = "";
-    document.body.style.userSelect = "";
-    document.removeEventListener("mousemove", handleColumnResizeMove);
-    document.removeEventListener("mouseup", handleColumnResizeEnd);
-  }, [handleColumnResizeMove]);
-  const handleColumnResizeStart = (event: ReactMouseEvent<HTMLElement>) => {
-    event.preventDefault();
-
-    if (!drawerBodyRef.current) {
-      return;
-    }
-
-    const containerWidth = drawerBodyRef.current.clientWidth;
-    const initialWidth =
-      chatColumnWidth ?? getDefaultChatColumnWidth(containerWidth);
-
-    columnResizeStateRef.current = {
-      startX: event.clientX,
-      startWidth: initialWidth,
-      isResizing: true,
-    };
-    hasUserResizedColumnsRef.current = true;
-    setChatColumnWidth(initialWidth);
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-    document.addEventListener("mousemove", handleColumnResizeMove);
-    document.addEventListener("mouseup", handleColumnResizeEnd);
-  };
+  });
+  // null = fluid (grid auto-sizing); number = fixed px width chosen by user
+  const chatColumnWidth = chatColumnWidthSize > 0 ? chatColumnWidthSize : null;
 
   useEffect(() => {
     if (workflow?.type !== WorkflowType.manual) {
@@ -307,22 +237,6 @@ export const WorkflowBottomDrawer = () => {
   }, [workflow?.id, workflow?.inputSchema, workflow?.type]);
 
   useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const handleWindowResize = () => {
-      setDrawerHeight((prev) => clampDrawerHeight(prev));
-    };
-
-    window.addEventListener("resize", handleWindowResize);
-
-    return () => {
-      window.removeEventListener("resize", handleWindowResize);
-    };
-  }, [clampDrawerHeight]);
-
-  useEffect(() => {
     const element = drawerBodyRef.current;
 
     if (!element || typeof window === "undefined") {
@@ -330,17 +244,11 @@ export const WorkflowBottomDrawer = () => {
     }
 
     const applyWidth = (containerWidth: number) => {
-      if (!containerWidth) {
-        return;
-      }
+      if (!containerWidth) return;
 
-      setChatColumnWidth((previous) => {
-        if (hasUserResizedColumnsRef.current && previous !== null) {
-          return clampChatColumnWidth(previous, containerWidth);
-        }
-
-        return getDefaultChatColumnWidth(containerWidth);
-      });
+      setChatColumnWidth((prev) =>
+        prev > 0 ? clampChatColumnWidth(prev, containerWidth) : 0,
+      );
     };
 
     if (typeof ResizeObserver === "undefined") {
@@ -365,23 +273,7 @@ export const WorkflowBottomDrawer = () => {
     return () => {
       observer.disconnect();
     };
-  }, [clampChatColumnWidth, getDefaultChatColumnWidth]);
-
-  useEffect(() => {
-    return () => {
-      document.removeEventListener("mousemove", handleResizeMove);
-      document.removeEventListener("mouseup", handleResizeEnd);
-    };
-  }, [handleResizeMove, handleResizeEnd]);
-
-  useEffect(() => {
-    return () => {
-      document.removeEventListener("mousemove", handleColumnResizeMove);
-      document.removeEventListener("mouseup", handleColumnResizeEnd);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [handleColumnResizeMove, handleColumnResizeEnd]);
+  }, [clampChatColumnWidth]);
 
   return (
     <BottomDrawer

--- a/packages/frontend/src/hooks/useResizableDrawerSize.ts
+++ b/packages/frontend/src/hooks/useResizableDrawerSize.ts
@@ -1,0 +1,157 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type MouseEvent as ReactMouseEvent,
+  type SetStateAction,
+} from "react";
+
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+
+export interface UseResizableDrawerSizeOptions {
+  /** Unique localStorage key — persists the width or height across sessions. */
+  sizeStorageKey: string;
+  /** Fallback size (px) when nothing is persisted yet. */
+  defaultSize: number;
+  /** Lower bound in pixels. */
+  minSize: number;
+  /**
+   * Upper bound in pixels. Pass a getter when the limit depends on a live DOM
+   * measurement (called on every mousemove). Return `undefined` to skip the
+   * upper clamp (e.g. before the container is mounted and `clientWidth` is 0).
+   */
+  maxSize?: number | (() => number | undefined);
+  /**
+   * - `"horizontal"` — tracks `clientX`, dragging right increases width.
+   * - `"vertical"`   — tracks `clientY`, dragging up increases height.
+   */
+  axis: "horizontal" | "vertical";
+  /**
+   * Called on mousedown with the current size. Use it to seed the size from a
+   * DOM measurement when the element starts in a fluid state (size === 0).
+   */
+  onResizeStart?: (initialSize: number) => void;
+}
+
+export interface UseResizableDrawerSizeReturn {
+  /** Current width or height in pixels. */
+  size: number;
+  /** Setter — use to re-clamp or reset the size externally. */
+  setSize: Dispatch<SetStateAction<number>>;
+  /** Attach to the resize handle's `onMouseDown`. */
+  handleResizeStart: (event: ReactMouseEvent<HTMLElement>) => void;
+}
+
+export const useResizableDrawerSize = ({
+  sizeStorageKey,
+  defaultSize,
+  minSize,
+  maxSize,
+  axis,
+  onResizeStart,
+}: UseResizableDrawerSizeOptions): UseResizableDrawerSizeReturn => {
+  const { getLocalStorage, setLocalStorage } = useLocalStorage();
+  // Normalize maxSize to a stable getter so clampSize never needs
+  // to re-register listeners when maxSize changes between renders.
+  const maxSizeRef = useRef<() => number | undefined>(
+    typeof maxSize === "function" ? maxSize : () => maxSize,
+  );
+
+  useEffect(() => {
+    maxSizeRef.current =
+      typeof maxSize === "function" ? maxSize : () => maxSize;
+  }, [maxSize]);
+
+  const clampSize = useCallback(
+    (value: number) => {
+      const max = maxSizeRef.current();
+
+      return Math.min(
+        max !== undefined ? max : Infinity,
+        Math.max(value, minSize),
+      );
+    },
+    [minSize],
+  );
+  const [size, setSize] = useState(() =>
+    clampSize(Number(getLocalStorage(sizeStorageKey, defaultSize))),
+  );
+  // Drag state bundled in one ref — avoids multiple individual refs.
+  const dragRef = useRef({
+    startCoord: 0,
+    startSize: 0,
+    currentSize: 0,
+    active: false,
+  });
+
+  // Re-clamp when bounds change (e.g. breakpoint switch).
+  useEffect(() => {
+    setSize((prev) => clampSize(prev));
+  }, [clampSize]);
+
+  // Global listeners so dragging continues outside the handle element.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const isHorizontal = axis === "horizontal";
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!dragRef.current.active) return;
+
+      const coord = isHorizontal ? event.clientX : event.clientY;
+      // Vertical is inverted: dragging up (decreasing clientY) grows the size.
+      const delta = isHorizontal
+        ? coord - dragRef.current.startCoord
+        : dragRef.current.startCoord - coord;
+      const next = clampSize(dragRef.current.startSize + delta);
+
+      dragRef.current.currentSize = next;
+      setSize(next);
+    };
+    const handleMouseUp = () => {
+      if (!dragRef.current.active) return;
+
+      dragRef.current.active = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      setLocalStorage(sizeStorageKey, String(dragRef.current.currentSize));
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [axis, clampSize, sizeStorageKey]);
+
+  const handleResizeStart = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      const isHorizontal = axis === "horizontal";
+
+      dragRef.current = {
+        active: true,
+        startCoord: isHorizontal ? event.clientX : event.clientY,
+        startSize: size,
+        currentSize: size,
+      };
+      document.body.style.cursor = isHorizontal ? "col-resize" : "row-resize";
+      document.body.style.userSelect = "none";
+      event.preventDefault();
+      onResizeStart?.(size);
+    },
+    [axis, onResizeStart, size],
+  );
+
+  return { size, setSize, handleResizeStart };
+};


### PR DESCRIPTION
## Summary
Introduces a generic `useResizableSize` hook that persists any draggable panel
dimension to `localStorage` and restores it on page load. Applies it to the
`WorkflowBottomDrawer` vertical height and horizontal column-divider width, both
of which were previously reset to defaults on every page refresh.

## Why
Users lost their layout preferences (drawer height, chat/debugger column ratio)
on every page reload, forcing them to re-adjust the panels on each session.

## How to review
Focus on `useResizableSize.ts` as the core primitive — particularly:
- The `maxSizeRef` initialization (fixes a first-render clamp bug where `maxSize`
  was `undefined` before the sync effect ran)
- The `dragRef.currentSize` pattern that replaces the old `latestSizeRef`
- The `WorkflowBottomDrawer` column-width `onResizeStart` callback that seeds the
  fluid sentinel (`size === 0`) with the measured DOM width before the first drag

## Validation
- Drag the bottom drawer height, refresh — height is restored
- Drag the column divider, refresh — column width is restored
- Resize the browser window after setting a fixed column width — column re-clamps
  correctly within the new container bounds
- Open the editor on a small breakpoint — column stays fluid (no stored `0` is
  misapplied)
- Typecheck passes: `pnpm --filter @hexabot-ai/frontend typecheck`