### PR TITLE
chore: clean up turbo test output warnings

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,8 +7,7 @@
       ],
       "outputs": [
         "dist/**",
-        "build/**",
-        "coverage/**"
+        "build/**"
       ],
       "outputLogs": "new-only"
     },
@@ -23,9 +22,7 @@
       "dependsOn": [
         "^build"
       ],
-      "outputs": [
-        "coverage/**"
-      ],
+      "outputs": [],
       "outputLogs": "new-only"
     },
     "typecheck": {


### PR DESCRIPTION
## Summary

Updated the Turbo configuration to properly handle test task outputs and eliminate warnings related to missing output files during test execution across workspace packages.

## Why

The test pipeline was generating repeated Turbo warnings such as:
`WARNING no output files found for task <package>#test. Please check your outputs key in turbo.json`

These warnings created noise in CI/CD logs and could lead to confusion when reviewing build and test results.

## How to review

* Review the changes in `turbo.json`.
* Verify that the `test` task configuration either correctly defines output files or explicitly disables outputs when tests do not generate artifacts.
* Ensure the configuration applies consistently across all affected packages:

  * `@hexabot-ai/agentic`
  * `@hexabot-ai/api`
  * `@hexabot-ai/cli`
  * `@hexabot-ai/frontend`
  * `@hexabot-ai/graph`
  * `@hexabot-ai/types`
  * `@hexabot-ai/widget`

## Validation

* Ran the test pipeline locally.
* Confirmed that Turbo no longer reports `no output files found for task ...#test` warnings.
* Verified that all test tasks execute successfully and caching behavior remains correct.

## Extra
<img width="1446" height="211" alt="image" src="https://github.com/user-attachments/assets/0f9c3936-8636-4cdb-a684-fcfd0e3fa991" />
