### PR TITLE
fix(graph): replace empty-state glitch with a loading indicator

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowDefinitionState.ts
+++ b/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowDefinitionState.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  type CompiledStep,
   validateWorkflow,
   type WorkflowCompileOptions,
   type WorkflowDefinition,
@@ -191,8 +192,13 @@ export const useWorkflowDefinitionState = ({
     flow,
     error: definitionError,
   } = useMemo(() => {
-    if (!yaml || actionsByName.size === 0) {
+    if (actionsByName.size === 0) {
+      // Actions not yet loaded — remain in loading limbo, not an empty workflow
       return { definition: undefined, error: null };
+    }
+    if (!yaml) {
+      // Actions ready but yaml is empty → workflow has no steps yet
+      return { definition: undefined, error: null, flow: [] as CompiledStep[] };
     }
 
     try {
@@ -362,6 +368,13 @@ export const useWorkflowDefinitionState = ({
   );
 
   useEffect(() => {
+    // currentVersion is `null` when workflow genuinely has no version.
+    // It is `undefined` when the version entity reference exists but hasn't been
+    // written into the TanStack Query cache yet (transient during normalization).
+    // Skipping the `undefined` case prevents a spurious yaml → "" reset that
+    // would briefly clear the compiled flow and flash the empty-workflow overlay.
+    if (currentVersion === undefined) return;
+
     const nextYaml = currentVersion?.definitionYml ?? "";
 
     definitionSignatureRef.current = nextYaml;

--- a/packages/graph/src/workflow/components/WorkflowGraph.tsx
+++ b/packages/graph/src/workflow/components/WorkflowGraph.tsx
@@ -75,6 +75,7 @@ import { applyWorkflowExecutionStatesToNodes } from "../utils/workflow-runtime-n
 import { WorkflowControls } from "./WorkflowControls";
 import { WorkflowEmptyState } from "./WorkflowEmptyState";
 import { WorkflowInsertContextMenu } from "./WorkflowInsertContextMenu";
+import { WorkflowLoadingState } from "./WorkflowLoadingState";
 
 export type WorkflowGraphModel = {
   definition?: WorkflowDefinition;
@@ -235,7 +236,7 @@ const WorkflowGraphCanvas = forwardRef<WorkflowGraphHandle, WorkflowGraphProps>(
     const [isGraphMoving, setIsGraphMoving] = useState(false);
     const [currentZoom, setCurrentZoom] = useState(1);
     const lastViewportRef = useRef<Viewport>({ x: 0, y: 0, zoom: 1 });
-    const { graphData, isEmptyWorkflow } = useWorkflowGraphLayout({
+    const { graphData, isEmptyWorkflow, isLoading } = useWorkflowGraphLayout({
       compiledFlow: model.compiledFlow,
       defs: model.definition?.defs,
       layoutDirection: model.layoutDirection,
@@ -434,6 +435,7 @@ const WorkflowGraphCanvas = forwardRef<WorkflowGraphHandle, WorkflowGraphProps>(
             {isEmptyWorkflow && insertion?.onInsertAtRoot ? (
               <WorkflowEmptyState onInsert={insertion.onInsertAtRoot} />
             ) : null}
+            {isLoading ? <WorkflowLoadingState /> : null}
             {children}
             <WorkflowInsertContextMenu
               id="workflow-insert-menu"

--- a/packages/graph/src/workflow/components/WorkflowLoadingState.tsx
+++ b/packages/graph/src/workflow/components/WorkflowLoadingState.tsx
@@ -1,0 +1,13 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { Loader2 } from "lucide-react";
+
+export const WorkflowLoadingState = () => (
+  <div className="workflow-loading-overlay" aria-label="Loading workflow">
+    <Loader2 className="workflow-icon-spin workflow-loading-icon" />
+  </div>
+);

--- a/packages/graph/src/workflow/hooks/useWorkflowGraphLayout.ts
+++ b/packages/graph/src/workflow/hooks/useWorkflowGraphLayout.ts
@@ -10,8 +10,8 @@ import { useEffect, useRef, useState } from "react";
 
 import { EMPTY_WORKFLOW_GRAPH } from "../constants/workflow.constants";
 import type {
-  WorkflowBindingCatalog,
   WorkflowAction,
+  WorkflowBindingCatalog,
   WorkflowGraphData,
 } from "../types/workflow-node.types";
 import {
@@ -37,7 +37,9 @@ export const useWorkflowGraphLayout = ({
   const [graphData, setGraphData] =
     useState<WorkflowGraphData>(EMPTY_WORKFLOW_GRAPH);
   const requestTokenRef = useRef(0);
-  const isEmptyWorkflow = !compiledFlow?.length;
+  const isEmptyWorkflow =
+    Array.isArray(compiledFlow) && compiledFlow.length === 0;
+  const isLoading = compiledFlow === undefined;
 
   useEffect(() => {
     const requestToken = requestTokenRef.current + 1;
@@ -87,5 +89,6 @@ export const useWorkflowGraphLayout = ({
   return {
     graphData,
     isEmptyWorkflow,
+    isLoading,
   };
 };

--- a/packages/graph/src/workflow/styles/workflow-insert-menu.css
+++ b/packages/graph/src/workflow/styles/workflow-insert-menu.css
@@ -8,6 +8,22 @@
   z-index: 4;
 }
 
+.workflow-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 4;
+}
+
+.workflow-loading-icon {
+  color: var(--workflow-accent);
+  height: 64px;
+  width: 100%;
+}
+
 .workflow-empty-state-action {
   display: inline-flex;
   pointer-events: all;
@@ -60,7 +76,8 @@
   color: #0288d1;
 }
 
-.workflow-insert-menu__item[data-item-id="conditional"] .workflow-insert-menu__icon {
+.workflow-insert-menu__item[data-item-id="conditional"]
+  .workflow-insert-menu__icon {
   color: #2162fb;
 }
 
@@ -68,7 +85,8 @@
   color: #0c9ba0;
 }
 
-.workflow-insert-menu__item[data-item-id="parallel"] .workflow-insert-menu__icon {
+.workflow-insert-menu__item[data-item-id="parallel"]
+  .workflow-insert-menu__icon {
   color: #0c9ba0;
 }
 


### PR DESCRIPTION
## Summary
Replaced the visual editor's "Add Node" placeholder glitch with a loading component to provide a smoother and more consistent user experience while node data is being initialized.

## Why
The placeholder was briefly rendering in an incorrect state, causing a visual glitch and creating confusion for users interacting with the editor. A dedicated loading component better represents the initialization state and eliminates the flicker.

## How to Review
* Open the visual editor and trigger scenarios where the node canvas is loading.
* Verify that the loading component is displayed instead of the "Add Node" placeholder.
* Confirm that the transition from loading state to the fully rendered editor is smooth and free of visual artifacts.

## Validation
* Tested editor initialization and node loading flows.
* Verified that the loading component appears during loading states.
* Confirmed that the previous placeholder flicker/glitch no longer occurs.

## Extra
After the fix :
<video src="https://github.com/user-attachments/assets/97ddedae-61c4-4569-b423-5fbb0eba5008"></video>
<video src="https://github.com/user-attachments/assets/8c2bac39-6de3-4bf7-b774-0cfe3e1e95d0"></video>

Before the fix :
<video src="https://github.com/user-attachments/assets/658866dd-76e4-4f60-b189-0bd110e11e46"></video>
<video src="https://github.com/user-attachments/assets/7caea17c-197b-41bd-8f4c-7e9739cb32f4"></video>
