### PR TITLE
fix(api): use proper TypeORM query syntax in handleMessageRead…

### DIFF
--- a/packages/api/src/chat/services/chat.service.ts
+++ b/packages/api/src/chat/services/chat.service.ts
@@ -6,7 +6,7 @@
 
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
-import { In } from 'typeorm';
+import { Between, In } from 'typeorm';
 
 import { StatsType } from '@/analytics/entities/stats.entity';
 import { MessageInboundEvent } from '@/channel/lib/inbound-events';
@@ -183,9 +183,10 @@ export class ChatService {
       try {
         await this.messageService.updateMany(
           {
-            // @ts-expect-error Invesstigate why this is causing a ts error
-            recipient: subscriber.id,
-            createdAt: { $lte: watermark, $gte: start },
+            where: {
+              recipient: { id: subscriber.id },
+              createdAt: Between(start, watermark),
+            },
           },
           {
             delivery: true,


### PR DESCRIPTION
### Summary

Updated the API to use the correct TypeORM query syntax in `handleMessageRead`. This aligns the query with TypeORM best practices and ensures the expected records are retrieved/updated reliably.

### Why

The previous query syntax could lead to incorrect behavior or compatibility issues with newer TypeORM versions. Using the proper syntax improves correctness, maintainability, and future compatibility.

### How to review

* Review the changes in `handleMessageRead`.
* Verify the updated TypeORM query construction and filtering logic.
* Ensure the behavior remains unchanged apart from the query syntax fix.

### Validation

* Verified the project builds successfully.
* Confirmed the message read flow works as expected.
* Checked that the updated query returns and updates the expected records.