### PR TITLE
fix(api): remove redundant afterAll cleanup from spec files

### DIFF
--- a/packages/api/src/analytics/controllers/stats.controller.spec.ts
+++ b/packages/api/src/analytics/controllers/stats.controller.spec.ts
@@ -5,14 +5,12 @@
  */
 
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { TestingModule } from '@nestjs/testing';
 
 import { MessageService } from '@/chat/services/message.service';
 import {
   installStatsFixturesTypeOrm,
   statsFixtures,
 } from '@/utils/test/fixtures/stats';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowRunService } from '@/workflow/services/workflow-run.service';
 import { WorkflowService } from '@/workflow/services/workflow.service';
@@ -23,7 +21,6 @@ import { StatsController } from './stats.controller';
 
 describe('StatsController', () => {
   let statsController: StatsController;
-  let module: TestingModule;
   const workflowService = {
     count: jest.fn(),
   } as jest.Mocked<Pick<WorkflowService, 'count'>>;
@@ -36,7 +33,7 @@ describe('StatsController', () => {
   } as jest.Mocked<Pick<MessageService, 'count'>>;
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [StatsController],
       providers: [
@@ -49,17 +46,8 @@ describe('StatsController', () => {
         fixtures: installStatsFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [statsController] = await getMocks([StatsController]);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/api/src/analytics/repositories/stats.repository.spec.ts
+++ b/packages/api/src/analytics/repositories/stats.repository.spec.ts
@@ -11,7 +11,6 @@ import {
   installStatsFixturesTypeOrm,
   statsFixtures,
 } from '@/utils/test/fixtures/stats';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { StatsType } from '../entities/stats.entity';
@@ -36,14 +35,6 @@ describe('StatsRepository (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findMessages', () => {
     it('should return messages', async () => {
       const from = new Date('2023-11-01T23:00:00.000Z');

--- a/packages/api/src/analytics/services/stats.service.spec.ts
+++ b/packages/api/src/analytics/services/stats.service.spec.ts
@@ -12,7 +12,6 @@ import {
   installStatsFixturesTypeOrm,
   statsFixtures,
 } from '@/utils/test/fixtures/stats';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowRunService } from '@/workflow/services/workflow-run.service';
 import { WorkflowService } from '@/workflow/services/workflow.service';
@@ -70,14 +69,6 @@ describe('StatsService', () => {
     ]);
     eventEmitter = module.get(EventEmitter2);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/api/src/attachment/controllers/attachment.controller.spec.ts
+++ b/packages/api/src/attachment/controllers/attachment.controller.spec.ts
@@ -27,7 +27,6 @@ import {
 } from '@/utils/test/fixtures/attachment';
 import { installSettingFixturesTypeOrm } from '@/utils/test/fixtures/setting';
 import { installUserFixturesTypeOrm } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { attachment, attachmentFile } from '../mocks/attachment.mock';
@@ -83,11 +82,6 @@ describe('AttachmentController', () => {
 
     helperService.register(new LocalStorageHelper());
   });
-
-  afterAll(async () => {
-    await closeTypeOrmConnections();
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();

--- a/packages/api/src/attachment/guards/attachment-ability.guard.spec.ts
+++ b/packages/api/src/attachment/guards/attachment-ability.guard.spec.ts
@@ -17,7 +17,6 @@ import { ModelService } from '@/user/services/model.service';
 import { PermissionService } from '@/user/services/permission.service';
 import { Action } from '@/user/types/action.type';
 import { TModel } from '@/user/types/model.type';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { attachment } from '../mocks/attachment.mock';
@@ -99,7 +98,6 @@ describe('AttachmentGuard', () => {
     if (module) {
       await module.close();
     }
-    await closeTypeOrmConnections();
   });
 
   describe('canActivate', () => {

--- a/packages/api/src/attachment/repositories/attachment.repository.spec.ts
+++ b/packages/api/src/attachment/repositories/attachment.repository.spec.ts
@@ -6,8 +6,6 @@
 
 import { randomUUID } from 'crypto';
 
-import { TestingModule } from '@nestjs/testing';
-
 import { config } from '@/config';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import {
@@ -15,7 +13,6 @@ import {
   installAttachmentFixturesTypeOrm,
 } from '@/utils/test/fixtures/attachment';
 import { installUserFixturesTypeOrm } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -27,7 +24,6 @@ import {
 import { AttachmentRepository } from './attachment.repository';
 
 describe('AttachmentRepository (TypeORM)', () => {
-  let module: TestingModule;
   let repository: AttachmentRepository;
   const createdAttachmentIds = new Set<string>();
   const CREATOR_UUID = '66666666-6666-6666-6666-666666666666';
@@ -44,7 +40,6 @@ describe('AttachmentRepository (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [repository] = await testing.getMocks([AttachmentRepository]);
   });
 
@@ -55,14 +50,6 @@ describe('AttachmentRepository (TypeORM)', () => {
       createdAttachmentIds.delete(id);
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('configuration', () => {
     it('exposes createdBy as the only populatable relation', () => {
       expect(repository.getPopulateRelations()).toEqual(['createdBy']);

--- a/packages/api/src/channel/source.controller.spec.ts
+++ b/packages/api/src/channel/source.controller.spec.ts
@@ -12,7 +12,6 @@ import { DataSource, Repository } from 'typeorm';
 import { MessageOrmEntity } from '@/chat/entities/message.entity';
 import { ThreadOrmEntity } from '@/chat/entities/thread.entity';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 import type { WebsocketGateway } from '@/websocket/websocket.gateway';
@@ -149,15 +148,6 @@ describe('SourceController (TypeORM cascade)', () => {
     threadRepository = dataSource.getRepository(ThreadOrmEntity);
     messageRepository = dataSource.getRepository(MessageOrmEntity);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-
-    await closeTypeOrmConnections();
-  });
-
   it('prevents deleting a source and preserves linked threads and messages', async () => {
     const source = await sourceRepository.findOne({
       where: { channel: 'web' },

--- a/packages/api/src/chat/controllers/label-group.controller.spec.ts
+++ b/packages/api/src/chat/controllers/label-group.controller.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 import { In } from 'typeorm';
 
 import { NOT_FOUND_ID } from '@/utils/constants/mock';
@@ -13,7 +12,6 @@ import {
   installLabelGroupFixturesTypeOrm,
   labelGroupFixtures,
 } from '@/utils/test/fixtures/label-group';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelGroupCreateDto } from '../dto/label-group.dto';
@@ -24,7 +22,6 @@ import { LabelGroupController } from './label-group.controller';
 describe('LabelGroupController', () => {
   let labelGroupController: LabelGroupController;
   let labelGroupService: LabelGroupService;
-  let module: TestingModule;
 
   beforeAll(async () => {
     const testing = await buildTestingMocks({
@@ -34,8 +31,6 @@ describe('LabelGroupController', () => {
         fixtures: installLabelGroupFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [labelGroupController, labelGroupService] = await testing.getMocks([
       LabelGroupController,
@@ -47,14 +42,6 @@ describe('LabelGroupController', () => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findPage', () => {
     it('should find label groups', async () => {
       const expected = await labelGroupService.find({});

--- a/packages/api/src/chat/controllers/label.controller.spec.ts
+++ b/packages/api/src/chat/controllers/label.controller.spec.ts
@@ -8,12 +8,10 @@ import { randomUUID } from 'crypto';
 
 import { Label } from '@hexabot-ai/types';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 import { In } from 'typeorm';
 
 import { installLabelFixturesTypeOrm } from '@/utils/test/fixtures/label';
 import { installSubscriberFixturesTypeOrm } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelCreateDto, LabelUpdateDto } from '../dto/label.dto';
@@ -26,7 +24,6 @@ const createUniqueLabelName = () => `LABEL_${randomString().toUpperCase()}`;
 const createUniqueLabelTitle = () => `Label ${randomString()}`;
 
 describe('LabelController (TypeORM)', () => {
-  let module: TestingModule;
   let labelController: LabelController;
   let labelService: LabelService;
 
@@ -42,8 +39,6 @@ describe('LabelController (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [labelController, labelService] = await testing.getMocks([
       LabelController,
       LabelService,
@@ -54,14 +49,6 @@ describe('LabelController (TypeORM)', () => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findPage', () => {
     it('should find labels without population', async () => {
       const expected = await labelService.find({});

--- a/packages/api/src/chat/controllers/message.controller.spec.ts
+++ b/packages/api/src/chat/controllers/message.controller.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { Message, MessageFull } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { ChannelService } from '@/channel/channel.service';
 import { MessageService } from '@/chat/services/message.service';
@@ -14,14 +13,12 @@ import {
   installMessageFixturesTypeOrm,
   messageFixtures,
 } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 
 import { MessageController } from './message.controller';
 
 describe('MessageController (TypeORM)', () => {
-  let module: TestingModule;
   let messageController: MessageController;
   let messageService: MessageService;
 
@@ -67,8 +64,6 @@ describe('MessageController (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [messageController, messageService] = await testing.getMocks([
       MessageController,
       MessageService,
@@ -95,14 +90,6 @@ describe('MessageController (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOne', () => {
     it('should find message by id with populated relations', async () => {
       const populateSpy = jest.spyOn(messageService, 'findOneAndPopulate');

--- a/packages/api/src/chat/controllers/subscriber.controller.spec.ts
+++ b/packages/api/src/chat/controllers/subscriber.controller.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { Subscriber, SubscriberFull } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { AttachmentService } from '@/attachment/services/attachment.service';
 import { SubscriberService } from '@/chat/services/subscriber.service';
@@ -13,13 +12,11 @@ import {
   installSubscriberFixturesTypeOrm,
   subscriberFixtures,
 } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SubscriberController } from './subscriber.controller';
 
 describe('SubscriberController (TypeORM)', () => {
-  let module: TestingModule;
   let subscriberController: SubscriberController;
   let subscriberService: SubscriberService;
 
@@ -51,8 +48,6 @@ describe('SubscriberController (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [subscriberController, subscriberService] = await testing.getMocks([
       SubscriberController,
       SubscriberService,
@@ -82,14 +77,6 @@ describe('SubscriberController (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOne', () => {
     it('should find subscriber by id with populated relations', async () => {
       const populateSpy = jest.spyOn(subscriberService, 'findOneAndPopulate');

--- a/packages/api/src/chat/controllers/thread.controller.spec.ts
+++ b/packages/api/src/chat/controllers/thread.controller.spec.ts
@@ -6,13 +6,11 @@
 
 import { Thread, ThreadFull } from '@hexabot-ai/types';
 import { BadRequestException, ArgumentMetadata } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 
 import { ThreadOrmEntity } from '@/chat/entities/thread.entity';
 import { ThreadService } from '@/chat/services/thread.service';
 import { TypeOrmSearchFilterPipe } from '@/utils/pipes/typeorm-search-filter.pipe';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -21,7 +19,6 @@ import {
 } from './thread.controller';
 
 describe('ThreadController (TypeORM)', () => {
-  let module: TestingModule;
   let threadController: ThreadController;
   let threadService: ThreadService;
 
@@ -42,7 +39,6 @@ describe('ThreadController (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [threadController, threadService] = await testing.getMocks([
       ThreadController,
       ThreadService,
@@ -64,14 +60,6 @@ describe('ThreadController (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('count', () => {
     it('counts threads', async () => {
       const countSpy = jest.spyOn(threadService, 'count');

--- a/packages/api/src/chat/repositories/label-group.repository.spec.ts
+++ b/packages/api/src/chat/repositories/label-group.repository.spec.ts
@@ -6,21 +6,17 @@
 
 import { randomUUID } from 'crypto';
 
-import { TestingModule } from '@nestjs/testing';
-
 import {
   groupedLabelFixtures,
   installLabelGroupFixturesTypeOrm,
   labelGroupFixtures,
 } from '@/utils/test/fixtures/label-group';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelGroupRepository } from './label-group.repository';
 import { LabelRepository } from './label.repository';
 
 describe('LabelGroupRepository (TypeORM)', () => {
-  let module: TestingModule;
   let labelRepository: LabelRepository;
   let labelGroupRepository: LabelGroupRepository;
   const createdLabelIds: string[] = [];
@@ -34,8 +30,6 @@ describe('LabelGroupRepository (TypeORM)', () => {
         fixtures: installLabelGroupFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [labelRepository, labelGroupRepository] = await testing.getMocks([
       LabelRepository,
@@ -56,14 +50,6 @@ describe('LabelGroupRepository (TypeORM)', () => {
       await Promise.all(ids.map((id) => labelGroupRepository.deleteOne(id)));
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('populate helpers', () => {
     it('exposes supported relations', () => {
       expect(labelGroupRepository.getPopulateRelations()).toEqual(['labels']);

--- a/packages/api/src/chat/repositories/label.repository.spec.ts
+++ b/packages/api/src/chat/repositories/label.repository.spec.ts
@@ -4,13 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TestingModule } from '@nestjs/testing';
 import { In } from 'typeorm';
 
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { labelFixtures } from '@/utils/test/fixtures/label';
 import { installSubscriberFixturesTypeOrm } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelRepository } from './label.repository';
@@ -20,7 +18,6 @@ const sortById = <T extends { id?: string }>(row1: T, row2: T) =>
   (row1.id ?? '').localeCompare(row2.id ?? '');
 
 describe('LabelRepository (TypeORM)', () => {
-  let module: TestingModule;
   let labelRepository: LabelRepository;
   let subscriberRepository: SubscriberRepository;
 
@@ -33,7 +30,6 @@ describe('LabelRepository (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [labelRepository, subscriberRepository] = await testing.getMocks([
       LabelRepository,
       SubscriberRepository,
@@ -43,14 +39,6 @@ describe('LabelRepository (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should load a label and populate its users', async () => {
       const label = await labelRepository.findOne({

--- a/packages/api/src/chat/repositories/message.repository.spec.ts
+++ b/packages/api/src/chat/repositories/message.repository.spec.ts
@@ -10,7 +10,6 @@ import { Repository } from 'typeorm';
 
 import { MessageOrmEntity } from '@/chat/entities/message.entity';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MessageRepository } from './message.repository';
@@ -47,14 +46,6 @@ describe('MessageRepository (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('returns a populated message by id', async () => {
       const reference = seededMessages.find(

--- a/packages/api/src/chat/repositories/subscriber.repository.spec.ts
+++ b/packages/api/src/chat/repositories/subscriber.repository.spec.ts
@@ -18,7 +18,6 @@ import {
   installSubscriberFixturesTypeOrm,
   subscriberFixtures,
 } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SubscriberRepository } from './subscriber.repository';
@@ -87,14 +86,6 @@ describe('SubscriberRepository (TypeORM)', () => {
       createdLabelIds.length = 0;
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   const createPersistedSubscriber = async (
     overrides: Partial<SubscriberOrmEntity> = {},
   ): Promise<SubscriberOrmEntity> => {

--- a/packages/api/src/chat/services/label.service.spec.ts
+++ b/packages/api/src/chat/services/label.service.spec.ts
@@ -4,13 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TestingModule } from '@nestjs/testing';
 import { In } from 'typeorm';
 
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { labelFixtures } from '@/utils/test/fixtures/label';
 import { installSubscriberFixturesTypeOrm } from '@/utils/test/fixtures/subscriber';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LabelRepository } from '../repositories/label.repository';
@@ -22,7 +20,6 @@ const sortById = <T extends { id?: string }>(row1: T, row2: T) =>
   (row1.id ?? '').localeCompare(row2.id ?? '');
 
 describe('LabelService (TypeORM)', () => {
-  let module: TestingModule;
   let labelService: LabelService;
   let labelRepository: LabelRepository;
   let subscriberRepository: SubscriberRepository;
@@ -36,7 +33,6 @@ describe('LabelService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [labelService, labelRepository, subscriberRepository] =
       await testing.getMocks([
         LabelService,
@@ -48,14 +44,6 @@ describe('LabelService (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findAllAndPopulate', () => {
     it('should find all labels and populate users', async () => {
       jest.spyOn(labelRepository, 'findAllAndPopulate');

--- a/packages/api/src/chat/services/message.service.spec.ts
+++ b/packages/api/src/chat/services/message.service.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { Message, MessageFull, Thread } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { MessageRepository } from '@/chat/repositories/message.repository';
 import { MessageService } from '@/chat/services/message.service';
@@ -13,11 +12,9 @@ import {
   installMessageFixturesTypeOrm,
   messageFixtures,
 } from '@/utils/test/fixtures/message';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 describe('MessageService (TypeORM)', () => {
-  let module: TestingModule;
   let messageService: MessageService;
   let messageRepository: MessageRepository;
 
@@ -38,8 +35,6 @@ describe('MessageService (TypeORM)', () => {
         fixtures: installMessageFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [messageService, messageRepository] = await testing.getMocks([
       MessageService,
@@ -80,14 +75,6 @@ describe('MessageService (TypeORM)', () => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('finds a message by id and populates relations', async () => {
       const spy = jest.spyOn(messageRepository, 'findOneAndPopulate');

--- a/packages/api/src/chat/services/subscriber.service.spec.ts
+++ b/packages/api/src/chat/services/subscriber.service.spec.ts
@@ -26,7 +26,6 @@ import { UserService } from '@/user/services/user.service';
 import { installLabelGroupFixturesTypeOrm } from '@/utils/test/fixtures/label-group';
 import { installSubscriberFixturesTypeOrm } from '@/utils/test/fixtures/subscriber';
 import { sortRowsBy } from '@/utils/test/sort';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WebsocketGateway } from '@/websocket/websocket.gateway';
 
@@ -139,14 +138,6 @@ describe('SubscriberService (TypeORM)', () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should find one subscriber and populate related data', async () => {
       const subscriber = await subscriberRepository.findOne({

--- a/packages/api/src/cms/controllers/content-type.controller.spec.ts
+++ b/packages/api/src/cms/controllers/content-type.controller.spec.ts
@@ -5,14 +5,12 @@
  */
 
 import { NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 
 import { LoggerService } from '@/logger/logger.service';
 import {
   contentTypeOrmFixtures,
   installContentTypeFixturesTypeOrm,
 } from '@/utils/test/fixtures/contenttype';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeCreateDto } from '../dto/contentType.dto';
@@ -21,14 +19,13 @@ import { ContentTypeService } from '../services/content-type.service';
 import { ContentTypeController } from './content-type.controller';
 
 describe('ContentTypeController (TypeORM)', () => {
-  let module: TestingModule;
   let controller: ContentTypeController;
   let service: ContentTypeService;
   let logger: LoggerService;
   const createdIds = new Set<string>();
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [ContentTypeController],
       providers: [],
@@ -36,21 +33,12 @@ describe('ContentTypeController (TypeORM)', () => {
         fixtures: installContentTypeFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [controller, service] = await getMocks([
       ContentTypeController,
       ContentTypeService,
     ]);
     logger = controller.logger;
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(async () => {
     jest.clearAllMocks();
     for (const id of Array.from(createdIds)) {

--- a/packages/api/src/cms/controllers/content.controller.spec.ts
+++ b/packages/api/src/cms/controllers/content.controller.spec.ts
@@ -7,7 +7,6 @@
 import { randomUUID } from 'crypto';
 
 import { NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 
 import { LoggerService } from '@/logger/logger.service';
 import {
@@ -15,7 +14,6 @@ import {
   installContentFixturesTypeOrm,
 } from '@/utils/test/fixtures/content';
 import { installContentTypeFixturesTypeOrm } from '@/utils/test/fixtures/contenttype';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeService } from '../services/content-type.service';
@@ -25,7 +23,6 @@ import { RagService } from '../services/rag.service';
 import { ContentController } from './content.controller';
 
 describe('ContentController (TypeORM)', () => {
-  let module: TestingModule;
   let controller: ContentController;
   let contentService: ContentService;
   let contentTypeService: ContentTypeService;
@@ -34,7 +31,7 @@ describe('ContentController (TypeORM)', () => {
   const createdContentIds = new Set<string>();
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [ContentController],
       providers: [],
@@ -47,7 +44,6 @@ describe('ContentController (TypeORM)', () => {
         },
       ],
     });
-    module = testingModule;
     [controller, contentService, contentTypeService, contentRagService] =
       await getMocks([
         ContentController,
@@ -57,14 +53,6 @@ describe('ContentController (TypeORM)', () => {
       ]);
     logger = controller.logger;
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(async () => {
     jest.clearAllMocks();
     for (const id of Array.from(createdContentIds)) {

--- a/packages/api/src/cms/controllers/menu.controller.spec.ts
+++ b/packages/api/src/cms/controllers/menu.controller.spec.ts
@@ -4,14 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TestingModule } from '@nestjs/testing';
-
 import { LoggerService } from '@/logger/logger.service';
 import {
   installMenuFixturesTypeOrm,
   offerMenuFixture,
 } from '@/utils/test/fixtures/menu';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuType } from '../entities/menu.entity';
@@ -20,32 +17,22 @@ import { MenuService } from '../services/menu.service';
 import { MenuController } from './menu.controller';
 
 describe('MenuController (TypeORM)', () => {
-  let module: TestingModule;
   let controller: MenuController;
   let menuService: MenuService;
   let logger: LoggerService;
   const createdMenuIds = new Set<string>();
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [MenuController],
       typeorm: {
         fixtures: installMenuFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [controller, menuService] = await getMocks([MenuController, MenuService]);
     logger = controller.logger;
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(async () => {
     jest.clearAllMocks();
     for (const id of Array.from(createdMenuIds)) {

--- a/packages/api/src/cms/repositories/content-type.repository.spec.ts
+++ b/packages/api/src/cms/repositories/content-type.repository.spec.ts
@@ -6,16 +6,12 @@
 
 import { randomUUID } from 'crypto';
 
-import { TestingModule } from '@nestjs/testing';
-
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeRepository } from './content-type.repository';
 import { ContentRepository } from './content.repository';
 
 describe('ContentTypeRepository (TypeORM)', () => {
-  let module: TestingModule;
   let repository: ContentTypeRepository;
   let contentRepository: ContentRepository;
 
@@ -24,20 +20,11 @@ describe('ContentTypeRepository (TypeORM)', () => {
       providers: [ContentRepository, ContentTypeRepository],
     });
 
-    module = testing.module;
     [repository, contentRepository] = await testing.getMocks([
       ContentTypeRepository,
       ContentRepository,
     ]);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('deleteOne cascade', () => {
     it('removes related contents when deleting a content type', async () => {
       const created = await repository.create({

--- a/packages/api/src/cms/repositories/menu.repository.spec.ts
+++ b/packages/api/src/cms/repositories/menu.repository.spec.ts
@@ -4,13 +4,10 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TestingModule } from '@nestjs/testing';
-
 import {
   installMenuFixturesTypeOrm,
   rootMenuFixtures,
 } from '@/utils/test/fixtures/menu';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuType } from '../entities/menu.entity';
@@ -18,29 +15,19 @@ import { MenuType } from '../entities/menu.entity';
 import { MenuRepository } from './menu.repository';
 
 describe('MenuRepository (TypeORM)', () => {
-  let module: TestingModule;
   let repository: MenuRepository;
   const createdMenuIds = new Set<string>();
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [MenuRepository],
       typeorm: {
         fixtures: installMenuFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [repository] = await getMocks([MenuRepository]);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(async () => {
     jest.clearAllMocks();
     for (const id of Array.from(createdMenuIds)) {

--- a/packages/api/src/cms/services/content-type.service.spec.ts
+++ b/packages/api/src/cms/services/content-type.service.spec.ts
@@ -4,13 +4,10 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TestingModule } from '@nestjs/testing';
-
 import {
   contentTypeOrmFixtures,
   installContentTypeFixturesTypeOrm,
 } from '@/utils/test/fixtures/contenttype';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeDto } from '../dto/contentType.dto';
@@ -18,29 +15,19 @@ import { ContentTypeDto } from '../dto/contentType.dto';
 import { ContentTypeService } from './content-type.service';
 
 describe('ContentTypeService (TypeORM)', () => {
-  let module: TestingModule;
   let service: ContentTypeService;
   const createdIds: string[] = [];
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [ContentTypeService],
       typeorm: {
         fixtures: installContentTypeFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [service] = await getMocks([ContentTypeService]);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(async () => {
     jest.clearAllMocks();
     if (createdIds.length > 0) {

--- a/packages/api/src/cms/services/content.service.spec.ts
+++ b/packages/api/src/cms/services/content.service.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { OutgoingMessageType, ContentOptions } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { LoggerService } from '@/logger/logger.service';
 import {
@@ -13,21 +12,19 @@ import {
   installContentFixturesTypeOrm,
 } from '@/utils/test/fixtures/content';
 import { installContentTypeFixturesTypeOrm } from '@/utils/test/fixtures/contenttype';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ContentTypeService } from './content-type.service';
 import { ContentService } from './content.service';
 
 describe('ContentService (TypeORM)', () => {
-  let module: TestingModule;
   let contentService: ContentService;
   let contentTypeService: ContentTypeService;
   let logger: LoggerService;
   const createdContentIds: string[] = [];
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [ContentService, ContentTypeService],
       typeorm: [
@@ -39,21 +36,12 @@ describe('ContentService (TypeORM)', () => {
         },
       ],
     });
-    module = testingModule;
     [contentService, contentTypeService] = await getMocks([
       ContentService,
       ContentTypeService,
     ]);
     logger = contentService.logger;
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(async () => {
     jest.clearAllMocks();
     if (createdContentIds.length > 0) {

--- a/packages/api/src/cms/services/menu.service.spec.ts
+++ b/packages/api/src/cms/services/menu.service.spec.ts
@@ -7,7 +7,6 @@
 import { randomUUID } from 'crypto';
 
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { TestingModule } from '@nestjs/testing';
 import { Cache } from 'cache-manager';
 
 import { MENU_CACHE_KEY } from '@/utils/constants/cache';
@@ -17,7 +16,6 @@ import {
   offersMenuFixtures,
   rootMenuFixtures,
 } from '@/utils/test/fixtures/menu';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MenuType } from '../entities/menu.entity';
@@ -25,30 +23,20 @@ import { MenuType } from '../entities/menu.entity';
 import { MenuService } from './menu.service';
 
 describe('MenuService (TypeORM)', () => {
-  let module: TestingModule;
   let menuService: MenuService;
   let cacheManager: Cache;
   const createdIds = new Set<string>();
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [MenuService],
       typeorm: {
         fixtures: installMenuFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [menuService, cacheManager] = await getMocks([MenuService, CACHE_MANAGER]);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(async () => {
     jest.clearAllMocks();
     for (const id of Array.from(createdIds)) {

--- a/packages/api/src/extension/cleanup.service.spec.ts
+++ b/packages/api/src/extension/cleanup.service.spec.ts
@@ -5,19 +5,16 @@
  */
 
 import { Setting } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import LocalStorageHelper from '@/extensions/helpers/local-storage/index.helper';
 import { HelperService } from '@/helper/helper.service';
 import { SettingService } from '@/setting/services/setting.service';
 import { installSettingFixturesTypeOrm } from '@/utils/test/fixtures/setting';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { CleanupService } from './cleanup.service';
 
 describe('CleanupService', () => {
-  let module: TestingModule;
   let initialSettings: Setting[];
   let helperService: HelperService;
   let cleanupService: CleanupService;
@@ -42,8 +39,6 @@ describe('CleanupService', () => {
       },
     });
 
-    module = testing.module;
-
     [cleanupService, settingService, helperService] = await testing.getMocks([
       CleanupService,
       SettingService,
@@ -54,14 +49,6 @@ describe('CleanupService', () => {
 
     helperService.register(new LocalStorageHelper());
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(async () => {
     jest.clearAllMocks();
     if (settingService) {

--- a/packages/api/src/extensions/channels/web/__test__/index.spec.ts
+++ b/packages/api/src/extensions/channels/web/__test__/index.spec.ts
@@ -24,7 +24,6 @@ import { MenuService } from '@/cms/services/menu.service';
 import { installLabelGroupFixturesTypeOrm } from '@/utils/test/fixtures/label-group';
 import { installMessageFixturesTypeOrm } from '@/utils/test/fixtures/message';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { SocketRequest } from '@/websocket/utils/socket-request';
 import { SocketResponse } from '@/websocket/utils/socket-response';
@@ -158,12 +157,8 @@ describe('WebChannelHandler', () => {
     await handler.onModuleInit();
   });
 
-  afterAll(async () => {
+  afterAll(() => {
     jest.restoreAllMocks();
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   it('should have correct name', () => {

--- a/packages/api/src/i18n/controllers/language.controller.spec.ts
+++ b/packages/api/src/i18n/controllers/language.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   installLanguageFixturesTypeOrm,
   languageFixtures,
 } from '@/utils/test/fixtures/language';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LanguageUpdateDto } from '../dto/language.dto';
@@ -47,7 +46,6 @@ describe('LanguageController', () => {
   });
 
   afterEach(jest.clearAllMocks);
-  afterAll(closeTypeOrmConnections);
 
   describe('findOne', () => {
     it('should find one translation by id', async () => {

--- a/packages/api/src/i18n/controllers/translation.controller.spec.ts
+++ b/packages/api/src/i18n/controllers/translation.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   translationFixtures,
 } from '@/utils/test/fixtures/translation';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowService } from '@/workflow/services/workflow.service';
 
@@ -57,7 +56,6 @@ describe('TranslationController', () => {
   });
 
   afterEach(jest.clearAllMocks);
-  afterAll(closeTypeOrmConnections);
 
   describe('findOne', () => {
     it('should find one translation by id', async () => {

--- a/packages/api/src/i18n/services/translation.service.spec.ts
+++ b/packages/api/src/i18n/services/translation.service.spec.ts
@@ -8,7 +8,6 @@ import { Workflow } from '@hexabot-ai/types';
 import { TestingModule } from '@nestjs/testing';
 
 import { I18nService } from '@/i18n/services/i18n.service';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowService } from '@/workflow/services/workflow.service';
 import { WorkflowType } from '@/workflow/types';
@@ -116,7 +115,6 @@ describe('TranslationService', () => {
     if (module) {
       await module.close();
     }
-    await closeTypeOrmConnections();
   });
 
   it('should call refreshDynamicTranslations with translations from findAll', async () => {

--- a/packages/api/src/migration/migration.service.spec.ts
+++ b/packages/api/src/migration/migration.service.spec.ts
@@ -8,7 +8,6 @@ import fs from 'fs';
 
 import { HttpService } from '@nestjs/axios';
 import { ModuleRef } from '@nestjs/core';
-import { TestingModule } from '@nestjs/testing';
 import { DataSource } from 'typeorm';
 
 import { AttachmentService } from '@/attachment/services/attachment.service';
@@ -16,7 +15,6 @@ import { config } from '@/config';
 import { LoggerService } from '@/logger/logger.service';
 import { MetadataOrmEntity } from '@/setting/entities/metadata.entity';
 import { MetadataService } from '@/setting/services/metadata.service';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MigrationOrmEntity } from './migration.entity';
@@ -28,7 +26,6 @@ describe('MigrationService', () => {
   let loggerService: LoggerService;
   let metadataService: MetadataService;
   let dataSource: DataSource;
-  let testingModule: TestingModule;
   let httpService: HttpService;
   let attachmentService: AttachmentService;
 
@@ -86,7 +83,6 @@ describe('MigrationService', () => {
       ],
     });
 
-    testingModule = mocks.module;
     [service, metadataService] = await mocks.getMocks([
       MigrationService,
       MetadataService,
@@ -105,12 +101,8 @@ describe('MigrationService', () => {
     metadataService = serviceInternals.metadataService;
   });
 
-  afterAll(async () => {
+  afterAll(() => {
     config.database.autoMigrate = originalAutoMigrate;
-    if (testingModule) {
-      await testingModule.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   afterEach(() => {

--- a/packages/api/src/setting/controllers/setting.controller.spec.ts
+++ b/packages/api/src/setting/controllers/setting.controller.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { Setting } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 import { I18nContext } from 'nestjs-i18n';
 
 import { I18nService } from '@/i18n/services/i18n.service';
@@ -14,7 +13,6 @@ import {
   settingFixtures,
 } from '@/utils/test/fixtures/setting';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -36,10 +34,9 @@ describe('SettingController', () => {
   let settingService: SettingService;
   let runtimeSettingsService: RuntimeSettingsService;
   let i18nService: I18nService<unknown>;
-  let module: TestingModule;
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [SettingController],
       providers: [I18nServiceProvider],
@@ -47,7 +44,6 @@ describe('SettingController', () => {
         fixtures: installSettingFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [settingController, settingService, runtimeSettingsService, i18nService] =
       await getMocks([
         SettingController,
@@ -56,14 +52,6 @@ describe('SettingController', () => {
         I18nService,
       ]);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   beforeEach(() => {
     runtimeSettingsService.reset();
     runtimeSettingsService.register({

--- a/packages/api/src/setting/repositories/setting.repository.spec.ts
+++ b/packages/api/src/setting/repositories/setting.repository.spec.ts
@@ -15,7 +15,6 @@ import {
   installSettingFixturesTypeOrm,
   settingFixtures,
 } from '@/utils/test/fixtures/setting';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { SettingOrmEntity } from '../entities/setting.entity';
@@ -51,14 +50,6 @@ describe('SettingRepository (TypeORM)', () => {
       createdIds.length = 0;
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findAll', () => {
     it('returns all settings', async () => {
       const result = await settingRepository.findAll();

--- a/packages/api/src/setting/services/setting.service.spec.ts
+++ b/packages/api/src/setting/services/setting.service.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { Setting } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 import { z } from 'zod';
 
 import {
@@ -13,7 +12,6 @@ import {
   settingFixtures,
 } from '@/utils/test/fixtures/setting';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -29,7 +27,6 @@ describe('SettingService', () => {
   let settingService: SettingService;
   let settingRepository: SettingRepository;
   let runtimeSettingsService: RuntimeSettingsService;
-  let module: TestingModule;
   const createdIds: string[] = [];
   const makeSetting = (overrides: Partial<Setting>): Setting => {
     return {
@@ -45,14 +42,13 @@ describe('SettingService', () => {
   };
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [SettingService, I18nServiceProvider],
       typeorm: {
         fixtures: installSettingFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [settingService, settingRepository, runtimeSettingsService] =
       await getMocks([
         SettingService,
@@ -60,14 +56,6 @@ describe('SettingService', () => {
         RuntimeSettingsService,
       ]);
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   beforeEach(() => {
     runtimeSettingsService.reset();
     runtimeSettingsService.register({

--- a/packages/api/src/transfer/workflow-transfer.service.spec.ts
+++ b/packages/api/src/transfer/workflow-transfer.service.spec.ts
@@ -34,7 +34,6 @@ import {
   installUserFixturesTypeOrm,
   userFixtureIds,
 } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 import type { WebsocketGateway } from '@/websocket/websocket.gateway';
@@ -289,14 +288,6 @@ describe('WorkflowTransferService', () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   const createDefinitionYml = (
     memoryId: string,
     mcpServerId: string,

--- a/packages/api/src/user/controllers/auth.controller.spec.ts
+++ b/packages/api/src/user/controllers/auth.controller.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { JwtModule } from '@nestjs/jwt';
-import { TestingModule } from '@nestjs/testing';
 
 import { LicenseService } from '@/license/services/license.service';
 import { ModelOrmEntity } from '@/user/entities/model.entity';
@@ -16,13 +15,11 @@ import { installLanguageFixturesTypeOrm } from '@/utils/test/fixtures/language';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
 import { MailerServiceProvider } from '@/utils/test/providers/mailer-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { LocalAuthController } from './auth.controller';
 
 describe('AuthController (TypeORM)', () => {
-  let module: TestingModule;
   let authController: LocalAuthController;
   let licenseService: Pick<LicenseService, 'getSnapshot'>;
   const licenseSnapshot = {
@@ -79,8 +76,6 @@ describe('AuthController (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [authController, licenseService] = await testing.getMocks([
       LocalAuthController,
       LicenseService,
@@ -88,14 +83,6 @@ describe('AuthController (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('session payload', () => {
     it('should include license snapshot in /auth/me payload', async () => {
       const req = {

--- a/packages/api/src/user/controllers/model.controller.spec.ts
+++ b/packages/api/src/user/controllers/model.controller.spec.ts
@@ -5,10 +5,8 @@
  */
 
 import { ModelFull } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelService } from '../services/model.service';
@@ -17,7 +15,6 @@ import { PermissionService } from '../services/permission.service';
 import { ModelController } from './model.controller';
 
 describe('ModelController (TypeORM)', () => {
-  let module: TestingModule;
   let modelController: ModelController;
   let modelService: ModelService;
   let permissionService: PermissionService;
@@ -32,22 +29,12 @@ describe('ModelController (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [modelController, modelService, permissionService] = await testing.getMocks(
       [ModelController, ModelService, PermissionService],
     );
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('find', () => {
     it('should find models', async () => {
       jest.spyOn(modelService, 'findAndPopulate');

--- a/packages/api/src/user/controllers/permission.controller.spec.ts
+++ b/packages/api/src/user/controllers/permission.controller.spec.ts
@@ -6,10 +6,8 @@
 
 import { Role, Model, Permission, PermissionFull } from '@hexabot-ai/types';
 import { NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { PermissionCreateDto } from '../dto/permission.dto';
@@ -21,7 +19,6 @@ import { Action } from '../types/action.type';
 import { PermissionController } from './permission.controller';
 
 describe('PermissionController (TypeORM)', () => {
-  let module: TestingModule;
   let permissionController: PermissionController;
   let permissionService: PermissionService;
   let roleService: RoleService;
@@ -40,8 +37,6 @@ describe('PermissionController (TypeORM)', () => {
         fixtures: installPermissionFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [permissionController, roleService, modelService, permissionService] =
       await testing.getMocks([
@@ -62,14 +57,6 @@ describe('PermissionController (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('find', () => {
     it('should find permissions', async () => {
       jest.spyOn(permissionService, 'find');

--- a/packages/api/src/user/controllers/role.controller.spec.ts
+++ b/packages/api/src/user/controllers/role.controller.spec.ts
@@ -6,12 +6,10 @@
 
 import { Role, RoleFull } from '@hexabot-ai/types';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 import { Request } from 'express';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { roleFixtureIds, roleOrmFixtures } from '@/utils/test/fixtures/role';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { RoleCreateDto, RoleUpdateDto } from '../dto/role.dto';
@@ -22,7 +20,6 @@ import { UserService } from '../services/user.service';
 import { RoleController } from './role.controller';
 
 describe('RoleController (TypeORM)', () => {
-  let module: TestingModule;
   let roleController: RoleController;
   let roleService: RoleService;
   let permissionService: PermissionService;
@@ -39,8 +36,6 @@ describe('RoleController (TypeORM)', () => {
         fixtures: installPermissionFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [roleController, roleService, permissionService, userService] =
       await testing.getMocks([
@@ -62,14 +57,6 @@ describe('RoleController (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findPage', () => {
     it('should find roles', async () => {
       jest.spyOn(roleService, 'find');

--- a/packages/api/src/user/controllers/user.controller.spec.ts
+++ b/packages/api/src/user/controllers/user.controller.spec.ts
@@ -7,7 +7,6 @@
 import { Role, User } from '@hexabot-ai/types';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { JwtModule, JwtService } from '@nestjs/jwt';
-import { TestingModule } from '@nestjs/testing';
 import { Request } from 'express';
 
 import { AttachmentService } from '@/attachment/services/attachment.service';
@@ -16,7 +15,6 @@ import { installLanguageFixturesTypeOrm } from '@/utils/test/fixtures/language';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
 import { MailerServiceProvider } from '@/utils/test/providers/mailer-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import {
@@ -32,7 +30,6 @@ import { ValidateAccountService } from '../services/validate-account.service';
 import { ReadWriteUserController } from './user.controller';
 
 describe('UserController (TypeORM)', () => {
-  let module: TestingModule;
   let userController: ReadWriteUserController;
   let userService: UserService;
   let roleService: RoleService;
@@ -76,8 +73,6 @@ describe('UserController (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [
       userController,
       userService,
@@ -100,14 +95,6 @@ describe('UserController (TypeORM)', () => {
     roles = await roleService.findAll();
     user = await userService.findOne({ where: { username: 'admin' } });
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(jest.clearAllMocks);
 
   describe('findOne', () => {

--- a/packages/api/src/user/repositories/credential.repository.spec.ts
+++ b/packages/api/src/user/repositories/credential.repository.spec.ts
@@ -12,7 +12,6 @@ import { Repository } from 'typeorm';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { CredentialOrmEntity } from '../entities/credential.entity';
@@ -62,14 +61,6 @@ describe('CredentialRepository (TypeORM)', () => {
       createdCredentialIds.length = 0;
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   const createPersistedCredential = async (
     overrides: Partial<CredentialOrmEntity> = {},
   ) => {

--- a/packages/api/src/user/repositories/model.repository.spec.ts
+++ b/packages/api/src/user/repositories/model.repository.spec.ts
@@ -4,14 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TestingModule } from '@nestjs/testing';
-
 import { modelFixtureIds } from '@/utils/test/fixtures/model';
 import {
   installPermissionFixturesTypeOrm,
   permissionOrmFixtures,
 } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelOrmEntity as ModelEntity } from '../entities/model.entity';
@@ -20,7 +17,6 @@ import { ModelRepository } from './model.repository';
 import { PermissionRepository } from './permission.repository';
 
 describe('ModelRepository (TypeORM)', () => {
-  let module: TestingModule;
   let modelRepository: ModelRepository;
   let permissionRepository: PermissionRepository;
   let contentTypeModel: ModelEntity;
@@ -33,8 +29,6 @@ describe('ModelRepository (TypeORM)', () => {
         fixtures: installPermissionFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [modelRepository, permissionRepository] = await testing.getMocks([
       ModelRepository,
@@ -49,14 +43,6 @@ describe('ModelRepository (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should find a model and populate its permissions', async () => {
       const expectedPermissions = permissionOrmFixtures.filter(

--- a/packages/api/src/user/repositories/permission.repository.spec.ts
+++ b/packages/api/src/user/repositories/permission.repository.spec.ts
@@ -5,13 +5,11 @@
  */
 
 import { Permission } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import {
   installPermissionFixturesTypeOrm,
   permissionOrmFixtures,
 } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { Action } from '../types/action.type';
@@ -21,7 +19,6 @@ import { PermissionRepository } from './permission.repository';
 import { RoleRepository } from './role.repository';
 
 describe('PermissionRepository (TypeORM)', () => {
-  let module: TestingModule;
   let modelRepository: ModelRepository;
   let roleRepository: RoleRepository;
   let permissionRepository: PermissionRepository;
@@ -36,8 +33,6 @@ describe('PermissionRepository (TypeORM)', () => {
         fixtures: installPermissionFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [modelRepository, roleRepository, permissionRepository] =
       await testing.getMocks([
@@ -60,14 +55,6 @@ describe('PermissionRepository (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should find a permission and populate its role and model', async () => {
       const role = await roleRepository.findOne(createPermission.role);

--- a/packages/api/src/user/repositories/role.repository.spec.ts
+++ b/packages/api/src/user/repositories/role.repository.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import { Role } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import {
   installPermissionFixturesTypeOrm,
@@ -13,7 +12,6 @@ import {
 } from '@/utils/test/fixtures/permission';
 import { roleFixtureIds } from '@/utils/test/fixtures/role';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { PermissionRepository } from './permission.repository';
@@ -21,7 +19,6 @@ import { RoleRepository } from './role.repository';
 import { UserRepository } from './user.repository';
 
 describe('RoleRepository (TypeORM)', () => {
-  let module: TestingModule;
   let roleRepository: RoleRepository;
   let permissionRepository: PermissionRepository;
   let userRepository: UserRepository;
@@ -37,8 +34,6 @@ describe('RoleRepository (TypeORM)', () => {
         fixtures: installPermissionFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [roleRepository, userRepository, permissionRepository] =
       await testing.getMocks([
@@ -58,14 +53,6 @@ describe('RoleRepository (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should find one role and populate its permissions and users', async () => {
       const permissions = await permissionRepository.find({

--- a/packages/api/src/user/repositories/user.repository.spec.ts
+++ b/packages/api/src/user/repositories/user.repository.spec.ts
@@ -7,20 +7,17 @@
 import { randomUUID } from 'crypto';
 
 import type { User } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { roleFixtureIds } from '@/utils/test/fixtures/role';
 import { userFixtures } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { RoleRepository } from './role.repository';
 import { UserRepository } from './user.repository';
 
 describe('UserRepository (TypeORM)', () => {
-  let module: TestingModule;
   let userRepository: UserRepository;
   let user: User | null;
 
@@ -45,8 +42,6 @@ describe('UserRepository (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [userRepository] = await testing.getMocks([UserRepository]);
 
     user = await userRepository.findOne({ where: { username: 'admin' } });
@@ -55,14 +50,6 @@ describe('UserRepository (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should find one user and populate roles', async () => {
       const result = await userRepository.findOneAndPopulate(user!.id);

--- a/packages/api/src/user/services/auth.service.spec.ts
+++ b/packages/api/src/user/services/auth.service.spec.ts
@@ -5,10 +5,8 @@
  */
 
 import type { User } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { UserRepository } from '../repositories/user.repository';
@@ -16,7 +14,6 @@ import { UserRepository } from '../repositories/user.repository';
 import { AuthService } from './auth.service';
 
 describe('AuthService (TypeORM)', () => {
-  let module: TestingModule;
   let authService: AuthService;
   let userRepository: UserRepository;
   let adminUser: User | null;
@@ -30,8 +27,6 @@ describe('AuthService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [authService, userRepository] = await testing.getMocks([
       AuthService,
       UserRepository,
@@ -42,14 +37,6 @@ describe('AuthService (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('validateUser', () => {
     const adminEmail = 'admin@admin.admin';
 

--- a/packages/api/src/user/services/model.service.spec.ts
+++ b/packages/api/src/user/services/model.service.spec.ts
@@ -5,11 +5,9 @@
  */
 
 import { Permission } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { modelFixtureIds, modelOrmFixtures } from '@/utils/test/fixtures/model';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelOrmEntity as ModelEntity } from '../entities/model.entity';
@@ -19,7 +17,6 @@ import { PermissionRepository } from '../repositories/permission.repository';
 import { ModelService } from './model.service';
 
 describe('ModelService (TypeORM)', () => {
-  let module: TestingModule;
   let modelService: ModelService;
   let modelRepository: ModelRepository;
   let permissionRepository: PermissionRepository;
@@ -34,8 +31,6 @@ describe('ModelService (TypeORM)', () => {
         fixtures: installPermissionFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [modelService, permissionRepository, modelRepository] =
       await testing.getMocks([
@@ -53,14 +48,6 @@ describe('ModelService (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should find a model and populate its permissions', async () => {
       const result = await modelService.findOneAndPopulate(model.id);

--- a/packages/api/src/user/services/passwordReset.service.spec.ts
+++ b/packages/api/src/user/services/passwordReset.service.spec.ts
@@ -7,7 +7,6 @@
 import type { User } from '@hexabot-ai/types';
 import { NotFoundException } from '@nestjs/common';
 import { JwtModule, JwtService } from '@nestjs/jwt';
-import { TestingModule } from '@nestjs/testing';
 import { compareSync } from 'bcryptjs';
 
 import { MailerService } from '@/mailer/mailer.service';
@@ -16,7 +15,6 @@ import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permissi
 import { users } from '@/utils/test/fixtures/user';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
 import { MailerServiceProvider } from '@/utils/test/providers/mailer-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { UserRepository } from '../repositories/user.repository';
@@ -25,7 +23,6 @@ import { PasswordResetService } from './passwordReset.service';
 import { UserService } from './user.service';
 
 describe('PasswordResetService (TypeORM)', () => {
-  let module: TestingModule;
   let passwordResetService: PasswordResetService;
   let mailerService: MailerService;
   let jwtService: JwtService;
@@ -50,8 +47,6 @@ describe('PasswordResetService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [
       passwordResetService,
       mailerService,
@@ -70,14 +65,6 @@ describe('PasswordResetService (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('requestReset', () => {
     it('should send an email with a token', async () => {
       const sendMailSpy = jest.spyOn(mailerService, 'sendMail');

--- a/packages/api/src/user/services/permission.service.spec.ts
+++ b/packages/api/src/user/services/permission.service.spec.ts
@@ -5,13 +5,11 @@
  */
 
 import { Permission } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import {
   installPermissionFixturesTypeOrm,
   permissionOrmFixtures,
 } from '@/utils/test/fixtures/permission';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { ModelRepository } from '../repositories/model.repository';
@@ -22,7 +20,6 @@ import { Action } from '../types/action.type';
 import { PermissionService } from './permission.service';
 
 describe('PermissionService (TypeORM)', () => {
-  let module: TestingModule;
   let permissionService: PermissionService;
   let modelRepository: ModelRepository;
   let roleRepository: RoleRepository;
@@ -37,8 +34,6 @@ describe('PermissionService (TypeORM)', () => {
         fixtures: installPermissionFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [permissionService, roleRepository, modelRepository, permissionRepository] =
       await testing.getMocks([
@@ -58,14 +53,6 @@ describe('PermissionService (TypeORM)', () => {
   });
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should find a permission and populate its role and model', async () => {
       jest.spyOn(permissionRepository, 'findOneAndPopulate');

--- a/packages/api/src/user/services/role.service.spec.ts
+++ b/packages/api/src/user/services/role.service.spec.ts
@@ -5,11 +5,9 @@
  */
 
 import { Role, Permission } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { roleFixtureIds, roleOrmFixtures } from '@/utils/test/fixtures/role';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { PermissionRepository } from '../repositories/permission.repository';
@@ -19,7 +17,6 @@ import { UserRepository } from '../repositories/user.repository';
 import { RoleService } from './role.service';
 
 describe('RoleService (TypeORM)', () => {
-  let module: TestingModule;
   let roleService: RoleService;
   let roleRepository: RoleRepository;
   let permissionRepository: PermissionRepository;
@@ -35,8 +32,6 @@ describe('RoleService (TypeORM)', () => {
         fixtures: installPermissionFixturesTypeOrm,
       },
     });
-
-    module = testing.module;
 
     [roleService, roleRepository, userRepository, permissionRepository] =
       await testing.getMocks([
@@ -56,14 +51,6 @@ describe('RoleService (TypeORM)', () => {
       where: { role: { id: roleFixtureIds.admin } },
     });
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   afterEach(jest.clearAllMocks);
 
   describe('findOneAndPopulate', () => {

--- a/packages/api/src/user/services/user.service.spec.ts
+++ b/packages/api/src/user/services/user.service.spec.ts
@@ -5,12 +5,10 @@
  */
 
 import type { User as UserDto } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
 import { installPermissionFixturesTypeOrm } from '@/utils/test/fixtures/permission';
 import { userFixtures } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { UserRepository } from '../repositories/user.repository';
@@ -18,7 +16,6 @@ import { UserRepository } from '../repositories/user.repository';
 import { UserService } from './user.service';
 
 describe('UserService (TypeORM)', () => {
-  let module: TestingModule;
   let userService: UserService;
   let userRepository: UserRepository;
   let user: UserDto | null;
@@ -44,8 +41,6 @@ describe('UserService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
-
     [userService, userRepository] = await testing.getMocks([
       UserService,
       UserRepository,
@@ -55,14 +50,6 @@ describe('UserService (TypeORM)', () => {
   }, 30000);
 
   afterEach(jest.clearAllMocks);
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findOneAndPopulate', () => {
     it('should find one user and populate its roles', async () => {
       jest.spyOn(userRepository, 'findOneAndPopulate');

--- a/packages/api/src/utils/generics/base-orm.controller.spec.ts
+++ b/packages/api/src/utils/generics/base-orm.controller.spec.ts
@@ -7,7 +7,6 @@
 import { randomUUID } from 'crypto';
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 import { In } from 'typeorm';
 
 import { LoggerService } from '@/logger/logger.service';
@@ -17,13 +16,11 @@ import {
   dummyFixtures,
   installDummyFixturesTypeOrm,
 } from '@/utils/test/fixtures/dummy';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { DummyController } from '../test/dummy/controllers/dummy.controller';
 
 describe('BaseOrmController', () => {
-  let module: TestingModule;
   let controller: DummyController;
   let dummyService: DummyService;
   let logger: LoggerService;
@@ -39,7 +36,6 @@ describe('BaseOrmController', () => {
       },
     });
 
-    module = testing.module;
     [controller, dummyService] = await testing.getMocks([
       DummyController,
       DummyService,
@@ -54,14 +50,6 @@ describe('BaseOrmController', () => {
       createdIds.delete(id);
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('count', () => {
     it('should count all records', async () => {
       const countSpy = jest.spyOn(dummyService, 'count');

--- a/packages/api/src/utils/generics/base-orm.repository.spec.ts
+++ b/packages/api/src/utils/generics/base-orm.repository.spec.ts
@@ -8,7 +8,6 @@ import { randomUUID } from 'crypto';
 
 import { NotFoundException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { TestingModule } from '@nestjs/testing';
 import { In, InsertEvent, RemoveEvent, Repository, UpdateEvent } from 'typeorm';
 
 import { DummyOrmEntity } from '@/utils/test/dummy/entities/dummy.entity';
@@ -17,22 +16,18 @@ import {
   dummyFixtures,
   installDummyFixturesTypeOrm,
 } from '@/utils/test/fixtures/dummy';
-import {
-  closeTypeOrmConnections,
-  getLastTypeOrmDataSource,
-} from '@/utils/test/test';
+import { getLastTypeOrmDataSource } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { EHook } from './base-orm.repository';
 
 describe('BaseOrmRepository', () => {
   let dummyRepository: DummyRepository;
-  let module: TestingModule;
   let ormRepository: Repository<DummyOrmEntity>;
   let baselineEntities: DummyOrmEntity[];
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [DummyRepository],
       typeorm: {
@@ -41,7 +36,6 @@ describe('BaseOrmRepository', () => {
       },
     });
 
-    module = testingModule;
     [dummyRepository] = await getMocks([DummyRepository]);
 
     const dataSource = getLastTypeOrmDataSource();
@@ -54,14 +48,6 @@ describe('BaseOrmRepository', () => {
       ormRepository.create(dummyFixtures),
     );
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('utility methods', () => {
     it('should expose the configured populate relations', () => {
       expect(dummyRepository.getPopulateRelations()).toEqual([]);

--- a/packages/api/src/utils/generics/base-orm.service.spec.ts
+++ b/packages/api/src/utils/generics/base-orm.service.spec.ts
@@ -7,7 +7,6 @@
 import { randomUUID } from 'crypto';
 
 import { Dummy } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 import { In } from 'typeorm';
 
 import { DummyOrmEntity } from '@/utils/test/dummy/entities/dummy.entity';
@@ -17,18 +16,16 @@ import {
   dummyFixtures,
   installDummyFixturesTypeOrm,
 } from '@/utils/test/fixtures/dummy';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 describe('BaseOrmService', () => {
-  let module: TestingModule;
   let dummyRepository: DummyRepository;
   let dummyService: DummyService;
   let baseline: Dummy[];
   let firstEntity: Dummy;
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['providers'],
       providers: [DummyService],
       typeorm: {
@@ -37,7 +34,6 @@ describe('BaseOrmService', () => {
       },
     });
 
-    module = testingModule;
     [dummyRepository, dummyService] = await getMocks([
       DummyRepository,
       DummyService,
@@ -53,14 +49,6 @@ describe('BaseOrmService', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('utilities', () => {
     it('exposes the configured repository', () => {
       expect(dummyService.getRepository()).toBe(dummyRepository);

--- a/packages/api/src/workflow/controllers/mcp-server.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/mcp-server.controller.spec.ts
@@ -7,7 +7,6 @@
 import { randomUUID } from 'crypto';
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 import { In } from 'typeorm';
 
 import { LoggerService } from '@/logger/logger.service';
@@ -17,7 +16,6 @@ import {
   mcpServerFixtureIds,
   mcpServerOrmFixtures,
 } from '@/utils/test/fixtures/mcp-server';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { McpClientPoolService } from '../services/mcp-client-pool.service';
@@ -27,7 +25,6 @@ import { McpServerTransport } from '../types';
 import { McpServerController } from './mcp-server.controller';
 
 describe('McpServerController (TypeORM)', () => {
-  let module: TestingModule;
   let controller: McpServerController;
   let service: McpServerService;
   let mcpClientPoolService: McpClientPoolService;
@@ -51,7 +48,7 @@ describe('McpServerController (TypeORM)', () => {
   };
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [McpServerController],
       providers: [
@@ -67,7 +64,6 @@ describe('McpServerController (TypeORM)', () => {
         fixtures: installMcpServerFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [controller, service, mcpClientPoolService] = await getMocks([
       McpServerController,
       McpServerService,
@@ -83,14 +79,6 @@ describe('McpServerController (TypeORM)', () => {
       createdIds.delete(id);
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('create', () => {
     it('creates an MCP server', async () => {
       const payload = buildPayload();

--- a/packages/api/src/workflow/controllers/memory-definition.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/memory-definition.controller.spec.ts
@@ -7,7 +7,6 @@
 import { randomUUID } from 'crypto';
 
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 import { JSONSchema7 as JsonSchema } from 'json-schema';
 import { In } from 'typeorm';
 
@@ -18,7 +17,6 @@ import {
   memoryDefinitionFixtureIds,
   memoryDefinitionOrmFixtures,
 } from '@/utils/test/fixtures/memory-definition';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MemoryDefinitionService } from '../services/memory-definition.service';
@@ -27,7 +25,6 @@ import { MemoryScope } from '../types';
 import { MemoryDefinitionController } from './memory-definition.controller';
 
 describe('MemoryDefinitionController (TypeORM)', () => {
-  let module: TestingModule;
   let controller: MemoryDefinitionController;
   let service: MemoryDefinitionService;
   let logger: LoggerService;
@@ -54,14 +51,13 @@ describe('MemoryDefinitionController (TypeORM)', () => {
   };
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [MemoryDefinitionController],
       typeorm: {
         fixtures: installMemoryDefinitionFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [controller, service] = await getMocks([
       MemoryDefinitionController,
       MemoryDefinitionService,
@@ -76,14 +72,6 @@ describe('MemoryDefinitionController (TypeORM)', () => {
       createdIds.delete(id);
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('create', () => {
     it('creates a memory definition', async () => {
       const payload = buildPayload();

--- a/packages/api/src/workflow/controllers/workflow-run.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow-run.controller.spec.ts
@@ -7,7 +7,6 @@
 import { randomUUID } from 'crypto';
 
 import { NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 
 import { LoggerService } from '@/logger/logger.service';
 import { IGNORED_TEST_FIELDS } from '@/utils/test/constants';
@@ -16,7 +15,6 @@ import {
   workflowRunFixtureIds,
   workflowRunOrmFixtures,
 } from '@/utils/test/fixtures/workflow-run';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { WorkflowRunService } from '../services/workflow-run.service';
@@ -24,20 +22,18 @@ import { WorkflowRunService } from '../services/workflow-run.service';
 import { WorkflowRunController } from './workflow-run.controller';
 
 describe('WorkflowRunController (TypeORM)', () => {
-  let module: TestingModule;
   let controller: WorkflowRunController;
   let service: WorkflowRunService;
   let logger: LoggerService;
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [WorkflowRunController],
       typeorm: {
         fixtures: installWorkflowRunFixturesTypeOrm,
       },
     });
-    module = testingModule;
     [controller, service] = await getMocks([
       WorkflowRunController,
       WorkflowRunService,
@@ -48,14 +44,6 @@ describe('WorkflowRunController (TypeORM)', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findMany', () => {
     it('returns workflow runs matching the provided filters', async () => {
       const options = { where: { status: 'running' as const } };

--- a/packages/api/src/workflow/controllers/workflow-version.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow-version.controller.spec.ts
@@ -8,7 +8,6 @@ import { randomUUID } from 'crypto';
 
 import { Workflow as WorkflowHelper } from '@hexabot-ai/agentic';
 import { INestApplication, NotFoundException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 
 import { LoggerService } from '@/logger/logger.service';
@@ -17,7 +16,6 @@ import {
   installMessagingWorkflowFixturesTypeOrm,
   installScheduledWorkflowFixturesTypeOrm,
 } from '@/utils/test/fixtures/workflow';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 
@@ -28,7 +26,6 @@ import { DirectionType, WorkflowType, WorkflowVersionAction } from '../types';
 import { WorkflowVersionController } from './workflow-version.controller';
 
 describe('WorkflowVersionController (TypeORM)', () => {
-  let module: TestingModule;
   let controller: WorkflowVersionController;
   let workflowService: WorkflowService;
   let workflowVersionService: WorkflowVersionService;
@@ -67,7 +64,7 @@ describe('WorkflowVersionController (TypeORM)', () => {
   };
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [WorkflowVersionController],
       providers: [
@@ -83,7 +80,6 @@ describe('WorkflowVersionController (TypeORM)', () => {
         ],
       },
     });
-    module = testingModule;
     [controller, workflowService, workflowVersionService] = await getMocks([
       WorkflowVersionController,
       WorkflowService,
@@ -101,14 +97,6 @@ describe('WorkflowVersionController (TypeORM)', () => {
       createdWorkflowIds.delete(id);
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findMany', () => {
     it('returns version history for a workflow', async () => {
       const payload = buildWorkflowPayload();

--- a/packages/api/src/workflow/controllers/workflow.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow.controller.spec.ts
@@ -13,7 +13,6 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { TestingModule } from '@nestjs/testing';
 import { JSONSchema7 as JsonSchema } from 'json-schema';
 import { I18nContext } from 'nestjs-i18n';
 import { z } from 'zod';
@@ -36,7 +35,6 @@ import {
   messagingWorkflowFixtures,
 } from '@/utils/test/fixtures/workflow';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 import type { WebsocketGateway } from '@/websocket/websocket.gateway';
@@ -90,7 +88,6 @@ class ManualOnlyAction extends BaseAction<
 }
 
 describe('WorkflowController (TypeORM)', () => {
-  let module: TestingModule;
   let workflowController: WorkflowController;
   let workflowService: WorkflowService;
   let agenticService: AgenticService;
@@ -131,7 +128,7 @@ describe('WorkflowController (TypeORM)', () => {
   };
 
   beforeAll(async () => {
-    const { module: testingModule, getMocks } = await buildTestingMocks({
+    const { getMocks } = await buildTestingMocks({
       autoInjectFrom: ['controllers'],
       controllers: [WorkflowController],
       providers: [
@@ -163,7 +160,6 @@ describe('WorkflowController (TypeORM)', () => {
         ],
       },
     });
-    module = testingModule;
     [
       agenticService,
       workflowController,
@@ -228,14 +224,6 @@ describe('WorkflowController (TypeORM)', () => {
       createdWorkflowIds.delete(id);
     }
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findMany', () => {
     it('returns workflows matching the provided filters', async () => {
       const options = {

--- a/packages/api/src/workflow/services/agentic.service.spec.ts
+++ b/packages/api/src/workflow/services/agentic.service.spec.ts
@@ -14,7 +14,6 @@ import {
 } from '@hexabot-ai/agentic';
 import type { User, WorkflowRunFull, WorkflowFull } from '@hexabot-ai/types';
 import { ModuleRef } from '@nestjs/core';
-import { TestingModule } from '@nestjs/testing';
 
 import { ActionService } from '@/actions/actions.service';
 import { RuntimeBindingsService } from '@/bindings/runtime-bindings.service';
@@ -23,7 +22,6 @@ import {
   installMessagingWorkflowFixturesTypeOrm,
   messagingWorkflowDefinition,
 } from '@/utils/test/fixtures/workflow';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 import { WorkflowContextFactory } from '@/workflow/contexts/workflow-context-factory';
@@ -108,7 +106,6 @@ const buildWorkflowInstance = (runner: jest.Mocked<WorkflowRunner>) =>
   }) as unknown as AgenticWorkflow;
 
 describe('AgenticService (TypeORM)', () => {
-  let module: TestingModule;
   let agenticService: AgenticService;
   let workflowService: WorkflowService;
   let workflowVersionService: WorkflowVersionService;
@@ -197,7 +194,6 @@ describe('AgenticService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [
       agenticService,
       workflowService,
@@ -228,14 +224,6 @@ describe('AgenticService (TypeORM)', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('handleEvent', () => {
     it('starts a new workflow run and persists a finished result', async () => {
       const event = createEvent({ text: 'hello' });

--- a/packages/api/src/workflow/services/memory-definition.service.spec.ts
+++ b/packages/api/src/workflow/services/memory-definition.service.spec.ts
@@ -4,15 +4,12 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TestingModule } from '@nestjs/testing';
-
 import {
   installMemoryDefinitionFixturesTypeOrm,
   memoryDefinitionFixtureIds,
   memoryDefinitionOrmFixtures,
 } from '@/utils/test/fixtures/memory-definition';
 import { installMemoryRecordFixturesTypeOrm } from '@/utils/test/fixtures/memory-record';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MemoryScope } from '../types';
@@ -30,7 +27,6 @@ const runDefinition = memoryDefinitionOrmFixtures.find(
 )!;
 
 describe('MemoryDefinitionService (TypeORM)', () => {
-  let module: TestingModule;
   let memoryDefinitionService: MemoryDefinitionService;
 
   beforeAll(async () => {
@@ -45,7 +41,6 @@ describe('MemoryDefinitionService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [memoryDefinitionService] = await testing.getMocks([
       MemoryDefinitionService,
     ]);
@@ -55,14 +50,6 @@ describe('MemoryDefinitionService (TypeORM)', () => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findBySlug', () => {
     it('returns the matching definition', async () => {
       const result = await memoryDefinitionService.findBySlug(

--- a/packages/api/src/workflow/services/memory-record.service.spec.ts
+++ b/packages/api/src/workflow/services/memory-record.service.spec.ts
@@ -6,8 +6,6 @@
 
 import { randomUUID } from 'crypto';
 
-import { TestingModule } from '@nestjs/testing';
-
 import {
   installMemoryDefinitionFixturesTypeOrm,
   memoryDefinitionFixtureIds,
@@ -21,10 +19,7 @@ import {
   memoryWorkflowFixtureId,
 } from '@/utils/test/fixtures/memory-record';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
-import {
-  closeTypeOrmConnections,
-  getLastTypeOrmDataSource,
-} from '@/utils/test/test';
+import { getLastTypeOrmDataSource } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import { MemoryDefinitionOrmEntity } from '../entities/memory-definition.entity';
@@ -46,7 +41,6 @@ const runRecord = memoryRecordOrmFixtures.find(
 )!;
 
 describe('MemoryRecordService (TypeORM)', () => {
-  let module: TestingModule;
   let memoryRecordService: MemoryRecordService;
 
   beforeAll(async () => {
@@ -61,7 +55,6 @@ describe('MemoryRecordService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [memoryRecordService] = await testing.getMocks([MemoryRecordService]);
   });
 
@@ -69,14 +62,6 @@ describe('MemoryRecordService (TypeORM)', () => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('findActiveByScope', () => {
     it('throws when ownerId is missing', async () => {
       await expect(

--- a/packages/api/src/workflow/services/memory.service.spec.ts
+++ b/packages/api/src/workflow/services/memory.service.spec.ts
@@ -4,8 +4,6 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TestingModule } from '@nestjs/testing';
-
 import {
   installMemoryDefinitionFixturesTypeOrm,
   memoryDefinitionFixtureIds,
@@ -19,7 +17,6 @@ import {
   memoryWorkflowFixtureId,
 } from '@/utils/test/fixtures/memory-record';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 
 import type { WorkflowRuntimeContext } from '../contexts/workflow-runtime.context';
@@ -53,7 +50,6 @@ const createContext = (): WorkflowRuntimeContext =>
   ({ state: {} as any }) as WorkflowRuntimeContext;
 
 describe('MemoryService (TypeORM)', () => {
-  let module: TestingModule;
   let memoryService: MemoryService;
   let memoryRecordService: MemoryRecordService;
 
@@ -69,7 +65,6 @@ describe('MemoryService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [memoryService, memoryRecordService] = await testing.getMocks([
       MemoryService,
       MemoryRecordService,
@@ -80,14 +75,6 @@ describe('MemoryService (TypeORM)', () => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   it('throws when ownerId is missing', async () => {
     const findSpy = jest.spyOn(memoryRecordService, 'findAndPopulate');
     const context = createContext();

--- a/packages/api/src/workflow/services/workflow-run.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-run.service.spec.ts
@@ -11,13 +11,11 @@ import {
   WorkflowSnapshot,
 } from '@hexabot-ai/agentic';
 import { Workflow, WorkflowRun, WorkflowRunFull } from '@hexabot-ai/types';
-import { TestingModule } from '@nestjs/testing';
 
 import {
   installUserFixturesTypeOrm,
   userFixtureIds,
 } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 
@@ -33,7 +31,6 @@ import { WorkflowVersionService } from './workflow-version.service';
 import { WorkflowService } from './workflow.service';
 
 describe('WorkflowRunService (TypeORM)', () => {
-  let module: TestingModule;
   let workflowService: WorkflowService;
   let workflowRepository: WorkflowRepository;
   let workflowRunService: WorkflowRunService;
@@ -87,7 +84,6 @@ describe('WorkflowRunService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [
       workflowService,
       workflowRepository,
@@ -139,14 +135,6 @@ describe('WorkflowRunService (TypeORM)', () => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('state transitions', () => {
     it('marks a run as running and forwards state', async () => {
       const payload = {

--- a/packages/api/src/workflow/services/workflow-scheduler.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-scheduler.service.spec.ts
@@ -16,10 +16,7 @@ import { EHook } from '@/utils/generics/base-orm.repository';
 import { userFixtureIds } from '@/utils/test/fixtures/user';
 import { installScheduledWorkflowFixturesTypeOrm } from '@/utils/test/fixtures/workflow';
 import { I18nServiceProvider } from '@/utils/test/providers/i18n-service.provider';
-import {
-  closeTypeOrmConnections,
-  getLastTypeOrmDataSource,
-} from '@/utils/test/test';
+import { getLastTypeOrmDataSource } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import type { InferActionsDto } from '@/utils/types/dto.types';
 import {
@@ -142,12 +139,8 @@ describe('WorkflowSchedulerService (TypeORM)', () => {
     clearCronJobs();
   });
 
-  afterAll(async () => {
+  afterAll(() => {
     clearCronJobs();
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
   });
 
   it('registers cron jobs for scheduled workflows and triggers the agent handler', async () => {

--- a/packages/api/src/workflow/services/workflow-version.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-version.service.spec.ts
@@ -11,17 +11,13 @@ import {
   DEFAULT_TIMEOUT_MS,
   validateWorkflow,
 } from '@hexabot-ai/agentic';
-import { TestingModule } from '@nestjs/testing';
 import { Repository } from 'typeorm';
 
 import {
   installUserFixturesTypeOrm,
   userFixtureIds,
 } from '@/utils/test/fixtures/user';
-import {
-  closeTypeOrmConnections,
-  getLastTypeOrmDataSource,
-} from '@/utils/test/test';
+import { getLastTypeOrmDataSource } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 
@@ -32,7 +28,6 @@ import { WorkflowType, WorkflowVersionAction } from '../types';
 import { WorkflowVersionService } from './workflow-version.service';
 
 describe('WorkflowVersionService (TypeORM)', () => {
-  let module: TestingModule;
   let workflowVersionService: WorkflowVersionService;
   let workflowRepository: Repository<WorkflowOrmEntity>;
   const websocketGatewayMock = {
@@ -65,7 +60,6 @@ describe('WorkflowVersionService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [workflowVersionService] = await testing.getMocks([WorkflowVersionService]);
     const dataSource = getLastTypeOrmDataSource();
     workflowRepository = dataSource.getRepository(WorkflowOrmEntity);
@@ -75,14 +69,6 @@ describe('WorkflowVersionService (TypeORM)', () => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   describe('createSnapshot', () => {
     it('creates a blank version with global defaults when workflow is created', async () => {
       const workflow = await createWorkflow();

--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -12,14 +12,12 @@ import {
 } from '@hexabot-ai/agentic';
 import { Workflow } from '@hexabot-ai/types';
 import { BadRequestException } from '@nestjs/common';
-import { TestingModule } from '@nestjs/testing';
 import { JSONSchema7 as JsonSchema } from 'json-schema';
 
 import {
   installUserFixturesTypeOrm,
   userFixtureIds,
 } from '@/utils/test/fixtures/user';
-import { closeTypeOrmConnections } from '@/utils/test/test';
 import { buildTestingMocks } from '@/utils/test/utils';
 import { WEBSOCKET_GATEWAY } from '@/websocket/tokens';
 import {
@@ -37,7 +35,6 @@ import { WorkflowVersionService } from './workflow-version.service';
 import { WorkflowService } from './workflow.service';
 
 describe('WorkflowService (TypeORM)', () => {
-  let module: TestingModule;
   let workflowService: WorkflowService;
   let workflowVersionService: WorkflowVersionService;
   let workflowRunService: WorkflowRunService;
@@ -114,7 +111,6 @@ describe('WorkflowService (TypeORM)', () => {
       },
     });
 
-    module = testing.module;
     [
       workflowService,
       workflowVersionService,
@@ -158,14 +154,6 @@ describe('WorkflowService (TypeORM)', () => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
-
-  afterAll(async () => {
-    if (module) {
-      await module.close();
-    }
-    await closeTypeOrmConnections();
-  });
-
   it('creates workflows and returns stored definitions', async () => {
     const stored = await workflowService.findOne(workflow.id);
 


### PR DESCRIPTION
## Summary
Removed redundant `afterAll` cleanup hooks from API spec files where test resources are already cleaned up by the shared test lifecycle. This simplifies the test suite and avoids unnecessary teardown logic.

## Why
The extra cleanup was duplicated across multiple spec files and provided no additional value. Removing it reduces boilerplate, improves test maintainability, and keeps teardown behavior centralized.

## How to review
Focus on the updated API spec files and verify that the redundant `afterAll` hooks have been removed without changing the test behavior.

## Validation
* Ran the affected API test suites.
* Confirmed all tests pass without the removed `afterAll` cleanup.
* Verified no resource leaks or teardown regressions were introduced.
