### PR TITLE
refactor(api): extract resolveRelationId into shared MCP utils

### DIFF
--- a/packages/api/src/mcp/tools/hexabot-mcp-tool.base.ts
+++ b/packages/api/src/mcp/tools/hexabot-mcp-tool.base.ts
@@ -49,16 +49,6 @@ export abstract class HexabotMcpToolBase {
     return Like(`%${value}%`);
   }
 
-  protected resolveRelationId(
-    relation: string | { id?: string | null } | null | undefined,
-  ): string | null {
-    if (typeof relation === 'string') {
-      return relation;
-    }
-
-    return relation?.id ?? null;
-  }
-
   protected getActor(request?: HexabotMcpRequest): User {
     const actor = request?.hexabotUser ?? request?.user;
     if (!actor?.id) {

--- a/packages/api/src/mcp/tools/hexabot-mcp.utils.ts
+++ b/packages/api/src/mcp/tools/hexabot-mcp.utils.ts
@@ -27,3 +27,13 @@ export const omitKeysDeep = <T>(value: T, keys: readonly string[]): T => {
       .map(([key, nestedValue]) => [key, omitKeysDeep(nestedValue, keys)]),
   ) as T;
 };
+
+export const resolveRelationId = (
+  relation: string | { id?: string | null } | null | undefined,
+): string | null => {
+  if (typeof relation === 'string') {
+    return relation;
+  }
+
+  return relation?.id ?? null;
+};

--- a/packages/api/src/mcp/tools/workflow-mcp.helper.ts
+++ b/packages/api/src/mcp/tools/workflow-mcp.helper.ts
@@ -21,6 +21,8 @@ import { WorkflowVersionService } from '@/workflow/services/workflow-version.ser
 import { WorkflowService } from '@/workflow/services/workflow.service';
 import { WorkflowVersionAction } from '@/workflow/types';
 
+import { resolveRelationId } from './hexabot-mcp.utils';
+
 type WorkflowVersionLike = WorkflowVersion | WorkflowVersionFull;
 
 type WorkflowVersionSummary = Pick<
@@ -85,7 +87,7 @@ export class HexabotWorkflowMcpHelper {
     }
     const parentVersion =
       params.parentVersion === undefined
-        ? this.resolveRelationId(workflow.currentVersion)
+        ? resolveRelationId(workflow.currentVersion)
         : params.parentVersion;
     const payload: WorkflowNewVersionDto = {
       workflow: params.workflowId,
@@ -205,15 +207,5 @@ export class HexabotWorkflowMcpHelper {
     return Object.fromEntries(
       Object.entries(summary).filter(([, value]) => value !== undefined),
     ) as WorkflowVersionSummary;
-  }
-
-  private resolveRelationId(
-    relation: string | { id?: string | null } | null | undefined,
-  ): string | null {
-    if (typeof relation === 'string') {
-      return relation;
-    }
-
-    return relation?.id ?? null;
   }
 }

--- a/packages/api/src/mcp/tools/workflow-run-mcp.tools.ts
+++ b/packages/api/src/mcp/tools/workflow-run-mcp.tools.ts
@@ -39,7 +39,7 @@ import {
   paginationSchema,
   uuidSchema,
 } from './hexabot-mcp.schemas';
-import { omitKeysDeep } from './hexabot-mcp.utils';
+import { omitKeysDeep, resolveRelationId } from './hexabot-mcp.utils';
 
 const WORKFLOW_DEFINITION_RESPONSE_KEYS = ['definitionYml'] as const;
 
@@ -175,7 +175,7 @@ export class HexabotWorkflowRunMcpTools extends HexabotMcpToolBase {
 
     const includeRelatedRuns = args.includeRelatedRuns ?? true;
     const childRunsLimit = args.childRunsLimit ?? 10;
-    const parentRunId = this.resolveRelationId(run.parentRun);
+    const parentRunId = resolveRelationId(run.parentRun);
     const childWhere = { parentRun: { id: run.id } } as any;
     const [parentRun, childRuns, childRunTotal] = includeRelatedRuns
       ? await Promise.all([

--- a/packages/api/src/mcp/tools/workflow-version-mcp.tools.ts
+++ b/packages/api/src/mcp/tools/workflow-version-mcp.tools.ts
@@ -34,6 +34,7 @@ import {
   paginationSchema,
   uuidSchema,
 } from './hexabot-mcp.schemas';
+import { resolveRelationId } from './hexabot-mcp.utils';
 import { HexabotWorkflowMcpHelper } from './workflow-mcp.helper';
 
 @Injectable()
@@ -199,7 +200,7 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
     const limit = args.limit ?? 16000;
     const { chunk, chunkByteLength, endOffset, totalByteLength } =
       this.sliceUtf8Chunk(definitionYml, offset, limit);
-    const workflowId = this.resolveRelationId(version.workflow);
+    const workflowId = resolveRelationId(version.workflow);
 
     return {
       workflowId,
@@ -342,7 +343,7 @@ export class HexabotWorkflowVersionMcpTools extends HexabotMcpToolBase {
       );
     }
     const workflow = await this.workflowHelper.requireWorkflow(workflowId);
-    const currentVersionId = this.resolveRelationId(workflow.currentVersion);
+    const currentVersionId = resolveRelationId(workflow.currentVersion);
     if (!currentVersionId) {
       throw new NotFoundException(
         `Workflow ${workflowId} has no current version`,


### PR DESCRIPTION
## Summary
Extracted the `resolveRelationId` logic into a shared MCP utility and updated the API to reuse the centralized implementation. This removes duplicated logic and keeps relation resolution consistent across MCP features.

## Why
Having a single implementation improves maintainability, reduces duplication, and makes future changes to relation ID resolution easier and less error-prone.

## How to review
* Review the new shared MCP utility containing `resolveRelationId`.
* Verify the API now imports and uses the shared utility instead of its local implementation.
* Ensure no behavior changes were introduced during the refactor.

## Validation
* Verified the project builds successfully.
* Ran the relevant test suite to ensure existing MCP relation resolution behavior remains unchanged.
