### PR TITLE
fix: resolve security vulnerabilities

### DIFF
--- a/packages/agentic/package.json
+++ b/packages/agentic/package.json
@@ -32,7 +32,7 @@
     "src"
   ],
   "dependencies": {
-    "jsonata": "^2.1.0",
+    "jsonata": "^2.2.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/packages/api/src/user/services/passwordReset.service.spec.ts
+++ b/packages/api/src/user/services/passwordReset.service.spec.ts
@@ -5,7 +5,6 @@
  */
 
 import type { User } from '@hexabot-ai/types';
-import { NotFoundException } from '@nestjs/common';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { compareSync } from 'bcryptjs';
 
@@ -78,11 +77,18 @@ describe('PasswordResetService (TypeORM)', () => {
       expect(signSpy).toHaveBeenCalled();
     });
 
-    it('should throw a 404 error', async () => {
+    it('should resolve silently for an unknown email (no account enumeration)', async () => {
+      const sendMailSpy = jest.spyOn(mailerService, 'sendMail');
+      const signSpy = jest.spyOn(passwordResetService, 'sign');
       const promise = passwordResetService.requestReset({
         email: 'a@b.ca',
       });
-      await expect(promise).rejects.toThrow(NotFoundException);
+      await expect(promise).resolves.toBeUndefined();
+
+      // No email is sent and no token is generated for a non-existent account,
+      // and the response is indistinguishable from the success case.
+      expect(sendMailSpy).not.toHaveBeenCalled();
+      expect(signSpy).not.toHaveBeenCalled();
     });
 
     it('should update the password and clear the reset token', async () => {

--- a/packages/api/src/user/services/passwordReset.service.ts
+++ b/packages/api/src/user/services/passwordReset.service.ts
@@ -9,7 +9,6 @@ import {
   Inject,
   Injectable,
   InternalServerErrorException,
-  NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService, JwtSignOptions, JwtVerifyOptions } from '@nestjs/jwt';
@@ -54,7 +53,15 @@ export class PasswordResetService {
       where: { email: dto.email },
     });
     if (!user) {
-      throw new NotFoundException('User not found');
+      // Do not disclose whether an account exists for the given email.
+      // Returning silently prevents user/account enumeration (CWE-204) via
+      // the public, unauthenticated password-reset endpoint.
+      this.logger.log(
+        `Password reset requested for a non-existent email`,
+        'PasswordResetService',
+      );
+
+      return;
     }
     const jwt = await this.sign({ ...dto });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   glob: 13.0.6
   ip-address: 10.1.1
   js-yaml: 4.2.0
+  jsonata: ^2.2.0
   lodash: 4.18.1
   lodash-es: 4.18.1
   minimatch: 10.2.5
@@ -52,8 +53,8 @@ importers:
   packages/agentic:
     dependencies:
       jsonata:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.0
+        version: 2.2.1
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -1758,6 +1759,7 @@ packages:
 
   '@clickhouse/client-common@1.8.1':
     resolution: {integrity: sha512-Z0R5zKaS3N35Op338WVRHIfoqDh9gotXZwekm0lbHQmwNaj3nY2iJ113dFYKjb1V+ESu+PvLEA//LJUGZyPQOg==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.8.1':
     resolution: {integrity: sha512-Ec0pCdwftIPD7hCxhOukHS0Zxr2tDc5mNAHBqkT3c0c6GO2WQdZkME9+EcfGcoF7+foUp82F5a0bPfSDDjfWmg==}
@@ -7720,8 +7722,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonata@2.1.0:
-    resolution: {integrity: sha512-OCzaRMK8HobtX8fp37uIVmL8CY1IGc/a6gLsDqz3quExFR09/U78HUzWYr7T31UEB6+Eu0/8dkVD5fFDOl9a8w==}
+  jsonata@2.2.1:
+    resolution: {integrity: sha512-xd1uwUrKeIcJbsWhaoS3qAX4Ea8m0Mw0G5nlnAQvPT7TbZ5qaPdzBVTQia9KfyuyQm+nenfyjvzUDTRYHsC2sw==}
     engines: {node: '>= 8'}
 
   jsonc-parser@3.3.1:
@@ -18719,7 +18721,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonata@2.1.0: {}
+  jsonata@2.2.1: {}
 
   jsonc-parser@3.3.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ overrides:
   "glob": "13.0.6"
   "ip-address": "10.1.1"
   "js-yaml": "4.2.0"
+  "jsonata": "^2.2.0"
   "lodash": "4.18.1"
   "lodash-es": "4.18.1"
   "minimatch": "10.2.5"


### PR DESCRIPTION
### Summary
This PR addresses two security issues. It upgrades the vulnerable `jsonata` dependency to a patched version using a workspace override and updates the direct dependency in `@hexabot-ai/agentic`. It also fixes an account enumeration vulnerability in the password reset endpoint by returning the same response regardless of whether the email exists.

### Why
* Eliminate a high-severity ReDoS vulnerability (`GHSA-86vw-mfpg-wwv9`) reported by `pnpm audit`.
* Prevent attackers from discovering registered user emails through the password reset endpoint (CWE-204), improving the application's security posture.

### How to review
* Review the dependency changes in `pnpm-workspace.yaml` and `packages/agentic/package.json` to verify the `jsonata` version override.
* Review `passwordReset.service.ts` to confirm unknown email addresses no longer produce a `404 User not found` error and instead return the same response as valid emails.
* Review `passwordReset.service.spec.ts` to verify the updated expectations for non-existing email addresses (no email sent, no token generated).

### Validation
* ✅ Ran `pnpm audit --prod` and confirmed there are no known production vulnerabilities.
* ✅ Verified the password reset endpoint returns an indistinguishable response for both existing and non-existing email addresses.
* ✅ Updated and executed unit tests covering the password reset behavior.

### Links
* Fixes high-severity advisory **GHSA-86vw-mfpg-wwv9** (`jsonata` ReDoS).
* Addresses **CWE-204: Observable Response Discrepancy (Account Enumeration)**.

### Extra
<img width="1007" height="435" alt="image" src="https://github.com/user-attachments/assets/3052fe56-afbf-4ebb-ae9b-caaecf7870c1" />

<img width="741" height="53" alt="image" src="https://github.com/user-attachments/assets/78b33a7f-3de2-4181-8619-0b74be2890e4" />
