### PR TITLE
fix: create workflow anomaly

### DIFF
--- a/packages/api/src/transfer/workflow-transfer.service.ts
+++ b/packages/api/src/transfer/workflow-transfer.service.ts
@@ -506,6 +506,11 @@ export class WorkflowTransferService {
           workflowVersionPayload,
         );
 
+      // The version's lifecycle hook moved the workflow's currentVersion
+      // pointer on a separately-loaded row; mirror it on the in-memory entity
+      // so the deferred workflow postCreate event carries the final pointer.
+      importedWorkflow.workflowEntity.currentVersion = workflowVersion;
+
       postCreateEvents.push(
         buildPostCreateEvent(
           'workflowVersion',

--- a/packages/api/src/workflow/controllers/workflow.controller.spec.ts
+++ b/packages/api/src/workflow/controllers/workflow.controller.spec.ts
@@ -90,6 +90,7 @@ class ManualOnlyAction extends BaseAction<
 describe('WorkflowController (TypeORM)', () => {
   let workflowController: WorkflowController;
   let workflowService: WorkflowService;
+  let workflowVersionRepository: WorkflowVersionRepository;
   let agenticService: AgenticService;
   let logger: LoggerService;
   let actionService: ActionService;
@@ -165,6 +166,7 @@ describe('WorkflowController (TypeORM)', () => {
       agenticService,
       workflowController,
       workflowService,
+      workflowVersionRepository,
       actionService,
       runtimeBindingsService,
       i18nService,
@@ -172,6 +174,7 @@ describe('WorkflowController (TypeORM)', () => {
       AgenticService,
       WorkflowController,
       WorkflowService,
+      WorkflowVersionRepository,
       ActionService,
       RuntimeBindingsService,
       I18nService,
@@ -484,8 +487,17 @@ describe('WorkflowController (TypeORM)', () => {
           ...payload,
           createdBy: userId,
         },
-        [...IGNORED_TEST_FIELDS],
+        [...IGNORED_TEST_FIELDS, 'currentVersion'],
       );
+
+      // The response must reference the blank version 0 created alongside
+      // the workflow.
+      const blankVersion = await workflowVersionRepository.findOne({
+        where: { workflow: { id: created.id }, version: 0 },
+      });
+
+      expect(blankVersion).toBeDefined();
+      expect(created.currentVersion).toBe(blankVersion!.id);
     });
   });
 

--- a/packages/api/src/workflow/entities/workflow.entity.ts
+++ b/packages/api/src/workflow/entities/workflow.entity.ts
@@ -188,6 +188,10 @@ export class WorkflowOrmEntity extends BaseOrmEntity<WorkflowDto> {
         message: null,
       });
       await event.manager.save(WorkflowVersionOrmEntity, version);
+      // The version's updateWorkflowVersions hook persists the pointer on a
+      // separately-loaded workflow row; mirror it on this instance so the
+      // create response and postCreate event carry the initial version.
+      this.currentVersion = version;
     } catch (error: any) {
       const codes = [error?.code, error?.driverError?.code];
       if (!codes.includes('SQLITE_CONSTRAINT_UNIQUE')) {

--- a/packages/api/src/workflow/repositories/workflow-version.repository.ts
+++ b/packages/api/src/workflow/repositories/workflow-version.repository.ts
@@ -8,7 +8,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
-import { BaseOrmRepository } from '@/utils/generics/base-orm.repository';
+import { BaseOrmRepository, EHook } from '@/utils/generics/base-orm.repository';
+import { InferCreateDto } from '@/utils/types/dto.types';
 
 import { WorkflowVersionOrmEntity } from '../entities/workflow-version.entity';
 
@@ -19,5 +20,28 @@ export class WorkflowVersionRepository extends BaseOrmRepository<WorkflowVersion
     repository: Repository<WorkflowVersionOrmEntity>,
   ) {
     super(repository, ['workflow', 'createdBy', 'parentVersion']);
+  }
+
+  /**
+   * Broadcast the postCreate mutation event for a version persisted outside
+   * create(), e.g. the blank version 0 inserted by the workflow entity
+   * lifecycle hook. Raw EntityManager writes bypass repository-level events,
+   * so callers owning such writes must emit them after commit.
+   *
+   * @param id - Identifier of the already-persisted version.
+   */
+  async emitPostCreateById(id: string): Promise<void> {
+    const version = await this.repository.findOne({ where: { id } });
+
+    if (!version) {
+      return;
+    }
+
+    await this.emitEvent<EHook.postCreate>({
+      action: EHook.postCreate,
+      entity: version,
+      payload:
+        version.toPlainCls() as unknown as InferCreateDto<WorkflowVersionOrmEntity>,
+    });
   }
 }

--- a/packages/api/src/workflow/services/workflow-version.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow-version.service.spec.ts
@@ -148,6 +148,31 @@ describe('WorkflowVersionService (TypeORM)', () => {
       expect(created.parentVersion ?? null).toBeNull();
     });
 
+    it('broadcasts the workflow currentVersion update when creating a snapshot', async () => {
+      const workflow = await createWorkflow();
+      const emitSpy = jest.spyOn(
+        workflowVersionService.repository.getEventEmitter(),
+        'emitAsync',
+      );
+      const created = await workflowVersionService.createSnapshot({
+        workflow: workflow.id,
+        definitionYml: 'version: 1',
+        action: WorkflowVersionAction.update,
+        createdBy: userFixtureIds.admin,
+      });
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        'hook:workflow:postUpdate',
+        expect.objectContaining({
+          entityName: 'workflow',
+          entity: expect.objectContaining({
+            id: workflow.id,
+            currentVersion: expect.objectContaining({ id: created.id }),
+          }),
+        }),
+      );
+    });
+
     it('increments version and maps parent/creator fields', async () => {
       const workflow = await createWorkflow();
       const initialDefinition = 'version: 1';

--- a/packages/api/src/workflow/services/workflow-version.service.ts
+++ b/packages/api/src/workflow/services/workflow-version.service.ts
@@ -55,13 +55,22 @@ export class WorkflowVersionService extends BaseOrmService<WorkflowVersionOrmEnt
       order: { version: 'DESC' },
     });
     const nextVersion = latestVersion ? latestVersion.version + 1 : 1;
-
-    return await this.create({
+    const created = await this.create({
       ...params,
       version: nextVersion,
       parentVersion: params.parentVersion,
       createdBy: params.createdBy,
     });
+
+    // The version's updateWorkflowVersions lifecycle hook already moved the
+    // workflow's currentVersion pointer, but through the raw TypeORM
+    // repository — re-apply it via the service so the workflow postUpdate
+    // event is broadcast.
+    await this.workflowService.updateOne(params.workflow, {
+      currentVersion: created.id,
+    });
+
+    return created;
   }
 
   /**
@@ -122,7 +131,7 @@ export class WorkflowVersionService extends BaseOrmService<WorkflowVersionOrmEnt
       );
     }
 
-    const restoredVersion = await this.createSnapshot({
+    return await this.createSnapshot({
       workflow: workflowId,
       definitionYml: targetVersion.definitionYml,
       message: payload?.message ?? undefined,
@@ -130,11 +139,5 @@ export class WorkflowVersionService extends BaseOrmService<WorkflowVersionOrmEnt
       createdBy: payload?.updatedBy ?? null,
       parentVersion: targetVersion.id,
     });
-
-    await this.workflowService.updateOne(workflowId, {
-      currentVersion: restoredVersion.id,
-    });
-
-    return restoredVersion;
   }
 }

--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -168,6 +168,44 @@ describe('WorkflowService (TypeORM)', () => {
     });
   });
 
+  it('returns the blank version pointer and broadcasts mutation events on create', async () => {
+    const emitSpy = jest.spyOn(
+      workflowRepository.getEventEmitter(),
+      'emitAsync',
+    );
+    const created = await workflowService.create({
+      name: `workflow_events_${++counter}`,
+      description: 'Workflow create event broadcast test',
+      type: WorkflowType.conversational,
+      schedule: null,
+      createdBy: creatorId,
+    });
+
+    expect(created.currentVersion).toEqual(expect.any(String));
+    expect(emitSpy).toHaveBeenCalledWith(
+      'hook:workflow:postCreate',
+      expect.objectContaining({
+        entityName: 'workflow',
+        entity: expect.objectContaining({
+          id: created.id,
+          currentVersion: expect.objectContaining({
+            id: created.currentVersion,
+          }),
+        }),
+      }),
+    );
+    expect(emitSpy).toHaveBeenCalledWith(
+      'hook:workflowVersion:postCreate',
+      expect.objectContaining({
+        entityName: 'workflowVersion',
+        entity: expect.objectContaining({
+          id: created.currentVersion,
+          version: 0,
+        }),
+      }),
+    );
+  });
+
   it('serializes YAML from definitions before persistence', async () => {
     const entity = await workflowService.findOneAndPopulate({
       where: { id: workflow.id },

--- a/packages/api/src/workflow/services/workflow.service.ts
+++ b/packages/api/src/workflow/services/workflow.service.ts
@@ -33,6 +33,7 @@ import type { WebsocketGateway } from '@/websocket/websocket.gateway';
 
 import { WorkflowUpdateDto } from '../dto/workflow.dto';
 import { WorkflowOrmEntity } from '../entities/workflow.entity';
+import { WorkflowVersionRepository } from '../repositories/workflow-version.repository';
 import { WorkflowRepository } from '../repositories/workflow.repository';
 import { WorkflowType } from '../types';
 
@@ -61,8 +62,29 @@ export class WorkflowService extends BaseOrmService<WorkflowOrmEntity> {
     @Inject(WEBSOCKET_GATEWAY)
     private readonly gateway: WorkflowSocketGateway,
     private readonly workflowRunService: WorkflowRunService,
+    private readonly workflowVersionRepository: WorkflowVersionRepository,
   ) {
     super(repository);
+  }
+
+  /**
+   * Create a workflow and broadcast its blank initial version.
+   *
+   * The blank version 0 (and the workflow's currentVersion pointer) is
+   * persisted by entity lifecycle hooks inside the insert transaction through
+   * the raw EntityManager, which bypasses repository-level mutation events —
+   * so the version's postCreate event is emitted here, after commit.
+   */
+  async create(payload: InferCreateDto<WorkflowOrmEntity>): Promise<Workflow> {
+    const created = await super.create(payload);
+
+    if (created.currentVersion) {
+      await this.workflowVersionRepository.emitPostCreateById(
+        created.currentVersion,
+      );
+    }
+
+    return created;
   }
 
   /**

--- a/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
@@ -430,10 +430,23 @@ export const WorkflowProvider: React.FC<WorkflowContextProps> = ({
 
     if (!flowId && workflows.length) {
       updateWorkflowURL(workflows.at(-1)?.id || workflows[0].id);
-    } else if (flowId && !workflows.some((w) => w.id === flowId)) {
+    } else if (
+      flowId &&
+      !workflows.some((w) => w.id === flowId) &&
+      // A just-created/imported workflow is in the item cache before the
+      // collection refetch lands; don't bounce to another workflow meanwhile.
+      !getWorkflowFromCache(flowId)
+    ) {
       void router.replace(`/${RouterType.WORKFLOW_EDITOR}/${workflows[0].id}`);
     }
-  }, [flowId, workflows, isWorkflowsSuccess, updateWorkflowURL, router]);
+  }, [
+    flowId,
+    workflows,
+    isWorkflowsSuccess,
+    updateWorkflowURL,
+    router,
+    getWorkflowFromCache,
+  ]);
 
   return (
     <WorkflowContext.Provider


### PR DESCRIPTION
## What changed?
After creating a new workflow from the visual editor ("New" → fill form → submit), the editor displayed a completely different workflow graph instead of the new blank one.

Two independent issues stacked up:

1. API — missing/incomplete mutation events on workflow creation. The blank initial version (and the workflow's currentVersion pointer) is persisted by entity lifecycle hooks through the raw EntityManager, which bypasses repository-level mutation events. Clients never received the version's postCreate event, the create response/postCreate event carried a stale currentVersion, and the pointer update on snapshot creation went through the raw TypeORM repository without broadcasting a workflow postUpdate.

2. Frontend — stale-collection race in the editor's fallback redirect. WorkflowProvider treats "flowId not in the cached workflows collection" as "workflow doesn't exist" and bounces to workflows[0] (the oldest workflow). Right after a create or import, the new workflow is legitimately absent from the collection until the websocket-triggered refetch lands, so the guard hijacked the navigation to the new workflow — synchronously, before any refetch could win the race.

## Changes

1. API

- WorkflowService.create() now emits the blank initial version's postCreate event after commit (via new WorkflowVersionRepository.emitPostCreateById()).
- The in-memory workflow entity mirrors the currentVersion pointer set by lifecycle hooks, so create responses, import postCreate events, and transfers carry the final pointer.
- WorkflowVersionService.createSnapshot() re-applies the currentVersion pointer through the service layer so the workflow postUpdate event is broadcast (restore no longer duplicates this).

2. Frontend

The WorkflowProvider fallback redirect now also checks the entity item cache before bouncing: a just-created/imported workflow is present there synchronously, so navigation stays on it while the collection refetch catches up. Deleted workflows still redirect correctly since the WS delete handler removes their item-cache entry. Cross-tab sync remains fully WS-driven — no local cache patching or extra invalidation.