### PR TITLE
fix(frontend): resolve stale workflow nodes after creation

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowDefinitionState.ts
+++ b/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowDefinitionState.ts
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWorkflowActionsCatalog } from "@/contexts/workflow-actions.context";
 import { useWorkflowBindingsCatalog } from "@/contexts/workflow-bindings.context";
 import { useCreate } from "@/hooks/crud/useCreate";
-import { useGetFromCache } from "@/hooks/crud/useGet";
+import { useGet } from "@/hooks/crud/useGet";
 import {
   useTanstackMutation,
   useTanstackQueryClient,
@@ -135,10 +135,18 @@ export const useWorkflowDefinitionState = ({
       });
     },
   });
-  const getVersionFromCache = useGetFromCache(EntityType.WORKFLOW_VERSION);
-  const currentVersion = workflow?.currentVersion
-    ? getVersionFromCache(workflow?.currentVersion)
-    : null;
+  // Reactive version read: served from the cache, fetched when missing.
+  const { data: currentVersionData } = useGet(
+    workflow?.currentVersion ?? "",
+    { entity: EntityType.WORKFLOW_VERSION },
+    {
+      enabled: !!workflow?.id && !!workflow?.currentVersion,
+      routeParams: { id: workflow?.id },
+    },
+  );
+  const currentVersion = workflow?.currentVersion ? currentVersionData : null;
+  const isDefinitionLoading =
+    !!workflow?.currentVersion && currentVersion === undefined;
   const [yaml, setYaml] = useState(
     currentVersion ? currentVersion.definitionYml : "",
   );
@@ -196,6 +204,10 @@ export const useWorkflowDefinitionState = ({
       // Actions not yet loaded — remain in loading limbo, not an empty workflow
       return { definition: undefined, error: null };
     }
+    if (isDefinitionLoading) {
+      // Version yaml not fetched yet — undefined flow keeps the graph loading
+      return { definition: undefined, error: null };
+    }
     if (!yaml) {
       // Actions ready but yaml is empty → workflow has no steps yet
       return { definition: undefined, error: null, flow: [] as CompiledStep[] };
@@ -215,7 +227,14 @@ export const useWorkflowDefinitionState = ({
     } catch (error) {
       return { definition: undefined, flow: undefined, error: error as Error };
     }
-  }, [actionsByName, compileActionsByName, bindingKinds, yaml, workflow?.id]);
+  }, [
+    actionsByName,
+    compileActionsByName,
+    bindingKinds,
+    isDefinitionLoading,
+    yaml,
+    workflow?.id,
+  ]);
   // New definition version not yet saved ?
   const isDefinitionDirty = useMemo(() => {
     if (workflow?.currentVersion && !currentVersion) {

--- a/packages/frontend/src/hooks/useEntityMutationSubscription.test.ts
+++ b/packages/frontend/src/hooks/useEntityMutationSubscription.test.ts
@@ -4,11 +4,13 @@
  * Full terms: see LICENSE.md.
  */
 
+import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 
 import { EntityType, QueryType } from "@/services/types";
 
 import {
+  hasMissingRelationRef,
   isThreadInfiniteQuery,
   mergeEntityCachePayload,
 } from "./useEntityMutationSubscription";
@@ -68,6 +70,46 @@ describe("useEntityMutationSubscription helpers", () => {
     expect(merged.status).toBe("finished");
     expect(merged.finishedAt).toEqual(previousData.finishedAt);
     expect(merged.stepLog).toEqual(previousData.stepLog);
+  });
+
+  it("detects a relation ref that is missing from the item cache", () => {
+    const queryClient = new QueryClient();
+    const workflowPayload = {
+      id: "workflow-1",
+      currentVersion: "version-1",
+      publishedVersion: null,
+    };
+
+    expect(
+      hasMissingRelationRef(queryClient, EntityType.WORKFLOW, workflowPayload),
+    ).toBe(true);
+
+    queryClient.setQueryData(
+      [QueryType.item, EntityType.WORKFLOW_VERSION, "version-1"],
+      { id: "version-1", definitionYml: "flow: []" },
+    );
+
+    expect(
+      hasMissingRelationRef(queryClient, EntityType.WORKFLOW, workflowPayload),
+    ).toBe(false);
+  });
+
+  it("ignores null and array relation values", () => {
+    const queryClient = new QueryClient();
+
+    expect(
+      hasMissingRelationRef(queryClient, EntityType.WORKFLOW, {
+        id: "workflow-1",
+        currentVersion: null,
+        publishedVersion: null,
+      }),
+    ).toBe(false);
+    expect(
+      hasMissingRelationRef(queryClient, EntityType.USER, {
+        id: "user-1",
+        roles: ["role-1"],
+      }),
+    ).toBe(false);
   });
 
   it("matches only infinite thread query keys for refetch", () => {

--- a/packages/frontend/src/hooks/useEntityMutationSubscription.ts
+++ b/packages/frontend/src/hooks/useEntityMutationSubscription.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { normalize } from "normalizr";
+import { normalize, schema as normalizrSchema } from "normalizr";
 import { useCallback } from "react";
 
 import { isSameEntity } from "@/hooks/crud/helpers";
@@ -16,7 +16,7 @@ import {
 import { ENTITY_MAP } from "@/services/entities";
 import { EntityType, QueryType } from "@/services/types";
 import { IBaseSchema } from "@/types/base.types";
-import { InfiniteData } from "@/types/tanstack.types";
+import { InfiniteData, QueryClient } from "@/types/tanstack.types";
 import { applyFullNameDerivedFields } from "@/utils/full-name.utils";
 import { useSocketGetQuery, useSubscribe } from "@/websocket/socket-hooks";
 
@@ -147,6 +147,31 @@ export const isThreadInfiniteQuery = (queryKey: readonly unknown[]) => {
     qType === QueryType.infinite && isSameEntity(qEntity, EntityType.THREAD)
   );
 };
+// Detects relation refs in a payload that are missing from the item cache.
+export const hasMissingRelationRef = (
+  queryClient: QueryClient,
+  entityType: EntityType,
+  entityData: CacheRecord,
+) => {
+  // normalizr typings omit the runtime `schema` getter
+  const relationSchemas: Record<string, unknown> =
+    (ENTITY_MAP[entityType] as unknown as { schema?: Record<string, unknown> })
+      .schema ?? {};
+
+  return Object.entries(relationSchemas).some(([relation, relationSchema]) => {
+    const relationId = entityData[relation];
+
+    return (
+      typeof relationId === "string" &&
+      relationSchema instanceof normalizrSchema.Entity &&
+      !queryClient.getQueryData([
+        QueryType.item,
+        relationSchema.key,
+        relationId,
+      ])
+    );
+  });
+};
 
 export const useEntityMutationSubscription = () => {
   const queryClient = useTanstackQueryClient();
@@ -200,6 +225,23 @@ export const useEntityMutationSubscription = () => {
           }
 
           affectedEntityTypes.forEach((affectedEntityType) => {
+            if (
+              hasMissingRelationRef(
+                queryClient,
+                affectedEntityType,
+                nextEntityData as CacheRecord,
+              )
+            ) {
+              // Skip the merge: it would mark the query fresh and cancel
+              // this invalidation for observers that mount later.
+              queryClient.invalidateQueries({
+                queryKey: [QueryType.item, affectedEntityType, id],
+                exact: true,
+              });
+
+              return;
+            }
+
             queryClient.setQueryData(
               [QueryType.item, affectedEntityType, id],
               (previousData: CacheRecord | undefined) => {


### PR DESCRIPTION
### Summary

This PR fixes a frontend issue where newly created workflow nodes could appear stale or out of sync with the latest workflow state. The node creation flow now ensures the visual editor reflects the freshly created node immediately without requiring a manual refresh or additional interaction.

### Why

Stale node state could lead to inconsistent behavior in the workflow editor, making it appear as if changes were not applied correctly. Keeping the client state synchronized after node creation provides a more reliable and predictable editing experience.

### How to review

* Review the workflow node creation flow in the frontend.
* Verify that the workflow state is updated immediately after a node is created.
* Confirm that newly created nodes render with the latest data and remain synchronized with subsequent edits.

### Validation

* Created nodes in multiple workflow scenarios and verified they appear immediately with the correct state.
* Confirmed existing workflow editing behavior remains unchanged.
* Verified there are no stale node references after creation or subsequent updates.
