### PR TITLE
fix(frontend): resolve hot-reload issue

### DIFF
--- a/packages/frontend/vite.config.mts
+++ b/packages/frontend/vite.config.mts
@@ -52,15 +52,12 @@ export default defineConfig({
       allow: [monorepoRoot], // allow Vite to serve shared workspace deps like hoisted node_modules
     },
     watch: {
-      // Use polling for graph/src so file reverts (atomic writes that swap
-      // inodes) are always detected as a "change" event by chokidar, rather
-      // than an unlink+add pair that can miss triggering hotUpdate.
+      // Use polling so atomic writes (inode swaps) in workspace packages are
+      // always detected as a "change" event rather than an unlink+add pair
+      // that can miss triggering hotUpdate.
       usePolling: true,
       interval: 100,
-      ignored: (f: string) => {
-        if (f.startsWith(graphSrc)) return false;
-        return true;
-      },
+      // No custom `ignored` — Vite's defaults already exclude node_modules/.git
     },
     proxy: {
       "/api": {


### PR DESCRIPTION
### Summary

This PR fixes a frontend hot-reload issue by removing the custom `watch.ignored` configuration from the Vite dev server. File watching now relies on Vite's default behavior, restoring reliable HMR during development.

### Why

The custom ignore function was preventing Vite's file watcher from detecting some file changes, causing hot reload to stop working consistently. Removing the override lets Vite manage ignored paths using its built-in, well-tested defaults.

### How to review

* Review the removal of the custom `watch.ignored` configuration.
* Verify that no other development server behavior is affected.
* Confirm that file changes are detected correctly without manual refreshes.

### Validation

* Started the frontend development server.
* Verified that changes to frontend source files trigger hot reload correctly.
* Confirmed normal development behavior after removing the custom watch configuration.
