### PR TITLE
feat(frontend): introduce useTimestampColumns hook

### DIFF
--- a/packages/frontend/src/app-components/tables/columns/useTimestampColumns.tsx
+++ b/packages/frontend/src/app-components/tables/columns/useTimestampColumns.tsx
@@ -1,0 +1,54 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { GridColDef, GridValidRowModel } from "@mui/x-data-grid";
+import { useMemo } from "react";
+
+import { useTranslate } from "@/hooks/useTranslate";
+import { getDateTimeFormatter } from "@/utils/date";
+
+const TIMESTAMP_COLUMN_WIDTH = 140;
+
+/**
+ * Returns the standard `createdAt` / `updatedAt` DataGrid columns shared by
+ * every entity list screen. Spread the result into a `columns` array, e.g.
+ * `[...baseColumns, ...useTimestampColumns<Label>(), actionColumns]`.
+ *
+ * The returned array is memoized and only changes when the active locale
+ * changes, so it is safe to include in downstream `useMemo` dep arrays.
+ */
+export const useTimestampColumns = <T extends GridValidRowModel>(
+  filter?: "createdAt" | "updatedAt",
+): GridColDef<T>[] => {
+  const { t } = useTranslate();
+
+  return useMemo<GridColDef<T>[]>(() => {
+    const all: GridColDef<T>[] = [
+      {
+        width: TIMESTAMP_COLUMN_WIDTH,
+        field: "createdAt",
+        headerName: t("label.createdAt"),
+        disableColumnMenu: true,
+        resizable: false,
+        headerAlign: "left",
+        valueGetter: (value: Date) =>
+          t("datetime.created_at", getDateTimeFormatter(value)),
+      },
+      {
+        width: TIMESTAMP_COLUMN_WIDTH,
+        field: "updatedAt",
+        headerName: t("label.updatedAt"),
+        disableColumnMenu: true,
+        resizable: false,
+        headerAlign: "left",
+        valueGetter: (value: Date) =>
+          t("datetime.updated_at", getDateTimeFormatter(value)),
+      },
+    ];
+
+    return filter ? all.filter((c) => c.field === filter) : all;
+  }, [t, filter]);
+};

--- a/packages/frontend/src/components/audit/index.tsx
+++ b/packages/frontend/src/components/audit/index.tsx
@@ -14,10 +14,10 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import {
   formatAuditActor,
@@ -58,20 +58,12 @@ export const Audit = () => {
     ],
     t("label.operations"),
   );
+  const timestampColumns = useTimestampColumns<AuditLog>("createdAt");
   const columns = useMemo(
     () =>
       [
         { field: "id", headerName: "ID", width: 100 },
-        {
-          minWidth: 160,
-          field: "createdAt",
-          headerName: t("label.createdAt"),
-          disableColumnMenu: true,
-          resizable: false,
-          headerAlign: "left",
-          valueGetter: (value) =>
-            t("datetime.created_at", getDateTimeFormatter(value)),
-        },
+        ...timestampColumns,
         {
           minWidth: 140,
           field: "operationStatus",
@@ -140,7 +132,7 @@ export const Audit = () => {
         },
         actionColumns,
       ] satisfies GridColDef<AuditLog>[],
-    [actionColumns, t],
+    [actionColumns, t, timestampColumns],
   );
 
   return (

--- a/packages/frontend/src/components/content-types/index.tsx
+++ b/packages/frontend/src/components/content-types/index.tsx
@@ -14,6 +14,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useAppRouter } from "@/hooks/useAppRouter";
@@ -21,7 +22,6 @@ import { useDialogs } from "@/hooks/useDialogs";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { ContentTypeFormDialog } from "./ContentTypeFormDialog";
 
@@ -30,6 +30,7 @@ export const ContentTypes = () => {
   const { toast } = useToast();
   const router = useAppRouter();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<ContentType>();
   const options = {
     onError: (error: Error) => {
       toast.error(error);
@@ -72,24 +73,7 @@ export const ContentTypes = () => {
   );
   const columns: GridColDef<ContentType>[] = [
     { flex: 1, field: "name", headerName: t("label.name") },
-    {
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/contents/index.tsx
+++ b/packages/frontend/src/components/contents/index.tsx
@@ -17,6 +17,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { isSameEntity } from "@/hooks/crud/helpers";
 import { useDelete } from "@/hooks/crud/useDelete";
@@ -30,7 +31,6 @@ import { useHasPermission } from "@/hooks/useHasPermission";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { ContentFormDialog } from "./ContentFormDialog";
 
@@ -38,6 +38,7 @@ export const Contents = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const { query } = useAppRouter();
+  const timestampColumns = useTimestampColumns<Content>();
   const queryClient = useTanstackQueryClient();
   const dialogs = useDialogs();
   const hasPermission = useHasPermission();
@@ -146,26 +147,7 @@ export const Contents = () => {
         />
       ),
     },
-    {
-      maxWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      maxWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/credentials/index.tsx
+++ b/packages/frontend/src/components/credentials/index.tsx
@@ -14,13 +14,13 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useDialogs } from "@/hooks/useDialogs";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { CredentialFormDialog } from "./CredentialFormDialog";
 
@@ -28,6 +28,7 @@ export const Credentials = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<Credential>();
   const { mutate: deleteCredential } = useDelete(EntityType.CREDENTIAL, {
     onError: () => {
       toast.error(t("message.internal_server_error"));
@@ -92,26 +93,7 @@ export const Credentials = () => {
       headerAlign: "left",
       valueGetter: () => "*************",
     },
-    {
-      minWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      minWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/labels/index.tsx
+++ b/packages/frontend/src/components/labels/index.tsx
@@ -14,6 +14,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useDeleteMany } from "@/hooks/crud/useDeleteMany";
@@ -22,7 +23,6 @@ import { useDialogs } from "@/hooks/useDialogs";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { LabelFormDialog } from "./LabelFormDialog";
 
@@ -30,6 +30,7 @@ export const Labels = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<Label>();
   const options = {
     onError: () => {
       toast.error(t("message.internal_server_error"));
@@ -103,26 +104,7 @@ export const Labels = () => {
       disableColumnMenu: true,
       headerAlign: "left",
     },
-    {
-      minWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      minWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
   const handleSelectionChange = (selection: GridRowSelectionModel) => {

--- a/packages/frontend/src/components/languages/index.tsx
+++ b/packages/frontend/src/components/languages/index.tsx
@@ -4,8 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Action } from "@hexabot-ai/types";
 import type { Language } from "@hexabot-ai/types";
+import { Action } from "@hexabot-ai/types";
 import { Switch } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 import { Flag, Plus } from "lucide-react";
@@ -15,6 +15,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { isSameEntity } from "@/hooks/crud/helpers";
 import { useDelete } from "@/hooks/crud/useDelete";
@@ -25,7 +26,6 @@ import { useHasPermission } from "@/hooks/useHasPermission";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { LanguageFormDialog } from "./LanguageFormDialog";
 
@@ -33,6 +33,7 @@ export const Languages = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<Language>();
   const hasPermission = useHasPermission();
   const { mutate: updateLanguage } = useUpdate(EntityType.LANGUAGE, {
     onError: () => {
@@ -143,26 +144,7 @@ export const Languages = () => {
         />
       ),
     },
-    {
-      minWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      minWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/mcp-servers/index.tsx
+++ b/packages/frontend/src/components/mcp-servers/index.tsx
@@ -16,6 +16,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useUpdate } from "@/hooks/crud/useUpdate";
@@ -32,7 +33,6 @@ import {
   IMcpServerTool,
   IMcpServerToolsDiscovery,
 } from "@/types/mcp-server.types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { McpServerFormDialog } from "./McpServerFormDialog";
 import { McpServerResultDrawer } from "./McpServerResultDrawer";
@@ -54,6 +54,7 @@ export const McpServers = () => {
   const { toast } = useToast();
   const dialogs = useDialogs();
   const hasPermission = useHasPermission();
+  const timestampColumns = useTimestampColumns<McpServer>();
   const [drawerMode, setDrawerMode] = useState<DrawerMode>(null);
   const [testDrawerState, setTestDrawerState] =
     useState<DrawerState>(INITIAL_DRAWER_STATE);
@@ -272,26 +273,7 @@ export const McpServers = () => {
           t("label.none")
         ),
     },
-    {
-      minWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      minWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/media-library/index.tsx
+++ b/packages/frontend/src/components/media-library/index.tsx
@@ -10,11 +10,11 @@ import { GridColDef, GridEventListener } from "@mui/x-data-grid";
 import { Images } from "lucide-react";
 
 import AttachmentThumbnail from "@/app-components/attachment/AttachmentThumbnail";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import useFormattedFileSize from "@/hooks/useFormattedFileSize";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 type MediaLibraryProps = {
   showTitle?: boolean;
@@ -25,6 +25,7 @@ type MediaLibraryProps = {
 export const MediaLibrary = ({ onSelect, accept }: MediaLibraryProps) => {
   const { t } = useTranslate();
   const formatFileSize = useFormattedFileSize();
+  const timestampColumns = useTimestampColumns<Attachment>();
   const columns: GridColDef<Attachment>[] = [
     { field: "id", headerName: "ID" },
     {
@@ -73,26 +74,7 @@ export const MediaLibrary = ({ onSelect, accept }: MediaLibraryProps) => {
       headerAlign: "left",
       width: 64,
     },
-    {
-      maxWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      maxWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
   ];
 
   return (

--- a/packages/frontend/src/components/memory-definitions/index.tsx
+++ b/packages/frontend/src/components/memory-definitions/index.tsx
@@ -14,13 +14,13 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useDialogs } from "@/hooks/useDialogs";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { MemoryDefinitionFormDialog } from "./MemoryDefinitionFormDialog";
 
@@ -28,6 +28,7 @@ export const MemoryDefinitions = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<MemoryDefinition>();
   const { mutate: deleteMemoryDefinition } = useDelete(
     EntityType.MEMORY_DEFINITION,
     {
@@ -99,26 +100,7 @@ export const MemoryDefinitions = () => {
       headerAlign: "left",
       valueGetter: (value) => value ?? t("label.permanent"),
     },
-    {
-      minWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      minWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/roles/index.tsx
+++ b/packages/frontend/src/components/roles/index.tsx
@@ -14,13 +14,13 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useDialogs } from "@/hooks/useDialogs";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { PermissionBodyDialog } from "./PermissionsBodyDialog";
 import { RoleFormDialog } from "./RoleFormDialog";
@@ -29,6 +29,7 @@ export const Roles = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<Role>();
   const { mutate: deleteRole } = useDelete(EntityType.ROLE, {
     onError: (error) => {
       toast.error(error);
@@ -81,26 +82,7 @@ export const Roles = () => {
       sortable: false,
       disableColumnMenu: true,
     },
-    {
-      maxWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      maxWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/sources/index.tsx
+++ b/packages/frontend/src/components/sources/index.tsx
@@ -26,6 +26,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useFind } from "@/hooks/crud/useFind";
 import { useUpdate } from "@/hooks/crud/useUpdate";
@@ -36,7 +37,6 @@ import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType, Format } from "@/services/types";
 import { IChannel } from "@/types/channel.types";
 import { writeToClipboard } from "@/utils/clipboard";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import {
   buildSourcesSearchParams,
@@ -56,6 +56,7 @@ export const Sources = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<SourceFull>();
   const [addMenuAnchorEl, setAddMenuAnchorEl] = useState<HTMLElement | null>(
     null,
   );
@@ -290,26 +291,7 @@ export const Sources = () => {
         );
       },
     },
-    {
-      minWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      minWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/subscribers/index.tsx
+++ b/packages/frontend/src/components/subscribers/index.tsx
@@ -15,6 +15,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { type Filter } from "@/app-components/tables/GenericFilters";
 import { useDialogs } from "@/hooks/useDialogs";
@@ -22,13 +23,13 @@ import { useQueryState } from "@/hooks/useQueryState";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { Subscriber } from "@/types/subscriber.types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { SubscriberFormDialog } from "./SubscriberFormDialog";
 
 export const Subscribers = () => {
   const { t } = useTranslate();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<Subscriber>();
   const actionColumns = useActionColumns<Subscriber>(
     EntityType.SUBSCRIBER,
     [
@@ -108,26 +109,7 @@ export const Subscribers = () => {
       headerAlign: "left",
       renderCell: ({ row }) => row.channel?.name,
     },
-    {
-      minWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      minWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      resizable: false,
-      headerAlign: "left",
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
   const [id, setId] = useQueryState("id");

--- a/packages/frontend/src/components/translations/index.tsx
+++ b/packages/frontend/src/components/translations/index.tsx
@@ -15,6 +15,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { useDelete } from "@/hooks/crud/useDelete";
 import { useFind } from "@/hooks/crud/useFind";
@@ -23,7 +24,6 @@ import { useDialogs } from "@/hooks/useDialogs";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { TranslationFormDialog } from "./TranslationFormDialog";
 
@@ -31,6 +31,7 @@ export const Translations = () => {
   const { t } = useTranslate();
   const { toast } = useToast();
   const dialogs = useDialogs();
+  const timestampColumns = useTimestampColumns<Translation>();
   const { data: languages } = useFind(
     { entity: EntityType.LANGUAGE },
     {
@@ -101,22 +102,7 @@ export const Translations = () => {
         </Stack>
       ),
     },
-    {
-      maxWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      resizable: false,
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
-    {
-      maxWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      resizable: false,
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     actionColumns,
   ];
 

--- a/packages/frontend/src/components/users/index.tsx
+++ b/packages/frontend/src/components/users/index.tsx
@@ -15,6 +15,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import {
   formatLicenseQuotaUsage,
@@ -39,7 +40,6 @@ import { useTranslate } from "@/hooks/useTranslate";
 import { PageHeader } from "@/layout/content/PageHeader";
 import { EntityType } from "@/services/types";
 import { User } from "@/types/user.types";
-import { getDateTimeFormatter } from "@/utils/date";
 
 import { CreateUserFormDialog } from "./CreateUserFormDialog";
 import { EditUserFormDialog } from "./EditUserFormDialog";
@@ -99,6 +99,7 @@ const UsersDataGrid = () => {
   const { toast } = useToast();
   const dialogs = useDialogs();
   const { user } = useAuth();
+  const timestampColumns = useTimestampColumns<User>();
   const usersQuota = getLicenseQuotaResource(user?.license, "users");
   const usersQuotaReached = isLicenseQuotaReached(user?.license, "users");
   const usersUpgradeTargetPlan = usersQuotaReached
@@ -231,26 +232,7 @@ const UsersDataGrid = () => {
         />
       ),
     },
-    {
-      minWidth: 140,
-      field: "createdAt",
-      headerName: t("label.createdAt"),
-      disableColumnMenu: true,
-      headerAlign: "left",
-      resizable: false,
-      valueGetter: (params) =>
-        t("datetime.created_at", getDateTimeFormatter(params)),
-    },
-    {
-      minWidth: 140,
-      field: "updatedAt",
-      headerName: t("label.updatedAt"),
-      disableColumnMenu: true,
-      headerAlign: "left",
-      resizable: false,
-      valueGetter: (params) =>
-        t("datetime.updated_at", getDateTimeFormatter(params)),
-    },
+    ...timestampColumns,
     ...(!ssoEnabled ? [actionColumns] : []),
   ];
 


### PR DESCRIPTION
### Summary

Introduces a new `useTimestampColumns` hook to centralize the creation and configuration of timestamp-related table columns in the frontend. This removes duplicated column logic and provides a single reusable implementation across data tables.

### Why

Timestamp column definitions were duplicated in multiple places, making them harder to maintain and increasing the risk of inconsistent formatting or behavior. Extracting the logic into a dedicated hook improves reusability, consistency, and maintainability.

### How to review

* Review the implementation of the new `useTimestampColumns` hook.
* Verify that the affected tables now consume the hook instead of defining timestamp columns inline.
* Confirm that timestamp formatting, sorting, filtering, and rendering behavior remain unchanged.

### Validation

* Verified that the frontend builds successfully.
* Confirmed that all affected tables render timestamp columns correctly.
* Manually tested sorting and rendering of timestamp fields to ensure no behavioral regressions.
