### PR TITLE
fix(frontend): resolve sidebar tooltop overlap issue

### DIFF
--- a/packages/frontend/src/app-components/menus/DashboardSidebar/DashboardSidebarPageItem.tsx
+++ b/packages/frontend/src/app-components/menus/DashboardSidebar/DashboardSidebarPageItem.tsx
@@ -170,9 +170,15 @@ export const DashboardSidebarPageItem = ({
         {tooltipTitle ? (
           <Tooltip
             title={tooltipTitle}
-            placement="right"
+            placement="top-start"
+            arrow
             enterDelay={700}
             disableInteractive
+            slotProps={{
+              popper: {
+                modifiers: [{ name: "offset", options: { offset: [8, -20] } }],
+              },
+            }}
             {...tooltip}
           >
             <Box component="span" sx={{ display: "block", width: "100%" }}>
@@ -190,7 +196,8 @@ export const DashboardSidebarPageItem = ({
                 position: "fixed",
                 positionAnchor: submenuAnchorName,
                 top: "anchor(top)",
-                left: "calc(anchor(right) + 8px)",
+                left: "anchor(right)",
+                pl: "8px",
               }}
             >
               <Paper elevation={8}>


### PR DESCRIPTION
## Screenshots
- After the fix
<img width="276" height="368" alt="image" src="https://github.com/user-attachments/assets/da08fa21-c99d-4a41-8074-bf1efb353ec7" />

- Before the fix
<img width="276" height="368" alt="image" src="https://github.com/user-attachments/assets/239aac2b-ea97-4f24-8cfd-1316aa6f0db3" />


## Summary

This PR fixes a frontend issue where sidebar tooltips could overlap each other or remain visible in unintended situations. Tooltip positioning and visibility are now handled correctly to ensure a consistent user experience.

## Why

Overlapping tooltips reduced readability and made navigating the sidebar feel inconsistent. This fix improves the overall UX and prevents visual glitches during sidebar interactions.

## How to review

* Hover over sidebar items and verify that tooltips are displayed correctly.
* Confirm that only the expected tooltip is visible at any given time.
* Check behavior while moving the cursor quickly between items and when expanding/collapsing the sidebar.

## Validation

* Verified tooltip behavior across sidebar interactions.
* Confirmed that overlapping tooltips no longer occur.
* Ensured no regressions in sidebar navigation or tooltip rendering.