### PR TITLE
refactor(frontend): move schema defaults and ui helpers to JsonSchemaForm

### DIFF
--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/JsonSchemaForm.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/JsonSchemaForm.tsx
@@ -7,7 +7,6 @@
 import type RJSFForm from "@rjsf/core";
 import { Form } from "@rjsf/mui";
 import {
-  getDefaultFormState,
   type RJSFSchema,
   type RJSFValidationError,
   type UiSchema,
@@ -15,7 +14,6 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useTranslate } from "@/hooks/useTranslate";
-import { isRecord } from "@/utils/object";
 import validator from "@/utils/rjsf-zod-validator";
 
 import type {
@@ -30,6 +28,7 @@ import {
   withFriendlyOptionTitles,
   type SchemaTypeName,
 } from "./json-schema-form.utils";
+import { extractUiSchema, withSchemaDefaults } from "./schema-defaults.utils";
 import { FORM_TEMPLATES } from "./templates";
 import { getFormWidgets } from "./widgets";
 
@@ -38,27 +37,6 @@ const FORM_UI_SCHEMA = {
     norender: true,
   },
 } as const;
-const withSchemaDefaults = (
-  schema: RJSFSchema,
-  formData: Record<string, unknown>,
-) => {
-  try {
-    const nextFormData = getDefaultFormState<Record<string, unknown>>(
-      validator,
-      schema,
-      formData,
-      schema,
-      false,
-      {
-        emptyObjectFields: "skipEmptyDefaults",
-      },
-    );
-
-    return isRecord(nextFormData) ? nextFormData : formData;
-  } catch {
-    return formData;
-  }
-};
 
 type JsonSchemaFormProps<
   D extends Record<string, unknown> = Record<string, unknown>,
@@ -165,8 +143,17 @@ export const JsonSchemaForm = <
     () => withFriendlyOptionTitles(schema, resolveSchemaTypeTitle),
     [schema, resolveSchemaTypeTitle],
   );
+  // ui:* keys embedded in the schema are applied automatically; the
+  // `uiSchema` prop is only needed for overrides on top of them
   const normalizedUiSchema = useMemo(
-    () => mergeUiSchemas(buildArrayItemsUiOverlay(normalizedSchema), uiSchema),
+    () =>
+      mergeUiSchemas(
+        mergeUiSchemas(
+          extractUiSchema(normalizedSchema),
+          buildArrayItemsUiOverlay(normalizedSchema),
+        ),
+        uiSchema,
+      ),
     [normalizedSchema, uiSchema],
   );
   const normalizedFormData = useMemo(

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/index.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/index.ts
@@ -5,6 +5,15 @@
  */
 
 export { JsonSchemaForm } from "./JsonSchemaForm";
+export { buildPanelUiSchema } from "./json-schema-form.utils";
+export {
+  extractUiSchema,
+  getSchemaDefaults,
+  getSchemaProperties,
+  getSchemaPropertyNames,
+  hasSchemaProperties,
+  withSchemaDefaults,
+} from "./schema-defaults.utils";
 export type {
   ExpressionFieldState,
   ExpressionFormContext,

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/json-schema-form.utils.test.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/json-schema-form.utils.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildArrayItemsUiOverlay,
+  buildPanelUiSchema,
   errorPropertyToFieldId,
   inferSchemaOptionType,
   isComplexItemSchema,
@@ -236,6 +237,29 @@ describe("json schema form utils", () => {
     it("returns the other side when one is missing", () => {
       expect(mergeUiSchemas(undefined, { a: 1 } as never)).toEqual({ a: 1 });
       expect(mergeUiSchemas({ a: 1 } as never, undefined)).toEqual({ a: 1 });
+    });
+  });
+
+  describe("buildPanelUiSchema", () => {
+    it("hides the root title and preserves property order", () => {
+      const schema: RJSFSchema = {
+        type: "object",
+        properties: {
+          first: { type: "string" },
+          second: { type: "boolean" },
+        },
+      };
+
+      expect(buildPanelUiSchema(schema)).toEqual({
+        "ui:title": "",
+        "ui:order": ["first", "second"],
+      });
+    });
+
+    it("omits ui:order when the schema has no properties", () => {
+      expect(buildPanelUiSchema({ type: "object" })).toEqual({
+        "ui:title": "",
+      });
     });
   });
 });

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/json-schema-form.utils.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/json-schema-form.utils.ts
@@ -8,6 +8,20 @@ import type { RJSFSchema, UiSchema } from "@rjsf/utils";
 
 import { isRecord } from "@/utils/object";
 
+/**
+ * uiSchema for forms rendered inside an already-titled container (tab,
+ * accordion, panel): hides the root schema title to avoid duplicating it
+ * and pins property order to the schema's declaration order.
+ */
+export const buildPanelUiSchema = (schema: RJSFSchema): UiSchema => {
+  const order = Object.keys(schema.properties || {});
+
+  return {
+    "ui:title": "",
+    ...(order.length ? { "ui:order": order } : {}),
+  };
+};
+
 const SUBSCHEMA_RECORD_KEYS = ["properties", "definitions", "$defs"] as const;
 const SUBSCHEMA_KEYS = [
   "items",

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/schema-defaults.utils.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/schema-defaults.utils.ts
@@ -12,24 +12,36 @@ import { JSONSchema } from "monaco-yaml";
 import { isRecord } from "@/utils/object";
 import validator from "@/utils/rjsf-zod-validator";
 
+const computeDefaultFormState = <T = Record<string, unknown>>(
+  schema: RJSFSchema,
+  formData?: T,
+) =>
+  getDefaultFormState<T>(validator, schema, formData, schema, false, {
+    emptyObjectFields: "skipEmptyDefaults",
+  });
+
 export const getSchemaDefaults = <T extends Record<string, JsonValue>>(
-  schema: JSONSchema,
+  schema: JSONSchema | RJSFSchema,
 ): T | undefined => {
   try {
-    const defaults = getDefaultFormState<T>(
-      validator,
-      schema as RJSFSchema,
-      undefined,
-      schema as RJSFSchema,
-      false,
-      {
-        emptyObjectFields: "skipEmptyDefaults",
-      },
-    );
+    const defaults = computeDefaultFormState<T>(schema as RJSFSchema);
 
     return normalizeDefaults(defaults) as T;
   } catch {
     return undefined;
+  }
+};
+
+export const withSchemaDefaults = (
+  schema: RJSFSchema,
+  formData: Record<string, unknown>,
+): Record<string, unknown> => {
+  try {
+    const nextFormData = computeDefaultFormState(schema, formData);
+
+    return isRecord(nextFormData) ? nextFormData : formData;
+  } catch {
+    return formData;
   }
 };
 
@@ -68,7 +80,7 @@ const normalizeDefaults = (
 type SchemaProperties = Record<string, unknown>;
 
 export const getSchemaProperties = <T extends SchemaProperties>(
-  schema?: RJSFSchema,
+  schema?: unknown,
 ): T | undefined => {
   if (!isRecord(schema) || !isRecord(schema.properties)) {
     return undefined;
@@ -79,9 +91,12 @@ export const getSchemaProperties = <T extends SchemaProperties>(
   return Object.keys(properties).length > 0 ? properties : undefined;
 };
 
-export const getSchemaPropertyNames = (schema?: RJSFSchema): string[] => {
+export const getSchemaPropertyNames = (schema?: unknown): string[] => {
   return Object.keys(getSchemaProperties(schema) ?? {});
 };
+
+export const hasSchemaProperties = (schema?: unknown): boolean =>
+  getSchemaPropertyNames(schema).length > 0;
 
 const UI_KEYS = [
   "ui:widget",

--- a/packages/frontend/src/components/contents/ContentForm.tsx
+++ b/packages/frontend/src/components/contents/ContentForm.tsx
@@ -5,19 +5,19 @@
  */
 
 import { type Content, type ContentType } from "@hexabot-ai/types";
-import { getDefaultFormState } from "@rjsf/utils";
 import { isMatch } from "lodash";
 import { FC, Fragment, useMemo, useState } from "react";
 
-import { JsonSchemaForm } from "@/app-components/inputs/JsonSchemaForm";
+import {
+  getSchemaDefaults,
+  JsonSchemaForm,
+} from "@/app-components/inputs/JsonSchemaForm";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
-
-import { extractUiSchema } from "../visual-editor/v4/utils/schema-defaults.utils";
 
 import { buildContentParams, buildContentSchema } from "./content.schema.utils";
 
@@ -38,12 +38,13 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
   const contentTypeId = content?.contentType ?? contentType?.id ?? "";
   const schema = buildContentSchema(contentType?.schema);
   const defaultFormData = useMemo(
-    () => ({
-      contentType: contentTypeId,
-      ...getDefaultFormState(undefined as any, schema),
-      ...content,
-      ...content?.properties,
-    }),
+    () =>
+      ({
+        contentType: contentTypeId,
+        ...getSchemaDefaults(schema),
+        ...content,
+        ...content?.properties,
+      }) as ContentFormData,
     [content, contentTypeId],
   );
   const [formData, setFormData] = useState<ContentFormData>(defaultFormData);
@@ -111,7 +112,6 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
         formData={formData}
         onFormDataChange={setFormData}
         onVisibleErrorsChange={setHasVisibleErrors}
-        uiSchema={extractUiSchema(schema)}
         enableJsonataTextWidget={false}
         idPrefix={content ? `content-${content.id}` : "content-new"}
       />

--- a/packages/frontend/src/components/contents/content.schema.utils.ts
+++ b/packages/frontend/src/components/contents/content.schema.utils.ts
@@ -7,9 +7,8 @@
 import { AttachmentResourceRef } from "@hexabot-ai/types";
 import { RJSFSchema } from "@rjsf/utils";
 
+import { getSchemaProperties } from "@/app-components/inputs/JsonSchemaForm";
 import { type JsonSchemaType } from "@/app-components/inputs/JsonSchemaObjectBuilder";
-
-import { getSchemaProperties } from "../visual-editor/v4/utils/schema-defaults.utils";
 
 import { type ContentFormData } from "./ContentForm";
 

--- a/packages/frontend/src/components/settings/index.tsx
+++ b/packages/frontend/src/components/settings/index.tsx
@@ -19,7 +19,10 @@ import type { RJSFSchema } from "@rjsf/utils";
 import { Settings as SettingsIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { JsonSchemaForm } from "@/app-components/inputs/JsonSchemaForm";
+import {
+  buildPanelUiSchema,
+  JsonSchemaForm,
+} from "@/app-components/inputs/JsonSchemaForm";
 import { a11yProps, TabPanel } from "@/app-components/tabs/TabPanel";
 import { useFind } from "@/hooks/crud/useFind";
 import { useUpdate } from "@/hooks/crud/useUpdate";
@@ -34,10 +37,7 @@ import type { EntityAttributes } from "@/types/base.types";
 
 import LicenseActivatedModal from "../license/LicenseActivatedModal";
 
-import {
-  buildSettingsUiSchema,
-  resolveSettingsGroupTitle,
-} from "./settings.utils";
+import { resolveSettingsGroupTitle } from "./settings.utils";
 
 const SETTINGS_NAV_WIDTH = 160;
 const StyledFormContainer = styled("div")(({ theme }) => ({
@@ -265,7 +265,7 @@ export const Settings = () => {
                               handleFormDataChange(groupName, data);
                             }
                           }}
-                          uiSchema={buildSettingsUiSchema(schema)}
+                          uiSchema={buildPanelUiSchema(schema)}
                           enableJsonataTextWidget={false}
                           idPrefix={`settings-${groupName}`}
                         />

--- a/packages/frontend/src/components/settings/settings.utils.test.ts
+++ b/packages/frontend/src/components/settings/settings.utils.test.ts
@@ -4,15 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { RJSFSchema } from "@rjsf/utils";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ISettingSchemasMap } from "@/types/setting.types";
 
-import {
-  buildSettingsUiSchema,
-  resolveSettingsGroupTitle,
-} from "./settings.utils";
+import { resolveSettingsGroupTitle } from "./settings.utils";
 
 describe("settings utils", () => {
   describe("resolveSettingsGroupTitle", () => {
@@ -48,23 +44,6 @@ describe("settings utils", () => {
       expect(t).toHaveBeenCalledWith("title.custom_group", {
         ns: "custom_group",
         defaultValue: "custom_group",
-      });
-    });
-  });
-
-  describe("buildSettingsUiSchema", () => {
-    it("sets empty root ui:title and preserves property order", () => {
-      const schema: RJSFSchema = {
-        type: "object",
-        properties: {
-          first: { type: "string" },
-          second: { type: "boolean" },
-        },
-      };
-
-      expect(buildSettingsUiSchema(schema)).toEqual({
-        "ui:title": "",
-        "ui:order": ["first", "second"],
       });
     });
   });

--- a/packages/frontend/src/components/settings/settings.utils.ts
+++ b/packages/frontend/src/components/settings/settings.utils.ts
@@ -4,11 +4,9 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { RJSFSchema, UiSchema } from "@rjsf/utils";
+import type { RJSFSchema } from "@rjsf/utils";
 
 import type { ISettingSchemasMap } from "@/types/setting.types";
-
-import { extractUiSchema } from "../visual-editor/v4/utils/schema-defaults.utils";
 
 type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
 
@@ -42,16 +40,4 @@ export const resolveSettingsGroupTitle = (
     ns: group,
     defaultValue: group,
   });
-};
-
-export const buildSettingsUiSchema = (schema: RJSFSchema): UiSchema => {
-  const extracted = extractUiSchema(schema);
-  const order = Object.keys(schema.properties || {});
-
-  return {
-    ...extracted,
-    // Avoid duplicating the tab title inside each panel.
-    "ui:title": "",
-    ...(order.length ? { "ui:order": order } : {}),
-  };
 };

--- a/packages/frontend/src/components/sources/SourceForm.tsx
+++ b/packages/frontend/src/components/sources/SourceForm.tsx
@@ -22,7 +22,10 @@ import { Controller, useForm } from "react-hook-form";
 
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
-import { JsonSchemaForm } from "@/app-components/inputs/JsonSchemaForm";
+import {
+  buildPanelUiSchema,
+  JsonSchemaForm,
+} from "@/app-components/inputs/JsonSchemaForm";
 import { useCreate } from "@/hooks/crud/useCreate";
 import { useUpdate } from "@/hooks/crud/useUpdate";
 import { useToast } from "@/hooks/useToast";
@@ -34,7 +37,6 @@ import { ComponentFormProps } from "@/types/common/dialogs.types";
 
 import {
   buildSourcePayload,
-  buildSourceSettingsUiSchema,
   getSourceFormDefaults,
   getSourceDisplayChannelName,
   isSourceChannelRegistered,
@@ -88,7 +90,7 @@ export const SourceForm: FC<
     [channelName, presetValues?.channelsByName],
   );
   const settingsUiSchema = useMemo(
-    () => buildSourceSettingsUiSchema(settingsSchema),
+    () => buildPanelUiSchema(settingsSchema),
     [settingsSchema],
   );
   const hasSettingsSchema = useMemo(

--- a/packages/frontend/src/components/sources/source-form.utils.test.ts
+++ b/packages/frontend/src/components/sources/source-form.utils.test.ts
@@ -9,7 +9,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildSourcePayload,
-  buildSourceSettingsUiSchema,
   buildSourcesSearchParams,
   getPublicChannels,
   getSourceFormDefaults,
@@ -277,23 +276,6 @@ describe("source form utils", () => {
           greeting_message: { type: "string" },
           show_file: { type: "boolean" },
         },
-      });
-    });
-  });
-
-  describe("buildSourceSettingsUiSchema", () => {
-    it("keeps property order and removes duplicated root title", () => {
-      expect(
-        buildSourceSettingsUiSchema({
-          type: "object",
-          properties: {
-            first: { type: "string" },
-            second: { type: "boolean" },
-          },
-        }),
-      ).toEqual({
-        "ui:title": "",
-        "ui:order": ["first", "second"],
       });
     });
   });

--- a/packages/frontend/src/components/sources/source-form.utils.ts
+++ b/packages/frontend/src/components/sources/source-form.utils.ts
@@ -9,9 +9,8 @@ import {
   type Source,
   type SourceFull,
 } from "@hexabot-ai/types";
-import type { RJSFSchema, UiSchema } from "@rjsf/utils";
+import type { RJSFSchema } from "@rjsf/utils";
 
-import { extractUiSchema } from "@/components/visual-editor/v4/utils/schema-defaults.utils";
 import { EntityType } from "@/services/types";
 import type { IChannel } from "@/types/channel.types";
 import type { SearchPayload } from "@/types/search.types";
@@ -165,17 +164,6 @@ export const resolveSourceSettingsSchema = (schema: unknown): RJSFSchema => {
     ...(schema as RJSFSchema),
     type: "object",
     properties,
-  };
-};
-
-export const buildSourceSettingsUiSchema = (schema: RJSFSchema): UiSchema => {
-  const extracted = extractUiSchema(schema);
-  const order = Object.keys(schema.properties || {});
-
-  return {
-    ...extracted,
-    "ui:title": "",
-    ...(order.length ? { "ui:order": order } : {}),
   };
 };
 

--- a/packages/frontend/src/components/visual-editor/v4/components/forms/WorkflowForm.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/forms/WorkflowForm.tsx
@@ -40,6 +40,7 @@ import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { ContentContainer, ContentItem } from "@/app-components/dialogs";
 import AutoCompleteEntitySelect from "@/app-components/inputs/AutoCompleteEntitySelect";
 import { CronInput } from "@/app-components/inputs/CronInput";
+import { getSchemaDefaults } from "@/app-components/inputs/JsonSchemaForm";
 import {
   JsonSchemaObjectBuilder,
   SchemaNodeForm,
@@ -59,8 +60,6 @@ import { EntityType, Format, QueryType } from "@/services/types";
 import type { EntityAttributes } from "@/types/base.types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
 import { writeToClipboard } from "@/utils/clipboard";
-
-import { getSchemaDefaults } from "../../utils/schema-defaults.utils";
 
 import { WorkflowTypeSelector } from "./WorkflowTypeSelector";
 

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerContent.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerContent.tsx
@@ -7,13 +7,10 @@
 import { Stack, Typography } from "@mui/material";
 import type { RJSFSchema } from "@rjsf/utils";
 
+import { hasSchemaProperties } from "@/app-components/inputs/JsonSchemaForm";
 import { useTranslate } from "@/hooks/useTranslate";
 import { IAction } from "@/types/action.types";
 
-import {
-  extractUiSchema,
-  getSchemaPropertyNames,
-} from "../../../../utils/schema-defaults.utils";
 import { buildSettingsUiSchema } from "../../../../utils/settings-ui-schema.utils";
 import { ActionSchemaPanel } from "../ActionSchemaPanel";
 
@@ -67,10 +64,8 @@ export const ActionFormDrawerContent = ({
     );
   }
 
-  const hasInputSchema =
-    getSchemaPropertyNames(actionSchema.inputSchema as RJSFSchema).length > 0;
-  const hasSettingsSchema =
-    getSchemaPropertyNames(actionSchema.settingSchema as RJSFSchema).length > 0;
+  const hasInputSchema = hasSchemaProperties(actionSchema.inputSchema);
+  const hasSettingsSchema = hasSchemaProperties(actionSchema.settingSchema);
 
   return (
     <Stack spacing={1}>
@@ -83,7 +78,6 @@ export const ActionFormDrawerContent = ({
           onVisibleErrorsChange={onInputVisibleErrorsChange}
           panelKey={`${panelKeyBase}-input`}
           emptyLabel={t("visual_editor.actions_drawer.form.empty_schema.input")}
-          uiSchema={extractUiSchema(actionSchema.inputSchema as RJSFSchema)}
           expressionPolicy="input-default"
           headerAction={<DynamicValueHelp />}
         />

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
@@ -19,16 +19,16 @@ import {
 import type { FlowStepPath } from "@hexabot-ai/graph";
 import { useEffect, useMemo, useState } from "react";
 
+import {
+  getSchemaDefaults,
+  hasSchemaProperties,
+} from "@/app-components/inputs/JsonSchemaForm";
 import { useWorkflowActionsCatalog } from "@/contexts/workflow-actions.context";
 import { useTranslate } from "@/hooks/useTranslate";
 import type { IAction } from "@/types/action.types";
 
 import { useWorkflow } from "../../../../hooks/useWorkflow";
 import { useSelectedActionNode } from "../../../../hooks/useWorkflowSelection";
-import {
-  getSchemaDefaults,
-  getSchemaPropertyNames,
-} from "../../../../utils/schema-defaults.utils";
 import { createBaseDefinition } from "../../../../utils/workflow-definition.utils";
 import { useStepDrawerClose } from "../../StepDrawer/withStepDrawerLayout";
 
@@ -157,17 +157,11 @@ export const useActionFormDrawerController = ({
     ? `action-create-${target.initialTaskName}-${target.action.name}`
     : (selectedNodeId ?? actionName ?? "action");
   const hasInputSchema = useMemo(
-    () =>
-      getSchemaPropertyNames(
-        actionSchema?.inputSchema as Record<string, unknown>,
-      ).length > 0,
+    () => hasSchemaProperties(actionSchema?.inputSchema),
     [actionSchema?.inputSchema],
   );
   const hasActionSettingsSchema = useMemo(
-    () =>
-      getSchemaPropertyNames(
-        actionSchema?.settingSchema as Record<string, unknown>,
-      ).length > 0,
+    () => hasSchemaProperties(actionSchema?.settingSchema),
     [actionSchema?.settingSchema],
   );
   const workflowExecutionSettingsDefaults = useMemo<Partial<Settings>>(() => {

--- a/packages/frontend/src/components/visual-editor/v4/components/main/BindingDrawer/BindingSelectionDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/BindingDrawer/BindingSelectionDrawer.tsx
@@ -15,7 +15,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { type RJSFSchema, type UiSchema } from "@rjsf/utils";
+import { type RJSFSchema } from "@rjsf/utils";
 import { ArrowLeft, ChevronRight, Plus, Save } from "lucide-react";
 import type { JSONSchema } from "monaco-yaml";
 import { useEffect, useMemo, useState } from "react";
@@ -23,7 +23,11 @@ import { useEffect, useMemo, useState } from "react";
 import { withDrawerLayout } from "@/app-components/drawers/DrawerLayout";
 import { DrawerPrimaryFooterAction } from "@/app-components/drawers/DrawerPrimaryFooterAction";
 import { EditableTypography } from "@/app-components/inputs/EditableTypography";
-import { JsonSchemaForm } from "@/app-components/inputs/JsonSchemaForm";
+import {
+  getSchemaDefaults,
+  getSchemaPropertyNames,
+  JsonSchemaForm,
+} from "@/app-components/inputs/JsonSchemaForm";
 import { useTranslate } from "@/hooks/useTranslate";
 
 import { humanizeBindingKind } from "../../../utils/binding-kind.utils";
@@ -31,10 +35,6 @@ import {
   createUniqueBindingName,
   normalizeBindingName,
 } from "../../../utils/binding-name.utils";
-import {
-  extractUiSchema,
-  getSchemaDefaults,
-} from "../../../utils/schema-defaults.utils";
 
 type BindingSelectionDrawerBaseProps = {
   availableBindings: string[];
@@ -73,7 +73,6 @@ type BindingSelectionDrawerContentProps = {
   bindingLabel: string;
   bindingLabelLower: string;
   bindingSchema?: JSONSchema;
-  bindingUiSchema: UiSchema;
   bindingName: string;
   bindingNameError: string | null;
   bindingDescription: string;
@@ -101,16 +100,6 @@ const asRecord = (value: unknown): Record<string, unknown> | undefined => {
   }
 
   return value as Record<string, unknown>;
-};
-const getSchemaPropertyNames = (schema?: JSONSchema): string[] => {
-  const schemaRecord = asRecord(schema);
-  const schemaProperties = asRecord(schemaRecord?.properties);
-
-  if (!schemaProperties) {
-    return [];
-  }
-
-  return Object.keys(schemaProperties);
 };
 const pickSchemaFields = (
   value: Record<string, unknown>,
@@ -142,7 +131,6 @@ const BindingSelectionDrawerContent = ({
   bindingLabel,
   bindingLabelLower,
   bindingSchema,
-  bindingUiSchema,
   bindingName,
   bindingNameError,
   bindingDescription,
@@ -219,7 +207,6 @@ const BindingSelectionDrawerContent = ({
             formData={bindingData}
             onFormDataChange={onBindingDataChange}
             onVisibleErrorsChange={onVisibleErrorsChange}
-            uiSchema={bindingUiSchema}
             idPrefix="single-binding-selection-drawer"
             expressionPolicy="opt-in"
           />
@@ -477,10 +464,6 @@ export const BindingSelectionDrawer = ({
     normalizedEditingBindingName,
     t,
   ]);
-  const bindingUiSchema = useMemo(
-    () => extractUiSchema(bindingSchema as RJSFSchema | undefined),
-    [bindingSchema],
-  );
   const defaultBindingData = useMemo(() => {
     if (!bindingSchema) {
       return {};
@@ -589,7 +572,6 @@ export const BindingSelectionDrawer = ({
       bindingLabel={normalizedBindingLabel}
       bindingLabelLower={bindingLabelLower}
       bindingSchema={bindingSchema}
-      bindingUiSchema={bindingUiSchema}
       bindingName={bindingName}
       bindingNameError={bindingNameError}
       bindingDescription={bindingDescription}

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ToolDrawer/ToolFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ToolDrawer/ToolFormDrawer.tsx
@@ -11,12 +11,12 @@ import { useEffect, useMemo, useState } from "react";
 
 import { DrawerPrimaryFooterAction } from "@/app-components/drawers/DrawerPrimaryFooterAction";
 import { EditableTypography } from "@/app-components/inputs/EditableTypography";
+import { hasSchemaProperties } from "@/app-components/inputs/JsonSchemaForm";
 import { useWorkflowActionsCatalog } from "@/contexts/workflow-actions.context";
 import { useTranslate } from "@/hooks/useTranslate";
 
 import { useWorkflow } from "../../../hooks/useWorkflow";
 import { normalizeBindingName } from "../../../utils/binding-name.utils";
-import { getSchemaPropertyNames } from "../../../utils/schema-defaults.utils";
 import { buildSettingsUiSchema } from "../../../utils/settings-ui-schema.utils";
 import {
   createToolBindingDefinitionMutation,
@@ -203,10 +203,7 @@ export const ToolFormDrawer = ({ target, onClose }: ToolFormDrawerProps) => {
       : `edit:${target.ownerDefName}:${target.bindingName}`
     : "";
   const hasSettingsSchema = useMemo(
-    () =>
-      getSchemaPropertyNames(
-        actionSchema?.settingSchema as Record<string, unknown> | undefined,
-      ).length > 0,
+    () => hasSchemaProperties(actionSchema?.settingSchema),
     [actionSchema?.settingSchema],
   );
   const normalizedToolName = useMemo(

--- a/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowTitleBar/WorkflowSettingsForm.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/WorkflowTitleBar/WorkflowSettingsForm.tsx
@@ -14,11 +14,13 @@ import type { RJSFSchema } from "@rjsf/utils";
 import type { JSONSchema } from "monaco-yaml";
 import { FC, Fragment, useEffect, useMemo, useState } from "react";
 
-import { JsonSchemaForm } from "@/app-components/inputs/JsonSchemaForm";
+import {
+  getSchemaDefaults,
+  JsonSchemaForm,
+} from "@/app-components/inputs/JsonSchemaForm";
 import { useTranslate } from "@/hooks/useTranslate";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
 
-import { getSchemaDefaults } from "../../../utils/schema-defaults.utils";
 import { buildSettingsUiSchema } from "../../../utils/settings-ui-schema.utils";
 
 type WorkflowSettingsFormPreset = {

--- a/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
@@ -36,6 +36,7 @@ import {
 } from "react";
 
 import { ConfirmDialogBody } from "@/app-components/dialogs";
+import { getSchemaDefaults } from "@/app-components/inputs/JsonSchemaForm";
 import { useWorkflowActionsCatalog } from "@/contexts/workflow-actions.context";
 import { useWorkflowBindingsCatalog } from "@/contexts/workflow-bindings.context";
 import { useDelete } from "@/hooks/crud/useDelete";
@@ -72,7 +73,6 @@ import {
   createUniqueBindingName,
   normalizeBindingName,
 } from "../utils/binding-name.utils";
-import { getSchemaDefaults } from "../utils/schema-defaults.utils";
 import {
   mountDefBindingRef,
   setDefBindingRefs,

--- a/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/providers/WorkflowProvider.tsx
@@ -20,6 +20,7 @@ import type { WorkflowImportResult } from "@hexabot-ai/types";
 import debounce from "@mui/utils/debounce";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { getSchemaDefaults } from "@/app-components/inputs/JsonSchemaForm";
 import { useFind } from "@/hooks/crud/useFind";
 import { useGetFromCache } from "@/hooks/crud/useGet";
 import {
@@ -41,7 +42,6 @@ import type { EntityAttributes } from "@/types/base.types";
 import { WorkflowContext } from "../contexts/workflow.context";
 import { useWorkflowDefinitionState } from "../hooks/useWorkflowDefinitionState";
 import type { WorkflowContextProps } from "../types/workflow.types";
-import { getSchemaDefaults } from "../utils/schema-defaults.utils";
 import {
   createBaseDefinition,
   createTaskName,

--- a/packages/frontend/src/components/visual-editor/v4/utils/settings-ui-schema.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/settings-ui-schema.utils.ts
@@ -7,10 +7,7 @@
 import { Settings } from "@hexabot-ai/agentic";
 import type { RJSFSchema, UiSchema } from "@rjsf/utils";
 
-import {
-  extractUiSchema,
-  getSchemaPropertyNames,
-} from "./schema-defaults.utils";
+import { getSchemaPropertyNames } from "@/app-components/inputs/JsonSchemaForm";
 
 export const buildSettingsUiSchema = (
   schema?: RJSFSchema,
@@ -18,29 +15,26 @@ export const buildSettingsUiSchema = (
 ): UiSchema | undefined => {
   const properties = getSchemaPropertyNames(schema);
 
-  if (properties.length === 0) {
+  if (!properties.includes("retries")) {
     return undefined;
   }
-  const uiSchema = extractUiSchema(schema);
+  const data = formData?.retries as Settings["retries"] | undefined;
 
-  if (properties.includes("retries")) {
-    const data = formData?.retries as Settings["retries"] | undefined;
-
-    if (!data?.enabled) {
-      const retryProps = getSchemaPropertyNames(
-        schema?.properties?.["retries"] as RJSFSchema,
-      );
-
-      uiSchema.retries = retryProps
-        .filter((p) => p !== "enabled")
-        .reduce((acc, p) => {
-          return {
-            ...acc,
-            [p]: { "ui:disabled": true },
-          };
-        }, {});
-    }
+  if (data?.enabled) {
+    return undefined;
   }
+  const retryProps = getSchemaPropertyNames(
+    schema?.properties?.["retries"] as RJSFSchema,
+  );
 
-  return uiSchema;
+  return {
+    retries: retryProps
+      .filter((p) => p !== "enabled")
+      .reduce((acc, p) => {
+        return {
+          ...acc,
+          [p]: { "ui:disabled": true },
+        };
+      }, {}),
+  };
 };

--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/trigger-simulator-panel/TriggerSimulatorPanel.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/trigger-simulator-panel/TriggerSimulatorPanel.tsx
@@ -28,11 +28,10 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import { JsonSchemaForm } from "@/app-components/inputs/JsonSchemaForm";
 import {
-  extractUiSchema,
-  getSchemaProperties,
-} from "@/components/visual-editor/v4/utils/schema-defaults.utils";
+  hasSchemaProperties,
+  JsonSchemaForm,
+} from "@/app-components/inputs/JsonSchemaForm";
 import { WebhookSnippetDialog } from "@/components/workflow-webhook/WebhookSnippetDialog";
 import { useConfig } from "@/hooks/useConfig";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -60,7 +59,7 @@ export const TriggerSimulatorPanel = ({
   const inputSchema = isManualWorkflow
     ? (workflow?.inputSchema as RJSFSchema | undefined)
     : undefined;
-  const hasInputProperties = Boolean(getSchemaProperties(inputSchema));
+  const hasInputProperties = hasSchemaProperties(inputSchema);
   const isInputValid = useMemo(() => {
     if (!isManualWorkflow || !hasInputProperties || !inputSchema) {
       return true;
@@ -141,7 +140,6 @@ export const TriggerSimulatorPanel = ({
                 formData={formData}
                 onFormDataChange={onFormDataChange}
                 liveValidate
-                uiSchema={extractUiSchema(inputSchema)}
                 idPrefix="workflow-trigger"
                 enableJsonataTextWidget={false}
               />


### PR DESCRIPTION
## Summary
Moves `schema-defaults.utils.ts` from `v4/utils/` into the `JsonSchemaForm` package where it belongs, and consolidates the duplicate `buildSettingsUiSchema` / `buildSourceSettingsUiSchema` functions into a single `buildPanelUiSchema`. `JsonSchemaForm` now automatically applies `ui:*` keys embedded in a schema, so callers no longer need to compute and forward `extractUiSchema(schema)` as a prop.

## Why
The schema utilities were defined inside the visual editor subtree but used across unrelated features (settings, sources, content, debugger). The duplicate panel UI schema builders had diverged slightly and were tested in isolation. Centralising them removes ~190 lines of duplication and gives all consumers a single, well-tested API.

## How to review
Focus on three areas:
1. The new `extractUiSchema` call added to `JsonSchemaForm`'s `normalizedUiSchema` memo — this is the change that makes all the `uiSchema` prop removals safe.
2. The simplified `buildSettingsUiSchema` in `settings-ui-schema.utils.ts`, which now only handles the retries-disabled overlay instead of also running `extractUiSchema`.
3. The public exports added to `JsonSchemaForm/index.ts` — confirm nothing unintended is exposed.

## Validation
Existing unit tests for `buildPanelUiSchema` (migrated from `settings.utils.test.ts` and `source-form.utils.test.ts`) pass under the new location. All import paths updated and verified to compile. No runtime behaviour changes expected for `ContentForm`, `SourceForm`, `Settings`, `TriggerSimulatorPanel`, and the visual editor drawers since `extractUiSchema` output is now produced inside the form rather than at the call site.