### PR TITLE
fix(frontend): register McpServerFormDialog in BASE_ADD_DIALOG_MAP

### DIFF
--- a/packages/frontend/src/app-components/dialogs/dialog.constants.ts
+++ b/packages/frontend/src/app-components/dialogs/dialog.constants.ts
@@ -11,6 +11,7 @@ import { ContentFormDialog } from "@/components/contents/ContentFormDialog";
 import { CredentialFormDialog } from "@/components/credentials/CredentialFormDialog";
 import { LabelFormDialog } from "@/components/labels/LabelFormDialog";
 import { LanguageFormDialog } from "@/components/languages/LanguageFormDialog";
+import { McpServerFormDialog } from "@/components/mcp-servers/McpServerFormDialog";
 import { MemoryDefinitionFormDialog } from "@/components/memory-definitions/MemoryDefinitionFormDialog";
 import { RoleFormDialog } from "@/components/roles/RoleFormDialog";
 import { TranslationFormDialog } from "@/components/translations/TranslationFormDialog";
@@ -43,6 +44,10 @@ export const BASE_ADD_DIALOG_MAP = {
   },
   [EntityType.LABEL]: {
     dialog: LabelFormDialog,
+    presetValues: undefined,
+  },
+  [EntityType.MCP_SERVER]: {
+    dialog: McpServerFormDialog,
     presetValues: undefined,
   },
   [EntityType.MEMORY_DEFINITION]: {


### PR DESCRIPTION
## Screenshots
- After the fix 
<img width="1127" height="642" alt="image" src="https://github.com/user-attachments/assets/973ad252-d530-4621-9bba-5b686ed52abc" />

- Before the fix
<img width="1127" height="642" alt="image" src="https://github.com/user-attachments/assets/baccf4ed-09e6-4362-99c2-104c27bfa107" />

## Summary
Registered `McpServerFormDialog` in `BASE_ADD_DIALOG_MAP`, making the MCP Server creation dialog available through the shared add-dialog registry. This allows the dialog to be resolved consistently wherever the base dialog map is used.

## Why
Without this registration, the MCP Server add flow cannot be opened through the common dialog resolution mechanism, resulting in missing or inaccessible functionality.

## How to review
* Verify that `McpServerFormDialog` has been added to `BASE_ADD_DIALOG_MAP`.
* Confirm that the dialog is correctly resolved and displayed when triggering the "Add MCP Server" action.
* Ensure existing dialog registrations continue to work as expected.
* 
## Validation
* Verified that the MCP Server dialog opens successfully through the shared dialog registry.
* Confirmed no regressions in other dialogs registered in `BASE_ADD_DIALOG_MAP`.
