### PR TITLE
feat(frontend): select newly created entity by default in AutoCompleteEntitySelect

### DIFF
--- a/packages/frontend/src/app-components/buttons/entities/CreateEntityButton.tsx
+++ b/packages/frontend/src/app-components/buttons/entities/CreateEntityButton.tsx
@@ -20,19 +20,31 @@ export const CreateEntityButton = <
   entity,
   slotProps,
   openOptions,
+  onEntityCreated,
 }: {
   entity: TE;
   slotProps?: ButtonProps;
-  openOptions?: OpenDialogOptions<THook<{ entity: TE }>["basic"]>;
+  openOptions?: OpenDialogOptions<THook<{ entity: TE }>["basic"] | boolean>;
+  onEntityCreated?: (created: THook<{ entity: TE }>["basic"]) => void;
 }) => {
   const { t } = useTranslate();
   const entityDialogs = useEntityDialogs(entity);
+  const handleClick = async () => {
+    const result = await entityDialogs.open(
+      { defaultValues: null },
+      openOptions,
+    );
+
+    if (result && typeof result === "object" && "id" in result) {
+      onEntityCreated?.(result);
+    }
+  };
 
   return (
     <Button
       size="small"
       variant="contained"
-      onClick={() => entityDialogs.open({ defaultValues: null }, openOptions)}
+      onClick={handleClick}
       startIcon={<Plus size={18} />}
       {...slotProps}
     >

--- a/packages/frontend/src/app-components/buttons/entities/EntityButtonWrapper.tsx
+++ b/packages/frontend/src/app-components/buttons/entities/EntityButtonWrapper.tsx
@@ -27,12 +27,14 @@ export const EntityButtonWrapper = <
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   confirmOptions = {},
   permissionAction,
+  onEntityCreated,
 }: {
   entity: TE;
   slotProps?: ButtonProps;
-  openOptions?: OpenDialogOptions<THook<{ entity: TE }>["basic"]>;
+  openOptions?: OpenDialogOptions<THook<{ entity: TE }>["basic"] | boolean>;
   confirmOptions?: ConfirmOptions & { selectedIds?: string[] };
   permissionAction: Action;
+  onEntityCreated?: (created: THook<{ entity: TE }>["basic"]) => void;
 }) => {
   const hasPermission = useHasPermission();
 
@@ -50,6 +52,7 @@ export const EntityButtonWrapper = <
         entity={entity}
         slotProps={slotProps}
         openOptions={openOptions}
+        onEntityCreated={onEntityCreated}
       />
     );
   }

--- a/packages/frontend/src/app-components/buttons/entities/WithEntityButton.tsx
+++ b/packages/frontend/src/app-components/buttons/entities/WithEntityButton.tsx
@@ -27,18 +27,21 @@ export const WithEntityButton = <
   slotProps,
   permissionAction,
   enableEntityAddButton,
+  onEntityCreated,
 }: PropsWithChildren<{
   entity: TE;
   payload?: TP;
   slotProps?: ButtonProps;
   permissionAction: Action;
   enableEntityAddButton?: boolean;
+  onEntityCreated?: (created: THook<{ entity: TE }>["basic"]) => void;
 }>) => {
   const Button = (
     <EntityButtonWrapper
       entity={entity}
       confirmOptions={payload}
       permissionAction={permissionAction}
+      onEntityCreated={onEntityCreated}
       {...slotProps}
     />
   );

--- a/packages/frontend/src/app-components/dialogs/GenericFormDialog.tsx
+++ b/packages/frontend/src/app-components/dialogs/GenericFormDialog.tsx
@@ -10,16 +10,19 @@ import { FormDialog as Wrapper } from "@/app-components/dialogs";
 import { useTranslate } from "@/hooks/useTranslate";
 import { TTranslationKeys } from "@/i18n/i18n.types";
 import {
-  ComponentFormDialogProps,
+  DialogProps,
+  ExtractFormProps,
+  FormButtonsProps,
   TPayload,
 } from "@/types/common/dialogs.types";
 
 type GenericFormDialogProps<T extends (arg: { data: any }) => unknown> =
-  ComponentFormDialogProps<T> & {
-    Form: React.ElementType;
-    addText?: TTranslationKeys;
-    editText?: TTranslationKeys;
-  } & { payload: TPayload<T> | null };
+  FormButtonsProps &
+    DialogProps<ExtractFormProps<T>, any> & {
+      Form: React.ElementType;
+      addText?: TTranslationKeys;
+      editText?: TTranslationKeys;
+    } & { payload: TPayload<T> | null };
 
 export const GenericFormDialog = ({
   Form,
@@ -33,8 +36,8 @@ export const GenericFormDialog = ({
 
   return (
     <Form
-      onSuccess={() => {
-        rest.onClose(true);
+      onSuccess={(result?: unknown) => {
+        rest.onClose(result ?? true);
       }}
       WrapperProps={{
         title: translationKey && t(translationKey),

--- a/packages/frontend/src/app-components/inputs/AutoCompleteEntitySelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteEntitySelect.tsx
@@ -6,9 +6,12 @@
 
 import { Action } from "@hexabot-ai/types";
 import { ChipTypeMap } from "@mui/material";
-import { AutocompleteProps } from "@mui/material/Autocomplete";
-import type { ReactNode } from "react";
-import { forwardRef, useEffect, useMemo, useRef } from "react";
+import {
+  AutocompleteProps,
+  AutocompleteValue,
+} from "@mui/material/Autocomplete";
+import type { ReactNode, SyntheticEvent } from "react";
+import { forwardRef, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useInfiniteFind } from "@/hooks/crud/useInfiniteFind";
 import { useSearch } from "@/hooks/useSearch";
@@ -56,6 +59,7 @@ export type AutoCompleteEntitySelectProps<
   noOptionsWarning?: string;
   isDisabledWhenEmpty?: boolean;
   enableEntityAddButton?: boolean;
+  disableAutoSelectOnCreate?: boolean;
   routeParams?: RouteParams;
   queryEnabled?: boolean;
   where?: Record<string, unknown>;
@@ -76,6 +80,7 @@ const AutoCompleteEntitySelect = <
     sortKey = "id",
     labelKey,
     enableEntityAddButton,
+    disableAutoSelectOnCreate,
     routeParams,
     queryEnabled = true,
     where,
@@ -140,18 +145,20 @@ const AutoCompleteEntitySelect = <
       ],
     },
   );
-  // flatten & filter unique & sort
-  const flattenedData = data?.pages
-    ?.flat()
-    .filter(
-      (a, idx, self) =>
-        self.findIndex((b) => a?.[idKey] === b?.[idKey]) === idx,
-    )
-    .sort((a, b) => -b[sortKey]?.localeCompare(a[sortKey]));
-  const options =
-    preprocess && flattenedData
+  const options = useMemo(() => {
+    // flatten & filter unique & sort
+    const flattenedData = data?.pages
+      ?.flat()
+      .filter(
+        (a, idx, self) =>
+          self.findIndex((b) => a?.[idKey] === b?.[idKey]) === idx,
+      )
+      .sort((a, b) => -b[sortKey]?.localeCompare(a[sortKey]));
+
+    return preprocess && flattenedData
       ? preprocess((flattenedData || []) as unknown as Value[])
       : ((flattenedData || []) as Value[]);
+  }, [data, idKey, sortKey, preprocess]);
 
   useEffect(() => {
     if (!queryEnabled) {
@@ -167,17 +174,43 @@ const AutoCompleteEntitySelect = <
     serializedWhere,
   ]);
 
+  const { multiple, value, onChange } = rest;
+  // Select the newly created entity (appended to the current selection when multiple)
+  const handleEntityCreated = useCallback(
+    (created: unknown) => {
+      const createdValue = created as Value;
+      const newValue = (
+        multiple
+          ? [
+              ...options.filter((option) =>
+                ((value as string[]) || []).includes(
+                  (option as Record<string, string>)[idKey],
+                ),
+              ),
+              createdValue,
+            ]
+          : createdValue
+      ) as AutocompleteValue<Value, Multiple, false, false>;
+
+      onChange?.({} as SyntheticEvent, newValue, "selectOption");
+    },
+    [multiple, value, onChange, options, idKey],
+  );
+
   return (
     <WithEntityButton
       entity={entity as keyof typeof BASE_ADD_DIALOG_MAP}
       permissionAction={Action.CREATE}
       enableEntityAddButton={enableEntityAddButton}
+      onEntityCreated={
+        disableAutoSelectOnCreate ? undefined : handleEntityCreated
+      }
     >
       <AutoCompleteSelect<Value, Label, Multiple>
         ref={ref}
         idKey={idKey}
         labelKey={labelKey}
-        options={options || []}
+        options={options}
         onSearch={onSearch}
         loading={isFetching}
         data-multiple={rest.multiple}

--- a/packages/frontend/src/components/content-types/ContentTypeForm.tsx
+++ b/packages/frontend/src/components/content-types/ContentTypeForm.tsx
@@ -68,8 +68,8 @@ export const ContentTypeForm: FC<ComponentFormProps<ContentType>> = ({
       rest.onError?.();
       toast.error(error);
     },
-    onSuccess: () => {
-      rest.onSuccess?.();
+    onSuccess: (data: ContentType) => {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   };

--- a/packages/frontend/src/components/contents/ContentForm.tsx
+++ b/packages/frontend/src/components/contents/ContentForm.tsx
@@ -60,8 +60,8 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
       rest.onError?.();
       toast.error(error);
     },
-    onSuccess: () => {
-      rest.onSuccess?.();
+    onSuccess: (data: Content) => {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   };

--- a/packages/frontend/src/components/credentials/CredentialForm.tsx
+++ b/packages/frontend/src/components/credentials/CredentialForm.tsx
@@ -37,8 +37,8 @@ export const CredentialForm: FC<ComponentFormProps<Credential>> = ({
       rest.onError?.();
       toast.error(t("message.internal_server_error"));
     },
-    onSuccess() {
-      rest.onSuccess?.();
+    onSuccess(data: Credential) {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   };

--- a/packages/frontend/src/components/labels/LabelForm.tsx
+++ b/packages/frontend/src/components/labels/LabelForm.tsx
@@ -53,8 +53,8 @@ export const LabelForm: FC<ComponentFormProps<Label>> = ({
       rest.onError?.();
       toast.error(error);
     },
-    onSuccess: () => {
-      rest.onSuccess?.();
+    onSuccess: (data: Label) => {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   };

--- a/packages/frontend/src/components/languages/LanguageForm.tsx
+++ b/packages/frontend/src/components/languages/LanguageForm.tsx
@@ -33,8 +33,8 @@ export const LanguageForm: FC<ComponentFormProps<Language>> = ({
       rest.onError?.();
       toast.error(t("message.internal_server_error"));
     },
-    onSuccess() {
-      rest.onSuccess?.();
+    onSuccess(data: Language) {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   };

--- a/packages/frontend/src/components/mcp-servers/McpServerForm.tsx
+++ b/packages/frontend/src/components/mcp-servers/McpServerForm.tsx
@@ -37,8 +37,8 @@ export const McpServerForm: FC<ComponentFormProps<McpServer>> = ({
       rest.onError?.();
       toast.error(error);
     },
-    onSuccess() {
-      rest.onSuccess?.();
+    onSuccess(data: McpServer) {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   };

--- a/packages/frontend/src/components/memory-definitions/MemoryDefinitionForm.tsx
+++ b/packages/frontend/src/components/memory-definitions/MemoryDefinitionForm.tsx
@@ -54,8 +54,8 @@ export const MemoryDefinitionForm: FC<ComponentFormProps<MemoryDefinition>> = ({
       rest.onError?.();
       toast.error(error);
     },
-    onSuccess: () => {
-      rest.onSuccess?.();
+    onSuccess: (data: MemoryDefinition) => {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   };

--- a/packages/frontend/src/components/roles/RoleForm.tsx
+++ b/packages/frontend/src/components/roles/RoleForm.tsx
@@ -32,8 +32,8 @@ export const RoleForm: FC<ComponentFormProps<Role>> = ({
     onError: (error: Error) => {
       toast.error(error);
     },
-    onSuccess() {
-      rest.onSuccess?.();
+    onSuccess(data: Role) {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   };

--- a/packages/frontend/src/components/translations/TranslationForm.tsx
+++ b/packages/frontend/src/components/translations/TranslationForm.tsx
@@ -63,8 +63,8 @@ export const TranslationForm: FC<ComponentFormProps<Translation>> = ({
       rest.onError?.();
       toast.error(error);
     },
-    onSuccess() {
-      rest.onSuccess?.();
+    onSuccess(data) {
+      rest.onSuccess?.(data);
       toast.success(t("message.success_save"));
     },
   });

--- a/packages/frontend/src/hooks/useEntityDialogs.ts
+++ b/packages/frontend/src/hooks/useEntityDialogs.ts
@@ -27,10 +27,10 @@ export const useEntityDialogs = <
   const dialogs = useDialogs();
   const EntityDialogComponent = BASE_ADD_DIALOG_MAP[entity][
     "dialog"
-  ] as unknown as DialogComponent<TP, TD>;
-  const open = (payload: TP, options?: OpenDialogOptions<TD>) => {
+  ] as unknown as DialogComponent<TP, TD | boolean>;
+  const open = (payload: TP, options?: OpenDialogOptions<TD | boolean>) => {
     if (EntityDialogComponent) {
-      dialogs.open(EntityDialogComponent, payload, {
+      return dialogs.open(EntityDialogComponent, payload, {
         ...BASE_ADD_DIALOG_MAP[entity]?.["options"],
         ...options,
       });

--- a/packages/frontend/src/layout/theme/customizations/inputs.tsx
+++ b/packages/frontend/src/layout/theme/customizations/inputs.tsx
@@ -47,6 +47,7 @@ const buttonsCustomizations: Components<Theme> = {
             style: {
               height: "2.25rem",
               padding: "3px 9px",
+              lineHeight: 1,
             },
           },
           {

--- a/packages/frontend/src/types/common/dialogs.types.ts
+++ b/packages/frontend/src/types/common/dialogs.types.ts
@@ -164,7 +164,7 @@ export type TPayload<D, P = unknown> = {
 export type ComponentFormProps<D, P = unknown> = FormButtonsProps & {
   data: TPayload<D, P>;
   onError?: () => void;
-  onSuccess?: () => void;
+  onSuccess?: (data?: D) => void;
   Wrapper?: React.FC<FormDialogProps>;
   WrapperProps?: Partial<FormDialogProps> & Partial<FormButtonsProps>;
 };
@@ -174,4 +174,8 @@ export type ExtractFormProps<T extends (arg: { data: any }) => unknown> =
 
 export type ComponentFormDialogProps<
   T extends (arg: { data: any }) => unknown,
-> = FormButtonsProps & DialogProps<ExtractFormProps<T>, boolean>;
+> = FormButtonsProps &
+  DialogProps<
+    ExtractFormProps<T>,
+    boolean | NonNullable<ExtractFormProps<T>["defaultValues"]>
+  >;


### PR DESCRIPTION
## Summary
When a new entity is created from `AutoCompleteEntitySelect`, it is now automatically selected as the current value instead of requiring the user to select it manually afterward. This provides a smoother and more intuitive creation flow.

## Why
Previously, creating a new entity left the autocomplete unchanged, forcing users to perform an extra selection step. Automatically selecting the newly created entity removes unnecessary friction and aligns with expected autocomplete behavior.

## How to review
Focus on the `AutoCompleteEntitySelect` component and the entity creation flow:
- Verify that newly created entities are automatically selected.
- Ensure existing selection behavior remains unchanged.
- Check that no regressions were introduced for normal search and selection.

## Validation
- Manually verified that creating a new entity immediately updates the selected value.
- Confirmed that selecting existing entities continues to work as before.
- Checked that the component state and emitted values remain consistent after creation.