### PR TITLE
fix(graph): enhance layout

### DIFF
--- a/packages/graph/src/workflow/constants/workflow.constants.ts
+++ b/packages/graph/src/workflow/constants/workflow.constants.ts
@@ -9,12 +9,12 @@ import { MarkerType, type Node } from "@xyflow/react";
 import {
   Brain,
   ChartNoAxesGantt,
-  CircleStop,
   GitBranch,
   ListTree,
   Play,
   Plus,
   Repeat,
+  Square,
   Zap,
   type LucideIcon,
 } from "lucide-react";
@@ -221,7 +221,7 @@ export const NODE_DEFINITIONS = {
     },
     [EIndicatorType.WORKFLOW_END]: {
       theme: {
-        Icon: CircleStop,
+        Icon: Square,
         borderColor: "#e95d32",
       },
       ports: [ELinkType.INDICATOR_IN],

--- a/packages/graph/src/workflow/utils/layout/branch-flow-origin.ts
+++ b/packages/graph/src/workflow/utils/layout/branch-flow-origin.ts
@@ -11,7 +11,7 @@ import type { GroupMeta } from "../graph-builder/types";
 
 import { runBranchGroupPass } from "./branch-group-pass";
 import { FLOW_LAYER_GAP } from "./constants";
-import type { AxisBounds, LayoutContext } from "./geometry";
+import type { LayoutContext } from "./geometry";
 import {
   collectAttachmentDescendants,
   countNodeIds,
@@ -35,13 +35,8 @@ export const alignBranchFlowOrigins = (
   groups: Map<string, GroupMeta>,
   ctx: LayoutContext,
 ): GraphNode[] => {
-  // A branch that starts with a group (e.g. a Loop) renders its box with
-  // extra padding on its leading edge — the group node itself doesn't exist
-  // yet at this stage of the pipeline (getGroupNodes runs after this pass),
-  // so the leading-edge bound computed below would otherwise ignore that
-  // padding and leave the eventual box's visible top edge sitting ahead of a
-  // sibling branch that starts with a plain node, even once their operator
-  // nodes share the same flow coordinate.
+  // Account for group leading padding before group nodes are materialized, so
+  // grouped and plain branch starts align on the same visible edge.
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
   const groupEntryLeadingInset = new Map<string, number>();
 
@@ -109,19 +104,17 @@ export const alignBranchFlowOrigins = (
       const targetLeading = Math.max(
         ...branches.map((branch) => branch.leading),
       );
-      // Branches of the same operator (e.g. every Parallel branch) commonly
-      // reconverge on a shared merge/join node. ELK already placed that shared
-      // node to clear the widest original branch, which is by definition at
-      // least as far along as `targetLeading` — so it never needs to move, and
-      // must not: nodes outside this group (e.g. the step after the whole
-      // Parallel) were already positioned relative to its original spot.
-      // Count which branches can reach each node so those shared convergence
-      // nodes can be excluded, then resolve one delta per remaining node — the
-      // largest any (single) branch requires — before moving anything.
+      // Shared convergence nodes keep ELK's position; shift only branch-local
+      // nodes, using the largest required delta per node.
       const branchCountByNodeId = countNodeIds(
         branches.map((branch) => branch.nodeIds),
       );
       const deltaByNodeId = new Map<string, number>();
+      const addDelta = (
+        deltas: Map<string, number>,
+        nodeId: string,
+        delta: number,
+      ) => deltas.set(nodeId, Math.max(deltas.get(nodeId) ?? delta, delta));
 
       branches.forEach((branch) => {
         const delta = targetLeading - branch.leading;
@@ -135,12 +128,7 @@ export const alignBranchFlowOrigins = (
             return;
           }
 
-          const existing = deltaByNodeId.get(nodeId);
-
-          deltaByNodeId.set(
-            nodeId,
-            existing === undefined ? delta : Math.max(existing, delta),
-          );
+          addDelta(deltaByNodeId, nodeId, delta);
         });
       });
 
@@ -149,28 +137,18 @@ export const alignBranchFlowOrigins = (
       const sharedNodeIds = [...branchCountByNodeId.entries()]
         .filter(([, count]) => count > 1)
         .map(([nodeId]) => nodeId);
+      const attachmentIds = new Set<string>();
 
-      if (!sharedNodeIds.length) {
-        return;
-      }
+      attachmentChildrenByParent.forEach((childIds) => {
+        childIds.forEach((childId) => attachmentIds.add(childId));
+      });
 
-      // A shared convergence node (e.g. a Parallel's join placeholder) is
-      // deliberately left where ELK put it, on the assumption ELK already
-      // placed it to clear every branch. That assumption can be wrong: ELK may
-      // not rank real nested content (e.g. a task buried inside one branch's
-      // own Conditional) as the deepest node, and the shared node must clear
-      // not just individual branch nodes but the group's full padded bounding
-      // box (the visual box drawn around the group) — otherwise it renders
-      // inside the group instead of after it. Everything reachable *after* the
-      // shared node (outside this group entirely — e.g. the step following the
-      // whole Parallel) must shift by the same flow-axis amount, or it would
-      // end up positioned before the node that now feeds it.
       const collectForwardNodeIds = (startId: string): Set<string> => {
         const forwardNodeIds = new Set<string>();
         const queue = [startId];
 
         while (queue.length) {
-          const current = queue.shift()!;
+          const current = queue.pop()!;
 
           if (forwardNodeIds.has(current)) {
             continue;
@@ -193,39 +171,82 @@ export const alignBranchFlowOrigins = (
 
         return forwardNodeIds;
       };
-      // Measure only the group's *other* real content — not the shared node(s)
-      // themselves, which are members of this group; including them would be
-      // circular since the rendered box always grows to enclose wherever we
-      // place them, so what they must clear is every other real member.
-      const groupBounds = branches
-        .flatMap((branch) => [...branch.nodeIds])
-        .filter((nodeId) => (branchCountByNodeId.get(nodeId) ?? 0) <= 1)
-        .map((nodeId) => getNodeBounds(nodeId, "flow"))
-        .filter((bounds): bounds is AxisBounds => Boolean(bounds));
+      const getTrailingEdge = (nodeIds: Iterable<string>) => {
+        let trailing = -Infinity;
 
-      if (!groupBounds.length) {
+        for (const nodeId of nodeIds) {
+          if (attachmentIds.has(nodeId)) {
+            continue;
+          }
+
+          const bounds = getNodeBounds(nodeId, "flow");
+
+          if (bounds) {
+            trailing = Math.max(trailing, bounds.trailing);
+          }
+        }
+
+        return isFinite(trailing) ? trailing + FLOW_LAYER_GAP : undefined;
+      };
+      const localNodeIds = function* () {
+        for (const [nodeId, count] of branchCountByNodeId) {
+          if (count <= 1) {
+            yield nodeId;
+          }
+        }
+      };
+      const sharedTrailing = getTrailingEdge(localNodeIds());
+
+      if (sharedTrailing !== undefined) {
+        sharedNodeIds.forEach((nodeId) => {
+          const bounds = getNodeBounds(nodeId, "flow");
+
+          if (!bounds) {
+            return;
+          }
+
+          const delta = sharedTrailing - bounds.leading;
+
+          if (delta >= 1) {
+            collectForwardNodeIds(nodeId).forEach((forwardId) =>
+              moveNode(forwardId, delta),
+            );
+          }
+        });
+      }
+
+      if (!deltaByNodeId.size) {
         return;
       }
 
-      const groupTrailing =
-        Math.max(...groupBounds.map((bounds) => bounds.trailing)) +
-        FLOW_LAYER_GAP;
+      const externalTrailing = getTrailingEdge(branchCountByNodeId.keys());
+      const externalDeltaByNodeId = new Map<string, number>();
 
-      sharedNodeIds.forEach((nodeId) => {
-        const bounds = getNodeBounds(nodeId, "flow");
+      if (externalTrailing === undefined) {
+        return;
+      }
 
-        if (!bounds) {
-          return;
-        }
+      branchCountByNodeId.forEach((_, memberId) => {
+        (outgoingBySource.get(memberId) ?? []).forEach(({ targetId }) => {
+          if (
+            group.memberNodeIds.has(targetId) ||
+            branchCountByNodeId.has(targetId)
+          ) {
+            return;
+          }
 
-        const delta = groupTrailing - bounds.leading;
+          const bounds = getNodeBounds(targetId, "flow");
+          const delta = bounds ? externalTrailing - bounds.leading : 0;
 
-        if (delta >= 1) {
-          collectForwardNodeIds(nodeId).forEach((forwardId) =>
-            moveNode(forwardId, delta),
-          );
-        }
+          if (delta >= 1) {
+            collectForwardNodeIds(targetId).forEach((forwardId) =>
+              addDelta(externalDeltaByNodeId, forwardId, delta),
+            );
+          }
+        });
       });
+
+      externalDeltaByNodeId.forEach((delta, nodeId) => moveNode(nodeId, delta));
     },
   );
 };

--- a/packages/graph/src/workflow/utils/layout/elk-layout.ts
+++ b/packages/graph/src/workflow/utils/layout/elk-layout.ts
@@ -68,6 +68,8 @@ type ElkModel = {
       layoutOptions: Record<string, string>;
       ports: Array<{
         id: string;
+        x?: number;
+        y?: number;
         properties: Record<string, string>;
       }>;
     }>;
@@ -241,14 +243,45 @@ const toElk = (nodes: GraphNode[], edges: Edge[], ctx: LayoutContext) => {
 
       nodeOffsets.set(node.id, offset);
 
+      // Pin ports to the visible card when attachments inflate the ELK box.
+      const isInflated =
+        dimensions.width !== sourceDimensions.width ||
+        dimensions.height !== sourceDimensions.height;
+      const portsBySide = new Map<string, ElkPort[]>();
+
+      ports.forEach((port) => appendMapValue(portsBySide, port.side, port));
+
+      const getPortCoordinates = (port: ElkPort) => {
+        const sidePorts = portsBySide.get(port.side) ?? [];
+        const ratio = (sidePorts.indexOf(port) + 1) / (sidePorts.length + 1);
+
+        return {
+          x:
+            port.side === "WEST"
+              ? 0
+              : port.side === "EAST"
+                ? dimensions.width
+                : offset.x + sourceDimensions.width * ratio,
+          y:
+            port.side === "NORTH"
+              ? 0
+              : port.side === "SOUTH"
+                ? dimensions.height
+                : offset.y + sourceDimensions.height * ratio,
+        };
+      };
+
       return {
         id: node.id,
         ...dimensions,
         layoutOptions: {
-          "org.eclipse.elk.portConstraints": "FIXED_ORDER",
+          "org.eclipse.elk.portConstraints": isInflated
+            ? "FIXED_POS"
+            : "FIXED_ORDER",
         },
         ports: ports.map((port) => ({
           id: port.elkId,
+          ...(isInflated ? getPortCoordinates(port) : {}),
           properties: { "org.eclipse.elk.port.side": port.side },
         })),
       };

--- a/packages/graph/src/workflow/utils/layout/trailing-placeholder-flow.ts
+++ b/packages/graph/src/workflow/utils/layout/trailing-placeholder-flow.ts
@@ -16,8 +16,8 @@ import {
   getFlowCoordinate,
   getFlowSize,
   isHorizontalDirection,
-  type LayoutContext,
   withFlowCoordinate,
+  type LayoutContext,
 } from "./geometry";
 import { isAttachmentEdge } from "./graph-maps";
 
@@ -41,19 +41,25 @@ export const tightenTrailingPlaceholders = (
   const isVertical = !isHorizontalDirection(ctx);
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
   const visibleSourcesByTarget = new Map<string, string[]>();
+  const directSourcesByTarget = new Map<string, string[]>();
 
   edges.forEach((edge) => {
-    if (isAttachmentEdge(edge) || edge.hidden) {
+    if (isAttachmentEdge(edge)) {
       return;
     }
 
-    appendMapValue(visibleSourcesByTarget, edge.target, edge.source);
+    const targetNode = nodesById.get(edge.target);
+
+    if (!edge.hidden && targetNode?.type === ENodeType.BRANCH_PLACEHOLDER) {
+      appendMapValue(visibleSourcesByTarget, edge.target, edge.source);
+    }
+
+    if (targetNode?.type === ENodeType.INDICATOR) {
+      appendMapValue(directSourcesByTarget, edge.target, edge.source);
+    }
   });
 
-  // The flow-axis edge a source's outgoing link leaves from: the node's far
-  // edge, or the padded far edge of a group's member bounds when the link
-  // comes from a group overlay (the overlay node doesn't exist yet at this
-  // stage of the pipeline).
+  // Use the source's far edge, or the future group overlay's padded far edge.
   const sourceFlowEnd = (sourceId: string): number | undefined => {
     const sourceNode = nodesById.get(sourceId);
 
@@ -89,41 +95,92 @@ export const tightenTrailingPlaceholders = (
       padding / 2
     );
   };
+  const tightenedPositions = new Map<string, GraphNode["position"]>();
 
-  return nodes.map((node) => {
+  nodes.forEach((node) => {
     if (node.type !== ENodeType.BRANCH_PLACEHOLDER) {
-      return node;
+      return;
     }
 
     const sources = visibleSourcesByTarget.get(node.id) ?? [];
 
-    // A join placeholder (several branches converging on it) marks a shared
-    // convergence point, and an operator-fed placeholder is an empty branch —
-    // both keep their position. Only a placeholder trailing a single step or
-    // group gets pulled.
     if (
       sources.length !== 1 ||
       nodesById.get(sources[0])?.type === ENodeType.OPERATOR
     ) {
-      return node;
+      return;
     }
 
     const flowEnd = sourceFlowEnd(sources[0]);
 
     if (flowEnd === undefined) {
-      return node;
+      return;
     }
 
     const targetFlow = flowEnd + FLOW_LAYER_GAP;
     const currentFlow = getFlowCoordinate(node.position, isVertical);
 
     if (Math.abs(currentFlow - targetFlow) < 0.5) {
-      return node;
+      return;
     }
 
-    return {
-      ...node,
-      position: withFlowCoordinate(node.position, isVertical, targetFlow),
-    };
+    tightenedPositions.set(
+      node.id,
+      withFlowCoordinate(node.position, isVertical, targetFlow),
+    );
+  });
+
+  nodes.forEach((node) => {
+    if (node.type !== ENodeType.INDICATOR) {
+      return;
+    }
+
+    const sources = (directSourcesByTarget.get(node.id) ?? []).filter((id) =>
+      nodesById.has(id),
+    );
+
+    if (!sources.length) {
+      return;
+    }
+
+    const maxSourceEnd = sources.reduce((max, sourceId) => {
+      const pos =
+        tightenedPositions.get(sourceId) ?? nodesById.get(sourceId)?.position;
+      const srcNode = nodesById.get(sourceId);
+
+      if (!pos || !srcNode) {
+        return max;
+      }
+
+      return Math.max(
+        max,
+        getFlowCoordinate(pos, isVertical) +
+          getFlowSize(
+            getWorkflowNodeDimensions(srcNode.type, ctx.config),
+            isVertical,
+          ),
+      );
+    }, -Infinity);
+
+    if (!isFinite(maxSourceEnd)) {
+      return;
+    }
+
+    const targetFlow = maxSourceEnd + FLOW_LAYER_GAP;
+    const currentFlow = getFlowCoordinate(node.position, isVertical);
+
+    // Only pull Stop left; alignBranchFlowOrigins handles rightward pushes.
+    if (targetFlow < currentFlow - 0.5) {
+      tightenedPositions.set(
+        node.id,
+        withFlowCoordinate(node.position, isVertical, targetFlow),
+      );
+    }
+  });
+
+  return nodes.map((node) => {
+    const newPosition = tightenedPositions.get(node.id);
+
+    return newPosition ? { ...node, position: newPosition } : node;
   });
 };

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -5,12 +5,12 @@
  */
 
 import {
-  type DefDefinitions,
   StepType,
   type CompiledConditionalStep,
   type CompiledLoopStep,
   type CompiledParallelStep,
   type CompiledStep,
+  type DefDefinitions,
   type TaskDefinition,
 } from "@hexabot-ai/agentic";
 import { describe, expect, it } from "vitest";
@@ -1893,6 +1893,95 @@ describe("buildNodesAndEdges", () => {
         });
       });
     }
+  }
+
+  for (const direction of ["horizontal", "vertical"] as const) {
+    it(`does not push Stop past the last main-flow node when a branch has wide attachment rows in ${direction} mode`, async () => {
+      // Regression: wide binding rows inflated Stop/placeholder gaps; keep
+      // them at the visible card's FLOW_LAYER_GAP spacing.
+      const conditionalStep: CompiledConditionalStep = {
+        id: "0:conditional",
+        label: "conditional",
+        type: StepType.Conditional,
+        branches: [
+          {
+            id: "0:conditional:when:0",
+            condition: { kind: "literal", value: "false" },
+            steps: [taskStep("0.cond.0:short_agent", "short_agent")],
+          },
+          {
+            id: "0:conditional:when:1",
+            steps: [
+              taskStep("0.cond.1:long_agent_1", "long_agent_1"),
+              taskStep("0.cond.1:long_agent_2", "long_agent_2"),
+            ],
+          },
+        ],
+      };
+      const graph = await buildGraph({
+        flow: [conditionalStep],
+        tasks: {
+          short_agent: { action: "agent_action", settings: {} },
+          long_agent_1: { action: "agent_action", settings: {} },
+          long_agent_2: {
+            action: "agent_action",
+            settings: {},
+            bindings: {
+              tools: ["tool_1"],
+              mcp: ["mcp_1"],
+              memory: ["mem_1"],
+              model: "model_1",
+            },
+          },
+        },
+        defs: {
+          tool_1: { kind: "tools", settings: {} },
+          mcp_1: { kind: "mcp", settings: {} },
+          mem_1: { kind: "memory", settings: {} },
+          model_1: { kind: "model", settings: {} },
+        },
+        actionCatalog: createActionCatalog({
+          agent_action: ["tools", "mcp", "model", "memory"],
+        }),
+        bindingCatalog: createBindingCatalog([
+          { kind: "tools", multiple: true },
+          { kind: "mcp", multiple: true },
+          { kind: "memory", multiple: true },
+          { kind: "model", multiple: false },
+        ]),
+        direction,
+      });
+      const endNode = graph.nodes.find((node) => node.id === END_INDICATOR_ID);
+      const lastMainFlowNode = graph.nodes.find(
+        (node) => node.id === createStepNodeId("0.cond.1:long_agent_2", "task"),
+      );
+
+      expect(endNode).toBeDefined();
+      expect(lastMainFlowNode).toBeDefined();
+
+      const taskDims = NODE_METRICS[ENodeType.TASK]?.dimensions ?? {
+        width: 0,
+        height: 0,
+      };
+      const bpDims = NODE_METRICS[ENodeType.BRANCH_PLACEHOLDER]?.dimensions ?? {
+        width: 0,
+        height: 0,
+      };
+      const endLeading =
+        direction === "vertical" ? endNode!.position.y : endNode!.position.x;
+      const lastNodeTrailing =
+        direction === "vertical"
+          ? lastMainFlowNode!.position.y + taskDims.height
+          : lastMainFlowNode!.position.x + taskDims.width;
+      const bpFlowSize =
+        direction === "vertical" ? bpDims.height : bpDims.width;
+
+      expect(endLeading).toBeGreaterThanOrEqual(lastNodeTrailing);
+      // Attachments must not inflate either last-node -> placeholder -> Stop gap.
+      expect(endLeading).toBeLessThanOrEqual(
+        lastNodeTrailing + 2 * FLOW_LAYER_GAP + bpFlowSize + 1,
+      );
+    });
   }
 
   it("does not create duplicate node or edge IDs", async () => {


### PR DESCRIPTION
### Brief
<img width="3280" height="2040" alt="image" src="https://github.com/user-attachments/assets/a61c2591-4ed3-4ba1-9055-e5a7195b6ade" />

### Screenshots
- After the fix
<img width="2067" height="837" alt="image" src="https://github.com/user-attachments/assets/a58a1cea-b11e-49ac-8fea-5a29bfa4af43" />
<img width="1756" height="316" alt="image" src="https://github.com/user-attachments/assets/5096a490-9ee9-4eaf-8e9c-75a460ddda06" />
<img width="341" height="252" alt="image" src="https://github.com/user-attachments/assets/8892264c-0858-4721-b700-86003cc25667" />

- Before the fix
<img width="2067" height="837" alt="image" src="https://github.com/user-attachments/assets/deb6420c-6f6f-4634-8e64-bf2c5d79b222" />
<img width="1756" height="316" alt="image" src="https://github.com/user-attachments/assets/a0ae2b55-8900-40f9-8470-ec581b696cb7" />
<img width="341" height="252" alt="image" src="https://github.com/user-attachments/assets/e75b0b49-2c57-467f-8884-22377b66ca46" />


### Summary
This PR improves the graph layout with several visual and positioning fixes. It updates the stop node icon, keeps edge ports anchored to the visible node card, aligns branch starting points when branches begin with groups, and improves join node placement after grouped branches. It also includes layout code cleanup and expands the test suite with new coverage.

### Why
These changes address several layout inconsistencies that could make workflows appear misaligned or cause connections to attach to unexpected locations. The result is a more predictable and visually consistent graph layout, especially for complex workflows containing groups and branches.

### How to review

Focus on the graph layout behavior:

* Verify the stop node now renders as a square.
* Confirm edge ports remain attached to the visible node card, even when attached nodes expand the layout bounds.
* Check that branches beginning with groups (e.g. Loop) align with branches beginning with regular nodes.
* Verify join nodes are positioned after the entire grouped branch and never overlap group containers.
* Review the new layout tests covering these scenarios.

### Validation

* Added ~90 lines of layout test coverage for the new positioning behavior.
* Verified graph layouts with grouped branches, nested groups, attached nodes, and join nodes.
* Confirmed stop node rendering and port positioning behave as expected.

