### PR TITLE
feat(frontend): add back to actions button in action form drawer

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -857,7 +857,8 @@
         },
         "description": {
           "placeholder": "Optional step description."
-        }
+        },
+        "back_to_actions": "Back to actions"
       }
     },
     "tool_drawer": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -855,7 +855,8 @@
         },
         "description": {
           "placeholder": "Description optionnelle de l'étape."
-        }
+        },
+        "back_to_actions": "Retour aux actions"
       }
     },
     "tool_drawer": {

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawer.tsx
@@ -22,11 +22,13 @@ export type { ActionFormDrawerCloseReason, ActionFormDrawerCreateTarget };
 type ActionFormDrawerProps = {
   target: ActionFormDrawerCreateTarget | null;
   onClose?: (reason: ActionFormDrawerCloseReason) => void;
+  onBack?: () => void;
 };
 
 export const ActionFormDrawer = ({
   target,
   onClose,
+  onBack,
 }: ActionFormDrawerProps) => {
   const {
     open,
@@ -47,7 +49,7 @@ export const ActionFormDrawer = ({
     headerProps,
     footerProps,
     onClose: handleClose,
-  } = useActionFormDrawerController({ target, onClose });
+  } = useActionFormDrawerController({ target, onClose, onBack });
 
   return (
     <ActionFormDrawerLayout

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerHeader.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerHeader.tsx
@@ -4,7 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Stack, Typography } from "@mui/material";
+import { Button, Stack, Typography } from "@mui/material";
+import { ArrowLeft } from "lucide-react";
 
 import { EditableTypography } from "@/app-components/inputs/EditableTypography";
 import { useTranslate } from "@/hooks/useTranslate";
@@ -19,6 +20,7 @@ export type ActionFormDrawerHeaderProps = {
   onTaskNameCancel: () => void;
   onDescriptionCommit: (nextDescription: string) => void;
   onDescriptionCancel: () => void;
+  onBack?: () => void;
 };
 
 export const ActionFormDrawerHeader = ({
@@ -31,11 +33,23 @@ export const ActionFormDrawerHeader = ({
   onTaskNameCancel,
   onDescriptionCommit,
   onDescriptionCancel,
+  onBack,
 }: ActionFormDrawerHeaderProps) => {
   const { t } = useTranslate();
 
   return (
     <Stack spacing={0.25} minWidth={0}>
+      {onBack ? (
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={onBack}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          {t("visual_editor.actions_drawer.form.back_to_actions")}
+        </Button>
+      ) : null}
       <EditableTypography
         component="div"
         variant="subtitle1"

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
@@ -69,6 +69,7 @@ export type ActionFormDrawerCreateTarget = {
 type UseActionFormDrawerControllerParams = {
   target: ActionFormDrawerCreateTarget | null;
   onClose?: (reason: ActionFormDrawerCloseReason) => void;
+  onBack?: () => void;
 };
 
 type SplitTaskSettingsResult = {
@@ -115,6 +116,7 @@ const splitTaskSettings = (
 export const useActionFormDrawerController = ({
   target,
   onClose,
+  onBack,
 }: UseActionFormDrawerControllerParams): UseActionFormDrawerControllerResult => {
   const { t } = useTranslate();
   const {
@@ -481,6 +483,7 @@ export const useActionFormDrawerController = ({
       onTaskNameCancel: handleTaskNameCancel,
       onDescriptionCommit: handleDescriptionCommit,
       onDescriptionCancel: handleDescriptionCancel,
+      onBack,
     },
     inputData,
     isUsingWorkflowExecutionDefaults,

--- a/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
@@ -1048,6 +1048,17 @@ export const Workflow = () => {
       />
       <ActionFormDrawer
         target={pendingActionCreateTarget}
+        onBack={
+          pendingActionCreateTarget
+            ? () => {
+                const insertPath = pendingActionCreateTarget.insertPath;
+
+                setPendingActionCreateTarget(null);
+                setPendingInsertPath(insertPath);
+                setActionsDrawerOpen(true);
+              }
+            : undefined
+        }
         onClose={(reason) => {
           const isCreateFlow = Boolean(pendingActionCreateTarget);
 


### PR DESCRIPTION
## Demo
<video src="https://github.com/user-attachments/assets/fd378e11-feab-428f-aede-aa158287c177"></video>

## Summary
Added a **Back to Actions** button to the Action Form drawer, allowing users to return to the actions list without closing the drawer or losing context. This improves navigation within the workflow editor.

## Why
When editing or creating an action, users had no direct way to return to the actions list from the form. Adding a dedicated navigation button makes the workflow more intuitive and reduces unnecessary drawer interactions.

## How to review
* Open the Action Form drawer from the Actions panel.
* Verify that the **Back to Actions** button is displayed.
* Confirm that clicking the button navigates back to the actions list while keeping the drawer open and preserving the expected state.
* Ensure existing create/edit action flows continue to work as before.

## Validation
* Verified that the **Back to Actions** button appears in the Action Form drawer.
* Tested navigation from the form back to the actions list.
* Confirmed that existing action creation and editing workflows remain functional.
