### PR TITLE
fix(api): update community workflows quota from 3 to 10

### DIFF
--- a/packages/api/src/license/services/license.service.spec.ts
+++ b/packages/api/src/license/services/license.service.spec.ts
@@ -77,7 +77,7 @@ const buildExpectedQuotas = (
     unlimited: 25,
   };
   const workflowsLimitByTier: Record<LicenseQuotaTier, number | null> = {
-    community: 3,
+    community: 10,
     starter: 25,
     pro: 150,
     unlimited: null,

--- a/packages/api/src/license/types/license-quota.ts
+++ b/packages/api/src/license/types/license-quota.ts
@@ -45,7 +45,7 @@ export const LICENSE_QUOTA_LIMITS: Record<
     unlimited: 25,
   },
   workflows: {
-    community: 3,
+    community: 10,
     starter: 25,
     pro: 150,
     unlimited: null,


### PR DESCRIPTION
## Summary
Updates the Community plan workflow quota from **3** to **10** in the API configuration to align with the current product limits.

## Why
The previous limit was outdated and no longer reflected the intended Community plan offering. Increasing the quota ensures the API enforces the correct usage limits.

## How to review
- Verify the Community plan workflow quota has been updated from **3** to **10**.
- Confirm the new limit is applied consistently wherever workflow quotas are enforced.

## Validation
- Verified the Community plan configuration now exposes a quota of **10** workflows.
- Confirmed the API uses the updated limit during quota validation.

