### PR TITLE
fix: duplicate child workflow execution on resume

### DIFF
--- a/packages/agentic/src/__tests__/workflow-runner.test.ts
+++ b/packages/agentic/src/__tests__/workflow-runner.test.ts
@@ -1341,6 +1341,191 @@ describe('WorkflowRunner', () => {
     }
   });
 
+  it('lets actions skip side effects via hasRecordedResult when replaying a resumed step', async () => {
+    const sideEffects: string[] = [];
+    const spawnAction = defineAction<
+      unknown,
+      { reply: string },
+      TestContext,
+      Settings
+    >({
+      name: 'spawn_then_wait_action',
+      inputSchema: z.any(),
+      outputSchema: z.object({ reply: z.string() }),
+      execute: async ({ context }) => {
+        // Deterministic replay re-runs this body; the guard must prevent the
+        // side effect from executing a second time.
+        if (!context.workflow.hasRecordedResult()) {
+          sideEffects.push('spawn');
+        }
+
+        const resumeData = (await context.workflow.suspend({
+          reason: 'awaiting_child_workflow',
+        })) as { reply: string };
+
+        return { reply: resumeData.reply };
+      },
+    });
+    const definition: WorkflowDefinition = {
+      defs: createTaskDefs({
+        wait_step: {
+          action: 'spawn_then_wait_action',
+          inputs: {},
+        },
+      }),
+      flow: [{ do: 'wait_step' }],
+      outputs: { reply: '=$output.wait_step.reply' },
+    };
+    const compiled = compileWorkflow(definition, {
+      actions: { spawn_then_wait_action: spawnAction },
+    });
+    const runner = new WorkflowRunner(compiled);
+    const startResult = await runner.start({
+      inputData: {},
+      context: new TestContext({}),
+    });
+
+    expect(startResult.status).toBe('suspended');
+    if (startResult.status !== 'suspended') {
+      throw new Error('Workflow did not suspend as expected');
+    }
+
+    expect(sideEffects).toEqual(['spawn']);
+
+    const runtimeState = runner.getState() as ExecutionState;
+    const rebuilt = await WorkflowRunner.fromPersistedState(compiled, {
+      state: {
+        input: { ...runtimeState.input },
+        output: { ...runtimeState.output },
+        iteration: runtimeState.iteration,
+        accumulator: runtimeState.accumulator,
+        iterationStack: [...runtimeState.iterationStack],
+      },
+      context: new TestContext({}),
+      snapshot: startResult.snapshot,
+      suspension: {
+        stepId: startResult.step.id,
+        reason: startResult.reason ?? null,
+        data: startResult.data,
+        stepExecId: startResult.stepExecId,
+        suspendIndex: startResult.suspendIndex,
+        suspendKey: startResult.suspendKey,
+        awaitResults: startResult.awaitResults,
+      },
+    });
+    const resumeResult = await rebuilt.resume({
+      resumeData: { reply: 'child-finished' },
+    });
+
+    expect(resumeResult.status).toBe('finished');
+    if (resumeResult.status === 'finished') {
+      expect(resumeResult.output.reply).toBe('child-finished');
+    }
+
+    // The side effect must not run a second time during deterministic replay.
+    expect(sideEffects).toEqual(['spawn']);
+  });
+
+  it('reports recorded results only for suspensions that will replay immediately', async () => {
+    const observed: boolean[] = [];
+    const multiSuspendAction = defineAction<
+      unknown,
+      { firstReply: string; secondReply: string },
+      TestContext,
+      Settings
+    >({
+      name: 'observing_multi_suspend_action',
+      inputSchema: z.any(),
+      outputSchema: z.object({
+        firstReply: z.string(),
+        secondReply: z.string(),
+      }),
+      execute: async ({ context }) => {
+        observed.push(context.workflow.hasRecordedResult());
+        const first = (await context.workflow.suspend({
+          reason: 'first_pause',
+        })) as { reply: string };
+
+        observed.push(context.workflow.hasRecordedResult());
+        const second = (await context.workflow.suspend({
+          reason: 'second_pause',
+        })) as { reply: string };
+
+        return {
+          firstReply: first.reply,
+          secondReply: second.reply,
+        };
+      },
+    });
+    const definition: WorkflowDefinition = {
+      defs: createTaskDefs({
+        wait_step: {
+          action: 'observing_multi_suspend_action',
+          inputs: {},
+        },
+      }),
+      flow: [{ do: 'wait_step' }],
+      outputs: {
+        firstReply: '=$output.wait_step.firstReply',
+        secondReply: '=$output.wait_step.secondReply',
+      },
+    };
+    const compiled = compileWorkflow(definition, {
+      actions: { observing_multi_suspend_action: multiSuspendAction },
+    });
+    const runner = new WorkflowRunner(compiled);
+    const firstSuspension = await runner.start({
+      inputData: {},
+      context: new TestContext({}),
+    });
+    expect(firstSuspension.status).toBe('suspended');
+
+    const secondSuspension = await runner.resume({
+      resumeData: { reply: 'first-answer' },
+    });
+    expect(secondSuspension.status).toBe('suspended');
+    if (secondSuspension.status !== 'suspended') {
+      throw new Error('Workflow did not suspend on second await point');
+    }
+
+    // In-memory execution never sees pre-recorded results.
+    expect(observed).toEqual([false, false]);
+
+    const runtimeState = runner.getState() as ExecutionState;
+    const rebuilt = await WorkflowRunner.fromPersistedState(compiled, {
+      state: {
+        input: { ...runtimeState.input },
+        output: { ...runtimeState.output },
+        iteration: runtimeState.iteration,
+        accumulator: runtimeState.accumulator,
+        iterationStack: [...runtimeState.iterationStack],
+      },
+      context: new TestContext({}),
+      snapshot: secondSuspension.snapshot,
+      suspension: {
+        stepId: secondSuspension.step.id,
+        reason: secondSuspension.reason ?? null,
+        data: secondSuspension.data,
+        stepExecId: secondSuspension.stepExecId,
+        suspendIndex: secondSuspension.suspendIndex,
+        suspendKey: secondSuspension.suspendKey,
+        awaitResults: secondSuspension.awaitResults,
+      },
+    });
+    const finalResult = await rebuilt.resume({
+      resumeData: { reply: 'second-answer' },
+    });
+
+    expect(finalResult.status).toBe('finished');
+    if (finalResult.status === 'finished') {
+      expect(finalResult.output.firstReply).toBe('first-answer');
+      expect(finalResult.output.secondReply).toBe('second-answer');
+    }
+
+    // During replay both suspensions have recorded results awaiting them.
+    expect(observed).toEqual([false, false, true, true]);
+  });
+
   it('fails resume when replay suspension metadata does not match the workflow code path', async () => {
     const suspendAction = defineAction<
       unknown,

--- a/packages/agentic/src/context.ts
+++ b/packages/agentic/src/context.ts
@@ -99,6 +99,18 @@ export interface WorkflowRuntimeControl {
    * @returns Promise resolved with the data supplied to {@link resume}.
    */
   suspend<T = unknown>(options?: SuspensionOptions): Promise<T>;
+  /**
+   * Reports whether the next {@link suspend} call in the currently running
+   * action already has a recorded resume result. This happens during
+   * deterministic replay of a resumed step: the action body re-executes and
+   * `suspend()` resolves immediately with the recorded payload. Actions that
+   * perform side effects before suspending must skip those side effects when
+   * this returns `true`, otherwise they run once per resume.
+   *
+   * @param key - Optional user key matching the `key` passed to `suspend`.
+   * @returns `true` when the upcoming suspension resolves from a recorded result.
+   */
+  hasRecordedResult(key?: string): boolean;
   resume(data?: unknown): void;
   getSnapshot(): WorkflowSnapshot;
 }

--- a/packages/agentic/src/runner-runtime-control.ts
+++ b/packages/agentic/src/runner-runtime-control.ts
@@ -157,6 +157,21 @@ export class RunnerRuntimeControl implements WorkflowRuntimeControl {
     return request.resume.promise as Promise<T>;
   }
 
+  hasRecordedResult(key?: string): boolean {
+    const currentStep = this.runner.getCurrentStep();
+    if (!currentStep) {
+      return false;
+    }
+
+    const execution = this.ensureStepExecution(currentStep.id);
+    const suspendKey = buildSuspendKey(execution.suspendCursor + 1, key);
+    if (execution.awaitResults.has(suspendKey)) {
+      return true;
+    }
+
+    return (this.primedResumeData.get(currentStep.id)?.length ?? 0) > 0;
+  }
+
   resume(data?: unknown): void {
     void this.runner.resume({ resumeData: data });
   }

--- a/packages/agentic/src/step-executors/parallel-executor.ts
+++ b/packages/agentic/src/step-executors/parallel-executor.ts
@@ -353,6 +353,12 @@ class ParallelWorkflowRuntimeControl implements WorkflowRuntimeControl {
     return Promise.reject(new ParallelSuspensionError());
   }
 
+  hasRecordedResult(): boolean {
+    // Suspension is not supported inside parallel blocks, so no resume
+    // result can ever be recorded for them.
+    return false;
+  }
+
   resume(data?: unknown): void {
     this.getParent().resume(data);
   }

--- a/packages/api/src/extensions/actions/workflow/call-workflow.action.spec.ts
+++ b/packages/api/src/extensions/actions/workflow/call-workflow.action.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2025 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { ActionService } from '@/actions/actions.service';
+import { WorkflowRuntimeContext } from '@/workflow/contexts/workflow-runtime.context';
+
+import { CallWorkflowAction } from './call-workflow.action';
+
+describe('CallWorkflowAction', () => {
+  const actionServiceMock = {
+    register: jest.fn(),
+  } as unknown as ActionService;
+  const workflowId = '11111111-1111-4111-8111-111111111111';
+  const childRunId = '22222222-2222-4222-8222-222222222222';
+  const finishedPayload = {
+    status: 'finished' as const,
+    workflow_id: workflowId,
+    workflow_run_id: childRunId,
+    output: { child: 'done' },
+  };
+  const buildContext = ({
+    hasRecordedResult,
+    callWorkflow,
+    suspend,
+  }: {
+    hasRecordedResult: jest.Mock;
+    callWorkflow: jest.Mock;
+    suspend: jest.Mock;
+  }) =>
+    ({
+      services: { agentic: { callWorkflow } },
+      workflow: { hasRecordedResult, suspend },
+    }) as unknown as WorkflowRuntimeContext;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('spawns the child workflow and suspends until the child result arrives', async () => {
+    const callWorkflow = jest.fn().mockResolvedValue({
+      status: 'suspended',
+      workflow_id: workflowId,
+      workflow_run_id: childRunId,
+    });
+    const suspend = jest.fn().mockResolvedValue(finishedPayload);
+    const context = buildContext({
+      hasRecordedResult: jest.fn(() => false),
+      callWorkflow,
+      suspend,
+    });
+    const action = new CallWorkflowAction(actionServiceMock);
+    const result = await action.execute({
+      input: { workflow_id: workflowId },
+      context,
+    } as any);
+
+    expect(callWorkflow).toHaveBeenCalledWith({
+      workflowId,
+      input: undefined,
+      parentContext: context,
+    });
+    expect(suspend).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'awaiting_child_workflow' }),
+    );
+    expect(result).toEqual(finishedPayload);
+  });
+
+  it('does not re-spawn the child workflow when replaying a recorded suspension', async () => {
+    const callWorkflow = jest.fn();
+    const suspend = jest.fn().mockResolvedValue(finishedPayload);
+    const context = buildContext({
+      hasRecordedResult: jest.fn(() => true),
+      callWorkflow,
+      suspend,
+    });
+    const action = new CallWorkflowAction(actionServiceMock);
+    const result = await action.execute({
+      input: { workflow_id: workflowId },
+      context,
+    } as any);
+
+    // Deterministic replay re-executes this action after the child completes;
+    // spawning again would create a duplicate, orphaned child run.
+    expect(callWorkflow).not.toHaveBeenCalled();
+    expect(suspend).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'awaiting_child_workflow' }),
+    );
+    expect(result).toEqual(finishedPayload);
+  });
+});

--- a/packages/api/src/extensions/actions/workflow/call-workflow.action.ts
+++ b/packages/api/src/extensions/actions/workflow/call-workflow.action.ts
@@ -10,7 +10,10 @@ import { z } from 'zod';
 import { createAction } from '@/actions/create-action';
 import { WorkflowRuntimeContext } from '@/workflow/contexts/workflow-runtime.context';
 import { workflowResourceRef } from '@/workflow/resource-refs';
-import { CallWorkflowResult } from '@/workflow/types';
+import {
+  AWAITING_CHILD_WORKFLOW_REASON,
+  CallWorkflowResult,
+} from '@/workflow/types';
 
 const callWorkflowInputSchema = z.object({
   workflow_id: z.uuid().meta({
@@ -81,6 +84,18 @@ export const CallWorkflowAction = createAction<
   inputSchema: callWorkflowInputSchema,
   outputSchema: callWorkflowFinishedSchema,
   async execute({ input, context }) {
+    // Deterministic replay re-executes this action when the parent resumes
+    // after the child completed. The child was already spawned by the original
+    // execution, so skip the spawn and let suspend() return the recorded
+    // child payload immediately.
+    if (context.workflow.hasRecordedResult()) {
+      const resumeData = await context.workflow.suspend<unknown>({
+        reason: AWAITING_CHILD_WORKFLOW_REASON,
+      });
+
+      return assertFinishedResult(callWorkflowResumeSchema.parse(resumeData));
+    }
+
     // AgenticService owns workflow resolution and run creation because the
     // target workflow is an API-persisted entity, not an agentic DSL primitive.
     const result = await context.services.agentic.callWorkflow({
@@ -97,7 +112,7 @@ export const CallWorkflowAction = createAction<
     // A future event resumes the child leaf first; AgenticService then resumes
     // this parent action with the final child payload.
     const resumeData = await context.workflow.suspend<unknown>({
-      reason: 'awaiting_child_workflow',
+      reason: AWAITING_CHILD_WORKFLOW_REASON,
       data: {
         workflow_id: result.workflow_id,
         workflow_run_id: result.workflow_run_id,

--- a/packages/api/src/workflow/services/agentic.service.spec.ts
+++ b/packages/api/src/workflow/services/agentic.service.spec.ts
@@ -707,6 +707,145 @@ describe('AgenticService (TypeORM)', () => {
       });
     });
 
+    it('reuses the recorded child run instead of spawning a duplicate during parent replay', async () => {
+      const childWorkflow = await createWorkflowWithDefinition();
+      // Parent is mid-resume: markRunning happened, but the persisted
+      // suspension bookkeeping from the original call_workflow is still there.
+      const parentRun = await createParentRun();
+      const childRun = await workflowRunService.create({
+        workflow: childWorkflow.id,
+        workflowVersion: childWorkflow.currentVersion?.id ?? null,
+        triggeredBy: initiator.id,
+        parentRun: parentRun.id,
+        status: 'finished',
+        input: { from: 'parent' },
+        output: { child: 'done' },
+      });
+      await workflowRunService.updateOne(parentRun.id, {
+        suspendedStep: 'call_child',
+        suspensionReason: 'awaiting_child_workflow',
+        suspensionData: {
+          workflow_id: childWorkflow.id,
+          workflow_run_id: childRun.id,
+        },
+      });
+      const event = createEvent({ text: 'reply that resumes the parent' });
+      const runnerSnapshot: WorkflowSnapshot = {
+        status: 'finished',
+        actions: {},
+      };
+      const runner = buildRunnerMock({
+        startResult: {
+          status: 'finished',
+          output: { duplicate: true },
+          snapshot: runnerSnapshot,
+        },
+        state: { input: {}, output: {}, iterationStack: [] },
+        snapshot: runnerSnapshot,
+      });
+      jest
+        .spyOn(AgenticWorkflow, 'fromDefinition')
+        .mockReturnValue(buildWorkflowInstance(runner));
+
+      const result = await agenticService.callWorkflow({
+        workflowId: childWorkflow.id,
+        input: { from: 'parent' },
+        parentContext: {
+          workflowRunId: parentRun.id,
+          event,
+          // The runtime control reports a recorded resume result for the
+          // upcoming suspend() — the signature of a deterministic replay.
+          workflow: { hasRecordedResult: () => true },
+        } as any,
+      });
+      const childRuns = (await workflowRunService.findAndPopulate({
+        where: { workflow: { id: childWorkflow.id } },
+      })) as WorkflowRunFull[];
+
+      expect(childRuns).toHaveLength(1);
+      expect(runner.start).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        status: 'finished',
+        workflow_id: childWorkflow.id,
+        workflow_run_id: childRun.id,
+        output: { child: 'done' },
+      });
+    });
+
+    it('spawns a new child run for a later call even when stale suspension bookkeeping matches', async () => {
+      const childWorkflow = await createWorkflowWithDefinition();
+      const parentRun = await createParentRun();
+      const previousChildRun = await workflowRunService.create({
+        workflow: childWorkflow.id,
+        workflowVersion: childWorkflow.currentVersion?.id ?? null,
+        triggeredBy: initiator.id,
+        parentRun: parentRun.id,
+        status: 'finished',
+        input: { from: 'parent' },
+        output: { child: 'done' },
+      });
+      // Suspension fields are not cleared when the parent resumes, so a
+      // subsequent sequential call to the same workflow sees stale metadata.
+      await workflowRunService.updateOne(parentRun.id, {
+        suspendedStep: 'call_child',
+        suspensionReason: 'awaiting_child_workflow',
+        suspensionData: {
+          workflow_id: childWorkflow.id,
+          workflow_run_id: previousChildRun.id,
+        },
+      });
+      const event = createEvent({ text: 'second sequential call' });
+      const runtimeContext = { state: {}, event } as any;
+      workflowContextFactoryMock.create.mockResolvedValue(runtimeContext);
+      const runnerSnapshot: WorkflowSnapshot = {
+        status: 'finished',
+        actions: {},
+      };
+      const runner = buildRunnerMock({
+        startResult: {
+          status: 'finished',
+          output: { child: 'done-again' },
+          snapshot: runnerSnapshot,
+        },
+        state: {
+          input: { from: 'parent' },
+          output: { child: 'done-again' },
+          iterationStack: [],
+        },
+        snapshot: runnerSnapshot,
+      });
+      jest
+        .spyOn(AgenticWorkflow, 'fromDefinition')
+        .mockReturnValue(buildWorkflowInstance(runner));
+
+      const result = await agenticService.callWorkflow({
+        workflowId: childWorkflow.id,
+        input: { from: 'parent' },
+        parentContext: {
+          workflowRunId: parentRun.id,
+          event,
+          // No recorded result: this is a fresh call, not a replay.
+          workflow: { hasRecordedResult: () => false },
+        } as any,
+      });
+      const childRuns = (await workflowRunService.findAndPopulate({
+        where: { workflow: { id: childWorkflow.id } },
+      })) as WorkflowRunFull[];
+
+      expect(childRuns).toHaveLength(2);
+      expect(runner.start).toHaveBeenCalled();
+      expect(result).toEqual(
+        expect.objectContaining({
+          status: 'finished',
+          workflow_id: childWorkflow.id,
+          output: { child: 'done-again' },
+        }),
+      );
+      expect(result).not.toEqual(
+        expect.objectContaining({ workflow_run_id: previousChildRun.id }),
+      );
+    });
+
     it('resumes a suspended child leaf before unwinding the parent run', async () => {
       const childWorkflow = await createWorkflowWithDefinition();
       const parentRun = await createParentRun();

--- a/packages/api/src/workflow/services/agentic.service.ts
+++ b/packages/api/src/workflow/services/agentic.service.ts
@@ -32,6 +32,7 @@ import type {
   WorkflowCallService,
   WorkflowResult,
 } from '../types';
+import { AWAITING_CHILD_WORKFLOW_REASON } from '../types';
 
 import { WorkflowRunService } from './workflow-run.service';
 import { WorkflowService } from './workflow.service';
@@ -165,6 +166,27 @@ export class AgenticService implements WorkflowCallService {
       throw new Error(
         `Unable to load parent workflow run ${parentContext.workflowRunId}`,
       );
+    }
+
+    // Defense in depth against deterministic replay: if the parent is
+    // re-executing an already-resolved `call_workflow` suspension, reuse the
+    // child run it originally spawned instead of creating a duplicate.
+    const replayedChildRun = await this.findReplayedChildRun(
+      parentRun,
+      workflowId,
+      parentContext,
+    );
+    if (replayedChildRun) {
+      this.logger.log(
+        'Reusing recorded child workflow run during parent replay',
+        {
+          parentRunId: parentRun.id,
+          childRunId: replayedChildRun.id,
+          workflowId,
+        },
+      );
+
+      return this.toPersistedCallWorkflowResult(replayedChildRun);
     }
 
     const workflow = await this.workflowService.findOneAndPopulate(workflowId);
@@ -495,6 +517,101 @@ export class AgenticService implements WorkflowCallService {
       workflow_id: run.workflow.id,
       workflow_run_id: run.id,
       error: this.stringifyError(result.error),
+    };
+  }
+
+  /**
+   * Detect a deterministic replay of a `call_workflow` suspension and return
+   * the child run originally spawned by that call, if any.
+   *
+   * Replay is identified by the parent runtime control reporting a recorded
+   * resume result for the upcoming suspension; the persisted parent
+   * suspension metadata then pins which child run the original call created.
+   * The runtime signal is required because suspension bookkeeping is not
+   * cleared on resume, so metadata alone would also match a later sequential
+   * call to the same workflow.
+   */
+  private async findReplayedChildRun(
+    parentRun: WorkflowRunFull,
+    workflowId: string,
+    parentContext: WorkflowRuntimeContext,
+  ): Promise<WorkflowRunFull | null> {
+    if (!this.isReplayingRecordedSuspension(parentContext)) {
+      return null;
+    }
+
+    if (parentRun.suspensionReason !== AWAITING_CHILD_WORKFLOW_REASON) {
+      return null;
+    }
+
+    const suspensionData = parentRun.suspensionData as
+      | { workflow_id?: unknown; workflow_run_id?: unknown }
+      | null
+      | undefined;
+    if (
+      suspensionData?.workflow_id !== workflowId ||
+      typeof suspensionData.workflow_run_id !== 'string'
+    ) {
+      return null;
+    }
+
+    const childRun = await this.workflowRunService.findOneAndPopulate(
+      suspensionData.workflow_run_id,
+    );
+    if (
+      !childRun ||
+      this.resolveRunId(childRun.parentRun) !== parentRun.id ||
+      childRun.workflow.id !== workflowId
+    ) {
+      return null;
+    }
+
+    return childRun;
+  }
+
+  /**
+   * Report whether the parent context is replaying a suspension whose resume
+   * result is already recorded.
+   */
+  private isReplayingRecordedSuspension(
+    parentContext: WorkflowRuntimeContext,
+  ): boolean {
+    try {
+      return parentContext.workflow.hasRecordedResult();
+    } catch {
+      // The context may not be attached to a running workflow runtime.
+      return false;
+    }
+  }
+
+  /**
+   * Build the `call_workflow` contract payload from a persisted child run.
+   */
+  private toPersistedCallWorkflowResult(
+    run: WorkflowRunFull,
+  ): CallWorkflowResult {
+    if (run.status === 'finished') {
+      return {
+        status: 'finished',
+        workflow_id: run.workflow.id,
+        workflow_run_id: run.id,
+        output: run.output ?? {},
+      };
+    }
+
+    if (run.status === 'failed') {
+      return {
+        status: 'failed',
+        workflow_id: run.workflow.id,
+        workflow_run_id: run.id,
+        error: run.error ?? 'Child workflow run failed',
+      };
+    }
+
+    return {
+      status: 'suspended',
+      workflow_id: run.workflow.id,
+      workflow_run_id: run.id,
     };
   }
 

--- a/packages/api/src/workflow/types.ts
+++ b/packages/api/src/workflow/types.ts
@@ -38,6 +38,12 @@ export type MemoryValue = Record<string, unknown>;
 export type WorkflowResult = WorkflowStartResult | WorkflowResumeResult;
 
 /**
+ * Suspension reason used by the `call_workflow` action while its parent run
+ * waits for a spawned child run to reach a terminal state.
+ */
+export const AWAITING_CHILD_WORKFLOW_REASON = 'awaiting_child_workflow';
+
+/**
  * Payload passed from a child workflow back to the suspended `call_workflow`
  * action in its parent. Only `finished` is exposed as the action output; the
  * action converts `failed` into a thrown error and treats `suspended` as a


### PR DESCRIPTION
### Problem

`call_workflow` spawns its child run **before** calling `context.workflow.suspend()`. When the child finishes and the parent is resumed, deterministic replay re-executes the suspended step's action body — so the spawn ran a second time. The result: a duplicate child run whose opening steps re-executed visibly (e.g. its first message sent twice), left orphaned in `suspended` forever, where it would later swallow an unrelated inbound message via `findSuspendedRunByInitiator`. The parent itself completed correctly, which made the duplicate easy to miss.

Issue : #2119 

### Fix (two layers)

**Engine (`@hexabot-ai/agentic`):** new `WorkflowRuntimeControl.hasRecordedResult(key?)` lets an action detect that its upcoming `suspend()` will resolve immediately from a recorded replay result, so side effects placed before the suspend can be skipped. This gives every side-effecting-then-suspending action a correct pattern, not just `call_workflow`.

**API:**
- `call_workflow` now guards its spawn with `hasRecordedResult()` and goes straight to `suspend()` on replay.
- `AgenticService.callWorkflow` adds defense in depth: when the runtime signals a replay *and* the parent's persisted suspension metadata (`awaiting_child_workflow` + linked `workflow_run_id`) matches, it returns the existing child run's persisted result instead of spawning. The runtime signal is required because suspension bookkeeping isn't cleared on resume — metadata alone would misfire on a later sequential call to the same workflow (covered by a dedicated test).

### Tests

- Engine: replay of a rebuilt runner no longer re-runs guarded side effects; `hasRecordedResult` reports per-suspension replay state across multi-suspend steps.
- API: new `call-workflow.action.spec.ts`; service-level tests assert no duplicate child run is created during replay, and that fresh sequential calls still spawn.

All written TDD-style, each reproduced the duplicate-spawn before the fix.