### PR TITLE
fix: translation refresh pool exhaustion &  in nested expressions

### DIFF
--- a/packages/agentic/src/__tests__/workflow-values.test.ts
+++ b/packages/agentic/src/__tests__/workflow-values.test.ts
@@ -92,6 +92,32 @@ describe('workflow values', () => {
     });
   });
 
+  it('registers custom functions on nested expressions inside literal values', async () => {
+    const translate = jest.fn((key: string) => `translated:${key}`);
+    const mapping = {
+      payload: compileValue(
+        {
+          title: "=$t('Title')",
+          actions: ['=$t("Confirm")', { label: "=$t('Cancel')" }],
+        },
+        { jsonataFunctions: { t: translate } },
+      ),
+    };
+    const values = await evaluateMapping(mapping, {
+      input: {},
+      context: new TestContext().state,
+      output: {},
+    });
+
+    expect(values).toEqual({
+      payload: {
+        title: 'translated:Title',
+        actions: ['translated:Confirm', { label: 'translated:Cancel' }],
+      },
+    });
+    expect(translate).toHaveBeenCalledTimes(3);
+  });
+
   it('handles missing mappings and deep merges settings', async () => {
     await expect(
       evaluateMapping(undefined, {

--- a/packages/agentic/src/workflow-types.ts
+++ b/packages/agentic/src/workflow-types.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { Expression } from 'jsonata';
+import type { Expression, Focus } from 'jsonata';
 import type { ZodType } from 'zod';
 
 import type { Action } from './action/action.types';
@@ -15,10 +15,40 @@ import { StepType, type StepInfo } from './workflow-event-emitter';
 
 export type { CompiledTaskBindings } from './bindings/base-binding';
 
-/** Value representation used by the runtime after compilation. */
+/** Custom function callable from JSONata expressions. */
+export type JsonataFunctionImplementation = (
+  this: Focus,
+  ...args: any[]
+) => unknown;
+
+/** Function implementation, optionally paired with a JSONata type signature. */
+export type JsonataFunctionConfig =
+  | JsonataFunctionImplementation
+  | {
+      implementation: JsonataFunctionImplementation;
+      signature?: string;
+    };
+
+/** Map of function names to implementations, registered on compiled expressions. */
+export type JsonataFunctionRegistry = Record<string, JsonataFunctionConfig>;
+
+/**
+ * Value representation used by the runtime after compilation.
+ * The function registry is kept so nested `=` expressions discovered at
+ * evaluation time can be compiled with the same custom functions.
+ */
 export type CompiledValue =
-  | { kind: 'literal'; value: unknown }
-  | { kind: 'expression'; source: string; expression: Expression };
+  | {
+      kind: 'literal';
+      value: unknown;
+      jsonataFunctions?: JsonataFunctionRegistry;
+    }
+  | {
+      kind: 'expression';
+      source: string;
+      expression: Expression;
+      jsonataFunctions?: JsonataFunctionRegistry;
+    };
 
 /** Map of variable names to compiled values. */
 export type CompiledMapping = Record<string, CompiledValue>;

--- a/packages/agentic/src/workflow-values.ts
+++ b/packages/agentic/src/workflow-values.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import type { Expression, Focus } from 'jsonata';
+import type { Expression } from 'jsonata';
 import jsonata from 'jsonata';
 
 import type { JsonValue, Settings } from './dsl.types';
@@ -12,21 +12,14 @@ import type {
   CompiledMapping,
   CompiledValue,
   EvaluationScope,
+  JsonataFunctionRegistry,
 } from './workflow-types';
 
-export type JsonataFunctionImplementation = (
-  this: Focus,
-  ...args: any[]
-) => unknown;
-
-export type JsonataFunctionConfig =
-  | JsonataFunctionImplementation
-  | {
-      implementation: JsonataFunctionImplementation;
-      signature?: string;
-    };
-
-export type JsonataFunctionRegistry = Record<string, JsonataFunctionConfig>;
+export type {
+  JsonataFunctionConfig,
+  JsonataFunctionImplementation,
+  JsonataFunctionRegistry,
+} from './workflow-types';
 
 export type CompileValueOptions = {
   jsonataFunctions?: JsonataFunctionRegistry;
@@ -38,10 +31,11 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 const resolveNestedExpressions = async (
   value: unknown,
   scope: EvaluationScope,
+  jsonataFunctions?: JsonataFunctionRegistry,
   seen: WeakSet<object> = new WeakSet(),
 ): Promise<unknown> => {
   if (typeof value === 'string' && value.startsWith('=')) {
-    return evaluateValue(compileValue(value), scope);
+    return evaluateValue(compileValue(value, { jsonataFunctions }), scope);
   }
 
   if (Array.isArray(value)) {
@@ -51,7 +45,9 @@ const resolveNestedExpressions = async (
     seen.add(value);
 
     return Promise.all(
-      value.map((entry) => resolveNestedExpressions(entry, scope, seen)),
+      value.map((entry) =>
+        resolveNestedExpressions(entry, scope, jsonataFunctions, seen),
+      ),
     );
   }
 
@@ -64,7 +60,7 @@ const resolveNestedExpressions = async (
     const entries = await Promise.all(
       Object.entries(value).map(async ([key, entry]) => [
         key,
-        await resolveNestedExpressions(entry, scope, seen),
+        await resolveNestedExpressions(entry, scope, jsonataFunctions, seen),
       ]),
     );
 
@@ -108,14 +104,16 @@ export const compileValue = (
   value: unknown,
   options?: CompileValueOptions,
 ): CompiledValue => {
+  const jsonataFunctions = options?.jsonataFunctions;
+
   if (typeof value === 'string' && value.startsWith('=')) {
     const expression = jsonata(value.slice(1));
-    registerJsonataFunctions(expression, options?.jsonataFunctions);
+    registerJsonataFunctions(expression, jsonataFunctions);
 
-    return { kind: 'expression', source: value, expression };
+    return { kind: 'expression', source: value, expression, jsonataFunctions };
   }
 
-  return { kind: 'literal', value };
+  return { kind: 'literal', value, jsonataFunctions };
 };
 
 /**
@@ -162,6 +160,7 @@ export const evaluateMapping = async (
       await resolveNestedExpressions(
         await evaluateValue(compiled, scope),
         scope,
+        compiled.jsonataFunctions,
       ),
     ]),
   );

--- a/packages/api/src/i18n/controllers/translation.controller.ts
+++ b/packages/api/src/i18n/controllers/translation.controller.ts
@@ -15,7 +15,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
-import { FindManyOptions, In, Not } from 'typeorm';
+import { FindManyOptions } from 'typeorm';
 import { DeleteResult } from 'typeorm/driver/mongodb/typings';
 
 import { UuidParam } from '@/utils';
@@ -85,10 +85,9 @@ export class TranslationController extends BaseOrmController<TranslationOrmEntit
 
   /**
    * Refresh translations : Add new strings and remove old ones
-   * @returns {Promise<any>}
    */
   @Post('refresh')
-  async refresh(): Promise<any> {
+  async refresh(): Promise<DeleteResult> {
     const defaultLanguage = await this.languageService.getDefaultLanguage();
     const languages = await this.languageService.getLanguages();
     const defaultTrans: TranslationOrmEntity['translations'] = Object.keys(
@@ -103,25 +102,10 @@ export class TranslationController extends BaseOrmController<TranslationOrmEntit
         },
         {} as { [key: string]: string },
       );
-    // Scan workflows
-    let strings = await this.translationService.getAllWorkflowStrings();
-    // Filter unique and not empty messages
-    strings = strings.filter((str, pos) => {
-      return str && strings.indexOf(str) == pos;
-    });
-    // Perform refresh
-    const queue = strings.map((str) =>
-      this.translationService.findOneOrCreate(
-        { where: { str } },
-        { str, translations: defaultTrans },
-      ),
-    );
-    await Promise.all(queue);
-    // Purge non existing translations
-    const deleteOptions: FindManyOptions<TranslationOrmEntity> =
-      strings.length > 0 ? { where: { str: Not(In(strings)) } } : {};
 
-    return await this.translationService.deleteMany(deleteOptions);
+    return await this.translationService.refreshWorkflowTranslations(
+      defaultTrans,
+    );
   }
 
   /**

--- a/packages/api/src/i18n/services/translation.service.spec.ts
+++ b/packages/api/src/i18n/services/translation.service.spec.ts
@@ -12,6 +12,7 @@ import { buildTestingMocks } from '@/utils/test/utils';
 import { WorkflowService } from '@/workflow/services/workflow.service';
 import { WorkflowType } from '@/workflow/types';
 
+import { TranslationOrmEntity } from '../entities/translation.entity';
 import { TranslationRepository } from '../repositories/translation.repository';
 import { TranslationService } from '../services/translation.service';
 
@@ -149,5 +150,54 @@ describe('TranslationService', () => {
     expect(strings).not.toContain('Workflow description');
     expect(strings).not.toContain('Internal workflow description');
     expect(strings).not.toContain('Task description to ignore');
+  });
+
+  it('refreshes workflow translations sequentially with one dynamic i18n reload', async () => {
+    const operationOrder: string[] = [];
+    jest
+      .spyOn(service, 'getAllWorkflowStrings')
+      .mockResolvedValue(['Hello user', '', 'Pick one', 'Hello user']);
+    const resetSpy = jest
+      .spyOn(service, 'resetI18nTranslations')
+      .mockResolvedValue(undefined);
+    const findOneOrCreateSpy = jest
+      .spyOn(service, 'findOneOrCreate')
+      .mockImplementation(async (options, payload) => {
+        const str = (options as { where: { str: string } }).where.str;
+        operationOrder.push(`start:${str}`);
+        await service.handleTranslationsUpdate();
+        operationOrder.push(`end:${str}`);
+
+        return payload as TranslationOrmEntity;
+      });
+    const deleteManySpy = jest
+      .spyOn(service, 'deleteMany')
+      .mockImplementation(async () => {
+        await service.handleTranslationsUpdate();
+
+        return { acknowledged: true, deletedCount: 0 };
+      });
+
+    await expect(
+      service.refreshWorkflowTranslations({ fr: '' }),
+    ).resolves.toEqual({
+      acknowledged: true,
+      deletedCount: 0,
+    });
+
+    expect(findOneOrCreateSpy).toHaveBeenCalledTimes(2);
+    expect(
+      findOneOrCreateSpy.mock.calls.map(
+        ([options]) => (options as { where: { str: string } }).where.str,
+      ),
+    ).toEqual(['Hello user', 'Pick one']);
+    expect(operationOrder).toEqual([
+      'start:Hello user',
+      'end:Hello user',
+      'start:Pick one',
+      'end:Pick one',
+    ]);
+    expect(deleteManySpy).toHaveBeenCalledTimes(1);
+    expect(resetSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/api/src/i18n/services/translation.service.ts
+++ b/packages/api/src/i18n/services/translation.service.ts
@@ -14,6 +14,8 @@ import { extractTaskDefinitions as extractTaskDefinitionsFromDefs } from '@hexab
 import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import jsonata from 'jsonata';
+import { FindManyOptions, In, Not } from 'typeorm';
+import { DeleteResult } from 'typeorm/driver/mongodb/typings';
 
 import { I18nService } from '@/i18n/services/i18n.service';
 import { BaseOrmService } from '@/utils/generics/base-orm.service';
@@ -24,6 +26,9 @@ import { TranslationRepository } from '../repositories/translation.repository';
 
 @Injectable()
 export class TranslationService extends BaseOrmService<TranslationOrmEntity> {
+  /** Number of in-flight batch operations deferring the i18n refresh. */
+  private i18nRefreshDeferrals = 0;
+
   constructor(
     repository: TranslationRepository,
     private readonly workflowService: WorkflowService,
@@ -36,6 +41,38 @@ export class TranslationService extends BaseOrmService<TranslationOrmEntity> {
   public async resetI18nTranslations() {
     const translations = await this.findAll();
     this.i18n.refreshDynamicTranslations(translations);
+  }
+
+  /**
+   * Synchronize stored translations with the strings currently used by
+   * workflows: create missing ones and purge those no longer referenced.
+   *
+   * Writes run sequentially with the per-event i18n refresh deferred to a
+   * single reload at the end, so a large refresh cannot exhaust the DB pool.
+   *
+   * @param defaultTranslations - Empty translations map seeded on new strings.
+   * @returns The result of purging stale translations.
+   */
+  async refreshWorkflowTranslations(
+    defaultTranslations: TranslationOrmEntity['translations'],
+  ): Promise<DeleteResult> {
+    return await this.deferI18nRefresh(async () => {
+      const strings = [
+        ...new Set((await this.getAllWorkflowStrings()).filter(Boolean)),
+      ];
+
+      for (const str of strings) {
+        await this.findOneOrCreate(
+          { where: { str } },
+          { str, translations: { ...defaultTranslations } },
+        );
+      }
+
+      const deleteOptions: FindManyOptions<TranslationOrmEntity> =
+        strings.length > 0 ? { where: { str: Not(In(strings)) } } : {};
+
+      return await this.deleteMany(deleteOptions);
+    });
   }
 
   /**
@@ -73,8 +110,29 @@ export class TranslationService extends BaseOrmService<TranslationOrmEntity> {
    * Updates the in-memory translations
    */
   @OnEvent('hook:translation:*')
-  handleTranslationsUpdate() {
-    this.resetI18nTranslations();
+  async handleTranslationsUpdate(): Promise<void> {
+    if (this.i18nRefreshDeferrals > 0) {
+      return;
+    }
+
+    await this.resetI18nTranslations();
+  }
+
+  /**
+   * Run a batch of translation writes with the event-driven i18n refresh
+   * deferred, then reload the in-memory translations once at the end.
+   */
+  private async deferI18nRefresh<T>(operation: () => Promise<T>): Promise<T> {
+    this.i18nRefreshDeferrals++;
+
+    try {
+      return await operation();
+    } finally {
+      this.i18nRefreshDeferrals--;
+      if (this.i18nRefreshDeferrals === 0) {
+        await this.resetI18nTranslations();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

Mentioned in issue #2119 

### 1. POST /api/translation/refresh self-deadlocks the DB pool beyond ~7 strings

The refresh endpoint fired all findOneOrCreate calls in parallel via Promise.all. Each write held a pool connection while its hook:translation:* event triggered a full resetI18nTranslations() (→ findAll), which needed yet another connection — exhausting the pool and deadlocking the request.

### 2. $t() broken inside array/object input literals

Nested = expressions found inside literal values were recompiled at evaluation time without the registered JSONata functions, so $t('...') failed anywhere but top-level expressions.

## Changes

### API
- Moved the refresh logic from the controller into TranslationService.refreshWorkflowTranslations().
- Writes now run sequentially, and the event-driven i18n refresh is deferred (via an i18nRefreshDeferrals counter) to a single reload at the end of the batch — safe under concurrent refresh requests.
- Kept the idiomatic wildcard `@OnEvent('hook:translation:*')` handler (consistent with role, menu, setting, language services) so postUpdateMany and future hooks stay covered.
- Replaced the O(n²) indexOf dedupe with a Set; typed the controller's refresh() as Promise<DeleteResult>.

### Agentic Lib
CompiledValue now carries the jsonataFunctions registry, and resolveNestedExpressions threads it through when recompiling nested = strings — so custom functions like $t are registered on every nested expression, at any depth.
