### PR TITLE
fix(frontend): unconstrain ExpressionAssist dropdown width

### DIFF
--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/ExpressionAssist.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/ExpressionAssist.tsx
@@ -76,13 +76,6 @@ export const ExpressionAssist = ({
         open={Boolean(menuAnchor)}
         onClose={onMenuClose}
         onClick={(event) => event.stopPropagation()}
-        slotProps={{
-          paper: {
-            sx: {
-              maxWidth: 320,
-            },
-          },
-        }}
       >
         <MenuItem onClick={onReplaceWithExpression}>
           <ListItemText


### PR DESCRIPTION
### Screenshots
- After the fix
<img width="566" height="252" alt="image" src="https://github.com/user-attachments/assets/f561b878-ff6b-40fe-89bb-62d0eb45acfd" />

- Before the fix
<img width="566" height="252" alt="image" src="https://github.com/user-attachments/assets/5daf2785-cdbe-477c-a304-73b32babb050" />

### Summary
Removes the hardcoded `maxWidth: 320px` constraint from the `ExpressionAssist` dropdown, allowing it to size naturally based on its content and available space. This improves the usability of the expression picker, especially for long expressions and function names.

### Why
The fixed width caused the dropdown content to be unnecessarily truncated, making expressions harder to read and select. Removing the constraint provides a better editing experience without affecting functionality.

### How to review
* Open the **ExpressionAssist** dropdown in the frontend.
* Verify that the dropdown is no longer limited to `320px`.
* Check that long expressions, variables, and function names are displayed correctly and that the dropdown behaves as expected across different viewport sizes.

### Validation
* Verified the dropdown expands beyond the previous `320px` limit when space is available.
* Confirmed expression suggestions render correctly and remain fully functional.
* Checked there are no visual regressions in the expression editor.
