### PR TITLE
fix: mono-repo dynamic extensions loading

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "hexabot": {
+      "type": "http",
+      "url": "${HEXABOT_MCP_URL:-http://localhost:3000/api/mcp}",
+      "headers": {
+        "Authorization": "Bearer ${HEXABOT_MCP_TOKEN}"
+      }
+    }
+  }
+}

--- a/packages/api/src/actions/actions.module.ts
+++ b/packages/api/src/actions/actions.module.ts
@@ -7,14 +7,17 @@
 import { Global, Module } from '@nestjs/common';
 import { InjectDynamicProviders } from 'nestjs-dynamic-providers';
 
+import { extensionNodeModulesGlobs } from '@/utils/helpers/extension-globs';
+
 import { ActionService } from './actions.service';
 
 @Global()
 @InjectDynamicProviders(
   // Built-in core actions
   'node_modules/@hexabot-ai/api/dist/extensions/actions/**/*.action.js',
-  // Community extensions installed via npm
-  'node_modules/hexabot-action-*/**/*.action.js',
+  // Community extensions installed via npm, wherever the package manager
+  // placed them (flat install, hoisted workspace root, …)
+  ...extensionNodeModulesGlobs('hexabot-action-*/**/*.action.js'),
   // Custom & under dev actions
   'dist/extensions/actions/**/*.action.js',
 )

--- a/packages/api/src/bindings/bindings.module.ts
+++ b/packages/api/src/bindings/bindings.module.ts
@@ -7,14 +7,17 @@
 import { Global, Module } from '@nestjs/common';
 import { InjectDynamicProviders } from 'nestjs-dynamic-providers';
 
+import { extensionNodeModulesGlobs } from '@/utils/helpers/extension-globs';
+
 import { RuntimeBindingsService } from './runtime-bindings.service';
 
 @Global()
 @InjectDynamicProviders(
   // Built-in core runtime binding kinds
   'node_modules/@hexabot-ai/api/dist/extensions/actions/**/*.binding.js',
-  // Community runtime binding kinds installed via npm
-  'node_modules/hexabot-action-*/**/*.binding.js',
+  // Community runtime binding kinds installed via npm, wherever the package
+  // manager placed them (flat install, hoisted workspace root, …)
+  ...extensionNodeModulesGlobs('hexabot-action-*/**/*.binding.js'),
   // Custom & under dev runtime binding kinds
   'dist/extensions/actions/**/*.binding.js',
 )

--- a/packages/api/src/channel/channel.module.ts
+++ b/packages/api/src/channel/channel.module.ts
@@ -14,6 +14,7 @@ import { AttachmentModule } from '@/attachment/attachment.module';
 import { ChatModule } from '@/chat/chat.module';
 import { CmsModule } from '@/cms/cms.module';
 import { UserModule } from '@/user/user.module';
+import { extensionNodeModulesGlobs } from '@/utils/helpers/extension-globs';
 import { WorkflowOrmEntity } from '@/workflow/entities/workflow.entity';
 import { WorkflowModule } from '@/workflow/workflow.module';
 
@@ -38,8 +39,9 @@ export interface ChannelModuleOptions {
 @InjectDynamicProviders(
   // Built-in core channels
   'node_modules/@hexabot-ai/api/dist/extensions/channels/**/*.channel.js',
-  // Community extensions installed via npm
-  'node_modules/hexabot-channel-*/**/*.channel.js',
+  // Community extensions installed via npm, wherever the package manager
+  // placed them (flat install, hoisted workspace root, …)
+  ...extensionNodeModulesGlobs('hexabot-channel-*/**/*.channel.js'),
   // Custom & under dev channels
   'dist/extensions/channels/**/*.channel.js',
 )

--- a/packages/api/src/helper/helper.module.ts
+++ b/packages/api/src/helper/helper.module.ts
@@ -10,6 +10,7 @@ import { InjectDynamicProviders } from 'nestjs-dynamic-providers';
 
 import { ChatModule } from '@/chat/chat.module';
 import { CmsModule } from '@/cms/cms.module';
+import { extensionNodeModulesGlobs } from '@/utils/helpers/extension-globs';
 
 import { HelperController } from './helper.controller';
 import { HelperService } from './helper.service';
@@ -18,8 +19,9 @@ import { HelperService } from './helper.service';
 @InjectDynamicProviders(
   // Built-in core helpers
   'node_modules/@hexabot-ai/api/dist/extensions/helpers/**/*.helper.js',
-  // Community extensions installed via npm
-  'node_modules/hexabot-helper-*/**/*.helper.js',
+  // Community extensions installed via npm, wherever the package manager
+  // placed them (flat install, hoisted workspace root, …)
+  ...extensionNodeModulesGlobs('hexabot-helper-*/**/*.helper.js'),
   // Custom & under dev helpers
   'dist/extensions/helpers/**/*.helper.js',
 )

--- a/packages/api/src/setting/setting.module.ts
+++ b/packages/api/src/setting/setting.module.ts
@@ -8,6 +8,8 @@ import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { InjectDynamicProviders } from 'nestjs-dynamic-providers';
 
+import { extensionNodeModulesGlobs } from '@/utils/helpers/extension-globs';
+
 import { SettingController } from './controllers/setting.controller';
 import { MetadataOrmEntity } from './entities/metadata.entity';
 import { SettingOrmEntity } from './entities/setting.entity';
@@ -30,8 +32,9 @@ const runtimeSettingProviderPatterns = [
     : [
         // API package settings groups installed via npm
         'node_modules/@hexabot-ai/api/dist/**/*.settings.js',
-        // Community settings groups installed via npm
-        'node_modules/hexabot-*/**/*.settings.js',
+        // Community settings groups installed via npm, wherever the package
+        // manager placed them (flat install, hoisted workspace root, …)
+        ...extensionNodeModulesGlobs('hexabot-*/**/*.settings.js'),
       ]),
 ] as const;
 

--- a/packages/api/src/transfer/workflow-transfer.module.ts
+++ b/packages/api/src/transfer/workflow-transfer.module.ts
@@ -11,6 +11,7 @@ import { InjectDynamicProviders } from 'nestjs-dynamic-providers';
 import { ChatModule } from '@/chat/chat.module';
 import { CmsModule } from '@/cms/cms.module';
 import { UserModule } from '@/user/user.module';
+import { extensionNodeModulesGlobs } from '@/utils/helpers/extension-globs';
 import { WorkflowModule } from '@/workflow/workflow.module';
 
 import { ContentTypeTransferAdapter } from './adapters/content-type-transfer.adapter';
@@ -25,7 +26,9 @@ import { WorkflowTransferService } from './workflow-transfer.service';
 
 @InjectDynamicProviders(
   'node_modules/@hexabot-ai/api/dist/extensions/**/*.workflow-transfer.adapter.js',
-  'node_modules/hexabot-*/**/*.workflow-transfer.adapter.js',
+  // Community adapters installed via npm, wherever the package manager
+  // placed them (flat install, hoisted workspace root, …)
+  ...extensionNodeModulesGlobs('hexabot-*/**/*.workflow-transfer.adapter.js'),
   'dist/extensions/**/*.workflow-transfer.adapter.js',
 )
 @Module({

--- a/packages/api/src/utils/helpers/extension-globs.ts
+++ b/packages/api/src/utils/helpers/extension-globs.ts
@@ -1,0 +1,52 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Files marking the root of a project or workspace. The node_modules walk
+ * never escapes the first ancestor containing one of these, so extensions
+ * are only discovered inside the current project.
+ */
+const PROJECT_ROOT_MARKERS = [
+  '.git',
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'bun.lock',
+  'bun.lockb',
+];
+const isProjectRoot = (dir: string): boolean =>
+  PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)));
+
+/**
+ * Build glob patterns matching npm-installed extension files in the
+ * node_modules directories Node's module resolver would consult from this
+ * package. Installers place extensions differently depending on the layout
+ * (flat npm/yarn install in the starter template, hoisted root node_modules
+ * in a pnpm workspace, …); mirroring `module.paths` keeps discovery aligned
+ * with wherever `require()` would actually find the extension.
+ *
+ * Only node_modules directories that exist are kept, and the walk stops at
+ * the project/workspace root instead of continuing to the filesystem root.
+ */
+export const extensionNodeModulesGlobs = (pattern: string): string[] => {
+  const globs: string[] = [];
+
+  for (const nodeModulesDir of module.paths) {
+    if (fs.existsSync(nodeModulesDir)) {
+      globs.push([nodeModulesDir.split(path.sep).join('/'), pattern].join('/'));
+    }
+
+    if (isProjectRoot(path.dirname(nodeModulesDir))) {
+      break;
+    }
+  }
+
+  return globs;
+};


### PR DESCRIPTION
## What changed?
Extension discovery globs (`node_modules/hexabot-action-*/**/*.action.js`, …) are resolved relative to the API's working directory. In a pnpm workspace with nodeLinker: hoisted (this monorepo), npm-installed extensions land in the workspace root node_modules, not in packages/api/node_modules. So packages like hexabot-action-ai-coding-agent were installed but never discovered or registered. The only symptom was downstream: workflows referencing the action failed validation.

## Solution
New `extensionNodeModulesGlobs()` helper (`utils/helpers/extension-globs.ts`) that mirrors Node's own module resolution (module.paths) to build the community-extension glob list, so discovery looks wherever `require()` would actually find the package.