### PR TITLE
feat(frontend): enhance the workflow error panel display

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -787,9 +787,14 @@
   "visual_editor": {
     "workflow_graph": {
       "invalid_workflow": "This workflow can't be displayed",
+      "invalid_workflow_hint": "Fix the issues below in the YAML editor to restore the graph.",
+      "issue_count_one": "{{count}} issue",
+      "issue_count_other": "{{count}} issues",
       "missing_action": "The \"{{0}}\" action is not available on this server. Install or enable the extension that provides it, then restart the API.",
       "catalog_error": "The action catalog could not be loaded from the server. Check that the API is running, then reload the page.",
-      "open_yaml_editor": "Open YAML editor"
+      "open_yaml_editor": "Open YAML editor",
+      "go_to_line": "Go to line {{0}} in the YAML editor",
+      "line_label": "Line {{0}}"
     },
     "flows_drawer": {
       "title": "Flows",
@@ -1021,8 +1026,7 @@
     },
     "yaml_editor": {
       "show": "Show YAML editor",
-      "hide": "Hide YAML editor",
-      "validation_title": "Workflow definition has errors"
+      "hide": "Hide YAML editor"
     },
     "guided_tour": {
       "workflow_name_prefix": "My first workflow",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -785,9 +785,14 @@
   "visual_editor": {
     "workflow_graph": {
       "invalid_workflow": "Ce workflow ne peut pas être affiché",
+      "invalid_workflow_hint": "Corrigez les problèmes ci-dessous dans l'éditeur YAML pour restaurer le graphe.",
+      "issue_count_one": "{{count}} problème",
+      "issue_count_other": "{{count}} problèmes",
       "missing_action": "L'action « {{0}} » n'est pas disponible sur ce serveur. Installez ou activez l'extension qui la fournit, puis redémarrez l'API.",
       "catalog_error": "Le catalogue d'actions n'a pas pu être chargé depuis le serveur. Vérifiez que l'API est en cours d'exécution, puis rechargez la page.",
-      "open_yaml_editor": "Ouvrir l'éditeur YAML"
+      "open_yaml_editor": "Ouvrir l'éditeur YAML",
+      "go_to_line": "Aller à la ligne {{0}} dans l'éditeur YAML",
+      "line_label": "Ligne {{0}}"
     },
     "flows_drawer": {
       "title": "Flux",
@@ -1019,8 +1024,7 @@
     },
     "yaml_editor": {
       "show": "Afficher l'éditeur YAML",
-      "hide": "Masquer l'éditeur YAML",
-      "validation_title": "La définition du workflow contient des erreurs"
+      "hide": "Masquer l'éditeur YAML"
     },
     "guided_tour": {
       "workflow_name_prefix": "Mon premier workflow",

--- a/packages/frontend/src/components/visual-editor/v4/components/main/FlowsDrawer/FlowsDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/FlowsDrawer/FlowsDrawer.tsx
@@ -404,9 +404,10 @@ export const FlowsDrawer = ({
     // highlight/reveal handled entirely via the highlightDef prop on YamlEditor
   }, [activeCodeDef]);
 
-  // React to external open-YAML requests (e.g. the graph error panel CTA)
+  // React to external open-YAML requests (e.g. the graph error panel). The
+  // requested line, when present, is revealed by the YAML editor itself.
   useEffect(() => {
-    if (!openYamlRequest) return;
+    if (!openYamlRequest?.nonce) return;
 
     setShowVersions(false);
     setOpen((prevOpen) => {
@@ -417,7 +418,7 @@ export const FlowsDrawer = ({
       return true;
     });
     setShowYaml(true);
-  }, [openYamlRequest]);
+  }, [openYamlRequest?.nonce]);
   const handleToggleType = (key: string) =>
     setOpenTypeKeys((prev) =>
       prev.includes(key) ? prev.filter((item) => item !== key) : [...prev, key],
@@ -533,6 +534,7 @@ export const FlowsDrawer = ({
                 <YamlEditor
                   onHighlightClear={onActiveDefChange}
                   highlightDef={activeCodeDef}
+                  revealTarget={openYamlRequest}
                 />
               </YamlEditorContainer>
             </>

--- a/packages/frontend/src/components/visual-editor/v4/components/main/FlowsDrawer/types.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/FlowsDrawer/types.ts
@@ -10,16 +10,19 @@ import type { LucideIcon } from "lucide-react";
 
 import type { TTranslationKeys } from "@/i18n/i18n.types";
 
+import type { YamlEditorRevealTarget } from "../../yaml-editor/useYamlEditorController";
+
 export type FlowsDrawerProps = {
   onNew?: () => void;
   onEdit?: (workflow: Workflow) => void;
   activeCodeDef?: string;
   onActiveDefChange?: () => void;
   /**
-   * External request to open the YAML editor panel (e.g. from the graph
-   * error panel CTA). Every increment opens the drawer on the YAML view.
+   * External request to open the YAML editor panel (e.g. from the graph error
+   * panel). `nonce` changes on every request so repeat clicks re-open/re-reveal;
+   * `line`, when set, is revealed in the editor.
    */
-  openYamlRequest?: number;
+  openYamlRequest?: YamlEditorRevealTarget;
 };
 
 export type FlowTypeKey = WorkflowType | string;

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/YamlEditor.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/YamlEditor.tsx
@@ -5,32 +5,35 @@
  */
 
 import Editor, { Monaco } from "@monaco-editor/react";
-import { Alert, AlertTitle, useColorScheme } from "@mui/material";
+import { useColorScheme } from "@mui/material";
 
 import { handleEditorWillMount } from "@/app-components/inputs/JsonataFormulaField/monaco";
-import { useTranslate } from "@/hooks/useTranslate";
-
-import { uniqueIssueMessages } from "../../utils/workflow-issue-localization";
 
 import { YAML_EDITOR_OPTIONS } from "./constants";
-import { useYamlEditorController } from "./useYamlEditorController";
+import {
+  useYamlEditorController,
+  type YamlEditorRevealTarget,
+} from "./useYamlEditorController";
 
 import "./yaml.worker";
 
 type YamlEditorProps = {
   onHighlightClear?: () => void;
   highlightDef?: string;
+  revealTarget?: YamlEditorRevealTarget;
 };
 
 export function YamlEditor({
   onHighlightClear,
   highlightDef,
+  revealTarget,
 }: YamlEditorProps) {
-  const { value, definitionIssues, onChange, beforeMount, onMount } =
-    useYamlEditorController(onHighlightClear, highlightDef);
+  const { value, onChange, beforeMount, onMount } = useYamlEditorController(
+    onHighlightClear,
+    highlightDef,
+    revealTarget,
+  );
   const { mode } = useColorScheme();
-  const { t } = useTranslate();
-  const issueMessages = uniqueIssueMessages(definitionIssues);
 
   return (
     <div className="yaml-editor nokey">
@@ -50,18 +53,6 @@ export function YamlEditor({
           options={YAML_EDITOR_OPTIONS}
         />
       </div>
-      {issueMessages.length > 0 ? (
-        <Alert severity="error" className="yaml-editor__alert">
-          <AlertTitle>
-            {t("visual_editor.yaml_editor.validation_title")}
-          </AlertTitle>
-          <ul className="yaml-editor__error-list">
-            {issueMessages.map((issueMessage) => (
-              <li key={issueMessage}>{issueMessage}</li>
-            ))}
-          </ul>
-        </Alert>
-      ) : null}
     </div>
   );
 }

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/styles/yaml-editor.css
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/styles/yaml-editor.css
@@ -14,12 +14,3 @@
   flex: 1;
   min-height: 0;
 }
-
-.yaml-editor__alert {
-  margin: 0.5rem;
-}
-
-.yaml-editor__error-list {
-  margin: 0;
-  padding-left: 1.25rem;
-}

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/useYamlEditorController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/useYamlEditorController.ts
@@ -25,9 +25,20 @@ import { applyWorkflowValidationMarkers } from "./validation/validation";
 
 const HIGHLIGHT_CLASS = "workflow-yaml-node-def-highlight";
 
+/**
+ * Request to reveal a specific line in the editor. `nonce` changes on every
+ * request so repeat clicks on the same line re-trigger the reveal; `line` is
+ * a 1-based line number (undefined = just open, no reveal).
+ */
+export type YamlEditorRevealTarget = {
+  nonce: number;
+  line?: number;
+};
+
 export function useYamlEditorController(
   onHighlightClear?: () => void,
   highlightDef?: string,
+  revealTarget?: YamlEditorRevealTarget,
 ) {
   const { yaml, definitionIssues, updateDefinitionState, taskIds } =
     useWorkflow();
@@ -44,10 +55,42 @@ export function useYamlEditorController(
   const rangeRef = useRef<{ startLine: number; endLine: number } | null>(null);
   const onHighlightClearRef = useRef(onHighlightClear);
   const highlightDefRef = useRef(highlightDef);
+  const revealTargetRef = useRef(revealTarget);
+  // Nonce of the reveal request already applied, so each request reveals once.
+  const appliedRevealNonceRef = useRef<number | undefined>(undefined);
 
   onHighlightClearRef.current = onHighlightClear;
   highlightDefRef.current = highlightDef;
+  revealTargetRef.current = revealTarget;
 
+  const revealLine = useCallback((line: number) => {
+    const editorInstance = editorRef.current;
+    const monacoInstance = monacoRef.current;
+
+    if (!editorInstance || !monacoInstance) return;
+
+    const model = editorInstance.getModel();
+
+    if (!model) return;
+
+    const clamped = Math.min(Math.max(line, 1), model.getLineCount());
+
+    editorInstance.revealLineInCenter(
+      clamped,
+      monacoInstance.editor.ScrollType.Immediate,
+    );
+    editorInstance.setPosition({ lineNumber: clamped, column: 1 });
+    editorInstance.focus();
+  }, []);
+  const applyPendingReveal = useCallback(() => {
+    const target = revealTargetRef.current;
+
+    if (!target || target.line === undefined) return;
+    if (appliedRevealNonceRef.current === target.nonce) return;
+
+    appliedRevealNonceRef.current = target.nonce;
+    revealLine(target.line);
+  }, [revealLine]);
   const clearHighlight = useCallback((notify = false) => {
     if (editorRef.current) {
       decorationsRef.current = editorRef.current.deltaDecorations(
@@ -156,6 +199,9 @@ export function useYamlEditorController(
       if (highlightDefRef.current) {
         setHighlight(highlightDefRef.current);
       }
+      // Apply a reveal request queued while the editor was still unmounted
+      // (e.g. the drawer just opened from a graph error line click).
+      applyPendingReveal();
       editorInstance.onMouseDown((e) => {
         const { startLine, endLine } = rangeRef.current ?? {};
 
@@ -168,12 +214,19 @@ export function useYamlEditorController(
         clearHighlight(true);
       });
     },
-    [applyAllMarkers, setHighlight, clearHighlight],
+    [applyAllMarkers, applyPendingReveal, setHighlight, clearHighlight],
   );
 
   useEffect(() => {
     applyAllMarkers();
   }, [applyAllMarkers]);
+
+  // Reveal a newly requested line once the editor is already mounted.
+  useEffect(() => {
+    if (!editorRef.current) return;
+
+    applyPendingReveal();
+  }, [revealTarget?.nonce, applyPendingReveal]);
 
   useDebouncedEffect(
     () => {
@@ -225,5 +278,5 @@ export function useYamlEditorController(
     };
   }, []);
 
-  return { value: yaml, definitionIssues, onChange, beforeMount, onMount };
+  return { value: yaml, onChange, beforeMount, onMount };
 }

--- a/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/layouts/Workflow.tsx
@@ -90,7 +90,7 @@ import {
   createBaseDefinition,
   createTaskName,
 } from "../utils/workflow-definition.utils";
-import { uniqueIssueMessages } from "../utils/workflow-issue-localization";
+import { uniqueIssueLocations } from "../utils/workflow-issue-locations";
 import "./workflow-layout.css";
 
 const StyledBox = styled(Box)(() => ({
@@ -180,11 +180,15 @@ export const Workflow = () => {
     useState<ToolFormDrawerTarget | null>(null);
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
   const [menuFlowId, setMenuFlowId] = useState<string | null>(null);
-  // Incremented whenever the graph asks the drawer to open the YAML editor
-  // (e.g. from the error panel CTA); FlowsDrawer reacts to the change.
-  const [yamlOpenRequest, setYamlOpenRequest] = useState(0);
-  const handleOpenYamlEditor = useCallback(() => {
-    setYamlOpenRequest((request) => request + 1);
+  // Bumped whenever the graph asks the drawer to open the YAML editor (error
+  // panel CTA or a per-error line link). `nonce` changes every request so
+  // repeat clicks re-fire; `line` (when set) is revealed in the editor.
+  const [yamlOpenRequest, setYamlOpenRequest] = useState<{
+    nonce: number;
+    line?: number;
+  }>({ nonce: 0 });
+  const handleOpenYamlEditor = useCallback((line?: number) => {
+    setYamlOpenRequest((prev) => ({ nonce: prev.nonce + 1, line }));
   }, []);
   const actionsDrawerId = "workflow-actions-drawer";
   const publishLabel = t("button.publish");
@@ -888,9 +892,9 @@ export const Workflow = () => {
   const graphIssues = useMemo(
     () =>
       definitionStatus === "invalid"
-        ? uniqueIssueMessages(definitionIssues)
+        ? uniqueIssueLocations(yaml, definitionIssues)
         : undefined,
-    [definitionIssues, definitionStatus],
+    [definitionIssues, definitionStatus, yaml],
   );
   // While the YAML is temporarily invalid (e.g. mid-edit), keep the last
   // successfully compiled graph rendered behind the error panel instead of

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-issue-locations.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-issue-locations.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowIssue } from "../types/workflow.types";
+
+import { uniqueIssueLocations } from "./workflow-issue-locations";
+
+const makeIssue = (issue: Partial<WorkflowIssue>): WorkflowIssue =>
+  ({
+    code: "schema",
+    message: "issue",
+    rawMessage: "issue",
+    ...issue,
+  }) as WorkflowIssue;
+const yaml = [
+  "defs:", // 1
+  "  greet:", // 2
+  "    kind: task", // 3
+  "    action: missing_action", // 4
+  "flow:", // 5
+  "  - do: greet", // 6
+  "  - do: ghost_task", // 7
+  "outputs:", // 8
+  '  result: "=true"', // 9
+].join("\n");
+
+describe("uniqueIssueLocations", () => {
+  it("resolves each issue path to its 1-based YAML line", () => {
+    const result = uniqueIssueLocations(yaml, [
+      makeIssue({
+        code: "missing_action",
+        message: 'The "missing_action" action is not available',
+        path: ["defs", "greet", "action"],
+      }),
+      makeIssue({
+        code: "unknown_task",
+        message: "Unknown task(s) referenced in flow: ghost_task",
+        path: ["flow", 1, "do"],
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        message: 'The "missing_action" action is not available',
+        line: 4,
+      },
+      {
+        message: "Unknown task(s) referenced in flow: ghost_task",
+        line: 7,
+      },
+    ]);
+  });
+
+  it("deduplicates by message, keeping the first occurrence's line", () => {
+    const result = uniqueIssueLocations(yaml, [
+      makeIssue({
+        code: "missing_action",
+        message: "same message",
+        path: ["defs", "greet", "action"],
+      }),
+      makeIssue({
+        code: "missing_action",
+        message: "same message",
+        path: ["flow", 1, "do"],
+      }),
+    ]);
+
+    expect(result).toEqual([{ message: "same message", line: 4 }]);
+  });
+
+  it("omits the line when the issue has no path", () => {
+    const result = uniqueIssueLocations(yaml, [
+      makeIssue({ code: "catalog_error", message: "catalog down" }),
+    ]);
+
+    expect(result).toEqual([{ message: "catalog down", line: undefined }]);
+  });
+
+  it("omits lines when the YAML has syntax errors", () => {
+    const result = uniqueIssueLocations("defs: [ unclosed", [
+      makeIssue({
+        code: "missing_action",
+        message: "still shown",
+        path: ["defs", "greet", "action"],
+      }),
+    ]);
+
+    expect(result).toEqual([{ message: "still shown", line: undefined }]);
+  });
+});

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-issue-locations.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-issue-locations.ts
@@ -1,0 +1,46 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type { WorkflowGraphIssue } from "@hexabot-ai/graph";
+import { LineCounter, parseDocument } from "yaml";
+
+import { getRangeForPath } from "../components/yaml-editor/validation/validation.paths";
+import type { WorkflowIssue } from "../types/workflow.types";
+
+/**
+ * Deduplicated issues for the graph error panel, each resolved to the 1-based
+ * YAML line it points at when possible (so the panel can offer a jump-to-line
+ * link). Falls back to no line when the YAML can't be parsed or the issue has
+ * no locatable path.
+ */
+export const uniqueIssueLocations = (
+  yaml: string,
+  issues: WorkflowIssue[],
+): WorkflowGraphIssue[] => {
+  const lineCounter = new LineCounter();
+  const doc = parseDocument(yaml, { lineCounter });
+  // A YAML syntax error makes node offsets unreliable, so don't guess a line.
+  const canLocate = doc.errors.length === 0;
+  const seen = new Set<string>();
+  const locations: WorkflowGraphIssue[] = [];
+
+  for (const issue of issues) {
+    if (seen.has(issue.message)) {
+      continue;
+    }
+
+    seen.add(issue.message);
+
+    const line =
+      canLocate && issue.path
+        ? getRangeForPath(doc, issue.path, lineCounter).startLineNumber
+        : undefined;
+
+    locations.push({ message: issue.message, line });
+  }
+
+  return locations;
+};

--- a/packages/graph/src/workflow/components/WorkflowErrorState.tsx
+++ b/packages/graph/src/workflow/components/WorkflowErrorState.tsx
@@ -4,12 +4,14 @@
  * Full terms: see LICENSE.md.
  */
 
-import { TriangleAlert } from "lucide-react";
+import { ArrowUpRight, TriangleAlert } from "lucide-react";
 
 import { useWorkflowGraphHost } from "../contexts/workflow-graph-host.context";
 
+import type { WorkflowGraphIssue } from "./WorkflowGraph";
+
 type WorkflowErrorStateProps = {
-  issues: string[];
+  issues: WorkflowGraphIssue[];
 };
 
 export const WorkflowErrorState = ({ issues }: WorkflowErrorStateProps) => {
@@ -18,22 +20,64 @@ export const WorkflowErrorState = ({ issues }: WorkflowErrorStateProps) => {
   return (
     <div className="workflow-error-overlay" role="alert">
       <div className="workflow-error-panel">
-        <div className="workflow-error-title">
-          <TriangleAlert className="workflow-error-icon" />
-          {translate("visual_editor.workflow_graph.invalid_workflow")}
+        <div className="workflow-error-header">
+          <span className="workflow-error-badge" aria-hidden="true">
+            <TriangleAlert className="workflow-error-icon" />
+          </span>
+          <div className="workflow-error-heading">
+            <div className="workflow-error-title">
+              {translate("visual_editor.workflow_graph.invalid_workflow")}
+            </div>
+            <p className="workflow-error-subtitle">
+              {translate("visual_editor.workflow_graph.invalid_workflow_hint")}
+            </p>
+          </div>
+          <span className="workflow-error-count">
+            {translate("visual_editor.workflow_graph.issue_count", {
+              count: issues.length,
+            })}
+          </span>
         </div>
         <ul className="workflow-error-list">
-          {issues.map((issue) => (
-            <li key={issue}>{issue}</li>
-          ))}
+          {issues.map((issue, index) => {
+            const canJumpToLine =
+              onOpenYamlEditor !== undefined && issue.line !== undefined;
+
+            return (
+              <li
+                className="workflow-error-row"
+                key={`${issue.message}:${index}`}
+              >
+                <span className="workflow-error-marker" aria-hidden="true" />
+                <span className="workflow-error-message">{issue.message}</span>
+                {canJumpToLine ? (
+                  <button
+                    type="button"
+                    className="workflow-error-goto"
+                    onClick={() => onOpenYamlEditor?.(issue.line)}
+                    title={translate(
+                      "visual_editor.workflow_graph.go_to_line",
+                      { 0: issue.line as number },
+                    )}
+                  >
+                    {translate("visual_editor.workflow_graph.line_label", {
+                      0: issue.line as number,
+                    })}
+                    <ArrowUpRight className="workflow-error-goto-icon" />
+                  </button>
+                ) : null}
+              </li>
+            );
+          })}
         </ul>
         {onOpenYamlEditor ? (
           <button
             type="button"
             className="workflow-error-cta"
-            onClick={onOpenYamlEditor}
+            onClick={() => onOpenYamlEditor()}
           >
             {translate("visual_editor.workflow_graph.open_yaml_editor")}
+            <ArrowUpRight className="workflow-error-cta-icon" />
           </button>
         ) : null}
       </div>

--- a/packages/graph/src/workflow/components/WorkflowGraph.tsx
+++ b/packages/graph/src/workflow/components/WorkflowGraph.tsx
@@ -76,6 +76,16 @@ import { WorkflowErrorState } from "./WorkflowErrorState";
 import { WorkflowInsertContextMenu } from "./WorkflowInsertContextMenu";
 import { WorkflowLoadingState } from "./WorkflowLoadingState";
 
+/**
+ * A single reason the workflow could not be compiled. `line` is the 1-based
+ * YAML line the issue maps to, when the host can resolve one, enabling a
+ * jump-to-line link in the error panel.
+ */
+export type WorkflowGraphIssue = {
+  message: string;
+  line?: number;
+};
+
 export type WorkflowGraphModel = {
   definition?: WorkflowDefinition;
   compiledFlow?: CompiledStep[];
@@ -85,12 +95,12 @@ export type WorkflowGraphModel = {
   layoutDirection?: ResizeControlDirection;
   activeCodeDefName?: string;
   /**
-   * Human-readable reasons why the workflow could not be compiled (missing
-   * actions, validation errors, …). When set, a blocking error panel is
-   * overlaid on the canvas — over the last-good graph when the host keeps
-   * providing one via `compiledFlow`, or over the empty canvas otherwise.
+   * Reasons why the workflow could not be compiled (missing actions, validation
+   * errors, …). When set, a blocking error panel is overlaid on the canvas —
+   * over the last-good graph when the host keeps providing one via
+   * `compiledFlow`, or over the empty canvas otherwise.
    */
-  issues?: string[];
+  issues?: WorkflowGraphIssue[];
 };
 
 export type WorkflowGraphSelection = {
@@ -117,7 +127,7 @@ export type WorkflowGraphCallbacks = {
   onRemoveBinding?: (payload: WorkflowBindingRemovePayload) => void;
   onRotate: (nextDirection: "horizontal" | "vertical") => Promise<boolean>;
   onViewNodeCode?: (defName: string) => void;
-  onOpenYamlEditor?: () => void;
+  onOpenYamlEditor?: (line?: number) => void;
 };
 
 export type WorkflowGraphColorMode = "light" | "dark" | "system";
@@ -202,6 +212,24 @@ const areStringArraysEqual = (
 
   return left.every((value, index) => value === right[index]);
 };
+const areWorkflowIssuesEqual = (
+  left: readonly WorkflowGraphIssue[] | undefined,
+  right: readonly WorkflowGraphIssue[] | undefined,
+): boolean => {
+  if (left === right) {
+    return true;
+  }
+
+  if (!left || !right || left.length !== right.length) {
+    return false;
+  }
+
+  return left.every(
+    (issue, index) =>
+      issue.message === right[index].message &&
+      issue.line === right[index].line,
+  );
+};
 const isSameViewportState = (
   left: ViewportState | null | undefined,
   right: ViewportState | null | undefined,
@@ -235,7 +263,7 @@ const areWorkflowGraphPropsEqual = (
   previous.model.executionStates === next.model.executionStates &&
   previous.model.layoutDirection === next.model.layoutDirection &&
   previous.model.activeCodeDefName === next.model.activeCodeDefName &&
-  areStringArraysEqual(previous.model.issues, next.model.issues) &&
+  areWorkflowIssuesEqual(previous.model.issues, next.model.issues) &&
   areStringArraysEqual(
     previous.selection.selectedNodeIds,
     next.selection.selectedNodeIds,

--- a/packages/graph/src/workflow/contexts/workflow-graph-host.context.ts
+++ b/packages/graph/src/workflow/contexts/workflow-graph-host.context.ts
@@ -28,7 +28,7 @@ export type WorkflowGraphHostContextValue = {
   onAddBinding?: (payload: WorkflowBindingAddPayload) => void;
   onRemoveBinding?: (payload: WorkflowBindingRemovePayload) => void;
   onViewNodeCode?: (defName: string) => void;
-  onOpenYamlEditor?: () => void;
+  onOpenYamlEditor?: (line?: number) => void;
   activeCodeDefName?: string;
 };
 

--- a/packages/graph/src/workflow/index.ts
+++ b/packages/graph/src/workflow/index.ts
@@ -8,6 +8,7 @@ export { WorkflowGraph } from "./components/WorkflowGraph";
 export type {
   WorkflowGraphColorMode,
   WorkflowGraphHandle,
+  WorkflowGraphIssue,
   WorkflowGraphProps,
 } from "./components/WorkflowGraph";
 export * from "./contexts/workflow-graph-host.context";

--- a/packages/graph/src/workflow/styles/workflow-error-state.css
+++ b/packages/graph/src/workflow/styles/workflow-error-state.css
@@ -7,8 +7,15 @@
   position: absolute;
   inset: 0;
   display: flex;
+  /*
+   * Center the panel within the area below the host's title bar: the top inset
+   * reserves that space so a short panel looks centered while a tall list fills
+   * the area and scrolls instead of growing up into the title bar.
+   * The top inset can be overridden by the host via --workflow-error-overlay-top.
+   */
   align-items: center;
   justify-content: center;
+  padding: var(--workflow-error-overlay-top, 72px) 24px 24px;
   pointer-events: all;
   background: var(--workflow-error-backdrop);
   z-index: 5;
@@ -16,9 +23,13 @@
 
 .workflow-error-panel {
   pointer-events: all;
-  max-width: min(520px, calc(100% - 48px));
-  max-height: calc(100% - 48px);
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  max-width: min(520px, 100%);
+  /* Fills at most the padded overlay area; the list scrolls beyond that. */
+  max-height: 100%;
+  /* Only the error list scrolls; the title and CTA stay pinned. */
+  overflow: hidden;
   padding: 20px 24px;
   border-radius: 12px;
   border: 1px solid var(--workflow-error-border);
@@ -27,32 +38,146 @@
   color: var(--workflow-error-text);
 }
 
-.workflow-error-title {
+/* Title row: icon badge, heading block, and the issue-count pill. */
+.workflow-error-header {
+  flex: 0 0 auto;
   display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.workflow-error-badge {
+  flex: 0 0 auto;
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
-  font-weight: 600;
+  justify-content: center;
+  height: 34px;
+  width: 34px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--workflow-error-accent) 14%, transparent);
 }
 
 .workflow-error-icon {
-  flex-shrink: 0;
   height: 20px;
   width: 20px;
   color: var(--workflow-error-accent);
 }
 
+.workflow-error-heading {
+  flex: 1 1 auto;
+  min-width: 0;
+  /* Nudge the two-line block so its center aligns with the icon badge. */
+  padding-top: 1px;
+}
+
+.workflow-error-title {
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.workflow-error-subtitle {
+  margin: 2px 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: color-mix(in srgb, var(--workflow-error-text) 72%, transparent);
+}
+
+.workflow-error-count {
+  flex: 0 0 auto;
+  align-self: center;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--workflow-error-accent) 16%, transparent);
+  color: var(--workflow-error-accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
 .workflow-error-list {
-  margin: 12px 0 0;
-  padding-left: 20px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   font-size: 0.875rem;
 }
 
+/* Each issue is a card so a long list stays scannable rather than blurring. */
+.workflow-error-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 9px;
+  border: 1px solid
+    color-mix(in srgb, var(--workflow-error-accent) 18%, transparent);
+  background: color-mix(in srgb, var(--workflow-error-accent) 6%, transparent);
+}
+
+.workflow-error-marker {
+  flex: 0 0 auto;
+  height: 6px;
+  width: 6px;
+  margin-top: 7px;
+  border-radius: 50%;
+  background: var(--workflow-error-accent);
+}
+
+.workflow-error-message {
+  flex: 1 1 auto;
+  min-width: 0;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.workflow-error-goto {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 1px;
+  padding: 1px 6px 1px 8px;
+  border: 1px solid
+    color-mix(in srgb, var(--workflow-error-accent) 45%, transparent);
+  border-radius: 999px;
+  background: var(--workflow-error-surface);
+  color: var(--workflow-error-accent);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.5;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.workflow-error-goto:hover {
+  background: color-mix(in srgb, var(--workflow-error-accent) 14%, transparent);
+  border-color: var(--workflow-error-accent);
+}
+
+.workflow-error-goto-icon {
+  height: 13px;
+  width: 13px;
+}
+
 .workflow-error-cta {
-  margin-top: 14px;
-  padding: 6px 14px;
+  flex: 0 0 auto;
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 16px;
+  padding: 7px 14px;
   border: 0;
   border-radius: 8px;
   background: var(--workflow-error-accent);
@@ -61,6 +186,7 @@
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
+  transition: background 0.12s ease;
 }
 
 .workflow-error-cta:hover {
@@ -69,4 +195,9 @@
     var(--workflow-error-accent) 85%,
     var(--workflow-pulse-hover-mix)
   );
+}
+
+.workflow-error-cta-icon {
+  height: 15px;
+  width: 15px;
 }


### PR DESCRIPTION
## What changed?

Improves the blocking overlay shown when a workflow can't be compiled, making a long list of issues easier to scan and act on.

## Changes

- Header: icon now sits in a tinted badge, with a one-line hint ("Fix the issues below in the YAML editor…") and an issue-count pill so the scope reads at a glance.
- Issue list: each issue is now a bordered card with a dot marker instead of a flat list, keeping each Line N jump chip tied to its message.
- Affordances: Line N chips get a solid surface + hover border; the "Open YAML editor" CTA gains a trailing arrow and hover transitions.
- i18n: added invalid_workflow_hint and pluralized issue_count keys (en + fr).

All colors derive from the existing --workflow-error-* tokens via color-mix, so light and dark themes work with no new variables. Purely presentational — no behavior or overlay-semantics changes.
