### PR TITLE
fix(frontend): resolve getDateTimeFormatter issue

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -781,8 +781,8 @@
     "reset": "Forgot your password?"
   },
   "datetime": {
-    "created_at": "{{val, datetime, dateFormat}}",
-    "updated_at": "{{val, datetime, dateFormat}}"
+    "created_at": "{{val, datetime}}",
+    "updated_at": "{{val, datetime}}"
   },
   "visual_editor": {
     "workflow_graph": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -779,8 +779,8 @@
     "reset": "Mot de passe oublié?"
   },
   "datetime": {
-    "created_at": "{{val, datetime, dateFormat}}",
-    "updated_at": "{{val, datetime, dateFormat}}"
+    "created_at": "{{val, datetime}}",
+    "updated_at": "{{val, datetime}}"
   },
   "visual_editor": {
     "workflow_graph": {

--- a/packages/frontend/src/i18n/config.ts
+++ b/packages/frontend/src/i18n/config.ts
@@ -27,9 +27,4 @@ i18n
     },
   });
 
-i18n.services.formatter?.add("dateFormat", (value, lng, options) =>
-  new Intl.DateTimeFormat(lng, options?.formatParams?.val).format(
-    new Date(options?.date || value),
-  ),
-);
 export default i18n;

--- a/packages/frontend/src/utils/date.test.ts
+++ b/packages/frontend/src/utils/date.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import i18n from "@/i18n/config";
+
+import { getDateTimeFormatter } from "./date";
+
+describe("getDateTimeFormatter", () => {
+  it("formats datetime translations instead of exposing interpolation syntax", () => {
+    i18n.addResourceBundle(
+      "en",
+      "translation",
+      {
+        datetime: {
+          created_at: "{{val, datetime}}",
+        },
+      },
+      true,
+      true,
+    );
+
+    const formatted = i18n.t(
+      "datetime.created_at",
+      getDateTimeFormatter(new Date("2026-07-15T10:30:00Z")),
+    );
+
+    expect(formatted).not.toContain("{{");
+    expect(formatted).toContain("2026");
+  });
+});

--- a/packages/frontend/src/utils/date.ts
+++ b/packages/frontend/src/utils/date.ts
@@ -22,7 +22,7 @@ dayjs.extend(localizedFormat);
 dayjs.extend(duration);
 
 export const getDateTimeFormatter = (date: Date) => ({
-  date,
+  val: date,
   formatParams: {
     val: DATE_TIME_FORMAT,
   },


### PR DESCRIPTION
## Screenshots
- After the fix
<img width="736" height="220" alt="image" src="https://github.com/user-attachments/assets/19b24c5e-37af-460e-8490-7866f4e4177a" />

- Before the fix 
<img width="765" height="230" alt="image" src="https://github.com/user-attachments/assets/d3e4dfda-bd01-4769-85aa-18a4372a27e9" />

## Summary
Fixes an issue in `getDateTimeFormatter` that could produce incorrect or inconsistent date/time formatting under certain conditions. The implementation has been updated to ensure formatter creation behaves reliably across supported use cases.

## Why
The previous implementation could lead to incorrect formatting behavior and inconsistencies in the UI. This change improves the reliability and predictability of date/time formatting throughout the frontend.

## How to review
* Review the changes in `getDateTimeFormatter`.
* Verify that the formatter is created correctly for the supported locales and formatting options.
* Check any components relying on this utility for potential regressions.

## Validation
* Verified that date/time values are formatted correctly in the affected UI.
* Confirmed existing formatting behavior remains unchanged for unaffected scenarios.
* Ran the relevant frontend tests and linting.
