### PR TITLE
fix(frontend): enhance duration formatting

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -474,7 +474,7 @@
     "status": "Status",
     "closed": "Closed",
     "duration": "Duration",
-    "latency_ms": "Latency (ms)",
+    "latency": "Latency",
     "tool_count": "Tool Count",
     "error": "Error",
     "operations": "Operations",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -473,7 +473,7 @@
     "status": "Statut",
     "closed": "Fermé",
     "duration": "Durée",
-    "latency_ms": "Latence (ms)",
+    "latency": "Latence",
     "tool_count": "Nombre d'outils",
     "error": "Erreur",
     "operations": "Opérations",

--- a/packages/frontend/src/components/mcp-servers/result-drawer/DiagnosticsResultSection.tsx
+++ b/packages/frontend/src/components/mcp-servers/result-drawer/DiagnosticsResultSection.tsx
@@ -17,7 +17,7 @@ import {
 
 import { useTranslate } from "@/hooks/useTranslate";
 import { IMcpServerDiagnostics } from "@/types/mcp-server.types";
-import { formatSmartDate } from "@/utils/date";
+import { formatDurationMs, formatSmartDate } from "@/utils/date";
 
 import { ServerDetailsCard } from "./ServerDetailsCard";
 import { SummaryGrid } from "./SummaryGrid";
@@ -52,8 +52,8 @@ export const DiagnosticsResultSection = ({
               }
             />
             <SummaryItem
-              label={t("label.latency_ms")}
-              value={`${diagnostics.latencyMs}ms`}
+              label={t("label.latency")}
+              value={formatDurationMs(diagnostics.latencyMs)}
             />
             <SummaryItem
               label={t("label.checked_at")}

--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/inspector-panel/InspectorTabs.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/inspector-panel/InspectorTabs.tsx
@@ -16,7 +16,7 @@ import { EntityType } from "@/services/types";
 import { formatDurationMs } from "@/utils/date";
 
 import { formatRunTimestamp, getInitiatorName } from "../../../utils";
-import { getDurationLabel } from "../step-trace-panel/utils";
+import { getStepDuration } from "../step-trace-panel/utils";
 
 import type { OverviewLabels } from "./overview.types";
 import { OverviewContainer } from "./OverviewContainer";
@@ -143,7 +143,9 @@ export const InspectorTabs = ({ run, step }: InspectorTabsProps) => {
     return t("label.yes");
   }, [inspectedError, t]);
   const hasError = Boolean(inspectedError);
-  const stepDurationLabel = step ? getDurationLabel(step) : "-";
+  const stepDurationLabel = step
+    ? formatDurationMs(getStepDuration(step))
+    : "-";
   const statusLabels = useMemo(
     () => ({
       completed: t("label.step_trace.status_completed"),

--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/StepTraceItem.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/StepTraceItem.tsx
@@ -11,9 +11,10 @@ import { alpha, useColorScheme, useTheme } from "@mui/material/styles";
 import type { KeyboardEvent } from "react";
 
 import { useWorkflowActionsCatalog } from "@/contexts/workflow-actions.context";
+import { formatDurationMs } from "@/utils/date";
 
 import { ActionStatusIndicator } from "./ActionStatusIndicator";
-import { getDurationLabel } from "./utils";
+import { getStepDuration } from "./utils";
 
 type StepTraceItemProps = {
   step: StepExecutionRecord;
@@ -167,7 +168,7 @@ export const StepTraceItem = ({
       <Box display="flex" alignItems="center" gap={1.5} justifySelf="end">
         <ActionStatusIndicator status={step.status} />
         <Typography variant="caption" color="text.secondary">
-          {getDurationLabel(step)}
+          {formatDurationMs(getStepDuration(step))}
         </Typography>
       </Box>
     </Paper>

--- a/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/utils.ts
+++ b/packages/frontend/src/components/workflow-run-debugger/components/panels/step-trace-panel/utils.ts
@@ -13,12 +13,12 @@ export const getStepOrder = (id: string): number => {
   return Number.isFinite(order) ? order : Number.MAX_SAFE_INTEGER;
 };
 
-export const getDurationLabel = (step: StepExecutionRecord): string => {
+export const getStepDuration = (step: StepExecutionRecord): number => {
   const candidate = (step as StepExecutionRecord & { duration?: number })
     .duration;
 
   if (typeof candidate === "number" && Number.isFinite(candidate)) {
-    return `${Math.round(candidate)}ms`;
+    return candidate;
   }
 
   if (
@@ -27,8 +27,8 @@ export const getDurationLabel = (step: StepExecutionRecord): string => {
     typeof step.endedAt === "number" &&
     Number.isFinite(step.endedAt)
   ) {
-    return `${Math.round(Math.max(0, step.endedAt - step.startedAt))}ms`;
+    return Math.max(0, step.endedAt - step.startedAt);
   }
 
-  return "—";
+  return 0;
 };

--- a/packages/frontend/src/components/workflow-runs/index.tsx
+++ b/packages/frontend/src/components/workflow-runs/index.tsx
@@ -130,7 +130,7 @@ export const WorkflowRuns = ({
           sortable: false,
           disableColumnMenu: true,
           headerAlign: "left",
-          valueGetter: (_value, row) => formatDurationMs(row.duration),
+          valueGetter: (_value, { duration }) => formatDurationMs(duration),
         },
         {
           flex: 1,

--- a/packages/frontend/src/utils/date.test.ts
+++ b/packages/frontend/src/utils/date.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { formatDurationMs } from "./date";
+
+describe("formatDurationMs", () => {
+  it("formats empty and millisecond values", () => {
+    expect(formatDurationMs(null)).toBe("-");
+    expect(formatDurationMs(undefined)).toBe("-");
+    expect(formatDurationMs(250)).toBe("250ms");
+  });
+
+  it("formats seconds, minutes, and hours", () => {
+    expect(formatDurationMs(25000)).toBe("25s");
+    expect(formatDurationMs(61000)).toBe("1m 1s");
+    expect(formatDurationMs(3661000)).toBe("1h 1m 1s");
+  });
+
+  it("uses a custom separator", () => {
+    expect(formatDurationMs(61000, "")).toBe("1m1s");
+  });
+});

--- a/packages/frontend/src/utils/date.ts
+++ b/packages/frontend/src/utils/date.ts
@@ -78,19 +78,17 @@ export const formatDurationMs = (
 ): string => {
   if (durationMs == null) return "-";
 
-  const diffMs = Math.max(0, durationMs);
-  const dur = dayjs.duration(diffMs);
-  const h = Math.floor(dur.asHours());
-  const m = dur.minutes();
-  const s = dur.seconds();
+  const ms = Math.max(0, durationMs);
 
-  if (h > 0) {
-    return `${h}h${separator}${m}m${separator}${s}s`;
-  }
+  if (ms < 1000) return `${ms}ms`;
 
-  if (m > 0) {
-    return `${m}m${separator}${s}s`;
-  }
+  const totalSeconds = Math.floor(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+
+  if (h > 0) return `${h}h${separator}${m}m${separator}${s}s`;
+  if (m > 0) return `${m}m${separator}${s}s`;
 
   return `${s}s`;
 };


### PR DESCRIPTION
## Screenshots
- After the fix
<img width="116" height="260" alt="image" src="https://github.com/user-attachments/assets/08e494fa-d448-4174-8b46-e9a330329d3a"></img>
<img width="455" height="285" alt="image" src="https://github.com/user-attachments/assets/7941b7e2-174f-4eec-bb48-1bd81a95a3ab"></img>
<img width="431" height="170" alt="image" src="https://github.com/user-attachments/assets/d09530b2-5830-46f5-a49e-c4b8655d2581"></img>

- Before the fix
<img width="116" height="260" alt="image" src="https://github.com/user-attachments/assets/80ac8420-7219-45ec-96e7-570b12197044"></img>
<img width="455" height="285" alt="image" src="https://github.com/user-attachments/assets/4fcc8660-b43d-4849-89ab-ada8ef807ea0"></img>
<img width="431" height="170" alt="image" src="https://github.com/user-attachments/assets/6f9a36c5-06cd-4cf8-836e-87e06eabf2e7"></img>

## Summary
Improves duration formatting across the frontend to produce clearer, more consistent, and user-friendly time values. The formatting logic has been refined to better handle different duration ranges and edge cases.

## Why
Consistent duration formatting improves readability and provides a better user experience wherever elapsed time or durations are displayed.

## How to review
* Review the updated duration formatting logic.
* Verify formatting for short, medium, and long durations.
* Pay special attention to edge cases (e.g. zero values, sub-second durations, and large durations).

## Validation
* Verified duration formatting for representative duration values across supported ranges.
* Confirmed existing duration displays continue to render correctly.
