### PR TITLE
fix(frontend): live step updates

### DIFF
--- a/packages/frontend/src/components/workflow-run-debugger/components/WorkflowRunDebugger.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/WorkflowRunDebugger.tsx
@@ -11,7 +11,7 @@ import Stack from "@mui/material/Stack";
 import { FC, useEffect, useMemo, useState } from "react";
 
 import { useFind } from "@/hooks/crud/useFind";
-import { useGetFromCache } from "@/hooks/crud/useGet";
+import { useGet, useGetFromCache } from "@/hooks/crud/useGet";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType, Format } from "@/services/types";
 
@@ -78,9 +78,22 @@ export const WorkflowRunDebugger: FC<WorkflowRunDebuggerProps> = ({
     setSelectedRunId(runId ?? latestRun?.id);
   }, [runId, latestRun?.id]);
 
+  // Subscribe reactively to the selected run's item cache. The live-update hook
+  // merges each step into `[item, WORKFLOW_RUN, runId]` via `setQueryData`, but
+  // the `useFind` collection reads that cache non-reactively, so item merges
+  // alone never re-render this component. Observing the item query here ensures
+  // every incremental step update is reflected in real time.
+  const { data: liveSelectedRun } = useGet(
+    selectedRunId ?? "",
+    { entity: EntityType.WORKFLOW_RUN, format: Format.FULL },
+    { enabled: Boolean(selectedRunId) },
+  );
   const selectedRun = useMemo(
-    () => workflowRuns.find((run) => run.id === selectedRunId) ?? latestRun,
-    [latestRun, selectedRunId, workflowRuns],
+    () =>
+      liveSelectedRun ??
+      workflowRuns.find((run) => run.id === selectedRunId) ??
+      latestRun,
+    [latestRun, liveSelectedRun, selectedRunId, workflowRuns],
   );
   const selectedStep = useMemo(() => {
     if (!selectedStepId) return null;


### PR DESCRIPTION
## Problem

On the standalone Workflow Run Debugger page, steps stream in real time only up to the await_requirement step. The steps that run after resume don't appear until the run finishes, then all at once. The embedded debugger in the workflow editor looks fine.

## Root cause
Live workflow events are merged into the item cache ([item, WORKFLOW_RUN, runId]) by useWorkflowRunLiveUpdates, but WorkflowRunDebugger renders the run from the useFind collection, read non-reactively via getFromCache. So item-cache merges never re-render the component. The compensating collection "touch" ([...collection]) is deduped to a no-op by React Query's structural sharing once the run is already in the list — so nothing re-renders until an unrelated event (a refetch, or the terminal workflow:finish) forces one. The editor only appeared to work because surrounding UI activity triggered frequent incidental re-renders that masked the issue.

## Fix
Subscribe WorkflowRunDebugger to the selected run's item query via useGet, so every incremental step merge re-renders the component. The existing useFind/latestRun fallback is preserved for initial paint.

