### PR TITLE
fix(frontend): validate schema onSubmit action drawer

### DIFF
--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/JsonSchemaForm.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/JsonSchemaForm.tsx
@@ -260,6 +260,7 @@ export const JsonSchemaForm = <
         expressionFieldStates,
         expressionPolicy,
         formData: liveFormData,
+        validateOnMount,
         reportExpressionFieldState,
         reportFieldVisibleError,
       }}

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawer.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawer.tsx
@@ -37,6 +37,7 @@ export const ActionFormDrawer = ({
     actionSettingsData,
     executionSettingsData,
     isUsingWorkflowExecutionDefaults,
+    validateActionSchemas,
     panelKeyBase,
     emptyStateLabel,
     onInputDataChange,
@@ -59,6 +60,7 @@ export const ActionFormDrawer = ({
       actionSettingsData={actionSettingsData}
       executionSettingsData={executionSettingsData}
       isUsingWorkflowExecutionDefaults={isUsingWorkflowExecutionDefaults}
+      validateActionSchemas={validateActionSchemas}
       panelKeyBase={panelKeyBase}
       emptyStateLabel={emptyStateLabel}
       onInputDataChange={onInputDataChange}

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerContent.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/ActionFormDrawerContent.tsx
@@ -24,6 +24,7 @@ export type ActionFormDrawerContentProps = {
   actionSettingsData: Record<string, unknown>;
   executionSettingsData: Record<string, unknown>;
   isUsingWorkflowExecutionDefaults: boolean;
+  validateActionSchemas: boolean;
   panelKeyBase: string;
   emptyStateLabel: string;
   onInputDataChange: (data: Record<string, unknown>) => void;
@@ -42,6 +43,7 @@ export const ActionFormDrawerContent = ({
   actionSettingsData,
   executionSettingsData,
   isUsingWorkflowExecutionDefaults,
+  validateActionSchemas,
   panelKeyBase,
   emptyStateLabel,
   onInputDataChange,
@@ -80,6 +82,7 @@ export const ActionFormDrawerContent = ({
           emptyLabel={t("visual_editor.actions_drawer.form.empty_schema.input")}
           expressionPolicy="input-default"
           headerAction={<DynamicValueHelp />}
+          validateOnMount={validateActionSchemas}
         />
       ) : null}
       {hasSettingsSchema ? (
@@ -99,6 +102,7 @@ export const ActionFormDrawerContent = ({
           )}
           expressionPolicy="opt-in"
           headerAction={<DynamicValueHelp />}
+          validateOnMount={validateActionSchemas}
         />
       ) : null}
       <ExecutionSettingsPanel

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
@@ -17,6 +17,7 @@ import {
   type WorkflowDefinition,
 } from "@hexabot-ai/agentic";
 import type { FlowStepPath } from "@hexabot-ai/graph";
+import type { RJSFSchema } from "@rjsf/utils";
 import { useEffect, useMemo, useState } from "react";
 
 import {
@@ -26,6 +27,7 @@ import {
 import { useWorkflowActionsCatalog } from "@/contexts/workflow-actions.context";
 import { useTranslate } from "@/hooks/useTranslate";
 import type { IAction } from "@/types/action.types";
+import validator from "@/utils/rjsf-zod-validator";
 
 import { useWorkflow } from "../../../../hooks/useWorkflow";
 import { useSelectedActionNode } from "../../../../hooks/useWorkflowSelection";
@@ -44,6 +46,7 @@ type UseActionFormDrawerControllerResult = {
   headerProps: ActionFormDrawerHeaderProps;
   inputData: Record<string, unknown>;
   isUsingWorkflowExecutionDefaults: boolean;
+  validateActionSchemas: boolean;
   onExecutionSettingsDataChange: (data: Record<string, unknown>) => void;
   onExecutionSettingsModeChange: (useWorkflowDefaults: boolean) => void;
   onExecutionSettingsVisibleErrorsChange: (hasVisibleErrors: boolean) => void;
@@ -82,6 +85,15 @@ const EXECUTION_SETTING_KEYS = new Set(Object.keys(BaseSettingsSchema.shape));
 const DEFAULT_WORKFLOW_EXECUTION_SETTINGS: Partial<Settings> = {
   timeout_ms: DEFAULT_TIMEOUT_MS,
   retries: { ...DEFAULT_RETRY_SETTINGS },
+};
+const hasSchemaValidationErrors = (
+  schema: unknown,
+  data: Record<string, unknown>,
+): boolean => {
+  return (
+    Boolean(schema) &&
+    !validator.isValid(schema as RJSFSchema, data, schema as RJSFSchema)
+  );
 };
 const splitTaskSettings = (
   settings: Record<string, unknown> | undefined,
@@ -150,6 +162,7 @@ export const useActionFormDrawerController = ({
   const [hasInputVisibleErrors, setHasInputVisibleErrors] = useState(false);
   const [hasActionSettingsVisibleErrors, setHasActionSettingsVisibleErrors] =
     useState(false);
+  const [validateActionSchemas, setValidateActionSchemas] = useState(false);
   const [
     hasExecutionSettingsVisibleErrors,
     setHasExecutionSettingsVisibleErrors,
@@ -202,6 +215,7 @@ export const useActionFormDrawerController = ({
       setInputData({});
       setActionSettingsData({});
       setExecutionSettingsData({});
+      setValidateActionSchemas(false);
 
       return;
     }
@@ -227,6 +241,7 @@ export const useActionFormDrawerController = ({
       setActionSettingsData(actionSettings);
       setExecutionSettingsData(resolvedExecutionSettings);
       setIsUsingWorkflowExecutionDefaults(!hasExecutionOverride);
+      setValidateActionSchemas(false);
       setHasExecutionSettingsVisibleErrors(false);
 
       return;
@@ -236,6 +251,7 @@ export const useActionFormDrawerController = ({
       setInputData({});
       setActionSettingsData({});
       setExecutionSettingsData({});
+      setValidateActionSchemas(false);
 
       return;
     }
@@ -255,6 +271,7 @@ export const useActionFormDrawerController = ({
     setActionSettingsData(actionSettings);
     setExecutionSettingsData(resolvedExecutionSettings);
     setIsUsingWorkflowExecutionDefaults(!hasExecutionOverride);
+    setValidateActionSchemas(false);
     setHasExecutionSettingsVisibleErrors(false);
     // Hydrate only when opening the drawer or selecting a different node.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -309,6 +326,15 @@ export const useActionFormDrawerController = ({
       isUsingWorkflowExecutionDefaults ? false : hasVisibleErrors,
     );
   };
+  const handleInputDataChange = (data: Record<string, unknown>) => {
+    setValidateActionSchemas(true);
+    setInputData(data);
+  };
+  const handleActionSettingsDataChange = (data: Record<string, unknown>) => {
+    setValidateActionSchemas(true);
+    setActionSettingsData(data);
+  };
+  const isAttachmentAction = actionSchema?.name === "send_attachment";
   const handleSave = () => {
     const currentDefinition =
       definition ?? (isCreateMode && workflow ? createBaseDefinition() : null);
@@ -317,7 +343,15 @@ export const useActionFormDrawerController = ({
       return;
     }
 
+    setValidateActionSchemas(true);
+
     if (
+      (isAttachmentAction &&
+        (hasSchemaValidationErrors(actionSchema.inputSchema, inputData) ||
+          hasSchemaValidationErrors(
+            actionSchema.settingSchema,
+            actionSettingsData,
+          ))) ||
       hasInputVisibleErrors ||
       hasActionSettingsVisibleErrors ||
       hasExecutionSettingsVisibleErrors
@@ -445,7 +479,16 @@ export const useActionFormDrawerController = ({
     handleSaveClose();
   };
   const canSaveDefinition = Boolean(definition || (isCreateMode && workflow));
+  const hasActionSchemaValidationErrors =
+    actionSchema && isAttachmentAction && validateActionSchemas
+      ? hasSchemaValidationErrors(actionSchema.inputSchema, inputData) ||
+        hasSchemaValidationErrors(
+          actionSchema.settingSchema,
+          actionSettingsData,
+        )
+      : false;
   const saveDisabled =
+    hasActionSchemaValidationErrors ||
     hasInputVisibleErrors ||
     hasActionSettingsVisibleErrors ||
     hasExecutionSettingsVisibleErrors ||
@@ -487,13 +530,14 @@ export const useActionFormDrawerController = ({
     },
     inputData,
     isUsingWorkflowExecutionDefaults,
+    validateActionSchemas: isAttachmentAction && validateActionSchemas,
     onExecutionSettingsDataChange: setExecutionSettingsData,
     onExecutionSettingsModeChange: handleExecutionSettingsModeChange,
     onExecutionSettingsVisibleErrorsChange:
       handleExecutionSettingsVisibleErrorsChange,
-    onInputDataChange: setInputData,
+    onInputDataChange: handleInputDataChange,
     onInputVisibleErrorsChange: setHasInputVisibleErrors,
-    onActionSettingsDataChange: setActionSettingsData,
+    onActionSettingsDataChange: handleActionSettingsDataChange,
     onActionSettingsVisibleErrorsChange: setHasActionSettingsVisibleErrors,
     onClose: () => {
       onClose?.("cancel");

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionSchemaPanel.tsx
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionSchemaPanel.tsx
@@ -31,6 +31,7 @@ export type ActionSchemaPanelProps = {
   uiSchema?: UiSchema;
   expressionPolicy?: ExpressionPolicy;
   headerAction?: ReactNode;
+  validateOnMount?: boolean;
 };
 
 export const ActionSchemaPanel = ({
@@ -44,6 +45,7 @@ export const ActionSchemaPanel = ({
   uiSchema,
   expressionPolicy = "input-default",
   headerAction,
+  validateOnMount,
 }: ActionSchemaPanelProps) => (
   <Accordion variant="elevation" defaultExpanded>
     <AccordionSummary>
@@ -78,6 +80,7 @@ export const ActionSchemaPanel = ({
           uiSchema={uiSchema}
           idPrefix={`action-${panelKey}`}
           expressionPolicy={expressionPolicy}
+          validateOnMount={validateOnMount}
         />
       ) : (
         <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
**Summary:**
Validate the action schema before submitting the Action Drawer form. This prevents invalid configurations from being submitted and ensures users receive immediate feedback when required fields or schema constraints are not satisfied.

**Why:**
Submitting invalid action configurations can lead to inconsistent workflow definitions and downstream errors. Performing schema validation on submit improves data integrity and provides a better user experience by surfacing validation errors early.

**How to review:**

* Open the Action Drawer and create or edit an action.
* Try submitting both valid and invalid configurations.
* Verify that schema validation is executed on submit and that validation errors are displayed correctly.
* Confirm that valid configurations are submitted without changing existing behavior.

**Validation:**

* Manually tested Action Drawer submission with valid and invalid inputs.
* Verified that invalid payloads are blocked from submission.
* Confirmed that valid payloads continue to submit successfully.
