### PR TITLE
fix(frontend): update valdiation logic to support attachment

### DIFF
--- a/packages/api/src/extensions/actions/messaging/attachment.action.ts
+++ b/packages/api/src/extensions/actions/messaging/attachment.action.ts
@@ -6,7 +6,6 @@
 
 import {
   attachmentPayloadSchema,
-  FileType,
   stdQuickReplySchema,
 } from '@hexabot-ai/types';
 import { Injectable } from '@nestjs/common';
@@ -25,7 +24,9 @@ import {
 
 const attachmentInputSchema = z.object({
   attachment: attachmentPayloadSchema
-    .default({ payload: { id: null }, type: FileType.image })
+    .extend({
+      payload: z.object({ id: z.string().min(1) }),
+    })
     .meta({
       title: 'Attachment',
       description: 'File attachment submitted via an Attachment action',

--- a/packages/frontend/src/app-components/attachment/AttachmentInput.tsx
+++ b/packages/frontend/src/app-components/attachment/AttachmentInput.tsx
@@ -4,14 +4,19 @@
  * Full terms: see LICENSE.md.
  */
 
-import { AttachmentResourceRef, type Attachment } from "@hexabot-ai/types";
-import { Action } from "@hexabot-ai/types";
+import {
+  Action,
+  AttachmentResourceRef,
+  type Attachment,
+} from "@hexabot-ai/types";
 import { Box, FormHelperText, FormLabel } from "@mui/material";
 import { ReactNode, forwardRef } from "react";
 
 import { useGet } from "@/hooks/crud/useGet";
 import { useHasPermission } from "@/hooks/useHasPermission";
 import { EntityType } from "@/services/types";
+
+import { labelTooltipInputLabelSx } from "../inputs/JsonSchemaForm/widgets/shared";
 
 import AttachmentThumbnail from "./AttachmentThumbnail";
 import AttachmentUploader from "./AttachmentUploader";
@@ -67,8 +72,9 @@ const AttachmentInput = forwardRef<HTMLDivElement, AttachmentThumbnailProps>(
       <Box ref={ref}>
         <FormLabel
           component="label"
+          error={error}
           required={required}
-          style={{ display: "inline-block", marginBottom: 1 }}
+          sx={labelTooltipInputLabelSx}
         >
           {label}
         </FormLabel>
@@ -83,6 +89,7 @@ const AttachmentInput = forwardRef<HTMLDivElement, AttachmentThumbnailProps>(
           <AttachmentUploader
             accept={accept}
             enableMediaLibrary={enableMediaLibrary}
+            error={error}
             onChange={handleChange}
             resourceRef={resourceRef}
           />

--- a/packages/frontend/src/app-components/attachment/AttachmentUploader.tsx
+++ b/packages/frontend/src/app-components/attachment/AttachmentUploader.tsx
@@ -29,17 +29,20 @@ import { EntityType } from "@/services/types";
 import { AttachmentFormDialog } from "./AttachmentFormDialog";
 import AttachmentThumbnail from "./AttachmentThumbnail";
 
-const FileUploadLabel = styled("label")(
-  ({ isDragOver }: { isDragOver: boolean }) => `
+const FileUploadLabel = styled("label")<{
+  error?: boolean;
+  isDragOver: boolean;
+}>(
+  ({ error, isDragOver, theme }) => `
   position: relative;
   cursor: pointer;
   text-align: center;
   display: flex;
   width: 100%;
   height: 256px;
-  border: 2px dashed #b0b0b0;
+  border: 2px dashed ${error ? theme.palette.error.main : theme.palette.grey[400]};
   border-radius: 15px;
-  transition: all 0.4s ease-in-out;
+  transition: opacity 0.4s ease-in-out;
   &:hover p,
   &:hover svg,
   & img {
@@ -72,6 +75,7 @@ export type FileUploadProps = {
   imageButton?: boolean;
   accept: string;
   enableMediaLibrary?: boolean;
+  error?: boolean;
   onChange?: (data?: Attachment | null) => void;
   onUploadComplete?: () => void;
   resourceRef: AttachmentResourceRef;
@@ -80,6 +84,7 @@ export type FileUploadProps = {
 const AttachmentUploader: FC<FileUploadProps> = ({
   accept,
   enableMediaLibrary,
+  error,
   onChange,
   onUploadComplete,
   resourceRef,
@@ -159,6 +164,7 @@ const AttachmentUploader: FC<FileUploadProps> = ({
           />
           <FileUploadLabel
             htmlFor={`file-upload${uid}`}
+            error={error}
             isDragOver={isDragOver}
             onMouseEnter={() => setIsDragOver(true)}
             onMouseLeave={() => setIsDragOver(false)}

--- a/packages/frontend/src/app-components/inputs/AutoCompleteSelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteSelect.tsx
@@ -44,6 +44,7 @@ type AutoCompleteSelectProps<
   onSearch?: (keywords: string) => void;
   inputLabelSx?: unknown;
   error?: boolean;
+  required?: boolean;
   helperText?: string | null | undefined;
   noOptionsWarning?: string;
   isDisabledWhenEmpty?: boolean;
@@ -66,6 +67,7 @@ const AutoCompleteSelect = <
     onSearch,
     inputLabelSx,
     error,
+    required,
     helperText,
     isOptionEqualToValue = (option, value) =>
       option?.[idKey] === value?.[idKey],
@@ -165,6 +167,7 @@ const AutoCompleteSelect = <
             label={label}
             onChange={(e) => handleSearch(e.target.value)}
             error={error}
+            required={required}
             helperText={helperText}
             slotProps={{
               inputLabel: {

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/fields/ActionAttachmentField.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/fields/ActionAttachmentField.tsx
@@ -71,6 +71,8 @@ export const ActionAttachmentField = ({
   required,
   disabled,
   readonly,
+  rawErrors,
+  registry,
 }: FieldProps) => {
   const { t } = useTranslate();
   const options =
@@ -83,6 +85,13 @@ export const ActionAttachmentField = ({
   const description = getDescription(schema as RJSFSchema);
   const currentAttachment = getAttachmentValue(formData);
   const isReadOnly = disabled || readonly;
+  const hasError =
+    Boolean(rawErrors?.length) ||
+    Boolean(
+      registry.formContext?.validateOnMount &&
+        required &&
+        !currentAttachment?.id,
+    );
   const handleChange = (id: string | null, mimeType: string | null) => {
     const path = fieldPathId.path as FieldPathList;
 
@@ -110,6 +119,8 @@ export const ActionAttachmentField = ({
         accept={ATTACHMENT_ACCEPT}
         enableMediaLibrary={!isReadOnly}
         size={128}
+        error={hasError}
+        helperText={rawErrors?.[0]}
         onChange={handleChange}
         resourceRef={resourceRef}
       />

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/fields/AutoCompleteField.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/fields/AutoCompleteField.tsx
@@ -35,11 +35,13 @@ export const AutoCompleteFieldWrapper = ({
   nestedArrayItemValue = "",
   title,
   value,
+  error,
   onChange,
 }: Rjsf["uiSchema"]["ui:options"] & {
   id: string;
   title?: string;
   value: any;
+  error?: boolean;
   entity: keyof IEntityMapTypes;
   onChange: (e: SyntheticEvent<Element, Event>, value: any) => void;
 }) => {
@@ -70,7 +72,9 @@ export const AutoCompleteFieldWrapper = ({
       options={hasOptions ? options : []}
       disabled={!hasOptions}
       onChange={onChange}
-      renderInput={(props) => <TextField {...props} label={title} />}
+      renderInput={(props) => (
+        <TextField {...props} error={error} label={title} />
+      )}
       getOptionLabel={(option) =>
         option.charAt(0).toUpperCase() + option.slice(1)
       }
@@ -85,6 +89,7 @@ export const AutoCompleteField = ({
   registry,
   fieldPathId,
   onChange,
+  rawErrors,
 }: FieldProps) => {
   const { entity, idFormPath, ...props } = (uiSchema?.["ui:options"] ??
     {}) as Rjsf["uiSchema"]["ui:options"];
@@ -103,6 +108,7 @@ export const AutoCompleteField = ({
       title={schema.title}
       value={formData}
       entity={normalizeEntity(entity)}
+      error={Boolean(rawErrors?.length)}
       onChange={handleChange}
       {...props}
     />

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/schema-defaults.utils.ts
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/schema-defaults.utils.ts
@@ -9,6 +9,10 @@ import { getDefaultFormState, RJSFSchema, UiSchema } from "@rjsf/utils";
 import { JSONSchema7 } from "json-schema";
 import { JSONSchema } from "monaco-yaml";
 
+import {
+  makeDefaultSchemaNode,
+  toJsonSchema,
+} from "@/app-components/inputs/JsonSchemaObjectBuilder";
 import { isRecord } from "@/utils/object";
 import validator from "@/utils/rjsf-zod-validator";
 
@@ -25,8 +29,26 @@ export const getSchemaDefaults = <T extends Record<string, JsonValue>>(
 ): T | undefined => {
   try {
     const defaults = computeDefaultFormState<T>(schema as RJSFSchema);
+    let next = normalizeDefaults(defaults) as T | undefined;
 
-    return normalizeDefaults(defaults) as T;
+    // JsonSchemaObjectField only syncs its value once the user edits the
+    // builder, so seed its fields with the builder's default schema
+    for (const [key, property] of Object.entries(
+      getSchemaProperties(schema) ?? {},
+    )) {
+      if (
+        isRecord(property) &&
+        property["ui:field"] === "JsonSchemaObjectField" &&
+        next?.[key] === undefined
+      ) {
+        next = {
+          ...(next ?? {}),
+          [key]: toJsonSchema(makeDefaultSchemaNode("object")),
+        } as T;
+      }
+    }
+
+    return next;
   } catch {
     return undefined;
   }

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/templates/ActionArrayFieldTemplate.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/templates/ActionArrayFieldTemplate.tsx
@@ -51,7 +51,13 @@ export const ActionArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
           <Typography
             variant="subtitle2"
             component="span"
-            sx={{ display: "inline-flex", alignItems: "center" }}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              "& .action-field-label-icon": {
+                order: 3,
+              },
+            }}
           >
             <LabelWithTooltip
               label={titleLabel}
@@ -59,7 +65,7 @@ export const ActionArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
               iconSize={14}
             />
             {required && titleLabel ? (
-              <Box component="span" aria-hidden ml={0.25}>
+              <Box component="span" aria-hidden ml={0.25} sx={{ order: 2 }}>
                 *
               </Box>
             ) : null}

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/ActionCheckboxWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/ActionCheckboxWidget.tsx
@@ -33,6 +33,7 @@ export const ActionCheckboxWidget = (props: WidgetProps) => {
     label: fieldLabel = "",
     hideLabel,
     autofocus,
+    rawErrors,
     onChange,
     onBlur,
     onFocus,
@@ -78,6 +79,7 @@ export const ActionCheckboxWidget = (props: WidgetProps) => {
           name={htmlName || id}
           checked={checked}
           required={required}
+          color={rawErrors?.length ? "error" : "primary"}
           disabled={disabled || readonly}
           autoFocus={autofocus}
           onChange={(_, nextChecked) => onChange(nextChecked)}

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
@@ -59,6 +59,7 @@ const AutoCompleteWidgetWrapper = ({
   label?: ReactNode;
   inputLabelSx?: unknown;
   error?: boolean;
+  required?: boolean;
   value: any;
   entity?: keyof IEntityMapTypes;
   multiple?: boolean;
@@ -150,6 +151,7 @@ export const AutoCompleteWidget = ({
   uiSchema,
   onChange,
   rawErrors,
+  required,
   registry,
 }: WidgetProps) => {
   const description = getDescription(schema as RJSFSchema, options);
@@ -222,6 +224,7 @@ export const AutoCompleteWidget = ({
         routeParams={dependencyQueryConfig.routeParams}
         queryEnabled={dependencyQueryConfig.queryEnabled}
         error={Boolean(rawErrors?.length)}
+        required={required}
         onChange={onChange}
         {...props}
       />

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/AutoCompleteWidget.tsx
@@ -58,6 +58,7 @@ const AutoCompleteWidgetWrapper = ({
 }: AutoCompleteWidgetOptions & {
   label?: ReactNode;
   inputLabelSx?: unknown;
+  error?: boolean;
   value: any;
   entity?: keyof IEntityMapTypes;
   multiple?: boolean;
@@ -148,6 +149,7 @@ export const AutoCompleteWidget = ({
   InputLabelProps,
   uiSchema,
   onChange,
+  rawErrors,
   registry,
 }: WidgetProps) => {
   const description = getDescription(schema as RJSFSchema, options);
@@ -219,6 +221,7 @@ export const AutoCompleteWidget = ({
         multiple={isMultiple}
         routeParams={dependencyQueryConfig.routeParams}
         queryEnabled={dependencyQueryConfig.queryEnabled}
+        error={Boolean(rawErrors?.length)}
         onChange={onChange}
         {...props}
       />

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/JsonataTextWidget.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/JsonataTextWidget.tsx
@@ -46,6 +46,7 @@ export const JsonataTextWidget = ({
   required,
   disabled,
   readonly,
+  rawErrors,
   value,
   onChange,
   onBlur,
@@ -150,6 +151,7 @@ export const JsonataTextWidget = ({
       onFocus={(next) => onFocus?.(id, normalizeValue(next))}
       globalsSchema={globalsSchema}
       disabled={disabled || readonly}
+      error={Boolean(rawErrors?.length)}
       enableExpressionAssist
       onExpressionStateChange={reportAllowedExpressionState}
       fullWidth

--- a/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/shared.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonSchemaForm/widgets/shared.tsx
@@ -18,7 +18,6 @@ type LabelWithTooltipProps = {
 const labelTooltipSx = {
   display: "inline-flex",
   alignItems: "center",
-  gap: 0.5,
   "& .MuiFormLabel-asterisk": {
     order: 2,
   },

--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/JsonataFormulaField.tsx
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/JsonataFormulaField.tsx
@@ -19,6 +19,8 @@ import * as React from "react";
 
 import { useTranslate } from "@/hooks/useTranslate";
 
+import { labelTooltipInputLabelSx } from "../JsonSchemaForm/widgets/shared";
+
 import {
   ensureExpressionPrefix,
   isExpressionValue,
@@ -66,6 +68,7 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
     onFocus,
     globalsSchema,
     disabled,
+    error = false,
     helperText,
     fullWidth,
     minHeightPx = 36,
@@ -435,7 +438,7 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
       triggerSuggestions: false,
     });
   };
-  const showError = Boolean(validationMessage);
+  const showError = error || Boolean(validationMessage);
   const { mode } = useColorScheme();
   const showAssistIcon = enableExpressionAssist;
   const showModeIcon = !showAssistIcon && isJsonataMode;
@@ -453,22 +456,7 @@ export function JsonataFormulaField(props: JsonataFormulaFieldProps) {
       variant="standard"
     >
       {label ? (
-        <FormLabel
-          sx={{
-            mb: 0.5,
-            fontSize: 13,
-            color: "text.secondary",
-            display: "inline-flex",
-            alignItems: "center",
-            "& .MuiFormLabel-asterisk": {
-              order: 2,
-            },
-            "& .action-field-label-icon": {
-              order: 3,
-            },
-          }}
-          required={required}
-        >
+        <FormLabel sx={labelTooltipInputLabelSx} required={required}>
           {label}
         </FormLabel>
       ) : null}

--- a/packages/frontend/src/app-components/inputs/JsonataFormulaField/types.ts
+++ b/packages/frontend/src/app-components/inputs/JsonataFormulaField/types.ts
@@ -72,6 +72,7 @@ export type JsonataFormulaFieldProps = {
   globalsSchema?: GlobalsSchema;
 
   disabled?: boolean;
+  error?: boolean;
   helperText?: React.ReactNode;
   fullWidth?: boolean;
 

--- a/packages/frontend/src/components/contents/ContentForm.tsx
+++ b/packages/frontend/src/components/contents/ContentForm.tsx
@@ -18,12 +18,9 @@ import { useToast } from "@/hooks/useToast";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
+import validator from "@/utils/rjsf-zod-validator";
 
-import {
-  buildContentParams,
-  buildContentSchema,
-  hasMissingRequiredFileFields,
-} from "./content.schema.utils";
+import { buildContentParams, buildContentSchema } from "./content.schema.utils";
 
 export type ContentFormData = Record<string, unknown> & {
   contentType: string;
@@ -58,9 +55,9 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
   );
   const [hasVisibleErrors, setHasVisibleErrors] = useState(false);
   const [validateOnSubmit, setValidateOnSubmit] = useState(false);
-  const hasMissingRequiredFiles = useMemo(
-    () => hasMissingRequiredFileFields(contentType?.schema, formData),
-    [contentType?.schema, formData],
+  const hasValidationErrors = useMemo(
+    () => !validator.isValid(schema, formData, schema),
+    [schema, formData],
   );
   const { mutate: createContent } = useCreate(EntityType.CONTENT);
   const { mutate: updateContent } = useUpdate(EntityType.CONTENT);
@@ -77,7 +74,7 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
   const onSubmitForm = () => {
     setValidateOnSubmit(true);
 
-    if (hasVisibleErrors || hasMissingRequiredFiles) {
+    if (hasVisibleErrors || hasValidationErrors) {
       return;
     }
 
@@ -104,13 +101,13 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
   const canSubmit = useMemo(() => {
     return (
       hasVisibleErrors ||
-      (validateOnSubmit && hasMissingRequiredFiles) ||
+      (validateOnSubmit && hasValidationErrors) ||
       isMatch(defaultFormData, formData) ||
       Boolean(WrapperProps?.confirmButtonProps?.disabled)
     );
   }, [
     formData,
-    hasMissingRequiredFiles,
+    hasValidationErrors,
     hasVisibleErrors,
     validateOnSubmit,
     WrapperProps?.confirmButtonProps?.disabled,

--- a/packages/frontend/src/components/contents/ContentForm.tsx
+++ b/packages/frontend/src/components/contents/ContentForm.tsx
@@ -19,7 +19,11 @@ import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType } from "@/services/types";
 import { ComponentFormProps } from "@/types/common/dialogs.types";
 
-import { buildContentParams, buildContentSchema } from "./content.schema.utils";
+import {
+  buildContentParams,
+  buildContentSchema,
+  hasMissingRequiredFileFields,
+} from "./content.schema.utils";
 
 export type ContentFormData = Record<string, unknown> & {
   contentType: string;
@@ -53,6 +57,11 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
     [formData, schema],
   );
   const [hasVisibleErrors, setHasVisibleErrors] = useState(false);
+  const [validateOnSubmit, setValidateOnSubmit] = useState(false);
+  const hasMissingRequiredFiles = useMemo(
+    () => hasMissingRequiredFileFields(contentType?.schema, formData),
+    [contentType?.schema, formData],
+  );
   const { mutate: createContent } = useCreate(EntityType.CONTENT);
   const { mutate: updateContent } = useUpdate(EntityType.CONTENT);
   const options = {
@@ -66,7 +75,9 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
     },
   };
   const onSubmitForm = () => {
-    if (hasVisibleErrors) {
+    setValidateOnSubmit(true);
+
+    if (hasVisibleErrors || hasMissingRequiredFiles) {
       return;
     }
 
@@ -93,10 +104,17 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
   const canSubmit = useMemo(() => {
     return (
       hasVisibleErrors ||
+      (validateOnSubmit && hasMissingRequiredFiles) ||
       isMatch(defaultFormData, formData) ||
       Boolean(WrapperProps?.confirmButtonProps?.disabled)
     );
-  }, [formData, hasVisibleErrors, WrapperProps?.confirmButtonProps?.disabled]);
+  }, [
+    formData,
+    hasMissingRequiredFiles,
+    hasVisibleErrors,
+    validateOnSubmit,
+    WrapperProps?.confirmButtonProps?.disabled,
+  ]);
 
   return (
     <Wrapper
@@ -112,6 +130,7 @@ export const ContentForm: FC<ComponentFormProps<Content, ContentType>> = ({
         formData={formData}
         onFormDataChange={setFormData}
         onVisibleErrorsChange={setHasVisibleErrors}
+        validateOnMount={validateOnSubmit}
         enableJsonataTextWidget={false}
         idPrefix={content ? `content-${content.id}` : "content-new"}
       />

--- a/packages/frontend/src/components/contents/content.schema.utils.ts
+++ b/packages/frontend/src/components/contents/content.schema.utils.ts
@@ -19,21 +19,15 @@ export type ContentField = {
 };
 
 export type ContentSchemaProperties = Record<string, ContentField>;
-const isMissingFileValue = (value: unknown) => {
-  if (!value || typeof value !== "object") {
-    return true;
-  }
-
-  const id = (value as { payload?: { id?: unknown } }).payload?.id;
-
-  return typeof id !== "string" || id.trim().length === 0;
-};
 const buildStringFieldSchema = (title: string): RJSFSchema => ({
   type: "string",
   title,
   default: "",
 });
-const buildFileFieldSchema = (title: string): RJSFSchema => ({
+const buildFileFieldSchema = (
+  title: string,
+  isRequired: boolean,
+): RJSFSchema => ({
   type: "object",
   title,
   properties: {
@@ -41,13 +35,17 @@ const buildFileFieldSchema = (title: string): RJSFSchema => ({
     payload: {
       type: "object",
       properties: {
-        id: {
-          anyOf: [{ type: "string" }, { type: "null" }],
-        },
+        id: isRequired
+          ? { type: "string", minLength: 1 }
+          : {
+              anyOf: [{ type: "string" }, { type: "null" }],
+            },
       },
+      ...(isRequired ? { required: ["id"] } : {}),
       additionalProperties: true,
     },
   },
+  ...(isRequired ? { required: ["payload"] } : {}),
   default: {},
   additionalProperties: true,
 });
@@ -57,7 +55,6 @@ const CONTENT_FIELD_SCHEMA_FACTORIES: Partial<
   boolean: (title) => ({ type: "boolean", title, default: false }),
   textarea: buildStringFieldSchema,
   uri: (title) => ({ type: "string", format: "uri", title, default: "" }),
-  file: buildFileFieldSchema,
   html: buildStringFieldSchema,
   string: buildStringFieldSchema,
 };
@@ -90,12 +87,15 @@ const CONTENT_FIELD_UI_SCHEMAS: Partial<
 const buildContentFieldSchema = (
   propertyKey: string,
   property: ContentField,
-  includeUiSchema = false,
+  requiredFields: Set<string>,
 ): RJSFSchema => {
   const fieldTitle = property.title || propertyKey;
   const schemaFactory =
     CONTENT_FIELD_SCHEMA_FACTORIES[property.type] ?? buildStringFieldSchema;
-  const baseFieldSchema = schemaFactory(fieldTitle);
+  const baseFieldSchema =
+    property.type === "file"
+      ? buildFileFieldSchema(fieldTitle, requiredFields.has(propertyKey))
+      : schemaFactory(fieldTitle);
   const fieldSchema = REQUIRED_NON_EMPTY_FIELD_TYPES.has(property.type)
     ? {
         ...baseFieldSchema,
@@ -105,35 +105,29 @@ const buildContentFieldSchema = (
             : 1,
       }
     : baseFieldSchema;
-
-  if (!includeUiSchema) {
-    return fieldSchema;
-  }
-
   const fieldUiSchema = CONTENT_FIELD_UI_SCHEMAS[property.type];
 
   return fieldUiSchema ? { ...fieldSchema, ...fieldUiSchema } : fieldSchema;
 };
-const transformContentSchema = (
-  rjsfSchema: RJSFSchema,
-  includeUiSchema = false,
-) => {
+
+export const buildContentSchema = (rjsfSchema: RJSFSchema) => {
   const properties = getSchemaProperties<ContentSchemaProperties>(rjsfSchema);
+  const requiredFields = new Set(
+    Array.isArray(rjsfSchema?.required) ? rjsfSchema.required : [],
+  );
   const schemaProperties: Record<string, RJSFSchema> = {
-    contentType: includeUiSchema
-      ? {
-          type: "string",
-          title: "contentType",
-          "ui:widget": "hidden",
-        }
-      : { type: "string", title: "contentType" },
+    contentType: {
+      type: "string",
+      title: "contentType",
+      "ui:widget": "hidden",
+    },
   };
 
   for (const [propertyKey, property] of Object.entries(properties || {})) {
     schemaProperties[propertyKey] = buildContentFieldSchema(
       propertyKey,
       property,
-      includeUiSchema,
+      requiredFields,
     );
   }
 
@@ -142,26 +136,6 @@ const transformContentSchema = (
     properties: schemaProperties,
     required: rjsfSchema?.["required"] || [],
   } as RJSFSchema;
-};
-
-export const buildContentSchema = (rjsfSchema: RJSFSchema) =>
-  transformContentSchema(rjsfSchema, true);
-
-export const hasMissingRequiredFileFields = (
-  rjsfSchema: RJSFSchema | undefined,
-  formData: Record<string, unknown>,
-) => {
-  const requiredFields = new Set(
-    Array.isArray(rjsfSchema?.required) ? rjsfSchema.required : [],
-  );
-  const properties = getSchemaProperties<ContentSchemaProperties>(rjsfSchema);
-
-  return Object.entries(properties || {}).some(
-    ([propertyKey, property]) =>
-      requiredFields.has(propertyKey) &&
-      property.type === "file" &&
-      isMissingFileValue(formData[propertyKey]),
-  );
 };
 
 export const buildContentParams = ({

--- a/packages/frontend/src/components/contents/content.schema.utils.ts
+++ b/packages/frontend/src/components/contents/content.schema.utils.ts
@@ -19,6 +19,15 @@ export type ContentField = {
 };
 
 export type ContentSchemaProperties = Record<string, ContentField>;
+const isMissingFileValue = (value: unknown) => {
+  if (!value || typeof value !== "object") {
+    return true;
+  }
+
+  const id = (value as { payload?: { id?: unknown } }).payload?.id;
+
+  return typeof id !== "string" || id.trim().length === 0;
+};
 const buildStringFieldSchema = (title: string): RJSFSchema => ({
   type: "string",
   title,
@@ -137,6 +146,23 @@ const transformContentSchema = (
 
 export const buildContentSchema = (rjsfSchema: RJSFSchema) =>
   transformContentSchema(rjsfSchema, true);
+
+export const hasMissingRequiredFileFields = (
+  rjsfSchema: RJSFSchema | undefined,
+  formData: Record<string, unknown>,
+) => {
+  const requiredFields = new Set(
+    Array.isArray(rjsfSchema?.required) ? rjsfSchema.required : [],
+  );
+  const properties = getSchemaProperties<ContentSchemaProperties>(rjsfSchema);
+
+  return Object.entries(properties || {}).some(
+    ([propertyKey, property]) =>
+      requiredFields.has(propertyKey) &&
+      property.type === "file" &&
+      isMissingFileValue(formData[propertyKey]),
+  );
+};
 
 export const buildContentParams = ({
   title,

--- a/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/main/ActionDrawer/ActionFormDrawer/useActionFormDrawerController.ts
@@ -334,7 +334,6 @@ export const useActionFormDrawerController = ({
     setValidateActionSchemas(true);
     setActionSettingsData(data);
   };
-  const isAttachmentAction = actionSchema?.name === "send_attachment";
   const handleSave = () => {
     const currentDefinition =
       definition ?? (isCreateMode && workflow ? createBaseDefinition() : null);
@@ -346,12 +345,11 @@ export const useActionFormDrawerController = ({
     setValidateActionSchemas(true);
 
     if (
-      (isAttachmentAction &&
-        (hasSchemaValidationErrors(actionSchema.inputSchema, inputData) ||
-          hasSchemaValidationErrors(
-            actionSchema.settingSchema,
-            actionSettingsData,
-          ))) ||
+      hasSchemaValidationErrors(actionSchema.inputSchema, inputData) ||
+      hasSchemaValidationErrors(
+        actionSchema.settingSchema,
+        actionSettingsData,
+      ) ||
       hasInputVisibleErrors ||
       hasActionSettingsVisibleErrors ||
       hasExecutionSettingsVisibleErrors
@@ -480,7 +478,7 @@ export const useActionFormDrawerController = ({
   };
   const canSaveDefinition = Boolean(definition || (isCreateMode && workflow));
   const hasActionSchemaValidationErrors =
-    actionSchema && isAttachmentAction && validateActionSchemas
+    actionSchema && validateActionSchemas
       ? hasSchemaValidationErrors(actionSchema.inputSchema, inputData) ||
         hasSchemaValidationErrors(
           actionSchema.settingSchema,
@@ -530,7 +528,7 @@ export const useActionFormDrawerController = ({
     },
     inputData,
     isUsingWorkflowExecutionDefaults,
-    validateActionSchemas: isAttachmentAction && validateActionSchemas,
+    validateActionSchemas,
     onExecutionSettingsDataChange: setExecutionSettingsData,
     onExecutionSettingsModeChange: handleExecutionSettingsModeChange,
     onExecutionSettingsVisibleErrorsChange:


### PR DESCRIPTION
**Summary**
Updated the frontend validation logic to correctly support attachment nodes and fields. Workflows that include attachments are now validated according to their expected requirements instead of being incorrectly flagged as invalid.

**Why**
The previous validation logic did not fully account for attachments, leading to incorrect validation results and a degraded user experience when building workflows that use them.

**How to review**

* Review the changes in the frontend validation logic.
* Verify how attachment-related fields and nodes are handled during validation.
* Confirm that existing validation behavior for non-attachment workflows remains unchanged.

**Validation**

* Tested workflows containing attachments to ensure they validate correctly.
* Verified that workflows without attachments continue to behave as before.
* Confirmed no regressions in the workflow editor validation flow.

