### PR TITLE
fix(frontend): resolve yaml defaults.settings.retries autocomplete

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/schema.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/schema.ts
@@ -10,8 +10,11 @@ import type { JSONSchema } from "monaco-yaml";
 export const WORKFLOW_SCHEMA_URI =
   "inmemory://model/hexabot-workflow.schema.json";
 
+// "input" keeps defaulted fields optional; the default "output" perspective
+// marks them required, causing false warnings and stray completions.
 const workflowSchema = WorkflowDefinitionSchema.toJSONSchema({
   target: "draft-07",
+  io: "input",
 });
 
 export const WORKFLOW_YAML_SCHEMA = workflowSchema as JSONSchema;


### PR DESCRIPTION
## Screenshots
- After the fix
<img width="446" height="272" alt="image" src="https://github.com/user-attachments/assets/1796ae78-0ee1-4c2c-b4f6-7d78660642f5" />

- Before the fix
<img width="446" height="296" alt="image" src="https://github.com/user-attachments/assets/244ccbfe-3bac-426b-b97b-30b495cf45af" />

## Summary
Resolved the YAML Editor autocomplete issue where the `defaults.settings.retries` path was not being suggested correctly. The autocomplete engine now recognizes and provides the expected completion for this configuration path.

## Why

This improves the YAML editing experience by ensuring valid configuration paths are discoverable, reducing manual typing and preventing configuration mistakes.

## How to review

* Open the YAML Editor.
* Navigate to the `defaults.settings` section.
* Verify that `retries` appears in the autocomplete suggestions and is inserted correctly.

## Validation

* Verified that `defaults.settings.retries` is suggested by the autocomplete.
* Confirmed the generated YAML path is correct.
* Checked that existing YAML autocomplete behavior remains unchanged for other paths.
