### PR TITLE
fix(frontend): resolve yaml action inputs completions

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/completion.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/completion.test.ts
@@ -7,6 +7,8 @@
 import type { Monaco } from "@monaco-editor/react";
 import { describe, expect, it, vi } from "vitest";
 
+import type { IAction } from "@/types/action.types";
+
 import { registerYamlCompletionProvider } from "./completion";
 import { YAML_LANGUAGE_ID } from "./constants";
 
@@ -23,6 +25,7 @@ const createMonacoMock = () => {
         Snippet: 1,
         Reference: 2,
         Function: 3,
+        Field: 4,
       },
       CompletionItemInsertTextRule: {
         InsertAsSnippet: 4,
@@ -44,6 +47,21 @@ const createMonacoMock = () => {
     getProvider: () => provider,
   };
 };
+/**
+ * A minimal multi-line model mock supporting the line-by-line lookback that
+ * `buildInputsCompletionItems` relies on to find the enclosing task's
+ * `action:` value.
+ */
+const createModelMock = (lines: string[]) =>
+  ({
+    getLineCount: () => lines.length,
+    getLineContent: (lineNumber: number) => lines[lineNumber - 1] ?? "",
+    getWordUntilPosition: (position: { column: number }) => ({
+      word: "",
+      startColumn: position.column,
+      endColumn: position.column,
+    }),
+  }) as never;
 
 describe("yaml completion", () => {
   it("suggests task ids from provider state for flow do references", () => {
@@ -77,6 +95,87 @@ describe("yaml completion", () => {
 
     expect(suggestions.map((suggestion) => suggestion.label)).toContain(
       "task_alpha",
+    );
+  });
+
+  it("suggests the action's real input keys under a task's inputs: block, excluding keys already present", () => {
+    const { monaco, getProvider } = createMonacoMock();
+    const aiAgentAction = {
+      name: "ai_agent",
+      inputSchema: {
+        type: "object",
+        properties: {
+          input_mode: { type: "string", title: "Input mode" },
+          prompt: { type: "string", title: "Prompt" },
+          messages_limit: { type: "integer", title: "Messages limit" },
+          system: { type: "string", title: "System" },
+        },
+      },
+    } as unknown as IAction;
+
+    registerYamlCompletionProvider(monaco, () => [aiAgentAction]);
+
+    const provider = getProvider();
+
+    if (!provider) {
+      throw new Error("Expected YAML completion provider to be registered");
+    }
+
+    const model = createModelMock([
+      "defs:",
+      "  ai_agent:",
+      "    kind: task",
+      "    action: ai_agent",
+      "    inputs:",
+      "      ",
+      "      messages_limit: 4",
+      "      system: You are a helpful assistant.",
+    ]);
+    const position = { lineNumber: 6, column: 7 };
+    const suggestions = provider.provideCompletionItems(
+      model,
+      position as never,
+      {} as never,
+      {} as never,
+    ).suggestions;
+    const labels = suggestions.map((suggestion) => suggestion.label);
+
+    expect(labels).toEqual(expect.arrayContaining(["input_mode", "prompt"]));
+    expect(labels).not.toContain("messages_limit");
+    expect(labels).not.toContain("system");
+  });
+
+  it("does not suggest action input keys for the workflow-level inputs: schema block", () => {
+    const { monaco, getProvider } = createMonacoMock();
+    const aiAgentAction = {
+      name: "ai_agent",
+      inputSchema: {
+        type: "object",
+        properties: {
+          system: { type: "string", title: "System" },
+        },
+      },
+    } as unknown as IAction;
+
+    registerYamlCompletionProvider(monaco, () => [aiAgentAction]);
+
+    const provider = getProvider();
+
+    if (!provider) {
+      throw new Error("Expected YAML completion provider to be registered");
+    }
+
+    const model = createModelMock(["inputs:", "  "]);
+    const position = { lineNumber: 2, column: 3 };
+    const suggestions = provider.provideCompletionItems(
+      model,
+      position as never,
+      {} as never,
+      {} as never,
+    ).suggestions;
+
+    expect(suggestions.map((suggestion) => suggestion.label)).not.toContain(
+      "system",
     );
   });
 });

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/completion.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/completion.ts
@@ -6,6 +6,7 @@
 
 import type { Monaco } from "@monaco-editor/react";
 import type { IDisposable, IPosition, editor } from "monaco-editor";
+import type { JSONSchema } from "monaco-yaml";
 
 import type { IAction } from "@/types/action.types";
 
@@ -130,6 +131,127 @@ const buildActionCompletionItems = (
     documentation: action.description || undefined,
   }));
 };
+const INPUTS_KEY_PATTERN = /^\s*inputs:\s*(#.*)?$/;
+const ACTION_KEY_PATTERN = /^\s*action:\s*(\S+)/;
+const MAP_KEY_PATTERN = /^\s*([A-Za-z0-9_-]+):/;
+/**
+ * Walks upward from `position` to find the enclosing task's `action:` value,
+ * but only when `position` sits directly inside that task's `inputs:` block.
+ */
+const findEnclosingInputsAction = (
+  model: editor.ITextModel,
+  position: IPosition,
+  currentIndent: number,
+): string | null => {
+  let lineNum = position.lineNumber - 1;
+  let inputsIndent: number | null = null;
+
+  // 1. Walk up to find the parent 'inputs:' key
+  while (lineNum >= 1) {
+    const line = model.getLineContent(lineNum--);
+
+    if (isCommentOrBlank(line)) continue;
+
+    const indent = countIndent(line);
+
+    if (indent < currentIndent) {
+      if (INPUTS_KEY_PATTERN.test(line)) inputsIndent = indent;
+      break;
+    }
+  }
+
+  if (inputsIndent === null) return null;
+
+  // 2. Walk up from the inputs key to find its sibling 'action:' key
+  while (lineNum >= 1) {
+    const line = model.getLineContent(lineNum--);
+
+    if (isCommentOrBlank(line)) continue;
+
+    const indent = countIndent(line);
+
+    if (indent < inputsIndent) break;
+    if (indent === inputsIndent) {
+      const match = line.match(ACTION_KEY_PATTERN);
+
+      if (match) return match[1];
+    }
+  }
+
+  return null;
+};
+const collectSiblingKeys = (
+  model: editor.ITextModel,
+  position: IPosition,
+  indent: number,
+) => {
+  const keys = new Set<string>();
+
+  for (let i = 1; i <= model.getLineCount(); i++) {
+    if (i === position.lineNumber) continue;
+    const line = model.getLineContent(i);
+
+    if (countIndent(line) === indent) {
+      const match = line.match(MAP_KEY_PATTERN);
+
+      if (match) keys.add(match[1]);
+    }
+  }
+
+  return keys;
+};
+const buildInputsCompletionItems = (
+  monacoInstance: Monaco,
+  model: editor.ITextModel,
+  position: IPosition,
+  actions?: IAction[],
+) => {
+  if (!actions?.length) return [];
+
+  const lineContent = model.getLineContent(position.lineNumber);
+  const linePrefix = lineContent.slice(0, position.column - 1);
+
+  // Early exit if the line is a comment or already contains a colon
+  if (lineContent.trim().startsWith("#") || linePrefix.includes(":")) {
+    return [];
+  }
+
+  const currentIndent = countIndent(linePrefix);
+  const actionName = findEnclosingInputsAction(model, position, currentIndent);
+
+  if (!actionName) return [];
+
+  const action = actions.find((a) => a.name === actionName);
+  const properties = (action?.inputSchema as JSONSchema | undefined)
+    ?.properties;
+
+  if (!properties) return [];
+
+  const { startColumn, endColumn } = model.getWordUntilPosition(position);
+  const range = {
+    startLineNumber: position.lineNumber,
+    endLineNumber: position.lineNumber,
+    startColumn,
+    endColumn,
+  };
+  const existingKeys = collectSiblingKeys(model, position, currentIndent);
+
+  return Object.entries(properties)
+    .filter(([key, schema]) => !existingKeys.has(key) && schema !== false)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, schema]) => {
+      const propSchema = typeof schema === "object" ? schema : undefined;
+
+      return {
+        label: key,
+        kind: monacoInstance.languages.CompletionItemKind.Field,
+        insertText: `${key}: `,
+        range,
+        detail: propSchema?.type ? String(propSchema.type) : "Task input",
+        documentation: propSchema?.description || propSchema?.title,
+      };
+    });
+};
 
 export const registerYamlCompletionProvider = (
   monacoInstance: Monaco,
@@ -155,6 +277,12 @@ export const registerYamlCompletionProvider = (
           position,
           getActions?.(),
         );
+        const inputsSuggestions = buildInputsCompletionItems(
+          monacoInstance,
+          model,
+          position,
+          getActions?.(),
+        );
         const includeBaseSuggestions = context?.triggerCharacter !== ":";
 
         return {
@@ -162,6 +290,7 @@ export const registerYamlCompletionProvider = (
             ...(includeBaseSuggestions ? suggestions : []),
             ...taskSuggestions,
             ...actionSuggestions,
+            ...inputsSuggestions,
           ],
         };
       },

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/schema.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/schema.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { WORKFLOW_YAML_SCHEMA } from "./schema";
+
+const getTaskDefSchema = () => {
+  const defsSchema = WORKFLOW_YAML_SCHEMA.properties?.defs;
+
+  if (!defsSchema || typeof defsSchema === "boolean") {
+    throw new Error("Expected defs schema to be an object");
+  }
+
+  const additionalProperties = defsSchema.additionalProperties;
+
+  if (!additionalProperties || typeof additionalProperties === "boolean") {
+    throw new Error("Expected defs.additionalProperties to be an object");
+  }
+
+  const taskSchema = additionalProperties.anyOf?.find(
+    (candidate) =>
+      typeof candidate !== "boolean" &&
+      candidate.properties?.action !== undefined,
+  );
+
+  if (!taskSchema || typeof taskSchema === "boolean") {
+    throw new Error("Expected to find the task branch of defs' anyOf");
+  }
+
+  return taskSchema;
+};
+
+describe("WORKFLOW_YAML_SCHEMA", () => {
+  it("drops the trivial propertyNames on a task's inputs record so monaco-yaml doesn't offer a generic 'property' placeholder", () => {
+    const taskSchema = getTaskDefSchema();
+    const inputsSchema = taskSchema.properties?.inputs;
+
+    if (!inputsSchema || typeof inputsSchema === "boolean") {
+      throw new Error("Expected inputs schema to be an object");
+    }
+
+    expect(inputsSchema.propertyNames).toBeUndefined();
+    expect(inputsSchema.additionalProperties).toBeDefined();
+  });
+
+  it("keeps propertyNames where it carries a real constraint (defs' snake_case key pattern)", () => {
+    const defsSchema = WORKFLOW_YAML_SCHEMA.properties?.defs;
+
+    if (!defsSchema || typeof defsSchema === "boolean") {
+      throw new Error("Expected defs schema to be an object");
+    }
+
+    const propertyNames = defsSchema.propertyNames;
+
+    if (!propertyNames || typeof propertyNames === "boolean") {
+      throw new Error("Expected defs.propertyNames to be an object");
+    }
+
+    expect(propertyNames.pattern).toBe("^[a-z0-9]+(?:_[a-z0-9]+)*$");
+  });
+});

--- a/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/schema.ts
+++ b/packages/frontend/src/components/visual-editor/v4/components/yaml-editor/schema.ts
@@ -10,11 +10,35 @@ import type { JSONSchema } from "monaco-yaml";
 export const WORKFLOW_SCHEMA_URI =
   "inmemory://model/hexabot-workflow.schema.json";
 
-// "input" keeps defaulted fields optional; the default "output" perspective
-// marks them required, causing false warnings and stray completions.
-const workflowSchema = WorkflowDefinitionSchema.toJSONSchema({
-  target: "draft-07",
-  io: "input",
-});
+// Zod emits a trivial `propertyNames: { type: "string" }` on every record
+// type, which makes monaco-yaml offer a useless generic "property" suggestion
+// alongside the real ones from completion.ts. Rebuild the tree without it,
+// keeping meaningful constraints intact (e.g. defs' snake_case key pattern).
+const stripTrivialPropertyNames = (node: unknown): unknown => {
+  if (Array.isArray(node)) return node.map(stripTrivialPropertyNames);
+  if (typeof node !== "object" || node === null) return node;
+
+  const record = node as Record<string, unknown>;
+  const propertyNames = record.propertyNames as
+    | Record<string, unknown>
+    | undefined;
+  const dropPropertyNames =
+    record.type === "object" &&
+    record.additionalProperties &&
+    propertyNames &&
+    Object.keys(propertyNames).length === 1 &&
+    "type" in propertyNames;
+
+  return Object.fromEntries(
+    Object.entries(record)
+      .filter(([key]) => key !== "propertyNames" || !dropPropertyNames)
+      .map(([key, value]) => [key, stripTrivialPropertyNames(value)]),
+  );
+};
+const workflowSchema = stripTrivialPropertyNames(
+  // "input" keeps defaulted fields optional; the default "output" perspective
+  // marks them required, causing false warnings and stray completions.
+  WorkflowDefinitionSchema.toJSONSchema({ target: "draft-07", io: "input" }),
+);
 
 export const WORKFLOW_YAML_SCHEMA = workflowSchema as JSONSchema;


### PR DESCRIPTION
## Screenshots
- After the fix
<img width="476" height="191" alt="image" src="https://github.com/user-attachments/assets/82bf6687-e03f-42ae-ac67-33d76843ac4c" />

- Before the fix
<img width="476" height="191" alt="image" src="https://github.com/user-attachments/assets/aae973d1-d271-49a3-9f3b-4a8afdc016de" />

## Summary
This PR fixes YAML autocompletion for action `inputs` by correctly detecting the enclosing action when editing inside a task's `inputs` block. Completions are now resolved only for task-level action inputs and no longer incorrectly trigger within workflow-level `inputs` declarations.

## Why
The previous detection logic could fail to identify the correct action context or confuse workflow-level and task-level `inputs`, resulting in missing or incorrect autocomplete suggestions. This improves the YAML editing experience and provides more accurate completions.

## How to review
* Review the logic responsible for resolving the enclosing action from the current cursor position.
* Verify that completions are only shown inside a task's `inputs` block.
* Confirm that workflow-level `inputs` schema declarations are ignored.

## Validation
* Verified autocompletion for multiple action types inside task `inputs`.
* Confirmed no completions are shown for workflow-level `inputs`.
* Tested nested tasks and different indentation levels to ensure the correct action context is resolved.
