### PR TITLE
fix(api): default ai infer object system prompt

### DIFF
--- a/packages/api/src/extensions/actions/ai/ai-schemas.spec.ts
+++ b/packages/api/src/extensions/actions/ai/ai-schemas.spec.ts
@@ -6,8 +6,11 @@
 
 import {
   DEFAULT_AI_MESSAGES_LIMIT,
+  DEFAULT_AI_OBJECT_SYSTEM_PROMPT,
   DEFAULT_AI_PROMPT,
+  DEFAULT_AI_SYSTEM_PROMPT,
   aiAgentInputSchema,
+  aiGenerateObjectInputSchema,
   aiGenerateObjectSettingsSchema,
   aiGenerateReplyInputSchema,
   aiGenerateReplySettingsSchema,
@@ -109,6 +112,33 @@ describe('ai prompt schemas', () => {
     expect(aiInferObjectInputSchema.parse(historyInput).messages_limit).toBe(
       DEFAULT_AI_MESSAGES_LIMIT,
     );
+  });
+});
+
+describe('structured output system prompts', () => {
+  it.each([
+    ['ai_infer_object', aiInferObjectInputSchema],
+    ['ai_generate_object', aiGenerateObjectInputSchema],
+  ])('defaults %s system to the structured output prompt', (_name, schema) => {
+    const system = schema.parse({}).system;
+
+    expect(system).toBe(DEFAULT_AI_OBJECT_SYSTEM_PROMPT);
+    expect(system).not.toBe(DEFAULT_AI_SYSTEM_PROMPT);
+  });
+
+  it('keeps the conversational default for text-producing actions', () => {
+    expect(aiGenerateReplyInputSchema.parse({}).system).toBe(
+      DEFAULT_AI_SYSTEM_PROMPT,
+    );
+    expect(aiGenerateTextInputSchema.parse({}).system).toBe(
+      DEFAULT_AI_SYSTEM_PROMPT,
+    );
+  });
+
+  it('keeps a user-provided system prompt', () => {
+    const system = 'Extract only the invoice total.';
+
+    expect(aiInferObjectInputSchema.parse({ system }).system).toBe(system);
   });
 });
 

--- a/packages/api/src/extensions/actions/ai/ai-schemas.ts
+++ b/packages/api/src/extensions/actions/ai/ai-schemas.ts
@@ -11,6 +11,25 @@ export const DEFAULT_AI_PROMPT = '=$input.text';
 
 export const DEFAULT_AI_MESSAGES_LIMIT = 4;
 
+export const DEFAULT_AI_SYSTEM_PROMPT = 'You are a helpful assistant.';
+
+/**
+ * Actions that request structured output need a system prompt that keeps the
+ * model on the schema; a conversational persona makes it answer in prose and
+ * the object comes back empty.
+ */
+export const DEFAULT_AI_OBJECT_SYSTEM_PROMPT = [
+  'You are a structured data extraction engine.',
+  'Read the input and return a single JSON object that conforms exactly to the requested output schema.',
+  '',
+  'Rules:',
+  '- Extract values only from the input. Never invent, guess, or complete missing information.',
+  '- Respect every type, enum, format, and constraint declared in the schema.',
+  '- Omit optional fields you cannot ground in the input instead of filling them with placeholders.',
+  '- Normalize values (trim whitespace, canonical casing, ISO 8601 for dates) without changing their meaning.',
+  '- Return only the object: no prose, no explanation, no fields outside the schema.',
+].join('\n');
+
 const aiPromptBaseSchema = z.object({
   input_mode: z
     .enum(['prompt', 'history'])
@@ -56,7 +75,7 @@ const aiPromptBaseSchema = z.object({
         },
       },
     }),
-  system: z.string().default('You are a helpful assistant.').optional().meta({
+  system: z.string().default(DEFAULT_AI_SYSTEM_PROMPT).optional().meta({
     title: 'System',
     description:
       'Optional system instruction prepended to the prompt or message history.',
@@ -67,11 +86,21 @@ const aiPromptOnlySchema = z.strictObject({
     title: 'Prompt',
     description: 'Prompt text to send directly to the model.',
   }),
-  system: z.string().default('You are a helpful assistant.').optional().meta({
+  system: z.string().default(DEFAULT_AI_SYSTEM_PROMPT).optional().meta({
     title: 'System',
     description: 'Optional system instruction prepended to the prompt.',
   }),
 });
+const aiObjectSystemField = z
+  .string()
+  .default(DEFAULT_AI_OBJECT_SYSTEM_PROMPT)
+  .optional()
+  .meta({
+    title: 'System',
+    description:
+      'System instruction prepended to the input. It should keep the model focused on filling the output schema.',
+    'ui:widget': 'textarea',
+  });
 
 export const aiPromptSchema = aiPromptBaseSchema;
 
@@ -239,13 +268,17 @@ export const aiGenerateReplyOutputSchema = aiGenerateTextOutputSchema;
 
 export const aiGenerateReplySettingsSchema = aiCommonSettingsSchema;
 
-export const aiGenerateObjectInputSchema = aiPromptOnlySchema;
+export const aiGenerateObjectInputSchema = aiPromptOnlySchema.extend({
+  system: aiObjectSystemField,
+});
 
 export const aiGenerateObjectOutputSchema = aiObjectOutputSchema;
 
 export const aiGenerateObjectSettingsSchema = aiObjectSettingsSchema;
 
-export const aiInferObjectInputSchema = aiPromptSchema;
+export const aiInferObjectInputSchema = aiPromptSchema.extend({
+  system: aiObjectSystemField,
+});
 
 export const aiInferObjectOutputSchema = aiObjectOutputSchema;
 

--- a/packages/api/src/extensions/actions/ai/i18n/en.translations.json
+++ b/packages/api/src/extensions/actions/ai/i18n/en.translations.json
@@ -39,7 +39,6 @@
     "Maximum number of agent steps before stopping.": "Maximum number of agent steps before stopping.",
     "Maximum number of tokens to generate in the output.": "Maximum number of tokens to generate in the output.",
     "Nucleus sampling probability mass to consider.": "Nucleus sampling probability mass to consider.",
-    "Optional system instruction prepended to the prompt.": "Optional system instruction prepended to the prompt.",
     "Output schema": "Output schema",
     "Penalty for introducing new topics or tokens.": "Penalty for introducing new topics or tokens.",
     "Penalty for repeating tokens frequently.": "Penalty for repeating tokens frequently.",
@@ -55,6 +54,7 @@
     "Stop tool call": "Stop tool call",
     "Stop when the specified tool call is triggered.": "Stop when the specified tool call is triggered.",
     "System": "System",
+    "System instruction prepended to the input. It should keep the model focused on filling the output schema.": "System instruction prepended to the input. It should keep the model focused on filling the output schema.",
     "Temperature": "Temperature",
     "Top K": "Top K",
     "Top P": "Top P"
@@ -130,7 +130,6 @@
     "Messages limit": "Messages limit",
     "Nucleus sampling probability mass to consider.": "Nucleus sampling probability mass to consider.",
     "Number of most recent conversation messages to include instead of a prompt.": "Number of most recent conversation messages to include instead of a prompt.",
-    "Optional system instruction prepended to the prompt or message history.": "Optional system instruction prepended to the prompt or message history.",
     "Output schema": "Output schema",
     "Penalty for introducing new topics or tokens.": "Penalty for introducing new topics or tokens.",
     "Penalty for repeating tokens frequently.": "Penalty for repeating tokens frequently.",
@@ -146,6 +145,7 @@
     "Stop tool call": "Stop tool call",
     "Stop when the specified tool call is triggered.": "Stop when the specified tool call is triggered.",
     "System": "System",
+    "System instruction prepended to the input. It should keep the model focused on filling the output schema.": "System instruction prepended to the input. It should keep the model focused on filling the output schema.",
     "Temperature": "Temperature",
     "Top K": "Top K",
     "Top P": "Top P"

--- a/packages/api/src/extensions/actions/ai/i18n/fr.translations.json
+++ b/packages/api/src/extensions/actions/ai/i18n/fr.translations.json
@@ -39,7 +39,6 @@
     "Maximum number of agent steps before stopping.": "Nombre maximal d'étapes de l'agent avant l'arrêt.",
     "Maximum number of tokens to generate in the output.": "Nombre maximal de tokens à générer en sortie.",
     "Nucleus sampling probability mass to consider.": "Masse de probabilité à considérer pour l'échantillonnage nucleus (Top P).",
-    "Optional system instruction prepended to the prompt.": "Instruction système optionnelle ajoutée avant le prompt.",
     "Output schema": "Schéma de sortie",
     "Penalty for introducing new topics or tokens.": "Pénalité pour l'introduction de nouveaux sujets ou tokens.",
     "Penalty for repeating tokens frequently.": "Pénalité pour la répétition fréquente de tokens.",
@@ -55,6 +54,7 @@
     "Stop tool call": "Appel d'outil d'arrêt",
     "Stop when the specified tool call is triggered.": "Arrête lorsque l'appel d'outil spécifié est déclenché.",
     "System": "Système",
+    "System instruction prepended to the input. It should keep the model focused on filling the output schema.": "Instruction système ajoutée avant l'entrée. Elle doit garder le modèle concentré sur le remplissage du schéma de sortie.",
     "Temperature": "Température",
     "Top K": "Top K",
     "Top P": "Top P"
@@ -130,7 +130,6 @@
     "Messages limit": "Limite de messages",
     "Nucleus sampling probability mass to consider.": "Masse de probabilité à considérer pour l'échantillonnage nucleus (Top P).",
     "Number of most recent conversation messages to include instead of a prompt.": "Nombre de messages de conversation les plus récents à inclure au lieu d'un prompt.",
-    "Optional system instruction prepended to the prompt or message history.": "Instruction système optionnelle ajoutée avant le prompt ou l'historique des messages.",
     "Output schema": "Schéma de sortie",
     "Penalty for introducing new topics or tokens.": "Pénalité pour l'introduction de nouveaux sujets ou tokens.",
     "Penalty for repeating tokens frequently.": "Pénalité pour la répétition fréquente de tokens.",
@@ -146,6 +145,7 @@
     "Stop tool call": "Appel d'outil d'arrêt",
     "Stop when the specified tool call is triggered.": "Arrête lorsque l'appel d'outil spécifié est déclenché.",
     "System": "Système",
+    "System instruction prepended to the input. It should keep the model focused on filling the output schema.": "Instruction système ajoutée avant l'entrée. Elle doit garder le modèle concentré sur le remplissage du schéma de sortie.",
     "Temperature": "Température",
     "Top K": "Top K",
     "Top P": "Top P"


### PR DESCRIPTION
## What changed?

`ai_infer_object` now defaults to an extraction-oriented system prompt instead of "You are a helpful assistant."