### PR TITLE
fix(agentic): validate tools settings

### DIFF
--- a/packages/agentic/src/__tests__/validation.test.ts
+++ b/packages/agentic/src/__tests__/validation.test.ts
@@ -632,6 +632,39 @@ describe('validateWorkflow', () => {
       expect(result.success).toBe(true);
     });
 
+    it('validates settings of non-task (bound) defs against their action schema', () => {
+      const buildWorkflow = (settings: Record<string, unknown>) => ({
+        defs: {
+          retrieve_rag_content: {
+            kind: 'tools',
+            action: 'retrieve_rag_content',
+            settings,
+          },
+        },
+        flow: [],
+        outputs: {},
+      });
+      const options = {
+        bindingKinds,
+        actions: {
+          retrieve_rag_content: {
+            settingSchema: z.strictObject({
+              include_inactive: z.boolean().optional(),
+            }),
+          },
+        },
+      };
+
+      expect(
+        validateWorkflow(buildWorkflow({ include_inactivdse: false }), options)
+          .success,
+      ).toBe(false);
+      expect(
+        validateWorkflow(buildWorkflow({ include_inactive: false }), options)
+          .success,
+      ).toBe(true);
+    });
+
     it('reports missing actions with code, actionName and path', () => {
       const workflow = {
         defs: mergeTaskDefs({

--- a/packages/agentic/src/bindings/base-binding.ts
+++ b/packages/agentic/src/bindings/base-binding.ts
@@ -16,6 +16,7 @@ export type BindingActionPolicy = 'forbidden' | 'optional' | 'required';
 
 export type BindingValidationActionMetadata = {
   supportedBindings?: readonly string[];
+  settingSchema?: z.ZodTypeAny;
 };
 
 export type BindingKindDescriptor<
@@ -341,6 +342,17 @@ export const validateAndResolveBindings = (
     }
 
     parsedSettingsByDefName.set(defName, parsedPayload.data);
+
+    const actionSchema = defDefinition.action
+      ? actions?.[defDefinition.action]?.settingSchema
+      : undefined;
+    const actionParsed = actionSchema?.safeParse(defDefinition.settings);
+
+    if (actionParsed && !actionParsed.success) {
+      issues.push(
+        ...toBindingSettingsIssues(actionParsed.error.issues, defName),
+      );
+    }
   }
 
   for (const [defName, defDefinition] of Object.entries(defs)) {


### PR DESCRIPTION
### Screenshots
- After the fix
<img width="710" height="217" alt="image" src="https://github.com/user-attachments/assets/4cc37873-285f-4534-8d76-826a80e83669" />

- Before the fix
<img width="2172" height="724" alt="image" src="https://github.com/user-attachments/assets/bdd62af4-9e5a-4e39-8a16-2243284fccb9" />

### Summary
This PR adds validation for tool settings in the `agentic` package to ensure tool configurations are checked before use. It prevents invalid or incomplete settings from being accepted, improving reliability and reducing runtime failures.

### Why
Invalid tool settings can lead to unexpected behavior or runtime errors that are difficult to diagnose. Validating configuration early provides clearer feedback and ensures only valid tool definitions are executed.

### How to review
* Review the tool settings validation logic in the `agentic` package.
* Verify the validation rules and error handling for invalid configurations.
* Confirm existing valid tool configurations continue to work without changes.

### Validation
* Tested with valid tool settings to confirm they are accepted.
* Tested with invalid and incomplete tool settings to verify appropriate validation errors are returned.
* Verified no regressions in the existing tool configuration workflow.
