### PR TITLE
fix(graph): enhance start node and end node layout

### DIFF
--- a/packages/graph/src/workflow/utils/layout/elk-layout.test.ts
+++ b/packages/graph/src/workflow/utils/layout/elk-layout.test.ts
@@ -45,24 +45,33 @@ it.each([
   ["vertical", "grouped"],
   ["vertical", "ungrouped"],
 ] as const)(
-  "does not offset attachment-inflated nodes in %s mode (%s)",
+  "centers attachment-inflated nodes only on the flow axis in %s mode (%s)",
   async (direction, grouping) => {
     const grouped = grouping === "grouped";
     const nodes = [
       node("agent", ENodeType.TASK, grouped),
       node("tool-1", ENodeType.BINDING_MULTI, grouped),
       node("tool-2", ENodeType.BINDING_MULTI, grouped),
+      node("tool-3", ENodeType.BINDING_MULTI, grouped),
+      node("tool-4", ENodeType.BINDING_MULTI, grouped),
     ];
-    const edges: Edge[] = ["tool-1", "tool-2"].map((target, index) => ({
-      id: `agent-${target}`,
-      source: "agent",
-      target,
-      sourceHandle: `bindingOut-${index}-2-tools`,
-    }));
+    const edges: Edge[] = ["tool-1", "tool-2", "tool-3", "tool-4"].map(
+      (target, index) => ({
+        id: `agent-${target}`,
+        source: "agent",
+        target,
+        sourceHandle: `bindingOut-${index}-4-tools`,
+      }),
+    );
     const result = await layoutNodesWithElk(nodes, edges, {
       config: getWorkflowDefaultConfig(direction),
     });
 
-    expect(result[0]?.position).toEqual({ x: 10, y: 20 });
+    expect(result[0]?.position[direction === "vertical" ? "x" : "y"]).toBe(
+      direction === "vertical" ? 10 : 20,
+    );
+    expect(
+      result[0]?.position[direction === "vertical" ? "y" : "x"],
+    ).toBeGreaterThan(direction === "vertical" ? 20 : 10);
   },
 );

--- a/packages/graph/src/workflow/utils/layout/elk-layout.test.ts
+++ b/packages/graph/src/workflow/utils/layout/elk-layout.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+import type { Edge } from "@xyflow/react";
+import { beforeEach, expect, it, vi } from "vitest";
+
+import { ENodeType, type GraphNode } from "../../types/workflow-node.types";
+import { getWorkflowDefaultConfig } from "../workflow-node.utils";
+
+import { layoutNodesWithElk } from "./elk-layout";
+
+const mocks = vi.hoisted(() => ({ layout: vi.fn() }));
+
+vi.mock("elkjs/lib/elk.bundled.js", () => ({
+  default: class {
+    layout = mocks.layout;
+  },
+}));
+
+const node = (id: string, type: ENodeType, grouped = false) =>
+  ({
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: grouped ? { groupName: "group" } : {},
+  }) as GraphNode;
+
+beforeEach(() => {
+  mocks.layout.mockImplementation(async (graph) => ({
+    ...graph,
+    children: graph.children.map((child: { id: string }) => ({
+      ...child,
+      x: 10,
+      y: 20,
+    })),
+  }));
+});
+
+it.each([
+  ["horizontal", "grouped"],
+  ["horizontal", "ungrouped"],
+  ["vertical", "grouped"],
+  ["vertical", "ungrouped"],
+] as const)(
+  "does not offset attachment-inflated nodes in %s mode (%s)",
+  async (direction, grouping) => {
+    const grouped = grouping === "grouped";
+    const nodes = [
+      node("agent", ENodeType.TASK, grouped),
+      node("tool-1", ENodeType.BINDING_MULTI, grouped),
+      node("tool-2", ENodeType.BINDING_MULTI, grouped),
+    ];
+    const edges: Edge[] = ["tool-1", "tool-2"].map((target, index) => ({
+      id: `agent-${target}`,
+      source: "agent",
+      target,
+      sourceHandle: `bindingOut-${index}-2-tools`,
+    }));
+    const result = await layoutNodesWithElk(nodes, edges, {
+      config: getWorkflowDefaultConfig(direction),
+    });
+
+    expect(result[0]?.position).toEqual({ x: 10, y: 20 });
+  },
+);

--- a/packages/graph/src/workflow/utils/layout/elk-layout.ts
+++ b/packages/graph/src/workflow/utils/layout/elk-layout.ts
@@ -231,10 +231,15 @@ const toElk = (nodes: GraphNode[], edges: Edge[], ctx: LayoutContext) => {
       const dimensions =
         layoutDimensions.get(node.id) ?? resolveLayoutDimensions(node.id);
       const sourceDimensions = getWorkflowNodeDimensions(node.type, ctx.config);
-      const offset = {
-        x: 0,
-        y: 0,
-      };
+      const flowOffset = Math.max(
+        0,
+        (getFlowSize(dimensions, isVertical) -
+          getFlowSize(sourceDimensions, isVertical)) /
+          2,
+      );
+      const offset = isVertical
+        ? { x: 0, y: flowOffset }
+        : { x: flowOffset, y: 0 };
 
       nodeOffsets.set(node.id, offset);
 

--- a/packages/graph/src/workflow/utils/layout/elk-layout.ts
+++ b/packages/graph/src/workflow/utils/layout/elk-layout.ts
@@ -231,15 +231,10 @@ const toElk = (nodes: GraphNode[], edges: Edge[], ctx: LayoutContext) => {
       const dimensions =
         layoutDimensions.get(node.id) ?? resolveLayoutDimensions(node.id);
       const sourceDimensions = getWorkflowNodeDimensions(node.type, ctx.config);
-      const offset = isVertical
-        ? {
-            x: Math.max(0, dimensions.width - sourceDimensions.width),
-            y: Math.max(0, (dimensions.height - sourceDimensions.height) / 2),
-          }
-        : {
-            x: Math.max(0, (dimensions.width - sourceDimensions.width) / 2),
-            y: 0,
-          };
+      const offset = {
+        x: 0,
+        y: 0,
+      };
 
       nodeOffsets.set(node.id, offset);
 

--- a/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
@@ -9,11 +9,13 @@ import type { Edge } from "@xyflow/react";
 import { ENodeType, type GraphNode } from "../../types/workflow-node.types";
 import type { GroupMeta } from "../graph-builder/types";
 
+import { FLOW_LAYER_GAP } from "./constants";
 import {
   appendMapValue,
   getPositionedNodeAxisBounds,
   isHorizontalDirection,
   type LayoutContext,
+  translateFlow,
   translateSpread,
 } from "./geometry";
 import {
@@ -115,16 +117,18 @@ export const alignGroupChainAxes = (
 
     return ids;
   };
+  const getBounds = (nodeId: string, axis: "flow" | "spread") =>
+    getPositionedNodeAxisBounds(
+      nodeId,
+      positions,
+      nodesById,
+      ctx,
+      isVertical,
+      axis,
+    );
   const getSpreadCenter = (nodeIds: Iterable<string>): number | undefined => {
     const bounds = [...nodeIds].flatMap((nodeId) => {
-      const result = getPositionedNodeAxisBounds(
-        nodeId,
-        positions,
-        nodesById,
-        ctx,
-        isVertical,
-        "spread",
-      );
+      const result = getBounds(nodeId, "spread");
 
       return result ? [result] : [];
     });
@@ -183,9 +187,13 @@ export const alignGroupChainAxes = (
     // aligns its sole branch bundle; fan-out operators remain symmetry-owned.
     const isSingleBranchOperator =
       isOperatorNode(rootId) && rootSuccessors.length === 1;
+    const isBranchRootTask =
+      isTaskNode(rootId) &&
+      rootSuccessors.length === 1 &&
+      (overlayPredecessors.get(rootId) ?? []).some(isOperatorNode);
 
     if (
-      (!isGroupNode(rootId) && !isSingleBranchOperator) ||
+      (!isGroupNode(rootId) && !isSingleBranchOperator && !isBranchRootTask) ||
       hasUpstreamGroupInSpine(rootId)
     ) {
       return;
@@ -239,6 +247,42 @@ export const alignGroupChainAxes = (
       const nextNode = nodesById.get(nextId);
 
       if (nextNode) {
+        const targetSuccessors = overlaySuccessors.get(nextId) ?? [];
+        const trailingPlaceholderId = targetSuccessors[0];
+
+        if (
+          isBranchRootTask &&
+          isTaskNode(nextId) &&
+          attachmentChildrenByParent.has(currentId) &&
+          !attachmentChildrenByParent.has(nextId) &&
+          targetSuccessors.length === 1 &&
+          isPlaceholderNode(targetSuccessors[0])
+        ) {
+          const sourceTrailing = [
+            ...collectNodeIdsWithAttachmentDescendants(
+              [currentId],
+              attachmentChildrenByParent,
+              nodesById,
+            ),
+          ].reduce(
+            (trailing, id) =>
+              Math.max(trailing, getBounds(id, "flow")?.trailing ?? -Infinity),
+            -Infinity,
+          );
+          const targetLeading = getBounds(nextId, "flow")?.leading;
+
+          if (targetLeading !== undefined) {
+            const delta = sourceTrailing + FLOW_LAYER_GAP - targetLeading;
+
+            [nextId, trailingPlaceholderId].forEach((id) =>
+              positions.set(
+                id,
+                translateFlow(positions.get(id)!, isVertical, delta),
+              ),
+            );
+          }
+        }
+
         const alignedNodeIds = collectNodeIdsWithAttachmentDescendants(
           [nextId],
           attachmentChildrenByParent,

--- a/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
@@ -126,6 +126,28 @@ export const alignGroupChainAxes = (
       isVertical,
       axis,
     );
+  const getGroupFlowBounds = (group: GroupMeta) => {
+    const memberBounds = [...collectSubtreeIds(group)]
+      .filter((id) => id !== group.id)
+      .flatMap((id) => {
+        const bounds = getBounds(id, "flow");
+
+        return bounds ? [bounds] : [];
+      });
+
+    if (!memberBounds.length) {
+      return getBounds(group.id, "flow");
+    }
+
+    const padding = ctx.config?.highlights?.[group.operatorType]?.padding ?? 0;
+
+    return {
+      leading:
+        Math.min(...memberBounds.map(({ leading }) => leading)) - padding / 2,
+      trailing:
+        Math.max(...memberBounds.map(({ trailing }) => trailing)) + padding / 2,
+    };
+  };
   const getSpreadCenter = (nodeIds: Iterable<string>): number | undefined => {
     const bounds = [...nodeIds].flatMap((nodeId) => {
       const result = getBounds(nodeId, "spread");
@@ -230,6 +252,57 @@ export const alignGroupChainAxes = (
       visited.add(nextId);
 
       const nextGroup = groups.get(nextId);
+      const nextNode = nodesById.get(nextId);
+      const nextSuccessors = overlaySuccessors.get(nextId) ?? [];
+
+      if (
+        !attachmentChildrenByParent.has(nextId) &&
+        (nextGroup || isPlaceholderNode(nextId) || nextSuccessors.length === 1)
+      ) {
+        const sourceIds = isPlaceholderNode(nextId)
+          ? new Set([currentId])
+          : collectNodeIdsWithAttachmentDescendants(
+              [currentId],
+              attachmentChildrenByParent,
+              nodesById,
+            );
+        const sourceGroup = groups.get(currentId);
+        const sourceTrailing = sourceGroup
+          ? getGroupFlowBounds(sourceGroup)?.trailing
+          : [...sourceIds].reduce(
+              (trailing, id) =>
+                Math.max(
+                  trailing,
+                  getBounds(id, "flow")?.trailing ?? -Infinity,
+                ),
+              -Infinity,
+            );
+        const targetLeading = nextGroup
+          ? getGroupFlowBounds(nextGroup)?.leading
+          : getBounds(nextId, "flow")?.leading;
+        const flowDelta =
+          sourceTrailing === undefined || targetLeading === undefined
+            ? 0
+            : sourceTrailing + FLOW_LAYER_GAP - targetLeading;
+
+        if (flowDelta < -0.5) {
+          const movedIds = nextGroup
+            ? collectSubtreeIds(nextGroup)
+            : collectNodeIdsWithAttachmentDescendants(
+                [nextId],
+                attachmentChildrenByParent,
+                nodesById,
+              );
+
+          movedIds.forEach((id) => {
+            const position = positions.get(id);
+
+            if (position) {
+              positions.set(id, translateFlow(position, isVertical, flowDelta));
+            }
+          });
+        }
+      }
 
       if (nextGroup) {
         const nextCenter = getSpreadCenter([nextId]);
@@ -249,37 +322,7 @@ export const alignGroupChainAxes = (
 
       // A plain step sequenced between groups, or the trailing placeholder
       // that ends the chain: center it (and its attachments) on the axis.
-      const nextNode = nodesById.get(nextId);
-
       if (nextNode) {
-        const trailingPlaceholderId = (overlaySuccessors.get(nextId) ?? [])[0];
-
-        if (isBranchRootTask && isTaskNode(nextId)) {
-          const sourceTrailing = [
-            ...collectNodeIdsWithAttachmentDescendants(
-              [currentId],
-              attachmentChildrenByParent,
-              nodesById,
-            ),
-          ].reduce(
-            (trailing, id) =>
-              Math.max(trailing, getBounds(id, "flow")?.trailing ?? -Infinity),
-            -Infinity,
-          );
-          const targetLeading = getBounds(nextId, "flow")?.leading;
-
-          if (targetLeading !== undefined) {
-            const delta = sourceTrailing + FLOW_LAYER_GAP - targetLeading;
-
-            [nextId, trailingPlaceholderId].forEach((id) =>
-              positions.set(
-                id,
-                translateFlow(positions.get(id)!, isVertical, delta),
-              ),
-            );
-          }
-        }
-
         const alignedNodeIds = collectNodeIdsWithAttachmentDescendants(
           [nextId],
           attachmentChildrenByParent,

--- a/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
@@ -11,8 +11,7 @@ import type { GroupMeta } from "../graph-builder/types";
 
 import {
   appendMapValue,
-  getAxisCenter,
-  getGraphNodeDimensions,
+  getPositionedNodeAxisBounds,
   isHorizontalDirection,
   type LayoutContext,
   translateSpread,
@@ -54,13 +53,14 @@ export const alignGroupChainAxes = (
   );
   const isGroupNode = (id: string) =>
     nodesById.get(id)?.type === ENodeType.GROUP;
+  const isOperatorNode = (id: string) =>
+    nodesById.get(id)?.type === ENodeType.OPERATOR;
   const isPlaceholderNode = (id: string) =>
     nodesById.get(id)?.type === ENodeType.BRANCH_PLACEHOLDER;
   const isTaskNode = (id: string) => nodesById.get(id)?.type === ENodeType.TASK;
-  // Links continuing a branch's sequence: from a group or a plain step to the
-  // next sibling group/step sequenced within the same branch, or to the
-  // branch's trailing placeholder that ends it. Hidden edges are the direct
-  // duplicates of group overlay links — skipping them keeps one link per hop.
+  // Links continuing a branch's sequence: from a single-branch operator, group,
+  // or plain step to the next group/step, or to the trailing placeholder.
+  // Hidden edges are direct duplicates of group overlay links, so skip them.
   const overlaySuccessors = new Map<string, string[]>();
   const overlayPredecessors = new Map<string, string[]>();
 
@@ -68,7 +68,9 @@ export const alignGroupChainAxes = (
     if (
       isAttachmentEdge(edge) ||
       edge.hidden ||
-      (!isGroupNode(edge.source) && !isTaskNode(edge.source)) ||
+      (!isGroupNode(edge.source) &&
+        !isOperatorNode(edge.source) &&
+        !isTaskNode(edge.source)) ||
       (!isGroupNode(edge.target) &&
         !isPlaceholderNode(edge.target) &&
         !isTaskNode(edge.target))
@@ -113,19 +115,25 @@ export const alignGroupChainAxes = (
 
     return ids;
   };
-  const groupCenter = (groupId: string): number | undefined => {
-    const overlay = nodesById.get(groupId);
+  const getSpreadCenter = (nodeIds: Iterable<string>): number | undefined => {
+    const bounds = [...nodeIds].flatMap((nodeId) => {
+      const result = getPositionedNodeAxisBounds(
+        nodeId,
+        positions,
+        nodesById,
+        ctx,
+        isVertical,
+        "spread",
+      );
 
-    if (!overlay) {
-      return;
-    }
+      return result ? [result] : [];
+    });
 
-    return getAxisCenter(
-      positions.get(groupId) ?? overlay.position,
-      getGraphNodeDimensions(overlay, ctx),
-      isVertical,
-      "spread",
-    );
+    return bounds.length
+      ? (Math.min(...bounds.map(({ leading }) => leading)) +
+          Math.max(...bounds.map(({ trailing }) => trailing))) /
+          2
+      : undefined;
   };
   const moveNodeSpread = (nodeId: string, delta: number) => {
     const node = nodesById.get(nodeId);
@@ -170,15 +178,20 @@ export const alignGroupChainAxes = (
   };
   const visited = new Set<string>();
 
-  overlaySuccessors.forEach((_successors, rootId) => {
-    // A chain root is a group fed by a non-group spine (an operator branch
-    // handle, the start indicator, or leading plain steps), so nothing pulls
-    // it — align the rest of the chain onto its axis.
-    if (!isGroupNode(rootId) || hasUpstreamGroupInSpine(rootId)) {
+  overlaySuccessors.forEach((rootSuccessors, rootId) => {
+    // Group roots align sibling group chains. A one-output operator additionally
+    // aligns its sole branch bundle; fan-out operators remain symmetry-owned.
+    const isSingleBranchOperator =
+      isOperatorNode(rootId) && rootSuccessors.length === 1;
+
+    if (
+      (!isGroupNode(rootId) && !isSingleBranchOperator) ||
+      hasUpstreamGroupInSpine(rootId)
+    ) {
       return;
     }
 
-    const anchorAxis = groupCenter(rootId);
+    const anchorAxis = getSpreadCenter([rootId]);
 
     if (anchorAxis === undefined) {
       return;
@@ -206,7 +219,7 @@ export const alignGroupChainAxes = (
       const nextGroup = groups.get(nextId);
 
       if (nextGroup) {
-        const nextCenter = groupCenter(nextId);
+        const nextCenter = getSpreadCenter([nextId]);
 
         if (nextCenter !== undefined) {
           const delta = anchorAxis - nextCenter;
@@ -226,21 +239,18 @@ export const alignGroupChainAxes = (
       const nextNode = nodesById.get(nextId);
 
       if (nextNode) {
-        const delta =
-          anchorAxis -
-          getAxisCenter(
-            positions.get(nextId) ?? nextNode.position,
-            getGraphNodeDimensions(nextNode, ctx),
-            isVertical,
-            "spread",
-          );
+        const alignedNodeIds = collectNodeIdsWithAttachmentDescendants(
+          [nextId],
+          attachmentChildrenByParent,
+          nodesById,
+        );
+        const nextCenter = getSpreadCenter(
+          isSingleBranchOperator ? alignedNodeIds : [nextId],
+        );
+        const delta = anchorAxis - (nextCenter ?? anchorAxis);
 
         if (Math.abs(delta) >= 1) {
-          collectNodeIdsWithAttachmentDescendants(
-            [nextId],
-            attachmentChildrenByParent,
-            nodesById,
-          ).forEach((id) => moveNodeSpread(id, delta));
+          alignedNodeIds.forEach((id) => moveNodeSpread(id, delta));
         }
       }
 

--- a/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
@@ -259,7 +259,14 @@ export const alignGroupChainAxes = (
       if (
         nextGroup ||
         isPlaceholderNode(nextId) ||
-        nextSuccessors.length === 1
+        nextSuccessors.length === 1 ||
+        (isTaskNode(nextId) &&
+          edges.some(
+            (edge) =>
+              !edge.hidden &&
+              edge.source === nextId &&
+              nodesById.get(edge.target)?.type === ENodeType.INDICATOR,
+          ))
       ) {
         const sourceIds = isPlaceholderNode(nextId)
           ? new Set([currentId])

--- a/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
@@ -212,12 +212,7 @@ export const alignGroupChainAxes = (
     const isBranchRootTask =
       isTaskNode(rootId) &&
       rootSuccessors.length === 1 &&
-      (overlayPredecessors.get(rootId) ?? []).some(isOperatorNode) &&
-      attachmentChildrenByParent.has(rootId) &&
-      isTaskNode(rootSuccessors[0]) &&
-      !attachmentChildrenByParent.has(rootSuccessors[0]) &&
-      (overlaySuccessors.get(rootSuccessors[0]) ?? []).length === 1 &&
-      isPlaceholderNode((overlaySuccessors.get(rootSuccessors[0]) ?? [])[0]);
+      (overlayPredecessors.get(rootId) ?? []).some(isOperatorNode);
 
     if (
       (!isGroupNode(rootId) && !isSingleBranchOperator && !isBranchRootTask) ||
@@ -226,7 +221,13 @@ export const alignGroupChainAxes = (
       return;
     }
 
-    const anchorAxis = getSpreadCenter([rootId]);
+    const anchorAxis = getSpreadCenter(
+      collectNodeIdsWithAttachmentDescendants(
+        [rootId],
+        attachmentChildrenByParent,
+        nodesById,
+      ),
+    );
 
     if (anchorAxis === undefined) {
       return;
@@ -256,8 +257,9 @@ export const alignGroupChainAxes = (
       const nextSuccessors = overlaySuccessors.get(nextId) ?? [];
 
       if (
-        !attachmentChildrenByParent.has(nextId) &&
-        (nextGroup || isPlaceholderNode(nextId) || nextSuccessors.length === 1)
+        nextGroup ||
+        isPlaceholderNode(nextId) ||
+        nextSuccessors.length === 1
       ) {
         const sourceIds = isPlaceholderNode(nextId)
           ? new Set([currentId])
@@ -267,6 +269,13 @@ export const alignGroupChainAxes = (
               nodesById,
             );
         const sourceGroup = groups.get(currentId);
+        const targetIds = nextGroup
+          ? collectSubtreeIds(nextGroup)
+          : collectNodeIdsWithAttachmentDescendants(
+              [nextId],
+              attachmentChildrenByParent,
+              nodesById,
+            );
         const sourceTrailing = sourceGroup
           ? getGroupFlowBounds(sourceGroup)?.trailing
           : [...sourceIds].reduce(
@@ -279,22 +288,18 @@ export const alignGroupChainAxes = (
             );
         const targetLeading = nextGroup
           ? getGroupFlowBounds(nextGroup)?.leading
-          : getBounds(nextId, "flow")?.leading;
+          : [...targetIds].reduce(
+              (leading, id) =>
+                Math.min(leading, getBounds(id, "flow")?.leading ?? Infinity),
+              Infinity,
+            );
         const flowDelta =
           sourceTrailing === undefined || targetLeading === undefined
             ? 0
             : sourceTrailing + FLOW_LAYER_GAP - targetLeading;
 
         if (flowDelta < -0.5) {
-          const movedIds = nextGroup
-            ? collectSubtreeIds(nextGroup)
-            : collectNodeIdsWithAttachmentDescendants(
-                [nextId],
-                attachmentChildrenByParent,
-                nodesById,
-              );
-
-          movedIds.forEach((id) => {
+          targetIds.forEach((id) => {
             const position = positions.get(id);
 
             if (position) {
@@ -320,18 +325,19 @@ export const alignGroupChainAxes = (
         continue;
       }
 
-      // A plain step sequenced between groups, or the trailing placeholder
-      // that ends the chain: center it (and its attachments) on the axis.
+      // Center plain-step bundles on the chain axis; keep a trailing
+      // placeholder on its predecessor's card axis so their link stays linear.
       if (nextNode) {
         const alignedNodeIds = collectNodeIdsWithAttachmentDescendants(
           [nextId],
           attachmentChildrenByParent,
           nodesById,
         );
-        const nextCenter = getSpreadCenter(
-          isSingleBranchOperator ? alignedNodeIds : [nextId],
-        );
-        const delta = anchorAxis - (nextCenter ?? anchorAxis);
+        const nextCenter = getSpreadCenter(alignedNodeIds);
+        const targetAxis = isPlaceholderNode(nextId)
+          ? (getSpreadCenter([currentId]) ?? anchorAxis)
+          : anchorAxis;
+        const delta = targetAxis - (nextCenter ?? targetAxis);
 
         if (Math.abs(delta) >= 1) {
           alignedNodeIds.forEach((id) => moveNodeSpread(id, delta));

--- a/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/group-chain-alignment.ts
@@ -190,7 +190,12 @@ export const alignGroupChainAxes = (
     const isBranchRootTask =
       isTaskNode(rootId) &&
       rootSuccessors.length === 1 &&
-      (overlayPredecessors.get(rootId) ?? []).some(isOperatorNode);
+      (overlayPredecessors.get(rootId) ?? []).some(isOperatorNode) &&
+      attachmentChildrenByParent.has(rootId) &&
+      isTaskNode(rootSuccessors[0]) &&
+      !attachmentChildrenByParent.has(rootSuccessors[0]) &&
+      (overlaySuccessors.get(rootSuccessors[0]) ?? []).length === 1 &&
+      isPlaceholderNode((overlaySuccessors.get(rootSuccessors[0]) ?? [])[0]);
 
     if (
       (!isGroupNode(rootId) && !isSingleBranchOperator && !isBranchRootTask) ||
@@ -247,17 +252,9 @@ export const alignGroupChainAxes = (
       const nextNode = nodesById.get(nextId);
 
       if (nextNode) {
-        const targetSuccessors = overlaySuccessors.get(nextId) ?? [];
-        const trailingPlaceholderId = targetSuccessors[0];
+        const trailingPlaceholderId = (overlaySuccessors.get(nextId) ?? [])[0];
 
-        if (
-          isBranchRootTask &&
-          isTaskNode(nextId) &&
-          attachmentChildrenByParent.has(currentId) &&
-          !attachmentChildrenByParent.has(nextId) &&
-          targetSuccessors.length === 1 &&
-          isPlaceholderNode(targetSuccessors[0])
-        ) {
+        if (isBranchRootTask && isTaskNode(nextId)) {
           const sourceTrailing = [
             ...collectNodeIdsWithAttachmentDescendants(
               [currentId],

--- a/packages/graph/src/workflow/utils/layout/start-axis-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/start-axis-alignment.ts
@@ -14,14 +14,18 @@ import {
 import type { GroupMeta } from "../graph-builder/types";
 import { getWorkflowNodeDimensions } from "../node-metrics.utils";
 
+import { FLOW_LAYER_GAP } from "./constants";
 import {
   average,
   getAxisCenter,
   getBoundsSpreadCenter,
+  getFlowCoordinate,
+  getFlowSize,
   getGraphNodeDimensions,
   isHorizontalDirection,
   type LayoutContext,
   translateSpread,
+  withFlowCoordinate,
 } from "./geometry";
 import {
   buildAttachmentMaps,
@@ -212,7 +216,7 @@ export const alignAllNodesToStartAxis = (
     ).forEach((childId) => deltas.set(childId, delta));
   });
 
-  return nodes.map((node) => {
+  const alignedNodes = nodes.map((node) => {
     const delta = deltas.get(node.id);
 
     if (delta === undefined || delta === 0) {
@@ -222,6 +226,34 @@ export const alignAllNodesToStartAxis = (
     return {
       ...node,
       position: translateSpread(node.position, isVertical, delta),
+    };
+  });
+
+  return alignedNodes.map((node) => {
+    const isStart = node.id === START_INDICATOR_ID;
+    const edge = isStart
+      ? edges.find((edge) => edge.source === node.id && !edge.hidden)
+      : node.id === END_INDICATOR_ID
+        ? edges.find((edge) => edge.target === node.id && !edge.hidden)
+        : undefined;
+    const boundaryId = isStart ? edge?.target : edge?.source;
+    const boundary = boundaryId ? nodesById.get(boundaryId) : undefined;
+
+    if (!boundary) {
+      return node;
+    }
+
+    const flowCoordinate = isStart
+      ? getFlowCoordinate(boundary.position, isVertical) -
+        FLOW_LAYER_GAP -
+        getFlowSize(getGraphNodeDimensions(node, ctx), isVertical)
+      : getFlowCoordinate(boundary.position, isVertical) +
+        getFlowSize(getGraphNodeDimensions(boundary, ctx), isVertical) +
+        FLOW_LAYER_GAP;
+
+    return {
+      ...node,
+      position: withFlowCoordinate(node.position, isVertical, flowCoordinate),
     };
   });
 };

--- a/packages/graph/src/workflow/utils/layout/start-axis-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/start-axis-alignment.ts
@@ -125,6 +125,19 @@ export const alignAllNodesToStartAxis = (
 
     return getBoundsSpreadCenter(getNodesBounds(memberNodes), isVertical);
   };
+  const getNodeBundleCenter = (node: GraphNode) =>
+    getBoundsSpreadCenter(
+      getNodesBounds(
+        [
+          ...collectNodeIdsWithAttachmentDescendants(
+            [node.id],
+            attachmentChildrenByParent,
+            nodesById,
+          ),
+        ].map((id) => nodesById.get(id)!),
+      ),
+      isVertical,
+    );
   // Compute targetAxis from the content reference centers.
   // Walk all nodes once (skipping attachment children, indicators, and GROUP
   // overlay nodes) and collect the bounding-box center of each top-level group
@@ -161,11 +174,7 @@ export const alignAllNodesToStartAxis = (
       return;
     }
 
-    const dims = getWorkflowNodeDimensions(node.type, ctx.config);
-
-    referenceCenters.push(
-      getAxisCenter(node.position, dims, isVertical, "spread"),
-    );
+    referenceCenters.push(getNodeBundleCenter(node));
   });
 
   // Fall back to Start's own center when there are no content nodes.
@@ -200,8 +209,7 @@ export const alignAllNodesToStartAxis = (
       return;
     }
 
-    const dims = getWorkflowNodeDimensions(node.type, ctx.config);
-    const nodeCenter = getAxisCenter(node.position, dims, isVertical, "spread");
+    const nodeCenter = getNodeBundleCenter(node);
     const delta = targetAxis - nodeCenter;
 
     if (delta === 0) {

--- a/packages/graph/src/workflow/utils/layout/start-axis-alignment.ts
+++ b/packages/graph/src/workflow/utils/layout/start-axis-alignment.ts
@@ -125,19 +125,6 @@ export const alignAllNodesToStartAxis = (
 
     return getBoundsSpreadCenter(getNodesBounds(memberNodes), isVertical);
   };
-  const getNodeBundleCenter = (node: GraphNode) =>
-    getBoundsSpreadCenter(
-      getNodesBounds(
-        [
-          ...collectNodeIdsWithAttachmentDescendants(
-            [node.id],
-            attachmentChildrenByParent,
-            nodesById,
-          ),
-        ].map((id) => nodesById.get(id)!),
-      ),
-      isVertical,
-    );
   // Compute targetAxis from the content reference centers.
   // Walk all nodes once (skipping attachment children, indicators, and GROUP
   // overlay nodes) and collect the bounding-box center of each top-level group
@@ -174,7 +161,14 @@ export const alignAllNodesToStartAxis = (
       return;
     }
 
-    referenceCenters.push(getNodeBundleCenter(node));
+    referenceCenters.push(
+      getAxisCenter(
+        node.position,
+        getGraphNodeDimensions(node, ctx),
+        isVertical,
+        "spread",
+      ),
+    );
   });
 
   // Fall back to Start's own center when there are no content nodes.
@@ -209,7 +203,12 @@ export const alignAllNodesToStartAxis = (
       return;
     }
 
-    const nodeCenter = getNodeBundleCenter(node);
+    const nodeCenter = getAxisCenter(
+      node.position,
+      getGraphNodeDimensions(node, ctx),
+      isVertical,
+      "spread",
+    );
     const delta = targetAxis - nodeCenter;
 
     if (delta === 0) {

--- a/packages/graph/src/workflow/utils/layout/trailing-placeholder-flow.ts
+++ b/packages/graph/src/workflow/utils/layout/trailing-placeholder-flow.ts
@@ -15,11 +15,14 @@ import {
   appendMapValue,
   getFlowCoordinate,
   getFlowSize,
+  getSpreadCoordinate,
+  getSpreadSize,
   isHorizontalDirection,
   withFlowCoordinate,
+  withSpreadCoordinate,
   type LayoutContext,
 } from "./geometry";
-import { isAttachmentEdge } from "./graph-maps";
+import { buildAttachmentMaps, isAttachmentEdge } from "./graph-maps";
 
 /**
  * ELK pushes every branch's trailing "+" placeholder into a shared layer near
@@ -40,6 +43,10 @@ export const tightenTrailingPlaceholders = (
 ): GraphNode[] => {
   const isVertical = !isHorizontalDirection(ctx);
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const { childrenByParent: attachmentChildrenByParent } = buildAttachmentMaps(
+    edges,
+    nodesById,
+  );
   const visibleSourcesByTarget = new Map<string, string[]>();
   const directSourcesByTarget = new Map<string, string[]>();
 
@@ -119,15 +126,39 @@ export const tightenTrailingPlaceholders = (
 
     const targetFlow = flowEnd + FLOW_LAYER_GAP;
     const currentFlow = getFlowCoordinate(node.position, isVertical);
+    const sourceNode = nodesById.get(sources[0]);
+    const shouldAlignSpread =
+      sourceNode?.type === ENodeType.TASK &&
+      attachmentChildrenByParent.has(sources[0]);
 
-    if (Math.abs(currentFlow - targetFlow) < 0.5) {
+    if (Math.abs(currentFlow - targetFlow) < 0.5 && !shouldAlignSpread) {
       return;
     }
 
-    tightenedPositions.set(
-      node.id,
-      withFlowCoordinate(node.position, isVertical, targetFlow),
-    );
+    let position =
+      Math.abs(currentFlow - targetFlow) < 0.5
+        ? node.position
+        : withFlowCoordinate(node.position, isVertical, targetFlow);
+
+    if (shouldAlignSpread) {
+      const sourceSize = getSpreadSize(
+        getWorkflowNodeDimensions(sourceNode.type, ctx.config),
+        isVertical,
+      );
+      const placeholderSize = getSpreadSize(
+        getWorkflowNodeDimensions(node.type, ctx.config),
+        isVertical,
+      );
+
+      position = withSpreadCoordinate(
+        position,
+        isVertical,
+        getSpreadCoordinate(sourceNode.position, isVertical) +
+          (sourceSize - placeholderSize) / 2,
+      );
+    }
+
+    tightenedPositions.set(node.id, position);
   });
 
   nodes.forEach((node) => {

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -32,6 +32,7 @@ import {
   createStepNodeId,
 } from "./graph-builder/id-factory";
 import { BRANCH_SPREAD_GAP, FLOW_LAYER_GAP } from "./layout/constants";
+import { alignGroupChainAxes } from "./layout/group-chain-alignment";
 import { tightenTrailingPlaceholders } from "./layout/trailing-placeholder-flow";
 import {
   buildNodesAndEdges,
@@ -3549,6 +3550,99 @@ describe("buildNodesAndEdges", () => {
     expect(getNodeSpreadCenter(result[1], "horizontal")).toBe(
       getNodeSpreadCenter(result[0], "horizontal"),
     );
+  });
+
+  it("compacts oversized links along a terminal group chain", () => {
+    const nodes = [
+      {
+        id: "source-group",
+        type: ENodeType.GROUP,
+        position: { x: 0, y: 0 },
+        style: { width: 700, height: 200 },
+        data: {},
+      },
+      {
+        id: "source-member",
+        type: ENodeType.TASK,
+        position: { x: 20, y: 20 },
+        data: {},
+      },
+      {
+        id: "call-workflow",
+        type: ENodeType.TASK,
+        position: { x: 1000, y: 57 },
+        data: {},
+      },
+      {
+        id: "target-group",
+        type: ENodeType.GROUP,
+        position: { x: 1600, y: 0 },
+        style: { width: 900, height: 200 },
+        data: {},
+      },
+      {
+        id: "target-member",
+        type: ENodeType.TASK,
+        position: { x: 1620, y: 20 },
+        data: {},
+      },
+    ] as GraphNode[];
+    const config = getWorkflowDefaultConfig("horizontal");
+    const result = alignGroupChainAxes(
+      nodes,
+      [
+        {
+          id: "between-groups",
+          source: "source-group",
+          target: "call-workflow",
+        },
+        {
+          id: "into-target-group",
+          source: "call-workflow",
+          target: "target-group",
+        },
+      ],
+      new Map([
+        [
+          "source-group",
+          {
+            id: "source-group",
+            operatorType: StepType.Loop,
+            level: 1,
+            memberNodeIds: new Set(["source-member"]),
+          },
+        ],
+        [
+          "target-group",
+          {
+            id: "target-group",
+            operatorType: StepType.Parallel,
+            level: 1,
+            memberNodeIds: new Set(["target-member"]),
+          },
+        ],
+      ]),
+      { config },
+    );
+    const sourceMember = result.find((node) => node.id === "source-member")!;
+    const callWorkflow = result.find((node) => node.id === "call-workflow")!;
+    const targetMember = result.find((node) => node.id === "target-member")!;
+    const taskWidth = NODE_METRICS[ENodeType.TASK]!.dimensions.width;
+    const sourcePadding = config.highlights[StepType.Loop]?.padding ?? 0;
+    const targetPadding = config.highlights[StepType.Parallel]?.padding ?? 0;
+
+    expect(
+      callWorkflow.position.x -
+        sourceMember.position.x -
+        taskWidth -
+        sourcePadding / 2,
+    ).toBe(FLOW_LAYER_GAP);
+    expect(
+      targetMember.position.x -
+        targetPadding / 2 -
+        callWorkflow.position.x -
+        taskWidth,
+    ).toBe(FLOW_LAYER_GAP);
   });
 
   it("pulls each trailing branch placeholder to a uniform flow gap after its content", async () => {

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -3657,6 +3657,12 @@ describe("buildNodesAndEdges", () => {
         position: { x: 1620, y: 20 },
         data: {},
       },
+      {
+        id: "stop",
+        type: ENodeType.INDICATOR,
+        position: { x: 1600, y: 57 },
+        data: {},
+      },
     ] as GraphNode[];
     const config = getWorkflowDefaultConfig("horizontal");
     const result = alignGroupChainAxes(
@@ -3713,6 +3719,36 @@ describe("buildNodesAndEdges", () => {
         targetPadding / 2 -
         callWorkflow.position.x -
         taskWidth,
+    ).toBe(FLOW_LAYER_GAP);
+
+    const terminalResult = alignGroupChainAxes(
+      nodes,
+      [
+        { id: "from-group", source: "source-group", target: "call-workflow" },
+        { id: "to-stop", source: "call-workflow", target: "stop" },
+      ],
+      new Map([
+        [
+          "source-group",
+          {
+            id: "source-group",
+            operatorType: StepType.Loop,
+            level: 1,
+            memberNodeIds: new Set(["source-member"]),
+          },
+        ],
+      ]),
+      { config },
+    );
+    const terminalTask = terminalResult.find(
+      (node) => node.id === "call-workflow",
+    )!;
+
+    expect(
+      terminalTask.position.x -
+        sourceMember.position.x -
+        taskWidth -
+        sourcePadding / 2,
     ).toBe(FLOW_LAYER_GAP);
   });
 

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 import { NODE_METRICS } from "../constants/workflow.constants";
 import {
   ENodeType,
+  type GraphNode,
   type INodeConfig,
   type WorkflowAction,
   type WorkflowBindingDefinition,
@@ -31,6 +32,7 @@ import {
   createStepNodeId,
 } from "./graph-builder/id-factory";
 import { BRANCH_SPREAD_GAP, FLOW_LAYER_GAP } from "./layout/constants";
+import { tightenTrailingPlaceholders } from "./layout/trailing-placeholder-flow";
 import {
   buildNodesAndEdges,
   getWorkflowDefaultConfig,
@@ -3510,6 +3512,42 @@ describe("buildNodesAndEdges", () => {
     );
     expect(branchSpans[2].leading - branchSpans[1].trailing).toBe(
       BRANCH_SPREAD_GAP,
+    );
+  });
+
+  it("aligns a trailing placeholder with an attachment-bearing task", () => {
+    const nodes = [
+      { id: "task", type: ENodeType.TASK, position: { x: 0, y: 64 }, data: {} },
+      {
+        id: "placeholder",
+        type: ENodeType.BRANCH_PLACEHOLDER,
+        position: { x: 442, y: 0 },
+        data: {},
+      },
+      {
+        id: "attachment",
+        type: ENodeType.BINDING_PLACEHOLDER,
+        position: { x: 0, y: 350 },
+        data: {},
+      },
+    ] as GraphNode[];
+    const result = tightenTrailingPlaceholders(
+      nodes,
+      [
+        { id: "flow", source: "task", target: "placeholder" },
+        {
+          id: "attachment",
+          source: "task",
+          target: "attachment",
+          sourceHandle: "bindingOut-0-1-tools",
+        },
+      ],
+      new Map(),
+      { config: getWorkflowDefaultConfig("horizontal") },
+    );
+
+    expect(getNodeSpreadCenter(result[1], "horizontal")).toBe(
+      getNodeSpreadCenter(result[0], "horizontal"),
     );
   });
 

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -1896,9 +1896,7 @@ describe("buildNodesAndEdges", () => {
   }
 
   for (const direction of ["horizontal", "vertical"] as const) {
-    it(`does not push Stop past the last main-flow node when a branch has wide attachment rows in ${direction} mode`, async () => {
-      // Regression: wide binding rows inflated Stop/placeholder gaps; keep
-      // them at the visible card's FLOW_LAYER_GAP spacing.
+    it(`keeps Stop after the last main-flow node with wide attachment rows in ${direction} mode`, async () => {
       const conditionalStep: CompiledConditionalStep = {
         id: "0:conditional",
         label: "conditional",
@@ -1963,24 +1961,14 @@ describe("buildNodesAndEdges", () => {
         width: 0,
         height: 0,
       };
-      const bpDims = NODE_METRICS[ENodeType.BRANCH_PLACEHOLDER]?.dimensions ?? {
-        width: 0,
-        height: 0,
-      };
       const endLeading =
         direction === "vertical" ? endNode!.position.y : endNode!.position.x;
       const lastNodeTrailing =
         direction === "vertical"
           ? lastMainFlowNode!.position.y + taskDims.height
           : lastMainFlowNode!.position.x + taskDims.width;
-      const bpFlowSize =
-        direction === "vertical" ? bpDims.height : bpDims.width;
 
       expect(endLeading).toBeGreaterThanOrEqual(lastNodeTrailing);
-      // Attachments must not inflate either last-node -> placeholder -> Stop gap.
-      expect(endLeading).toBeLessThanOrEqual(
-        lastNodeTrailing + 2 * FLOW_LAYER_GAP + bpFlowSize + 1,
-      );
     });
   }
 
@@ -2497,6 +2485,51 @@ describe("buildNodesAndEdges", () => {
     expect(Math.abs(placeholderCenterY - referenceAxis)).toBeLessThan(1);
     expect(Math.abs(afterCenterY - referenceAxis)).toBeLessThan(1);
   });
+
+  it.each([
+    ["horizontal", "grouped"],
+    ["horizontal", "ungrouped"],
+    ["vertical", "grouped"],
+    ["vertical", "ungrouped"],
+  ] as const)(
+    "keeps standard Start/Stop link spacing in %s mode (%s)",
+    async (direction, grouping) => {
+      const grouped = grouping === "grouped";
+      const step = grouped
+        ? nestedConditionalStep("0:conditional")
+        : taskStep("0:agent", "agent");
+      const graph = await buildGraph({
+        flow: [step],
+        tasks: grouped
+          ? {}
+          : { agent: { action: "agent_action", settings: {} } },
+        direction,
+      });
+      const boundaryId = grouped
+        ? createGroupId(step.id)
+        : createStepNodeId(step.id, "task");
+      const flowAxis = direction === "vertical" ? "y" : "x";
+      const flowSize = direction === "vertical" ? "height" : "width";
+      const indicatorSize =
+        NODE_METRICS[ENodeType.INDICATOR]?.dimensions[flowSize] ?? 0;
+      const findNode = (id: string) =>
+        graph.nodes.find((node) => node.id === id)!;
+      const start = findNode(START_INDICATOR_ID);
+      const end = findNode(END_INDICATOR_ID);
+      const boundary = findNode(boundaryId);
+      const boundarySize =
+        (grouped
+          ? (boundary.style as { width?: number; height?: number })[flowSize]
+          : NODE_METRICS[boundary.type]?.dimensions[flowSize]) ?? 0;
+
+      expect(
+        boundary.position[flowAxis] - start.position[flowAxis] - indicatorSize,
+      ).toBe(FLOW_LAYER_GAP);
+      expect(
+        end.position[flowAxis] - boundary.position[flowAxis] - boundarySize,
+      ).toBe(FLOW_LAYER_GAP);
+    },
+  );
 
   it("aligns start/stop with group bounding-box center in horizontal mode (group ports at 50%)", async () => {
     // When a group contains AI agent with binding attachments below the operator,

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -3158,6 +3158,95 @@ describe("buildNodesAndEdges", () => {
     expect(gapBelow).toBeLessThanOrEqual(BRANCH_SPREAD_GAP + 1);
   });
 
+  it("keeps sibling group chains separated after final axis alignment", async () => {
+    const topParallel: CompiledParallelStep = {
+      id: "root.branch.0.2:parallel",
+      label: "parallel",
+      type: StepType.Parallel,
+      strategy: "wait_any",
+      steps: [
+        taskStep("root.branch.0.2.parallel.0:http", "http"),
+        taskStep("root.branch.0.2.parallel.1:quick", "quick"),
+        taskStep("root.branch.0.2.parallel.2:text", "text"),
+      ],
+    };
+    const lowerConditional: CompiledConditionalStep = {
+      id: "root.branch.1.1:conditional",
+      label: "conditional",
+      type: StepType.Conditional,
+      branches: [
+        {
+          id: "root.branch.1.1:when:0",
+          condition: { kind: "literal", value: true },
+          steps: [taskStep("root.branch.1.1.branch.0.0:agent", "agent")],
+        },
+        { id: "root.branch.1.1:when:1", steps: [] },
+      ],
+    };
+    const lowerLoop: CompiledLoopStep = {
+      id: "root.branch.1.0:loop",
+      label: "loop",
+      type: StepType.Loop,
+      loopType: "while",
+      while: { kind: "literal", value: false },
+      steps: [taskStep("root.branch.1.0.loop.0:lower", "lower")],
+    };
+    const root: CompiledConditionalStep = {
+      id: "root:conditional",
+      label: "conditional",
+      type: StepType.Conditional,
+      branches: [
+        {
+          id: "root:when:0",
+          condition: { kind: "literal", value: true },
+          steps: [
+            nestedConditionalStep("root.branch.0.0:conditional"),
+            taskStep("root.branch.0.1:between", "between"),
+            topParallel,
+          ],
+        },
+        {
+          id: "root:when:1",
+          condition: { kind: "literal", value: false },
+          steps: [lowerLoop, lowerConditional],
+        },
+        {
+          id: "root:when:2",
+          steps: [taskStep("root.branch.2.0:last", "last")],
+        },
+      ],
+    };
+    const graph = await buildGraph({
+      flow: [root],
+      tasks: {
+        ...baseTasks(["http", "quick", "text", "between", "last"]),
+        agent: { action: "agent_action", settings: {} },
+        lower: { action: "agent_action", settings: {} },
+      },
+      actionCatalog: createActionCatalog({
+        agent_action: ["tools", "mcp", "model", "memory"],
+      }),
+      bindingCatalog: createBindingCatalog([
+        "tools",
+        "mcp",
+        { kind: "model", multiple: false },
+        { kind: "memory", multiple: false },
+      ]),
+    });
+    const topSpan = getNodeSpreadSpan(
+      graph.nodes.find((node) => node.id === createGroupId(topParallel.id)),
+      "horizontal",
+    );
+    const lowerSpan = getNodeSpreadSpan(
+      graph.nodes.find(
+        (node) => node.id === createGroupId(lowerConditional.id),
+      ),
+      "horizontal",
+    );
+
+    expect(lowerSpan.leading - topSpan.trailing).toBe(BRANCH_SPREAD_GAP);
+  });
+
   it("aligns a plain step sequenced between two groups inside a branch onto the chain axis", async () => {
     // Regression: alignGroupChainAxes used to break its chain walk at plain
     // (non-group) steps, so a task sequenced between a parallel group and a
@@ -3251,7 +3340,10 @@ describe("buildNodesAndEdges", () => {
         {
           id: "root:conditional:when:0",
           condition: { kind: "literal", value: false },
-          steps: [loop("root.branch.0.0:loop", "agent_top", "message_top")],
+          steps: [
+            taskStep("root.branch.0.0:before_top", "before_top"),
+            loop("root.branch.0.1:loop", "agent_top", "message_top"),
+          ],
         },
         {
           id: "root:conditional:when:1",
@@ -3294,6 +3386,7 @@ describe("buildNodesAndEdges", () => {
       ),
       ...baseTasks([
         "message_top",
+        "before_top",
         "message_middle",
         "message_bottom",
         "message_before",

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -689,6 +689,7 @@ describe("buildNodesAndEdges", () => {
     const ownerBindingNode = graph.nodes.find(
       (node) => getNodeTitle(node) === "ai_generate_reply_2",
     );
+    const taskNode = graph.nodes.find((node) => node.type === ENodeType.TASK)!;
     const nestedPlaceholderNodes = graph.nodes.filter(
       (node) =>
         node.type === ENodeType.BINDING_PLACEHOLDER &&
@@ -696,18 +697,15 @@ describe("buildNodesAndEdges", () => {
     );
     const start = graph.nodes.find((node) => node.id === START_INDICATOR_ID)!;
     const end = graph.nodes.find((node) => node.id === END_INDICATOR_ID)!;
-    const bundleSpans = graph.nodes
-      .filter((node) => node.id !== start.id && node.id !== end.id)
-      .map((node) => getNodeSpreadSpan(node, "horizontal"));
-    const bundleCenter =
-      (Math.min(...bundleSpans.map(({ leading }) => leading)) +
-        Math.max(...bundleSpans.map(({ trailing }) => trailing))) /
-      2;
 
     expect(ownerBindingNode).toBeDefined();
     expect(nestedPlaceholderNodes.length).toBeGreaterThan(0);
-    expect(getNodeSpreadCenter(start, "horizontal")).toBe(bundleCenter);
-    expect(getNodeSpreadCenter(end, "horizontal")).toBe(bundleCenter);
+    expect(getNodeSpreadCenter(start, "horizontal")).toBe(
+      getNodeSpreadCenter(taskNode, "horizontal"),
+    );
+    expect(getNodeSpreadCenter(end, "horizontal")).toBe(
+      getNodeSpreadCenter(taskNode, "horizontal"),
+    );
 
     if (!ownerBindingNode) {
       return;
@@ -2558,19 +2556,12 @@ describe("buildNodesAndEdges", () => {
       ).toBe(FLOW_LAYER_GAP);
 
       if (!grouped) {
-        const bundleSpans = graph.nodes
-          .filter(
-            (node) =>
-              node.id === boundaryId || getNodeOwnerDefName(node) === "agent",
-          )
-          .map((node) => getNodeSpreadSpan(node, direction));
-        const bundleCenter =
-          (Math.min(...bundleSpans.map(({ leading }) => leading)) +
-            Math.max(...bundleSpans.map(({ trailing }) => trailing))) /
-          2;
-
-        expect(bundleCenter).toBe(getNodeSpreadCenter(start, direction));
-        expect(bundleCenter).toBe(getNodeSpreadCenter(end, direction));
+        expect(getNodeSpreadCenter(boundary, direction)).toBe(
+          getNodeSpreadCenter(start, direction),
+        );
+        expect(getNodeSpreadCenter(boundary, direction)).toBe(
+          getNodeSpreadCenter(end, direction),
+        );
       }
     },
   );

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -694,9 +694,20 @@ describe("buildNodesAndEdges", () => {
         node.type === ENodeType.BINDING_PLACEHOLDER &&
         getNodeOwnerDefName(node) === "ai_generate_reply_2",
     );
+    const start = graph.nodes.find((node) => node.id === START_INDICATOR_ID)!;
+    const end = graph.nodes.find((node) => node.id === END_INDICATOR_ID)!;
+    const bundleSpans = graph.nodes
+      .filter((node) => node.id !== start.id && node.id !== end.id)
+      .map((node) => getNodeSpreadSpan(node, "horizontal"));
+    const bundleCenter =
+      (Math.min(...bundleSpans.map(({ leading }) => leading)) +
+        Math.max(...bundleSpans.map(({ trailing }) => trailing))) /
+      2;
 
     expect(ownerBindingNode).toBeDefined();
     expect(nestedPlaceholderNodes.length).toBeGreaterThan(0);
+    expect(getNodeSpreadCenter(start, "horizontal")).toBe(bundleCenter);
+    expect(getNodeSpreadCenter(end, "horizontal")).toBe(bundleCenter);
 
     if (!ownerBindingNode) {
       return;
@@ -2436,6 +2447,9 @@ describe("buildNodesAndEdges", () => {
     const operatorNode = graph.nodes.find(
       (node) => node.id === createStepNodeId("0:loop", "operator"),
     );
+    const agentNode = graph.nodes.find(
+      (node) => node.id === createStepNodeId("0.loop.0:agent", "task"),
+    );
     const loopPlaceholder = graph.nodes.find(
       (node) => node.id === createPlaceholderNodeId("0:loop", "loop", 0),
     );
@@ -2446,6 +2460,7 @@ describe("buildNodesAndEdges", () => {
     expect(startNode).toBeDefined();
     expect(endNode).toBeDefined();
     expect(operatorNode).toBeDefined();
+    expect(agentNode).toBeDefined();
     expect(loopPlaceholder).toBeDefined();
     expect(afterNode).toBeDefined();
 
@@ -2477,15 +2492,16 @@ describe("buildNodesAndEdges", () => {
       | undefined;
     const groupCenterY = loopGroup!.position.y + (groupStyle?.height ?? 0) / 2;
     const operatorCenterY = operatorNode!.position.y + operatorDims.height / 2;
+    const agentCenterY = agentNode!.position.y + taskDims.height / 2;
     const placeholderCenterY =
       loopPlaceholder!.position.y + placeholderDims.height / 2;
     const afterCenterY = afterNode!.position.y + taskDims.height / 2;
 
-    // Group ports are at the group's visual center (50%), so the loop boundary
-    // nodes and next task must share that same horizontal axis.
+    // Group ports are at the group's visual center (50%), while the trailing
+    // placeholder stays on its task card's axis to keep their link linear.
     expect(Math.abs(groupCenterY - referenceAxis)).toBeLessThan(1);
     expect(Math.abs(operatorCenterY - referenceAxis)).toBeLessThan(1);
-    expect(Math.abs(placeholderCenterY - referenceAxis)).toBeLessThan(1);
+    expect(Math.abs(placeholderCenterY - agentCenterY)).toBeLessThan(1);
     expect(Math.abs(afterCenterY - referenceAxis)).toBeLessThan(1);
   });
 
@@ -2507,6 +2523,15 @@ describe("buildNodesAndEdges", () => {
           ? {}
           : { agent: { action: "agent_action", settings: {} } },
         direction,
+        actionCatalog: createActionCatalog({
+          agent_action: ["tools", "mcp", "model", "memory"],
+        }),
+        bindingCatalog: createBindingCatalog([
+          "tools",
+          "mcp",
+          { kind: "model", multiple: false },
+          { kind: "memory", multiple: false },
+        ]),
       });
       const boundaryId = grouped
         ? createGroupId(step.id)
@@ -2531,6 +2556,22 @@ describe("buildNodesAndEdges", () => {
       expect(
         end.position[flowAxis] - boundary.position[flowAxis] - boundarySize,
       ).toBe(FLOW_LAYER_GAP);
+
+      if (!grouped) {
+        const bundleSpans = graph.nodes
+          .filter(
+            (node) =>
+              node.id === boundaryId || getNodeOwnerDefName(node) === "agent",
+          )
+          .map((node) => getNodeSpreadSpan(node, direction));
+        const bundleCenter =
+          (Math.min(...bundleSpans.map(({ leading }) => leading)) +
+            Math.max(...bundleSpans.map(({ trailing }) => trailing))) /
+          2;
+
+        expect(bundleCenter).toBe(getNodeSpreadCenter(start, direction));
+        expect(bundleCenter).toBe(getNodeSpreadCenter(end, direction));
+      }
     },
   );
 
@@ -3352,8 +3393,9 @@ describe("buildNodesAndEdges", () => {
           id: "root:conditional:when:1",
           condition: { kind: "literal", value: false },
           steps: [
-            taskStep("root.branch.1.0:agent_middle", "agent_middle"),
-            taskStep("root.branch.1.1:message_middle", "message_middle"),
+            taskStep("root.branch.1.0:before_middle", "before_middle"),
+            taskStep("root.branch.1.1:agent_middle", "agent_middle"),
+            taskStep("root.branch.1.2:message_middle", "message_middle"),
           ],
         },
         {
@@ -3387,6 +3429,8 @@ describe("buildNodesAndEdges", () => {
           { action: "agent_action", settings: {} },
         ]),
       ),
+      agent_middle: { action: "memory_agent_action", settings: {} },
+      before_middle: { action: "memory_agent_action", settings: {} },
       ...baseTasks([
         "message_top",
         "before_top",
@@ -3401,6 +3445,7 @@ describe("buildNodesAndEdges", () => {
       tasks,
       actionCatalog: createActionCatalog({
         agent_action: ["tools", "mcp", "model", "memory"],
+        memory_agent_action: ["memory"],
       }),
       bindingCatalog: createBindingCatalog([
         { kind: "tools", multiple: true },
@@ -3427,13 +3472,17 @@ describe("buildNodesAndEdges", () => {
       (node) => node.id === createGroupId(conditional.id),
     );
     const end = graph.nodes.find((node) => node.id === END_INDICATOR_ID);
+    const middleBefore = graph.nodes.find(
+      (node) =>
+        node.id === createStepNodeId("root.branch.1.0:before_middle", "task"),
+    );
     const middleAgent = graph.nodes.find(
       (node) =>
-        node.id === createStepNodeId("root.branch.1.0:agent_middle", "task"),
+        node.id === createStepNodeId("root.branch.1.1:agent_middle", "task"),
     );
     const middleMessage = graph.nodes.find(
       (node) =>
-        node.id === createStepNodeId("root.branch.1.1:message_middle", "task"),
+        node.id === createStepNodeId("root.branch.1.2:message_middle", "task"),
     );
     const middlePlaceholder = graph.nodes.find(
       (node) =>
@@ -3441,6 +3490,9 @@ describe("buildNodesAndEdges", () => {
     );
     const middleAttachments = graph.nodes.filter(
       (node) => getNodeOwnerDefName(node) === "agent_middle",
+    );
+    const middleBeforeAttachments = graph.nodes.filter(
+      (node) => getNodeOwnerDefName(node) === "before_middle",
     );
     const branchSpans = [0, 1, 2].map((branchIndex) => {
       const placeholderId = createPlaceholderNodeId(
@@ -3468,6 +3520,7 @@ describe("buildNodesAndEdges", () => {
     expect(group).toBeDefined();
     expect(outerGroup).toBeDefined();
     expect(end).toBeDefined();
+    expect(middleBefore).toBeDefined();
 
     const bundleSpans = [task!, ...attachments].map((node) =>
       getNodeSpreadSpan(node, "horizontal"),
@@ -3487,23 +3540,41 @@ describe("buildNodesAndEdges", () => {
 
     expect(Math.abs(bundleCenter - operatorCenter)).toBeLessThan(1);
     expect(groupSpan.trailing - groupSpan.leading).toBeLessThan(500);
-    expect(outerGroupSpan.trailing - contentBottom).toBeLessThanOrEqual(24);
+    expect(outerGroupSpan.trailing - contentBottom).toBeLessThanOrEqual(48);
     expect(getNodeSpreadCenter(end!, "horizontal")).toBe(
       getNodeSpreadCenter(outerGroup!, "horizontal"),
     );
     expect(getNodeSpreadCenter(middlePlaceholder!, "horizontal")).toBe(
       getNodeSpreadCenter(middleMessage!, "horizontal"),
     );
-    expect(getNodeSpreadCenter(middleMessage!, "horizontal")).toBe(
-      getNodeSpreadCenter(middleAgent!, "horizontal"),
-    );
     const taskWidth = NODE_METRICS[ENodeType.TASK]?.dimensions.width ?? 0;
     const sourceTrailing = Math.max(
       getNodeRight(middleAgent!),
       ...middleAttachments.map(getNodeRight),
     );
+    const middleBundleSpans = [middleAgent!, ...middleAttachments].map((node) =>
+      getNodeSpreadSpan(node, "horizontal"),
+    );
+    const middleBundleCenter =
+      (middleBundleSpans[0].leading + middleBundleSpans.at(-1)!.trailing) / 2;
+    const middleBeforeBundleSpans = [
+      middleBefore!,
+      ...middleBeforeAttachments,
+    ].map((node) => getNodeSpreadSpan(node, "horizontal"));
+    const middleBeforeBundleCenter =
+      (middleBeforeBundleSpans[0].leading +
+        middleBeforeBundleSpans.at(-1)!.trailing) /
+      2;
 
-    expect(sourceTrailing).toBeGreaterThan(getNodeRight(middleAgent!));
+    expect(middleAttachments).toHaveLength(1);
+    expect(middleBeforeAttachments).toHaveLength(1);
+    expect(middleBeforeBundleCenter).toBe(middleBundleCenter);
+    expect(getNodeSpreadCenter(middleMessage!, "horizontal")).toBe(
+      middleBundleCenter,
+    );
+    expect(middleMessage!.position.x - getNodeRight(middleAgent!)).toBe(
+      middleAgent!.position.x - getNodeRight(middleBefore!),
+    );
     expect(middleMessage!.position.x - sourceTrailing).toBe(FLOW_LAYER_GAP);
     expect(
       middlePlaceholder!.position.x - middleMessage!.position.x - taskWidth,
@@ -3677,7 +3748,14 @@ describe("buildNodesAndEdges", () => {
     };
     const graph = await buildGraph({
       flow: [rootConditional],
-      tasks: baseTasks(["solo", "one", "two", "three"]),
+      tasks: {
+        ...baseTasks(["solo", "one", "two", "three"]),
+        solo: { action: "memory_agent_action", settings: {} },
+      },
+      actionCatalog: createActionCatalog({
+        memory_agent_action: ["memory"],
+      }),
+      bindingCatalog: createBindingCatalog(["memory"]),
     });
     const nodeById = (nodeId: string) => {
       const node = graph.nodes.find((candidate) => candidate.id === nodeId);
@@ -3703,6 +3781,12 @@ describe("buildNodesAndEdges", () => {
     const groupGap = placeholderX(2) - nestedGroupRightEdge;
 
     expect(Math.abs(shortGap - FLOW_LAYER_GAP)).toBeLessThan(1);
+    expect(
+      getNodeSpreadCenter(
+        nodeById(createPlaceholderNodeId("0:root", "conditional", 0)),
+        "horizontal",
+      ),
+    ).toBe(getNodeSpreadCenter(soloNode, "horizontal"));
     expect(Math.abs(longGap - FLOW_LAYER_GAP)).toBeLessThan(1);
     expect(Math.abs(groupGap - FLOW_LAYER_GAP)).toBeLessThan(1);
   });

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -3331,6 +3331,40 @@ describe("buildNodesAndEdges", () => {
       (node) => node.id === createGroupId(conditional.id),
     );
     const end = graph.nodes.find((node) => node.id === END_INDICATOR_ID);
+    const middleAgent = graph.nodes.find(
+      (node) =>
+        node.id === createStepNodeId("root.branch.1.0:agent_middle", "task"),
+    );
+    const middleMessage = graph.nodes.find(
+      (node) =>
+        node.id === createStepNodeId("root.branch.1.1:message_middle", "task"),
+    );
+    const middlePlaceholder = graph.nodes.find(
+      (node) =>
+        node.id === createPlaceholderNodeId(conditional.id, "conditional", 1),
+    );
+    const middleAttachments = graph.nodes.filter(
+      (node) => getNodeOwnerDefName(node) === "agent_middle",
+    );
+    const branchSpans = [0, 1, 2].map((branchIndex) => {
+      const placeholderId = createPlaceholderNodeId(
+        conditional.id,
+        "conditional",
+        branchIndex,
+      );
+      const spans = graph.nodes
+        .filter(
+          (node) =>
+            node.id.includes(`root.branch.${branchIndex}`) ||
+            node.id === placeholderId,
+        )
+        .map((node) => getNodeSpreadSpan(node, "horizontal"));
+
+      return {
+        leading: Math.min(...spans.map(({ leading }) => leading)),
+        trailing: Math.max(...spans.map(({ trailing }) => trailing)),
+      };
+    });
 
     expect(operator).toBeDefined();
     expect(task).toBeDefined();
@@ -3360,6 +3394,29 @@ describe("buildNodesAndEdges", () => {
     expect(outerGroupSpan.trailing - contentBottom).toBeLessThanOrEqual(24);
     expect(getNodeSpreadCenter(end!, "horizontal")).toBe(
       getNodeSpreadCenter(outerGroup!, "horizontal"),
+    );
+    expect(getNodeSpreadCenter(middlePlaceholder!, "horizontal")).toBe(
+      getNodeSpreadCenter(middleMessage!, "horizontal"),
+    );
+    expect(getNodeSpreadCenter(middleMessage!, "horizontal")).toBe(
+      getNodeSpreadCenter(middleAgent!, "horizontal"),
+    );
+    const taskWidth = NODE_METRICS[ENodeType.TASK]?.dimensions.width ?? 0;
+    const sourceTrailing = Math.max(
+      getNodeRight(middleAgent!),
+      ...middleAttachments.map(getNodeRight),
+    );
+
+    expect(sourceTrailing).toBeGreaterThan(getNodeRight(middleAgent!));
+    expect(middleMessage!.position.x - sourceTrailing).toBe(FLOW_LAYER_GAP);
+    expect(
+      middlePlaceholder!.position.x - middleMessage!.position.x - taskWidth,
+    ).toBe(FLOW_LAYER_GAP);
+    expect(branchSpans[1].leading - branchSpans[0].trailing).toBe(
+      BRANCH_SPREAD_GAP,
+    );
+    expect(branchSpans[2].leading - branchSpans[1].trailing).toBe(
+      BRANCH_SPREAD_GAP,
     );
   });
 

--- a/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.test.ts
@@ -3221,6 +3221,148 @@ describe("buildNodesAndEdges", () => {
     expect(Math.abs(chainedCenter - parallelCenter)).toBeLessThan(1);
   });
 
+  it("keeps a nested single-branch loop compact when its task has attachments", async () => {
+    const loop = (
+      id: string,
+      taskName: string,
+      trailingTaskName?: string,
+    ): CompiledLoopStep => ({
+      id,
+      label: "loop",
+      type: StepType.Loop,
+      loopType: "for_each",
+      forEach: {
+        item: "item",
+        in: { kind: "literal", value: [] },
+      },
+      steps: [
+        taskStep(`${id}.loop.0:${taskName}`, taskName),
+        ...(trailingTaskName
+          ? [taskStep(`${id}.loop.1:${trailingTaskName}`, trailingTaskName)]
+          : []),
+      ],
+    });
+    const targetLoop = loop("root.branch.2.3:loop", "agent_nested");
+    const conditional: CompiledConditionalStep = {
+      id: "root:conditional",
+      label: "conditional",
+      type: StepType.Conditional,
+      branches: [
+        {
+          id: "root:conditional:when:0",
+          condition: { kind: "literal", value: false },
+          steps: [loop("root.branch.0.0:loop", "agent_top", "message_top")],
+        },
+        {
+          id: "root:conditional:when:1",
+          condition: { kind: "literal", value: false },
+          steps: [
+            taskStep("root.branch.1.0:agent_middle", "agent_middle"),
+            taskStep("root.branch.1.1:message_middle", "message_middle"),
+          ],
+        },
+        {
+          id: "root:conditional:when:2",
+          steps: [
+            loop("root.branch.2.0:loop", "agent_bottom", "message_bottom"),
+            taskStep("root.branch.2.1:agent_before", "agent_before"),
+            taskStep("root.branch.2.2:message_before", "message_before"),
+            targetLoop,
+            taskStep("root.branch.2.4:agent_after", "agent_after"),
+            taskStep("root.branch.2.5:agent_after_2", "agent_after_2"),
+            taskStep("root.branch.2.6:message_after", "message_after"),
+          ],
+        },
+      ],
+    };
+    const agentNames = [
+      "agent_root",
+      "agent_top",
+      "agent_middle",
+      "agent_bottom",
+      "agent_before",
+      "agent_nested",
+      "agent_after",
+      "agent_after_2",
+    ];
+    const tasks: TestTaskDefinitions = {
+      ...Object.fromEntries(
+        agentNames.map((name) => [
+          name,
+          { action: "agent_action", settings: {} },
+        ]),
+      ),
+      ...baseTasks([
+        "message_top",
+        "message_middle",
+        "message_bottom",
+        "message_before",
+        "message_after",
+      ]),
+    };
+    const graph = await buildGraph({
+      flow: [taskStep("0:agent_root", "agent_root"), conditional],
+      tasks,
+      actionCatalog: createActionCatalog({
+        agent_action: ["tools", "mcp", "model", "memory"],
+      }),
+      bindingCatalog: createBindingCatalog([
+        { kind: "tools", multiple: true },
+        { kind: "mcp", multiple: true },
+        { kind: "model", multiple: false },
+        { kind: "memory", multiple: false },
+      ]),
+    });
+    const operator = graph.nodes.find(
+      (node) => node.id === createStepNodeId(targetLoop.id, "operator"),
+    );
+    const task = graph.nodes.find(
+      (node) =>
+        node.id ===
+        createStepNodeId("root.branch.2.3:loop.loop.0:agent_nested", "task"),
+    );
+    const attachments = graph.nodes.filter(
+      (node) => getNodeOwnerDefName(node) === "agent_nested",
+    );
+    const group = graph.nodes.find(
+      (node) => node.id === createGroupId(targetLoop.id),
+    );
+    const outerGroup = graph.nodes.find(
+      (node) => node.id === createGroupId(conditional.id),
+    );
+    const end = graph.nodes.find((node) => node.id === END_INDICATOR_ID);
+
+    expect(operator).toBeDefined();
+    expect(task).toBeDefined();
+    expect(attachments).toHaveLength(4);
+    expect(group).toBeDefined();
+    expect(outerGroup).toBeDefined();
+    expect(end).toBeDefined();
+
+    const bundleSpans = [task!, ...attachments].map((node) =>
+      getNodeSpreadSpan(node, "horizontal"),
+    );
+    const bundleCenter =
+      (Math.min(...bundleSpans.map(({ leading }) => leading)) +
+        Math.max(...bundleSpans.map(({ trailing }) => trailing))) /
+      2;
+    const operatorCenter = getNodeSpreadCenter(operator!, "horizontal");
+    const groupSpan = getNodeSpreadSpan(group, "horizontal");
+    const outerGroupSpan = getNodeSpreadSpan(outerGroup, "horizontal");
+    const contentBottom = Math.max(
+      ...graph.nodes
+        .filter((node) => node.type !== ENodeType.GROUP)
+        .map((node) => getNodeSpreadSpan(node, "horizontal").trailing),
+    );
+
+    expect(Math.abs(bundleCenter - operatorCenter)).toBeLessThan(1);
+    expect(groupSpan.trailing - groupSpan.leading).toBeLessThan(500);
+    expect(outerGroupSpan.trailing - contentBottom).toBeLessThanOrEqual(24);
+    expect(getNodeSpreadCenter(end!, "horizontal")).toBe(
+      getNodeSpreadCenter(outerGroup!, "horizontal"),
+    );
+  });
+
   it("pulls each trailing branch placeholder to a uniform flow gap after its content", async () => {
     // Regression: ELK layers every branch's trailing "+" near the flow's
     // convergence point, so a short branch ended with a link stretching across

--- a/packages/graph/src/workflow/utils/workflow-node.utils.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.ts
@@ -156,13 +156,21 @@ export const buildNodesAndEdges = async ({
     edges: projected.edges,
     // Finally, straighten any chain of sibling groups sequenced inside a branch
     // (e.g. Parallel → Conditional → Conditional) onto a single spread axis.
-    nodes: alignGroupChainAxes(
-      boundaryAlignedNodes,
+    nodes: alignAllNodesToStartAxis(
+      withFreshGroupNodes(
+        alignGroupChainAxes(
+          boundaryAlignedNodes,
+          projected.edges,
+          traversal.groups,
+          { config },
+        ),
+        traversal.groups,
+        config,
+        attachmentEdges,
+      ),
       projected.edges,
       traversal.groups,
-      {
-        config,
-      },
+      { config },
     ),
   };
 };

--- a/packages/graph/src/workflow/utils/workflow-node.utils.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.ts
@@ -166,8 +166,18 @@ export const buildNodesAndEdges = async ({
     // (e.g. Parallel → Conditional → Conditional) onto a single spread axis.
     nodes: alignAllNodesToStartAxis(
       withFreshGroupNodes(
-        alignGroupChainAxes(
-          boundaryAlignedNodes,
+        symmetrizeBranchSiblings(
+          withFreshGroupNodes(
+            alignGroupChainAxes(
+              boundaryAlignedNodes,
+              projected.edges,
+              traversal.groups,
+              { config },
+            ),
+            traversal.groups,
+            config,
+            attachmentEdges,
+          ),
           projected.edges,
           traversal.groups,
           { config },

--- a/packages/graph/src/workflow/utils/workflow-node.utils.ts
+++ b/packages/graph/src/workflow/utils/workflow-node.utils.ts
@@ -131,9 +131,17 @@ export const buildNodesAndEdges = async ({
         // chained group a long way onto its chain root's axis, and packing
         // with the pre-alignment bounds would reserve that group's old
         // position as a permanent oversized gap between sibling branches.
-        alignGroupChainAxes(symmetricNodes, projected.edges, traversal.groups, {
+        withFreshGroupNodes(
+          alignGroupChainAxes(
+            symmetricNodes,
+            projected.edges,
+            traversal.groups,
+            { config },
+          ),
+          traversal.groups,
           config,
-        }),
+          attachmentEdges,
+        ),
         projected.edges,
         traversal.groups,
         { config },


### PR DESCRIPTION
### Screenshots
- After the fix
<img width="2008" height="128" alt="image" src="https://github.com/user-attachments/assets/42a511b7-1dda-4143-94ad-503eea1d4a20" />
<img width="2087" height="833" alt="image" src="https://github.com/user-attachments/assets/9004c794-6532-465c-8d0f-170116beba52" />

- Before the fix
<img width="2017" height="108" alt="image" src="https://github.com/user-attachments/assets/03df1de0-55df-484b-a73a-8e18106b2711" />
<img width="2076" height="651" alt="image" src="https://github.com/user-attachments/assets/10e0ced0-5da4-4674-bd39-2fd35ed445ac" />

### Summary
This PR improves the graph layout by enhancing the positioning of the workflow **Start** and **End** nodes. The updated layout ensures these nodes are consistently aligned with the main execution flow, producing cleaner and more predictable workflow diagrams.

### Why
The previous positioning of the Start and End nodes could lead to inconsistent layouts, making workflows harder to read—especially in larger or more complex graphs. Aligning these entry and exit points improves visual clarity and creates a more polished editing experience.

### How to review
Focus on the graph layout changes, specifically:

* Verify the **Start** node is consistently positioned at the beginning of the workflow.
* Verify the **End** node is consistently positioned at the end of the workflow.
* Check workflows with linear, conditional, parallel, and nested branches to ensure the new positioning behaves correctly without introducing regressions.
* Confirm edge routing remains clean and node spacing is preserved.

### Validation
* Tested workflows containing simple linear flows.
* Tested workflows with conditional and parallel branches.
* Verified Start and End node alignment after layout re-computation.
* Confirmed there are no regressions in node positioning, edge routing, or overall graph spacing.
