### PR TITLE
fix(agentic): guard serialized action schemas during binding validation

### DIFF
--- a/packages/agentic/src/__tests__/validation.test.ts
+++ b/packages/agentic/src/__tests__/validation.test.ts
@@ -665,6 +665,32 @@ describe('validateWorkflow', () => {
       ).toBe(true);
     });
 
+    it('ignores serialized action schemas during binding validation', () => {
+      expect(() =>
+        validateWorkflow(
+          {
+            defs: {
+              retrieve_rag_content: {
+                kind: 'tools',
+                action: 'retrieve_rag_content',
+                settings: {},
+              },
+            },
+            flow: [],
+            outputs: {},
+          },
+          {
+            bindingKinds,
+            actions: {
+              retrieve_rag_content: {
+                settingSchema: {} as unknown as z.ZodTypeAny,
+              },
+            },
+          },
+        ),
+      ).not.toThrow();
+    });
+
     it('reports missing actions with code, actionName and path', () => {
       const workflow = {
         defs: mergeTaskDefs({

--- a/packages/agentic/src/bindings/base-binding.ts
+++ b/packages/agentic/src/bindings/base-binding.ts
@@ -346,7 +346,7 @@ export const validateAndResolveBindings = (
     const actionSchema = defDefinition.action
       ? actions?.[defDefinition.action]?.settingSchema
       : undefined;
-    const actionParsed = actionSchema?.safeParse(defDefinition.settings);
+    const actionParsed = actionSchema?.safeParse?.(defDefinition.settings);
 
     if (actionParsed && !actionParsed.success) {
       issues.push(


### PR DESCRIPTION
**Summary:**  
Guard the optional `safeParse` method when validating action schemas for workflow bindings. This prevents the workflow editor from crashing when the frontend provides a serialized JSON Schema instead of a live Zod schema.

**Why:**  
Frontend action schemas cross the API boundary as plain JSON objects and do not expose Zod methods. The compiler previously called `safeParse()` unconditionally when the schema existed, causing `actionSchema?.safeParse is not a function` for workflows containing action-backed tool definitions.

**How to review:**  
Focus on the defensive optional call in `base-binding.ts` and the regression test covering serialized action schemas during binding validation.

**Validation:**  

- Agentic validation tests pass: 28 tests
- Typecheck passes
- Lint passes
- Agentic package build passes
