### PR TITLE
refactor(api): deduplicate AI action setup

### DIFF
--- a/packages/api/src/extensions/actions/ai/agent.action.ts
+++ b/packages/api/src/extensions/actions/ai/agent.action.ts
@@ -5,7 +5,7 @@
  */
 
 import { Injectable } from '@nestjs/common';
-import { ToolLoopAgent, ToolSet } from 'ai';
+import { ToolLoopAgent } from 'ai';
 
 import { ExecArgs } from '@/actions';
 import { ActionService } from '@/actions/actions.service';
@@ -42,52 +42,19 @@ export class AiAgentAction extends AiBaseAction<
     );
   }
 
-  async execute({
-    input,
-    settings,
-    context,
-    bindings,
-    signal,
-  }: ExecArgs<AiAgentInput, WorkflowRuntimeContext, AiAgentSettings>) {
-    const logger = context.services.logger;
-    const modelBinding = bindings.model;
-    const providerName = modelBinding?.settings?.provider ?? 'openai';
-    const modelId = this.resolveModelId(modelBinding);
-    const credentials = await context.services.credentials.findOneValue(
-      modelBinding?.settings?.api_key,
-    );
-    const providerOptions = this.buildProviderInitOptions(
-      providerName,
-      modelBinding,
-      credentials,
-    );
-    const provider = await this.loadProvider(providerName, providerOptions);
-    const model = this.createModel(provider, modelId);
-    const selectedMemorySlugs = this.resolveMemoryBindingSlugs(
-      context,
-      bindings.memory,
-    );
-    const promptPayload = await this.buildPrompt(
-      input,
-      context,
-      selectedMemorySlugs,
-    );
-    const callSettings = this.buildCallSettings(settings);
-    const tools = (await this.buildTools(
-      context,
-      bindings.tools,
-      bindings.mcp,
-      selectedMemorySlugs,
-      signal,
-    )) as ToolSet | undefined;
-    const toolNames = [
-      ...Object.keys(bindings.tools ?? {}),
-      ...Object.keys(bindings.mcp ?? {}),
-    ];
-    const { stopWhen, stepCount, toolCall } = this.buildStopWhen(
-      settings,
+  async execute(
+    args: ExecArgs<AiAgentInput, WorkflowRuntimeContext, AiAgentSettings>,
+  ) {
+    const { input, signal } = args;
+    const {
+      callSettings,
+      logCall,
+      model,
+      modelId,
+      promptPayload,
+      stopWhen,
       tools,
-    );
+    } = await this.prepareCall(input, args);
     const agent = new ToolLoopAgent({
       ...callSettings,
       ...(promptPayload.system ? { instructions: promptPayload.system } : {}),
@@ -96,18 +63,7 @@ export class AiAgentAction extends AiBaseAction<
       tools,
     });
 
-    logger.debug(
-      `Calling model "${modelId}" via ai_agent action using provider "${providerName}"`,
-      {
-        provider: providerName,
-        base_url: providerOptions.baseURL,
-        tools: toolNames,
-        stop_when: {
-          step_count: stepCount,
-          tool_call: toolCall,
-        },
-      },
-    );
+    logCall();
     const agentPrompt =
       'messages' in promptPayload
         ? promptPayload.messages

--- a/packages/api/src/extensions/actions/ai/ai-base.action.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.ts
@@ -18,7 +18,7 @@ import {
 
 import { ActionService } from '@/actions/actions.service';
 import { BaseAction } from '@/actions/base-action';
-import { ActionMetadata, ActionName } from '@/actions/types';
+import { ActionMetadata, ActionName, ExecArgs } from '@/actions/types';
 import { RuntimeBindings } from '@/bindings/runtime-bindings';
 import { WorkflowRuntimeContext } from '@/workflow/contexts/workflow-runtime.context';
 import { McpToolBindingDefinitions } from '@/workflow/types';
@@ -384,6 +384,78 @@ export abstract class AiBaseAction<
     memoryBindings?: RuntimeBindings['memory'],
   ): string[] {
     return resolveMemoryBindingSlugs(context, memoryBindings);
+  }
+
+  protected async prepareCall(
+    input: AiPromptInput,
+    {
+      settings,
+      context,
+      bindings,
+      signal,
+    }: Pick<ExecArgs<I, C, S>, 'settings' | 'context' | 'bindings' | 'signal'>,
+  ) {
+    const logger = context.services.logger;
+    const modelBinding = bindings.model;
+    const providerName = modelBinding?.settings?.provider ?? 'openai';
+    const modelId = this.resolveModelId(modelBinding);
+    const credentials = await context.services.credentials.findOneValue(
+      modelBinding?.settings?.api_key,
+    );
+    const providerOptions = this.buildProviderInitOptions(
+      providerName,
+      modelBinding,
+      credentials,
+    );
+    const provider = await this.loadProvider(providerName, providerOptions);
+    const model = this.createModel(provider, modelId);
+    const selectedMemorySlugs = this.resolveMemoryBindingSlugs(
+      context,
+      bindings.memory,
+    );
+    const promptPayload = await this.buildPrompt(
+      input,
+      context,
+      selectedMemorySlugs,
+    );
+    const callSettings = this.buildCallSettings(settings);
+    const tools = await this.buildTools(
+      context,
+      bindings.tools,
+      bindings.mcp,
+      selectedMemorySlugs,
+      signal,
+    );
+    const toolNames = [
+      ...Object.keys(bindings.tools ?? {}),
+      ...Object.keys(bindings.mcp ?? {}),
+    ];
+    const { stopWhen, stepCount, toolCall } = this.buildStopWhen(
+      settings,
+      tools,
+    );
+
+    return {
+      callSettings,
+      logCall: () =>
+        logger.debug(
+          `Calling model "${modelId}" via ${this.name} action using provider "${providerName}"`,
+          {
+            provider: providerName,
+            base_url: providerOptions.baseURL,
+            tools: toolNames,
+            stop_when: {
+              step_count: stepCount,
+              tool_call: toolCall,
+            },
+          },
+        ),
+      model,
+      modelId,
+      promptPayload,
+      stopWhen,
+      tools,
+    };
   }
 
   protected buildMemoryPrompt(

--- a/packages/api/src/extensions/actions/ai/generate-object.base.action.ts
+++ b/packages/api/src/extensions/actions/ai/generate-object.base.action.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { JSONSchema7, Output, ToolSet, generateText, jsonSchema } from 'ai';
+import { JSONSchema7, Output, generateText, jsonSchema } from 'ai';
 
 import { ActionService } from '@/actions/actions.service';
 import { ActionMetadata, ExecArgs } from '@/actions/types';
@@ -30,55 +30,20 @@ export abstract class AiGenerateObjectBaseAction<
 
   protected abstract resolvePromptInput(input: I): AiPromptInput;
 
-  async execute({
-    input,
-    settings,
-    context,
-    bindings,
-    signal,
-  }: ExecArgs<I, C, AiGenerateObjectSettings>) {
-    const logger = context.services.logger;
-    const modelBinding = bindings.model;
-    const providerName = modelBinding?.settings?.provider ?? 'openai';
-    const modelId = this.resolveModelId(modelBinding);
-    const credentials = await context.services.credentials.findOneValue(
-      modelBinding?.settings?.api_key,
-    );
-    const providerOptions = this.buildProviderInitOptions(
-      providerName,
-      modelBinding,
-      credentials,
-    );
-    const provider = await this.loadProvider(providerName, providerOptions);
-    const model = this.createModel(provider, modelId);
-    const selectedMemorySlugs = this.resolveMemoryBindingSlugs(
-      context,
-      bindings.memory,
-    );
-    const promptPayload = await this.buildPrompt(
-      this.resolvePromptInput(input),
-      context,
-      selectedMemorySlugs,
-    );
-    const callSettings = this.buildCallSettings(settings);
+  async execute(args: ExecArgs<I, C, AiGenerateObjectSettings>) {
+    const { input, settings, signal } = args;
+    const {
+      callSettings,
+      logCall,
+      model,
+      modelId,
+      promptPayload,
+      stopWhen,
+      tools,
+    } = await this.prepareCall(this.resolvePromptInput(input), args);
     // Structured outputs do not support stop sequences in the AI SDK call.
     const { stopSequences: _stopSequences, ...callSettingsWithoutStops } =
       callSettings;
-    const tools = (await this.buildTools(
-      context,
-      bindings.tools,
-      bindings.mcp,
-      selectedMemorySlugs,
-      signal,
-    )) as ToolSet | undefined;
-    const toolNames = [
-      ...Object.keys(bindings.tools ?? {}),
-      ...Object.keys(bindings.mcp ?? {}),
-    ];
-    const { stopWhen, stepCount, toolCall } = this.buildStopWhen(
-      settings,
-      tools,
-    );
     const outputSchema = settings.output_schema as JSONSchema7;
     const output = Output.object({
       schema: jsonSchema(outputSchema),
@@ -86,18 +51,7 @@ export abstract class AiGenerateObjectBaseAction<
       description: outputSchema.description,
     });
 
-    logger.debug(
-      `Calling model "${modelId}" via ${this.name} action using provider "${providerName}"`,
-      {
-        provider: providerName,
-        base_url: providerOptions.baseURL,
-        tools: toolNames,
-        stop_when: {
-          step_count: stepCount,
-          tool_call: toolCall,
-        },
-      },
-    );
+    logCall();
     const result = await generateText({
       ...promptPayload,
       ...callSettingsWithoutStops,

--- a/packages/api/src/extensions/actions/ai/generate-text.base.action.ts
+++ b/packages/api/src/extensions/actions/ai/generate-text.base.action.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { ToolSet, generateText } from 'ai';
+import { generateText } from 'ai';
 
 import { ActionService } from '@/actions/actions.service';
 import { ActionMetadata, ExecArgs } from '@/actions/types';
@@ -26,64 +26,19 @@ export abstract class AiGenerateTextBaseAction<
 
   protected abstract resolvePromptInput(input: I): AiPromptInput;
 
-  async execute({
-    input,
-    settings,
-    context,
-    bindings,
-    signal,
-  }: ExecArgs<I, C, AiGenerateTextSettings>) {
-    const logger = context.services.logger;
-    const modelBinding = bindings.model;
-    const providerName = modelBinding?.settings?.provider ?? 'openai';
-    const modelId = this.resolveModelId(modelBinding);
-    const credentials = await context.services.credentials.findOneValue(
-      modelBinding?.settings?.api_key,
-    );
-    const providerOptions = this.buildProviderInitOptions(
-      providerName,
-      modelBinding,
-      credentials,
-    );
-    const provider = await this.loadProvider(providerName, providerOptions);
-    const model = this.createModel(provider, modelId);
-    const selectedMemorySlugs = this.resolveMemoryBindingSlugs(
-      context,
-      bindings.memory,
-    );
-    const promptPayload = await this.buildPrompt(
-      this.resolvePromptInput(input),
-      context,
-      selectedMemorySlugs,
-    );
-    const callSettings = this.buildCallSettings(settings);
-    const tools = (await this.buildTools(
-      context,
-      bindings.tools,
-      bindings.mcp,
-      selectedMemorySlugs,
-      signal,
-    )) as ToolSet | undefined;
-    const toolNames = [
-      ...Object.keys(bindings.tools ?? {}),
-      ...Object.keys(bindings.mcp ?? {}),
-    ];
-    const { stopWhen, stepCount, toolCall } = this.buildStopWhen(
-      settings,
+  async execute(args: ExecArgs<I, C, AiGenerateTextSettings>) {
+    const { input, signal } = args;
+    const {
+      callSettings,
+      logCall,
+      model,
+      modelId,
+      promptPayload,
+      stopWhen,
       tools,
-    );
-    logger.debug(
-      `Calling model "${modelId}" via ${this.name} action using provider "${providerName}"`,
-      {
-        provider: providerName,
-        base_url: providerOptions.baseURL,
-        tools: toolNames,
-        stop_when: {
-          step_count: stepCount,
-          tool_call: toolCall,
-        },
-      },
-    );
+    } = await this.prepareCall(this.resolvePromptInput(input), args);
+
+    logCall();
     const result = await generateText({
       ...promptPayload,
       ...callSettings,


### PR DESCRIPTION
## Summary

Centralized shared AI call preparation in `AiBaseAction` and updated the text, object, and agent actions to use it. This removes 63 net lines while preserving each action’s SDK invocation and response handling.

## Why

The three AI actions duplicated provider initialization, model resolution, prompt construction, tool setup, stop conditions, and logging. Consolidating this logic reduces maintenance overhead and keeps behavior consistent.

## How to review

Focus on `AiBaseAction.prepareCall()` and verify that each updated action still controls its action-specific SDK options, invocation, and response normalization.

## Validation

- 63 focused AI action tests passed
- API typecheck passed
- API lint passed
- Full API build passed