### PR TITLE
feat(frontend): add workflow run navigation buttons

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -703,6 +703,8 @@
     "redo": "Redo",
     "run": "Run",
     "run_now": "Run now",
+    "previous_run": "Previous run",
+    "next_run": "Next run",
     "view_code_snippet": "Get code snippet",
     "generate_token": "Generate token",
     "create_workflow": "Create Workflow",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -702,6 +702,8 @@
     "redo": "Rétablir",
     "run": "Exécuter",
     "run_now": "Exécuter maintenant",
+    "previous_run": "Exécution précédente",
+    "next_run": "Exécution suivante",
     "view_code_snippet": "Obtenir un extrait de code",
     "generate_token": "Générer un jeton",
     "create_workflow": "Créer un workflow",

--- a/packages/frontend/src/components/workflow-run-debugger/components/header/RunStatusSummary.tsx
+++ b/packages/frontend/src/components/workflow-run-debugger/components/header/RunStatusSummary.tsx
@@ -5,8 +5,8 @@
  */
 
 import type { WorkflowRun } from "@hexabot-ai/types";
-import { Button, Stack, Typography } from "@mui/material";
-import { ChevronDown } from "lucide-react";
+import { Button, IconButton, Stack, Typography } from "@mui/material";
+import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 import { MouseEvent, useMemo, useState } from "react";
 
 import { WorkflowRunStatusBadge } from "@/app-components/workflow/WorkflowRunStatusBadge";
@@ -51,9 +51,31 @@ export const RunStatusSummary = ({
     return t("placeholder.run_at", { "0": timestamp });
   }, [i18n.language, selectedRun, t, workflowRuns]);
   const durationLabel = formatDurationMs(selectedRun?.duration);
+  const selectedRunIndex = workflowRuns.findIndex(
+    ({ id }) => id === selectedRun?.id,
+  );
+  const previousRun = workflowRuns[selectedRunIndex + 1];
+  const nextRun =
+    selectedRunIndex > 0 ? workflowRuns[selectedRunIndex - 1] : undefined;
 
   return (
     <Stack direction="row" spacing={1} alignItems="center">
+      <IconButton
+        size="small"
+        aria-label={t("button.previous_run")}
+        disabled={!previousRun}
+        onClick={() => onSelectRun(previousRun.id)}
+      >
+        <ChevronLeft size={16} />
+      </IconButton>
+      <IconButton
+        size="small"
+        aria-label={t("button.next_run")}
+        disabled={!nextRun}
+        onClick={() => nextRun && onSelectRun(nextRun.id)}
+      >
+        <ChevronRight size={16} />
+      </IconButton>
       <Button
         variant="outlined"
         size="small"


### PR DESCRIPTION
## Screenshots
- After the update
<img width="617" height="82" alt="image" src="https://github.com/user-attachments/assets/57251012-9a75-4dfb-aebd-ed998c2009ff" />

- Before the update
<img width="617" height="82" alt="image" src="https://github.com/user-attachments/assets/761dcea7-def8-4cb0-9f51-dab0b11b3843" />

## Summary
Added previous and next navigation buttons to the workflow run debugger. Both buttons appear to the left of the run selector and disable at history boundaries.

## Why
This makes switching between consecutive workflow runs faster without reopening the run history menu.

## How to review
Focus on `RunStatusSummary`:

- Confirm previous selects an older run.
- Confirm next selects a newer run.
- Confirm both buttons are positioned left of the run selector.
- Confirm buttons disable at the oldest and newest runs.

## Validation
- Frontend typecheck passed.
- Frontend lint passed.
- All 224 frontend tests passed.
- Translation files and formatting were checked.