### PR TITLE
fix(frontend): restore drawer closing after router upgrade

### DIFF
--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -58,7 +58,7 @@ if (!rootElement) {
 }
 
 ReactDOM.createRoot(rootElement).render(
-  <BrowserRouter>
+  <BrowserRouter useTransitions={false}>
     <ConfigProvider>
       <AppTheme>
         <CssBaseline enableColorScheme />


### PR DESCRIPTION
## Summary
Disabled React Router transitions at the application boundary to restore reliable workflow drawer closing after the React Router 7 upgrade.

## Why
Router transitions allowed the stale node ID in the URL to reselect the graph node immediately after the drawer cleared its selection, causing the drawer to remain open or reopen.

## How to review
Focus on the `BrowserRouter` configuration in `packages/frontend/src/main.tsx`. Confirm that `useTransitions={false}` restores the routing behavior used before the upgrade.

## Validation
- Frontend typecheck passed
- Frontend lint passed
- All 224 frontend tests passed
- Production frontend build passed