### PR TITLE
fix(frontend): restore workflow execution state after refresh

### DIFF
--- a/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowExecutionState.ts
+++ b/packages/frontend/src/components/visual-editor/v4/hooks/useWorkflowExecutionState.ts
@@ -7,6 +7,9 @@
 import { type WorkflowExecutionStateMap } from "@hexabot-ai/graph";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useFind } from "@/hooks/crud/useFind";
+import { useAuth } from "@/hooks/useAuth";
+import { EntityType, Format } from "@/services/types";
 import { useWorkflowEventSubscription } from "@/websocket/workflow-event-hooks";
 
 import type {
@@ -17,12 +20,30 @@ import {
   type ExecutionStateUpdateAction,
   isWorkflowEventForFlow,
   mapWorkflowEventToExecutionActions,
+  restoreWorkflowExecutionStates,
 } from "../utils/workflow-execution-events.utils";
 
 export const useWorkflowExecutionState = (flowId?: string) => {
+  const { user } = useAuth();
+  const { data: workflowRuns = [] } = useFind(
+    { entity: EntityType.WORKFLOW_RUN, format: Format.FULL },
+    {
+      params: {
+        where: {
+          ["workflow.id"]: flowId,
+          ["triggeredBy.id"]: user?.id,
+        },
+      },
+      hasCount: false,
+      initialSortState: [{ field: "createdAt", sort: "desc" }],
+    },
+    { enabled: Boolean(flowId && user?.id) },
+  );
+  const latestRun = workflowRuns[0];
   const [executionStates, setExecutionStates] =
     useState<WorkflowExecutionStateMap>({});
   const executionTimeoutIdsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const hasLiveEventRef = useRef(false);
   const clearExecutionTimeouts = useCallback(() => {
     executionTimeoutIdsRef.current.forEach((timeoutId) => {
       clearTimeout(timeoutId);
@@ -75,6 +96,7 @@ export const useWorkflowExecutionState = (flowId?: string) => {
         return;
       }
 
+      hasLiveEventRef.current = true;
       const actions = mapWorkflowEventToExecutionActions(event);
 
       actions.forEach(scheduleExecutionAction);
@@ -86,8 +108,15 @@ export const useWorkflowExecutionState = (flowId?: string) => {
 
   useEffect(() => {
     clearExecutionTimeouts();
+    hasLiveEventRef.current = false;
     setExecutionStates({});
   }, [flowId, clearExecutionTimeouts]);
+
+  useEffect(() => {
+    if (!hasLiveEventRef.current) {
+      setExecutionStates(restoreWorkflowExecutionStates(latestRun?.stepLog));
+    }
+  }, [latestRun]);
 
   useEffect(() => {
     return () => {

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-execution-events.utils.test.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-execution-events.utils.test.ts
@@ -18,6 +18,7 @@ import {
   isStepWorkflowEvent,
   isWorkflowEventForFlow,
   mapWorkflowEventToExecutionActions,
+  restoreWorkflowExecutionStates,
 } from "./workflow-execution-events.utils";
 
 const stepInfo = {
@@ -70,8 +71,39 @@ const workflowFinishEvent: SubscribeWorkflowProps = {
 };
 
 describe("workflow-execution-events.utils", () => {
+  it("restores persisted execution states after a refresh", () => {
+    expect(
+      restoreWorkflowExecutionStates({
+        completed: {
+          id: "0:completed",
+          name: "completed",
+          status: "completed",
+          endedAt: 100,
+        },
+        failed: {
+          id: "1:failed",
+          name: "failed",
+          status: "failed",
+          startedAt: 110,
+          endedAt: 120,
+        },
+        suspended: {
+          id: "2:await_reply[1.2]",
+          name: "await_reply",
+          status: "suspended",
+          endedAt: 130,
+        },
+      }),
+    ).toEqual({
+      "0:completed": [{ state: "finish", t: 100 }],
+      "1:failed": [{ state: "error", t: 120 }],
+      "2:await_reply": [{ state: "suspended", t: 130 }],
+    });
+  });
+
   it("maps workflow start to workflow start indicator", () => {
     expect(mapWorkflowEventToExecutionActions(workflowStartEvent)).toEqual([
+      { type: "clear" },
       {
         type: "append",
         key: EIndicatorType.WORKFLOW_START,

--- a/packages/frontend/src/components/visual-editor/v4/utils/workflow-execution-events.utils.ts
+++ b/packages/frontend/src/components/visual-editor/v4/utils/workflow-execution-events.utils.ts
@@ -4,7 +4,11 @@
  * Full terms: see LICENSE.md.
  */
 
-import { EIndicatorType } from "@hexabot-ai/graph";
+import type { StepExecutionRecord } from "@hexabot-ai/agentic";
+import {
+  EIndicatorType,
+  type WorkflowExecutionStateMap,
+} from "@hexabot-ai/graph";
 
 import type {
   NodeExecutionState,
@@ -63,11 +67,39 @@ const hasLoopIterationSuffix = (stepId: string) => {
   return LOOP_ITERATION_SUFFIX_PATTERN.test(stepId);
 };
 
+export const restoreWorkflowExecutionStates = (
+  stepLog?: Record<string, StepExecutionRecord> | null,
+): WorkflowExecutionStateMap =>
+  Object.values(stepLog ?? {}).reduce<WorkflowExecutionStateMap>(
+    (states, step) => {
+      if (step.status === "pending" || step.status === "skipped") {
+        return states;
+      }
+
+      const state =
+        step.status === "failed"
+          ? "error"
+          : step.status === "completed"
+            ? "finish"
+            : step.status;
+      const key = toExecutionStepKey(step.id);
+
+      states[key] = [
+        ...(states[key] ?? []),
+        { state, t: step.endedAt ?? step.startedAt ?? 0 },
+      ];
+
+      return states;
+    },
+    {},
+  );
+
 export const mapWorkflowEventToExecutionActions = (
   event: SubscribeWorkflowProps,
 ): ExecutionStateUpdateAction[] => {
   if (event.workflowEvent === "workflow:start") {
     return [
+      { type: "clear" },
       {
         type: "append",
         key: EIndicatorType.WORKFLOW_START,


### PR DESCRIPTION
## Summary
Restores workflow node execution states from the latest persisted run after refreshing the editor. Supports running, completed, failed, suspended, and cancelled steps, and clears previous states when a new workflow run starts.

## Why
Execution states were driven only by live WebSocket events, so node indicators disappeared after a page refresh even though the run and step logs were persisted.

## How to review
Focus on:

- Mapping persisted step statuses to graph execution states.
- Restoring states from the latest run’s `stepLog`.
- Ensuring live events take precedence.
- Clearing restored states on `workflow:start`.
- Normalizing loop iteration step IDs.

## Validation
- Frontend test suite: 225 tests passed.
- Focused execution-state tests passed.
- Frontend typecheck passed.
- ESLint passed for changed files.
- Production build completed successfully.