### PR TITLE
fix(api): show base URL field and load provider for openai-compatible

### DIFF
--- a/packages/api/src/extensions/actions/ai/ai-base.action.ts
+++ b/packages/api/src/extensions/actions/ai/ai-base.action.ts
@@ -135,11 +135,17 @@ export abstract class AiBaseAction<
       return createGatewayProvider(options);
     }
 
-    if (providerId === 'litellm') {
+    if (providerId === 'litellm' || providerId === 'openai-compatible') {
+      if (!options.baseURL) {
+        throw new Error(
+          `No base URL provided for provider "${provider}". Set bindings.model.<def>.settings.base_url.`,
+        );
+      }
+
       return createOpenAICompatible({
         ...options,
-        name: 'litellm',
-        baseURL: options.baseURL || '',
+        name: providerId,
+        baseURL: options.baseURL,
       });
     }
 

--- a/packages/api/src/extensions/actions/ai/model.binding.ts
+++ b/packages/api/src/extensions/actions/ai/model.binding.ts
@@ -46,7 +46,7 @@ export const aiModelBindingSchema = z.strictObject({
       'ui:options': {
         showWhen: {
           field: 'provider',
-          in: ['gateway', 'litellm'],
+          in: ['gateway', 'litellm', 'openai-compatible'],
         },
       },
     }),

--- a/packages/api/src/extensions/helpers/pgvector/pgvector.settings.spec.ts
+++ b/packages/api/src/extensions/helpers/pgvector/pgvector.settings.spec.ts
@@ -39,7 +39,7 @@ describe('pgvectorSettingsSchema', () => {
       'ui:options': {
         showWhen: {
           field: 'embedding_provider',
-          in: ['gateway', 'litellm'],
+          in: ['gateway', 'litellm', 'openai-compatible'],
         },
       },
     });

--- a/packages/api/src/extensions/helpers/pgvector/pgvector.settings.ts
+++ b/packages/api/src/extensions/helpers/pgvector/pgvector.settings.ts
@@ -50,7 +50,7 @@ export const pgvectorSettingsSchema = z
         'ui:options': {
           showWhen: {
             field: 'embedding_provider',
-            in: ['gateway', 'litellm'],
+            in: ['gateway', 'litellm', 'openai-compatible'],
           },
         },
       }),


### PR DESCRIPTION
## Summary ##
Fixed the `openai-compatible` provider being unconfigurable for pgvector RAG embeddings and AI actions: the required base-URL field was hidden by a `showWhen` gate that only allowed `gateway`/`litellm`, and the AI action's provider loader had no working path to instantiate `openai-compatible` at all.

## Why ##
Selecting `openai-compatible` was a dead end — the base-URL field never showed up in the UI even though both provider loaders require it, and even with a URL supplied manually, the AI action's generic dynamic-import loader couldn't resolve the provider factory (`toPascalCase` produces `createOpenaiCompatible`, but the package exports `createOpenAICompatible`).

## How to review ##
- `pgvector.settings.ts` / `model.binding.ts` — one-line `showWhen.in` additions, low risk.
- `ai-base.action.ts` — new explicit `litellm`/`openai-compatible` branch in `loadProvider`, mirrored from pgvector's existing `index.helper.ts` handling. Worth confirming the error-on-missing-`baseURL` behavior matches expectations for `litellm` too (previously it silently defaulted to `''`).

## Validation ##
- `tsc --noEmit` on touched files — no errors
- `pgvector.settings.spec.ts` — passes, asserts `showWhen.in` now includes `openai-compatible`
- Manual check still recommended: select `openai-compatible` in both the pgvector helper settings and an AI action's model binding, confirm the base-URL field renders, and run a completion/embedding call against an OpenAI-compatible endpoint (e.g. Ollama/vLLM)
