### PR TITLE
fix(api): handle duplicate workflow name conflict

### DIFF
--- a/packages/api/src/workflow/services/workflow.service.spec.ts
+++ b/packages/api/src/workflow/services/workflow.service.spec.ts
@@ -11,7 +11,7 @@ import {
   Workflow as WorkflowHelper,
 } from '@hexabot-ai/agentic';
 import { Workflow } from '@hexabot-ai/types';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { JSONSchema7 as JsonSchema } from 'json-schema';
 
 import {
@@ -184,8 +184,17 @@ describe('WorkflowService (TypeORM)', () => {
       schedule: null,
       createdBy: creatorId,
     };
+    const createDuplicate = workflowService.create(duplicatePayload);
 
-    await expect(workflowService.create(duplicatePayload)).rejects.toThrow();
+    await expect(createDuplicate).rejects.toBeInstanceOf(ConflictException);
+    await expect(createDuplicate).rejects.toMatchObject({
+      status: 409,
+      response: {
+        statusCode: 409,
+        error: 'Conflict',
+        message: `Workflow "${workflow.name}" already exists`,
+      },
+    });
   });
 
   it('keeps the fixed conversational input schema on create', async () => {

--- a/packages/api/src/workflow/services/workflow.service.ts
+++ b/packages/api/src/workflow/services/workflow.service.ts
@@ -8,6 +8,7 @@ import type { WorkflowEventMap } from '@hexabot-ai/agentic';
 import { WorkflowFull, Workflow } from '@hexabot-ai/types';
 import {
   BadRequestException,
+  ConflictException,
   Inject,
   Injectable,
   InternalServerErrorException,
@@ -63,6 +64,23 @@ export class WorkflowService extends BaseOrmService<WorkflowOrmEntity> {
     private readonly workflowRunService: WorkflowRunService,
   ) {
     super(repository);
+  }
+
+  /**
+   * Create a workflow and expose name collisions as an HTTP conflict.
+   */
+  override async create(
+    payload: InferCreateDto<WorkflowOrmEntity>,
+  ): Promise<Workflow> {
+    const existing = await this.findOne({
+      where: { name: payload.name },
+    });
+
+    if (existing) {
+      throw new ConflictException(`Workflow "${payload.name}" already exists`);
+    }
+
+    return await super.create(payload);
   }
 
   /**


### PR DESCRIPTION
## Screenshots
- After the update
<img width="2392" height="1227" alt="image" src="https://github.com/user-attachments/assets/8aba22ca-c9c6-47ba-9b9f-1cd38c567158" />
- Before the update
<img width="2392" height="1227" alt="image" src="https://github.com/user-attachments/assets/7a66d0dd-56b9-4de8-8795-c18ba605a1a5" />

## Summary
Return a `409 Conflict` when creating a workflow with an existing name instead of exposing an unhandled database constraint error as a `500`.

## Why
Workflow names are unique, but duplicate creation previously surfaced SQLite’s `SQLITE_CONSTRAINT_UNIQUE` as an internal server error. A conflict response accurately represents the client-side error and enables the frontend’s existing duplicate-error handling.

## How to review
Focus on:

- The duplicate-name check in `WorkflowService.create()`.
- The use of the API’s existing `ConflictException` pattern.
- The updated service test asserting the `409` response and error message.

## Validation
- Focused workflow service and controller tests: 49 passed.
- Full API unit suite: 1,271 passed, 7 skipped.
- API typecheck passed.
- API lint passed.