### PR TITLE
fix(frontend): format content type timestamps

### DIFF
--- a/packages/frontend/src/services/entities.test.ts
+++ b/packages/frontend/src/services/entities.test.ts
@@ -7,8 +7,26 @@
 import { normalize } from "normalizr";
 import { describe, expect, it } from "vitest";
 
-import { RagHelperEntity } from "./entities";
+import { ContentTypeEntity, RagHelperEntity } from "./entities";
 import { EntityType, normalizeEntity } from "./types";
+
+describe("ContentType entity", () => {
+  it("normalizes timestamps as dates", () => {
+    const createdAt = "2026-07-27T08:32:11.261Z";
+    const updatedAt = "2026-07-27T15:09:25.884Z";
+    const normalized = normalize(
+      [{ id: "content-type-id", name: "Article", createdAt, updatedAt }],
+      [ContentTypeEntity],
+    );
+    const contentType =
+      normalized.entities?.[EntityType.CONTENT_TYPE]?.["content-type-id"];
+
+    expect(contentType).toMatchObject({
+      createdAt: new Date(createdAt),
+      updatedAt: new Date(updatedAt),
+    });
+  });
+});
 
 describe("RagHelper entity", () => {
   it("normalizes helpers by name", () => {

--- a/packages/frontend/src/services/entities.ts
+++ b/packages/frontend/src/services/entities.ts
@@ -186,6 +186,7 @@ export const ContentTypeEntity = new schema.Entity(
   undefined,
   {
     idAttribute: ({ id }) => id,
+    processStrategy: processCommonStrategy,
   },
 );
 


### PR DESCRIPTION
## Screenshots
<table>
  <tr>
    <td align="center">
      <h2>❌ Before</h2>
      <img src="https://github.com/user-attachments/assets/0a719a9a-d1f0-49f0-a904-39814c1500ab" alt="Before" width="400"></img>
    </td>
    <td align="center">
      <h2>✅ After</h2>
      <img src="https://github.com/user-attachments/assets/4407a1ad-c3c3-48ad-a8e4-be9a40fbfe55" alt="After" width="400"></img>
    </td>
  </tr>
</table>

## Summary
Fixed Content Type timestamp formatting by applying the shared entity normalization strategy to `createdAt` and `updatedAt`. Added a regression test covering timestamp conversion.

## Why
Content Type timestamps remained raw ISO strings because they were not converted to `Date` objects before reaching the shared timestamp formatter.

## How to review
Focus on the `ContentTypeEntity` normalization configuration and the new regression test in `packages/frontend/src/services/entities.test.ts`.

## Validation
- All 229 frontend tests pass.
- Frontend typecheck passes.
- ESLint passes for the changed files.
- `git diff --check` passes.