### PR TITLE
feat(frontend): redesign data grid and page header layouts

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -163,7 +163,26 @@
     "workflow_type_manual_trigger": "Triggered via API or manual calls.",
     "workflow_type_manual_schema_editability": "You can edit input schema. You define the input schema.",
     "workflow_type_scheduled_trigger": "Triggered on a schedule.",
-    "workflow_type_scheduled_schema_editability": "You can't edit input schema. Input is system-defined."
+    "workflow_type_scheduled_schema_editability": "You can't edit input schema. Input is system-defined.",
+    "page_description": {
+      "memory_definition": "Define reusable workflow memory structures.",
+      "content_type": "Define structures for reusable content.",
+      "content": "Manage entries for this content type.",
+      "attachment": "Browse and manage uploaded media.",
+      "language": "Manage supported languages and locales.",
+      "translation": "Manage localized interface content.",
+      "label": "Organize subscribers with reusable labels.",
+      "subscriber": "View and manage your audience.",
+      "user": "Manage users and account access.",
+      "role": "Manage roles and access permissions.",
+      "credential": "Manage organization keys and tokens.",
+      "source": "Configure channels connected to your bot.",
+      "audit_log": "Review administrative activity and system changes.",
+      "workflow_run": "Monitor workflow execution history.",
+      "mcp_server": "Configure external MCP server connections.",
+      "menu": "Manage persistent chatbot menu items.",
+      "setting": "Configure application and service settings."
+    }
   },
   "menu": {
     "logout": "Logout",
@@ -716,6 +735,7 @@
     "unpublish": "Unpublish",
     "submit": "Submit",
     "cancel": "Cancel",
+    "filters": "Filters",
     "add": "Add",
     "add_option": "Add option",
     "add_property": "Add property",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -162,7 +162,26 @@
     "workflow_type_manual_trigger": "Déclenché via API ou des appels manuels.",
     "workflow_type_manual_schema_editability": "Vous pouvez modifier le schéma d'entrée. Vous définissez le schéma d'entrée.",
     "workflow_type_scheduled_trigger": "Déclenché selon une planification.",
-    "workflow_type_scheduled_schema_editability": "Vous ne pouvez pas modifier le schéma d'entrée. L'entrée est définie par le système."
+    "workflow_type_scheduled_schema_editability": "Vous ne pouvez pas modifier le schéma d'entrée. L'entrée est définie par le système.",
+    "page_description": {
+      "memory_definition": "Définissez les structures de mémoire des workflows.",
+      "content_type": "Définissez des structures de contenu réutilisables.",
+      "content": "Gérez les entrées de ce type de contenu.",
+      "attachment": "Parcourez et gérez les médias importés.",
+      "language": "Gérez les langues et paramètres régionaux.",
+      "translation": "Gérez les contenus localisés de l’interface.",
+      "label": "Organisez les abonnés avec des étiquettes.",
+      "subscriber": "Consultez et gérez votre audience.",
+      "user": "Gérez les utilisateurs et leurs accès.",
+      "role": "Gérez les rôles et les permissions d’accès.",
+      "credential": "Gérez les clés et jetons de l’organisation.",
+      "source": "Configurez les canaux connectés à votre bot.",
+      "audit_log": "Consultez l’activité administrative et les modifications système.",
+      "workflow_run": "Suivez l’historique d’exécution des workflows.",
+      "mcp_server": "Configurez les connexions aux serveurs MCP externes.",
+      "menu": "Gérez les éléments du menu persistant.",
+      "setting": "Configurez les paramètres de l’application et des services."
+    }
   },
   "menu": {
     "logout": "Déconnexion",
@@ -715,6 +734,7 @@
     "unpublish": "Dépublier",
     "submit": "Valider",
     "cancel": "Annuler",
+    "filters": "Filtres",
     "add": "Ajouter",
     "add_option": "Ajouter une option",
     "add_property": "Ajouter une propriété",

--- a/packages/frontend/src/app-components/auth/resetPasswordRequest.tsx
+++ b/packages/frontend/src/app-components/auth/resetPasswordRequest.tsx
@@ -54,7 +54,7 @@ export const ResetPasswordRequest = () => {
   return (
     <PublicContentWrapper>
       <form onSubmit={handleSubmit(onSubmitForm)}>
-        <ContentContainer gap={2}>
+        <ContentContainer>
           <Title title={t("title.reset_password")} Icon={SendHorizontal} />
           <TextField
             label={t("label.email")}

--- a/packages/frontend/src/app-components/dialogs/layouts/ContentContainer.tsx
+++ b/packages/frontend/src/app-components/dialogs/layouts/ContentContainer.tsx
@@ -14,7 +14,7 @@ export const ContentContainer: FC<ContentContainerProps> = ({
   children,
   ...rest
 }) => (
-  <Grid container gap={1} direction="column" {...rest}>
+  <Grid container gap={2} direction="column" {...rest}>
     {children}
   </Grid>
 );

--- a/packages/frontend/src/app-components/displays/Badge.tsx
+++ b/packages/frontend/src/app-components/displays/Badge.tsx
@@ -17,6 +17,7 @@ export type BadgeWithTitleProps = {
   background?: string;
   width?: string;
   height?: string;
+  radius?: string | number;
   selected?: boolean;
   disableTooltip?: boolean;
   padding?: string;
@@ -44,6 +45,7 @@ export const Badge = ({
   color,
   height = "24px",
   width = "24px",
+  radius,
   title,
   selected,
   disableTooltip,
@@ -75,7 +77,8 @@ export const Badge = ({
             `2px solid ${selected ? theme.alpha(theme.vars.palette.primary.main, 0.8) : theme.alpha(theme.vars.palette.text.primary, 0.05)}`,
           background: `color-mix(in srgb, transparent, ${color} ${selected ? "25%" : "10%"})`,
           flexShrink: 0,
-          borderRadius: (theme) => (theme.shape.borderRadius as number) + 1,
+          borderRadius:
+            radius ?? ((theme) => (theme.shape.borderRadius as number) + 1),
           transform: selected ? "scale(1.1)" : "scale(1)",
           transition: "0.2s",
           ...(isLoading && { animation: "rotate infinite 700ms linear" }),

--- a/packages/frontend/src/app-components/tables/DataGrid.tsx
+++ b/packages/frontend/src/app-components/tables/DataGrid.tsx
@@ -12,14 +12,18 @@ import {
   GridValidRowModel,
   DataGrid as MuiDataGrid,
 } from "@mui/x-data-grid";
+import { useMemo } from "react";
 
 import { styledPaginationSlots } from "./DataGridStyledPagination";
 import { ErrorOverlay } from "./ErrorOverlay";
 import { NoDataOverlay } from "./NoDataOverlay";
 
+const DEFAULT_COLUMN_MIN_WIDTH = 100;
+const EMPTY_ROWS: never[] = [];
+
 export const DataGrid = <T extends GridValidRowModel = any>({
   columns,
-  rows = [],
+  rows = EMPTY_ROWS,
   disableRowSelectionOnClick = true,
   slots,
   showCellVerticalBorder = false,
@@ -27,22 +31,37 @@ export const DataGrid = <T extends GridValidRowModel = any>({
   error,
   ...rest
 }: DataGridProps<T> & { error?: boolean }) => {
-  const styledColumns: GridColDef<T>[] = columns.map((col) => ({
-    disableColumnMenu: true,
-    headerAlign: "left",
-    flex: 1,
-    ...col,
-  }));
-  const normalizedSlots =
-    slots ||
-    ({
-      noRowsOverlay: error ? ErrorOverlay : NoDataOverlay,
-      noResultsOverlay: error ? ErrorOverlay : NoDataOverlay,
-      ...styledPaginationSlots,
-    } as Partial<GridSlotsComponent> | undefined);
+  const styledColumns = useMemo<GridColDef<T>[]>(
+    () =>
+      columns.map((col) => ({
+        disableColumnMenu: true,
+        headerAlign: "left",
+        ...(col.width
+          ? { flex: 0 }
+          : {
+              flex: 1,
+              minWidth: Math.min(
+                DEFAULT_COLUMN_MIN_WIDTH,
+                col.maxWidth ?? Infinity,
+              ),
+            }),
+        ...col,
+      })),
+    [columns],
+  );
+  const normalizedSlots = useMemo(
+    () =>
+      slots ||
+      ({
+        noRowsOverlay: error ? ErrorOverlay : NoDataOverlay,
+        noResultsOverlay: error ? ErrorOverlay : NoDataOverlay,
+        ...styledPaginationSlots,
+      } as Partial<GridSlotsComponent> | undefined),
+    [slots, error],
+  );
 
   return (
-    <Grid size={12}>
+    <Grid size={12} minWidth={0}>
       <MuiDataGrid<T>
         disableRowSelectionOnClick={disableRowSelectionOnClick}
         slots={normalizedSlots}

--- a/packages/frontend/src/app-components/tables/DataGridStyledPagination.tsx
+++ b/packages/frontend/src/app-components/tables/DataGridStyledPagination.tsx
@@ -9,20 +9,15 @@
 
 import {
   Pagination as MuiPagination,
-  PaginationItem,
-  PaginationItemProps,
   TablePaginationProps,
 } from "@mui/material";
 import {
   DataGridProps,
-  GridFooter,
   gridPageCountSelector,
   GridPagination,
   useGridApiContext,
   useGridSelector,
 } from "@mui/x-data-grid";
-
-import { theme } from "@/layout/theme";
 
 function Pagination({
   page,
@@ -39,21 +34,6 @@ function Pagination({
       showFirstButton
       showLastButton
       shape="rounded"
-      renderItem={(props: PaginationItemProps) => (
-        <PaginationItem
-          {...props}
-          sx={{
-            ":is(.Mui-selected)": {
-              fontWeight: "bold",
-              color: theme.palette.primary.main,
-            },
-
-            ":hover": {
-              color: theme.palette.primary.dark,
-            },
-          }}
-        />
-      )}
       page={page + 1}
       siblingCount={2}
       onChange={(event, newPage) => {
@@ -71,7 +51,4 @@ function StyledPagination(props: any) {
 
 export const styledPaginationSlots: DataGridProps["slots"] = {
   pagination: StyledPagination,
-  footer: (props: any) => {
-    return <GridFooter sx={{ justifyContent: "start" }} {...props} />;
-  },
 };

--- a/packages/frontend/src/app-components/tables/GenericDataGrid.tsx
+++ b/packages/frontend/src/app-components/tables/GenericDataGrid.tsx
@@ -4,13 +4,15 @@
  * Full terms: see LICENSE.md.
  */
 
-import { Chip } from "@mui/material";
+import { Chip, useMediaQuery } from "@mui/material";
 import Grid from "@mui/material/Grid";
+import type { Theme } from "@mui/material/styles";
 import {
   DataGridProps,
   GridColDef,
   GridRowSelectionModel,
 } from "@mui/x-data-grid";
+import snakeCase from "lodash/snakeCase";
 import { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -32,7 +34,7 @@ import {
 import { FilterTextfield } from "../inputs/FilterTextfield";
 
 import { DataGrid } from "./DataGrid";
-import { type Filter, GenericFilters } from "./GenericFilters";
+import { type Filter, ResponsiveGenericFilters } from "./GenericFilters";
 
 export const GenericDataGrid = <
   TP extends THook["params"],
@@ -45,12 +47,10 @@ export const GenericDataGrid = <
   headerIcon,
   searchParams,
   initialSortState,
-  initialPaginationState = {
-    page: 0,
-    pageSize: 10,
-  },
+  initialPaginationState = { page: 0, pageSize: 10 },
   format,
   headerI18nTitle,
+  headerI18nDescription,
   headerTitleChip,
   headerLeftButtons,
   footerControls,
@@ -69,6 +69,7 @@ export const GenericDataGrid = <
   format?: F;
   columns: GridColDef<THook<{ entity: TE; format: F }>["current"]>[];
   headerI18nTitle?: TTranslationKeys;
+  headerI18nDescription?: TTranslationKeys;
   headerTitleChip?: string;
   headerLeftButtons?: React.ReactElement;
   footerControls?: ReactNode;
@@ -78,28 +79,32 @@ export const GenericDataGrid = <
 } & Pick<IFindConfigProps<TE>, "initialSortState" | "initialPaginationState"> &
   DataGridProps) => {
   const { t } = useTranslate();
-  const { dataGridProps, onSearch, searchText } = useDataGridProps(
-    {
-      entity,
-      format: format as any,
-    },
-    {
-      searchParams,
-      initialSortState,
-      initialPaginationState,
-    },
+  const isSmallView = useMediaQuery(
+    (theme: Theme) => theme.breakpoints.down("md"),
+    { noSsr: true },
   );
+  const { dataGridProps, onSearch, searchText } = useDataGridProps(
+    { entity, format: format as any },
+    { searchParams, initialSortState, initialPaginationState },
+  );
+  const descriptionKey =
+    headerI18nDescription ??
+    (`message.page_description.${snakeCase(entity)}` as TTranslationKeys);
 
   return (
-    <Grid width="100%">
-      <Grid container={!!headerI18nTitle} flexDirection="column" gap={3}>
+    <Grid width="100%" minWidth={0}>
+      <Grid
+        container={!!headerI18nTitle}
+        flexDirection="column"
+        gap={3}
+        minWidth={0}
+      >
         <PageHeader
           icon={headerIcon}
           title={headerI18nTitle && t(headerI18nTitle)}
+          description={headerI18nTitle && t(descriptionKey)}
           chip={
-            headerTitleChip ? (
-              <Chip label={headerTitleChip} size="medium" />
-            ) : null
+            headerTitleChip && <Chip label={headerTitleChip} size="medium" />
           }
           headerLeftButtons={headerLeftButtons}
         >
@@ -107,21 +112,37 @@ export const GenericDataGrid = <
             gap={1}
             container
             flexWrap="nowrap"
+            flexGrow={isSmallView ? 1 : 0}
             width="auto"
             justifyContent="end"
+            alignItems="flex-end"
+            sx={{ "& .MuiInputLabel-root.MuiInputLabel-root": { mb: 0.25 } }}
           >
-            {hasTextFilter ? (
-              <FilterTextfield onChange={onSearch} defaultValue={searchText} />
-            ) : null}
-            {filters?.length ? <GenericFilters filters={filters} /> : null}
-            <Grid size="auto" alignContent="end">
-              {buttons ? (
+            {hasTextFilter && (
+              <FilterTextfield
+                onChange={onSearch}
+                defaultValue={searchText}
+                sx={{
+                  minWidth: { xs: 0, sm: 280 },
+                  ...(isSmallView ? { flex: 1 } : { width: "auto" }),
+                }}
+              />
+            )}
+            {filters?.length && <ResponsiveGenericFilters filters={filters} />}
+            {buttons && (
+              <Grid size="auto" alignContent="end">
                 <ButtonActionsGroup entity={entity} buttons={buttons} />
-              ) : null}
-            </Grid>
+              </Grid>
+            )}
           </Grid>
         </PageHeader>
-        <Grid container flexDirection="column" gap={1}>
+        <Grid
+          container
+          flexDirection="column"
+          gap={1}
+          width="100%"
+          minWidth={0}
+        >
           <DataGrid
             columns={columns}
             {...dataGridProps}
@@ -129,11 +150,11 @@ export const GenericDataGrid = <
             onRowSelectionModelChange={selectionChangeHandler}
             {...restDataGridProps}
           />
-          {footerControls ? (
+          {footerControls && (
             <Grid container justifyContent="flex-end">
               {footerControls}
             </Grid>
-          ) : null}
+          )}
         </Grid>
       </Grid>
     </Grid>

--- a/packages/frontend/src/app-components/tables/GenericFilters.tsx
+++ b/packages/frontend/src/app-components/tables/GenericFilters.tsx
@@ -6,15 +6,23 @@
 
 import {
   Box,
+  Button,
   Grid,
   MenuItem,
+  Popover,
   TextField,
   TextFieldProps,
+  Tooltip,
   Typography,
+  useMediaQuery,
 } from "@mui/material";
+import type { Theme } from "@mui/material/styles";
+import { ListFilter } from "lucide-react";
+import { useState } from "react";
 import type { Path, PathValue } from "react-hook-form";
 
 import type { FlowTypeInfo } from "@/components/visual-editor/v4/components/main/FlowsDrawer/types";
+import { useTranslate } from "@/hooks/useTranslate";
 import { Format } from "@/services/types";
 import type { IEntityMapTypes, THook } from "@/types/base.types";
 
@@ -27,10 +35,7 @@ type filterDynamicFields<
   E extends keyof IEntityMapTypes,
   F extends Format,
   A extends { format?: Format } = { format?: F },
-  C = THook<{
-    entity: E;
-    format: F;
-  }>["current"],
+  C = THook<{ entity: E; format: F }>["current"],
 > = {
   [Field in Path<C>]: {
     field: Field;
@@ -51,17 +56,12 @@ type EntityField = {
   );
 };
 
-type EnumFilterType = Omit<TextFieldProps, "onChange"> & {
-  type: "enumFilter";
-};
+type EnumFilterType = Omit<TextFieldProps, "onChange"> & { type: "enumFilter" };
 
 type EntityFilterType = Omit<
   AutoCompleteEntitySelectProps<any, string, false>,
   "ref" | "format" | "onChange" | "labelKey" | "searchFields" | "value"
-> & {
-  type: "entitySelectFilter";
-  searchFields?: string[];
-};
+> & { type: "entitySelectFilter"; searchFields?: string[] };
 
 export type Filter = ({
   typeInfo?: Record<any, FlowTypeInfo>;
@@ -80,96 +80,132 @@ export const GenericFilters = ({ filters }: { filters?: Filter[] }) =>
       sortKey,
       labelKey = "",
       typeInfo,
-      defaultOption,
+      defaultOption: d = {},
       onChange,
       ...rest
     }) => {
-      const {
-        defaultValue,
-        width = "22px",
-        height = "22px",
-        padding = "2px",
-        ...defaultOptionRest
-      } = defaultOption || {};
+      const { defaultValue, ...bp } = {
+        width: "22px",
+        height: "22px",
+        padding: "2px",
+        ...d,
+      };
 
-      if (rest.type === "enumFilter") {
+      if (rest.type === "enumFilter")
         return (
           <Grid key={field} flex={1} minWidth="180px">
             <TextField
               select
               value={value || defaultValue}
-              onChange={(e) => {
-                onChange?.(e.target.value as never);
-              }}
+              onChange={(e) => onChange?.(e.target.value as never)}
               slotProps={{ input: { sx: { height: "2.25rem" } } }}
               {...rest}
             >
-              {defaultValue ? (
+              {defaultValue && (
                 <MenuItem value={defaultValue}>
-                  <BadgeWithTitle
-                    {...defaultOptionRest}
-                    {...{ width, height, padding }}
-                  />
+                  <BadgeWithTitle {...bp} />
                 </MenuItem>
-              ) : null}
-              {typeInfo
-                ? Object.entries(typeInfo).map(
-                    ([type, { key, ...infoRest }]) => (
-                      <MenuItem key={key} value={type}>
-                        <BadgeWithTitle
-                          {...infoRest}
-                          title={type}
-                          {...{ width, height, padding }}
-                        />
-                      </MenuItem>
-                    ),
-                  )
-                : null}
+              )}
+              {typeInfo &&
+                Object.entries(typeInfo).map(([type, { key, ...r }]) => (
+                  <MenuItem key={key} value={type}>
+                    <BadgeWithTitle {...bp} {...r} title={type} />
+                  </MenuItem>
+                ))}
             </TextField>
           </Grid>
         );
-      } else if (rest.type === "entitySelectFilter") {
-        const RenderedItem = ({ entity }: { entity: any }) =>
-          typeInfo ? (
-            <BadgeWithTitle
-              {...typeInfo?.[entity[labelKey]]}
-              title={entity[field]}
-              labelKey={undefined}
-              {...{ width, height, padding }}
-            />
-          ) : (
-            <Typography noWrap>{entity[labelKey]}</Typography>
-          );
-
-        return (
-          <Grid key={field} flex={1} minWidth="180px">
-            <AutoCompleteEntitySelect<any, string, false>
-              idKey={idKey?.toString()}
-              sortKey={sortKey?.toString()}
-              labelKey={labelKey}
-              entity={entity}
-              format={format}
-              value={value}
-              searchFields={rest.searchFields || []}
-              size="medium"
-              multiple={false}
-              renderValue={(entity) => (
-                <Box p="2px">
-                  <RenderedItem entity={entity} />
-                </Box>
-              )}
-              renderOption={(props, entity) => (
-                <li {...props}>
-                  <RenderedItem entity={entity} />
-                </li>
-              )}
-              onChange={(e, value) => {
-                onChange?.(value?.[field]);
-              }}
-              {...rest}
-            />
-          </Grid>
+      const renderItem = (e: any) =>
+        typeInfo ? (
+          <BadgeWithTitle
+            {...bp}
+            {...typeInfo?.[e[labelKey]]}
+            title={e[field]}
+            labelKey={undefined}
+          />
+        ) : (
+          <Typography noWrap>{e[labelKey]}</Typography>
         );
-      }
+
+      return (
+        <Grid key={field} flex={1} minWidth="180px">
+          <AutoCompleteEntitySelect<any, string, false>
+            idKey={idKey?.toString()}
+            sortKey={sortKey?.toString()}
+            labelKey={labelKey}
+            entity={entity}
+            format={format}
+            value={value}
+            searchFields={rest.searchFields || []}
+            size="medium"
+            multiple={false}
+            renderValue={(e) => <Box p="2px">{renderItem(e)}</Box>}
+            renderOption={(props, e) => <li {...props}>{renderItem(e)}</li>}
+            onChange={(_, v) => onChange?.(v?.[field])}
+            {...rest}
+          />
+        </Grid>
+      );
     },
   );
+
+const collapseBreakpoint = (n: number) => 720 + n * 190;
+const filtersButtonSx = (t: Theme) => ({
+  width: t.spacing(4.5),
+  minWidth: t.spacing(4.5),
+  p: 0,
+  "& .MuiButton-startIcon": { m: 0 },
+});
+const filtersPopoverSx = (t: Theme) => ({
+  width: `min(${t.spacing(45)}, calc(100vw - ${t.spacing(4)}))`,
+  p: 2,
+  mt: 1,
+});
+
+export const ResponsiveGenericFilters = ({
+  filters,
+}: {
+  filters: Filter[];
+}) => {
+  const { t } = useTranslate();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const isCollapsed = useMediaQuery(
+    (theme: Theme) =>
+      theme.breakpoints.down(collapseBreakpoint(filters.length)),
+    { noSsr: true },
+  );
+  const label = t("button.filters");
+
+  return !isCollapsed ? (
+    <GenericFilters filters={filters} />
+  ) : (
+    <>
+      <Tooltip title={label}>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<ListFilter size={18} />}
+          aria-label={label}
+          aria-haspopup="dialog"
+          aria-expanded={Boolean(anchorEl)}
+          sx={filtersButtonSx}
+          onClick={(e) => setAnchorEl(e.currentTarget)}
+        />
+      </Tooltip>
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        onClose={() => setAnchorEl(null)}
+        slotProps={{
+          paper: { role: "dialog", "aria-label": label, sx: filtersPopoverSx },
+        }}
+      >
+        <Box display="flex" flexDirection="column" gap={1.5}>
+          <GenericFilters filters={filters} />
+        </Box>
+      </Popover>
+    </>
+  );
+};

--- a/packages/frontend/src/app-components/tables/columns/getColumns.tsx
+++ b/packages/frontend/src/app-components/tables/columns/getColumns.tsx
@@ -89,6 +89,11 @@ export interface ActionColumn<T extends GridValidRowModel> {
 }
 
 const ACTION_ICON_SIZE = 18;
+// Mirrors the button size, gap and cell padding set in theme/customizations/dataGrid.
+const ACTION_BUTTON_WIDTH = 40;
+const ACTION_BUTTON_GAP = 4;
+const ACTION_CELL_PADDING = 24;
+const ACTION_COLUMN_MIN_WIDTH = 144;
 
 function StackComponent<T extends GridValidRowModel>({
   actions,
@@ -137,12 +142,22 @@ export const getActionsColumn = <T extends GridValidRowModel>(
   actions: ActionColumn<T>[],
   headerName: string,
 ): GridColDef<T> => {
+  const width = Math.max(
+    ACTION_COLUMN_MIN_WIDTH,
+    actions.length * (ACTION_BUTTON_WIDTH + ACTION_BUTTON_GAP) -
+      ACTION_BUTTON_GAP +
+      ACTION_CELL_PADDING * 2,
+  );
+
   return {
     field: "actions",
     headerName,
     sortable: false,
-    align: "left",
-    headerAlign: "left",
+    flex: 0,
+    width,
+    resizable: false,
+    align: "center",
+    headerAlign: "center",
     renderCell: (params) => (
       <StackComponent actions={actions} params={params} />
     ),

--- a/packages/frontend/src/app-components/tables/columns/useTimestampColumns.tsx
+++ b/packages/frontend/src/app-components/tables/columns/useTimestampColumns.tsx
@@ -4,51 +4,57 @@
  * Full terms: see LICENSE.md.
  */
 
-import { GridColDef, GridValidRowModel } from "@mui/x-data-grid";
+import { Stack, Typography } from "@mui/material";
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridValidRowModel,
+} from "@mui/x-data-grid";
 import { useMemo } from "react";
 
 import { useTranslate } from "@/hooks/useTranslate";
-import { getDateTimeFormatter } from "@/utils/date";
+import { TTranslationKeys } from "@/i18n/i18n.types";
+import { normalizeDate } from "@/utils/date";
 
-const TIMESTAMP_COLUMN_WIDTH = 140;
+type TimestampField = "createdAt" | "updatedAt";
 
-/**
- * Returns the standard `createdAt` / `updatedAt` DataGrid columns shared by
- * every entity list screen. Spread the result into a `columns` array, e.g.
- * `[...baseColumns, ...useTimestampColumns<Label>(), actionColumns]`.
- *
- * The returned array is memoized and only changes when the active locale
- * changes, so it is safe to include in downstream `useMemo` dep arrays.
- */
 export const useTimestampColumns = <T extends GridValidRowModel>(
-  filter?: "createdAt" | "updatedAt",
+  filter?: TimestampField,
+  headerI18nTitles?: Partial<Record<TimestampField, TTranslationKeys>>,
 ): GridColDef<T>[] => {
-  const { t } = useTranslate();
+  const { i18n, t } = useTranslate();
+  const { createdAt, updatedAt } = headerI18nTitles ?? {};
 
-  return useMemo<GridColDef<T>[]>(() => {
-    const all: GridColDef<T>[] = [
-      {
-        width: TIMESTAMP_COLUMN_WIDTH,
-        field: "createdAt",
-        headerName: t("label.createdAt"),
-        disableColumnMenu: true,
-        resizable: false,
-        headerAlign: "left",
-        valueGetter: (value: Date) =>
-          t("datetime.created_at", getDateTimeFormatter(value)),
-      },
-      {
-        width: TIMESTAMP_COLUMN_WIDTH,
-        field: "updatedAt",
-        headerName: t("label.updatedAt"),
-        disableColumnMenu: true,
-        resizable: false,
-        headerAlign: "left",
-        valueGetter: (value: Date) =>
-          t("datetime.updated_at", getDateTimeFormatter(value)),
-      },
-    ];
-
-    return filter ? all.filter((c) => c.field === filter) : all;
-  }, [t, filter]);
+  return useMemo<GridColDef<T>[]>(
+    () =>
+      (["createdAt", "updatedAt"] as const)
+        .filter((f) => !filter || f === filter)
+        .map((field) => ({
+          width: 150,
+          field,
+          disableColumnMenu: true,
+          resizable: false,
+          headerAlign: "left",
+          headerName: t(headerI18nTitles?.[field] ?? `label.${field}`),
+          renderCell: ({ value }: GridRenderCellParams<T, Date | string>) => (
+            <Stack>
+              <Typography>
+                {normalizeDate(i18n.language, value, {
+                  day: "2-digit",
+                  month: "2-digit",
+                  year: "numeric",
+                })}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {normalizeDate(i18n.language, value, {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                  hour12: false,
+                })}
+              </Typography>
+            </Stack>
+          ),
+        })),
+    [i18n.language, t, filter, createdAt, updatedAt],
+  );
 };

--- a/packages/frontend/src/components/menu/index.tsx
+++ b/packages/frontend/src/components/menu/index.tsx
@@ -41,7 +41,11 @@ export const Menu = () => {
 
   return (
     <Grid container gap={3} flexDirection="column">
-      <PageHeader icon={MenuIcon} title={t("title.manage_persistent_menu")}>
+      <PageHeader
+        icon={MenuIcon}
+        title={t("title.manage_persistent_menu")}
+        description={t("message.page_description.menu")}
+      >
         <Grid
           justifyContent="flex-end"
           gap={1}

--- a/packages/frontend/src/components/settings/index.tsx
+++ b/packages/frontend/src/components/settings/index.tsx
@@ -210,7 +210,11 @@ export const Settings = () => {
 
   return (
     <Grid container gap={3} flexDirection="column">
-      <PageHeader icon={SettingsIcon} title={t("title.settings")} />
+      <PageHeader
+        icon={SettingsIcon}
+        title={t("title.settings")}
+        description={t("message.page_description.setting")}
+      />
       <LicenseActivatedModal
         open={isLicenseModalOpen}
         onClose={() => setIsLicenseModalOpen(false)}

--- a/packages/frontend/src/components/users/index.tsx
+++ b/packages/frontend/src/components/users/index.tsx
@@ -58,7 +58,11 @@ const UsersLockedView = () => {
 
   return (
     <Stack gap={3}>
-      <PageHeader icon={UsersIcon} title={t("title.users")} />
+      <PageHeader
+        icon={UsersIcon}
+        title={t("title.users")}
+        description={t("message.page_description.user")}
+      />
       <Paper variant="spaced">
         <Stack spacing={2.5} sx={{ maxWidth: 760 }}>
           <Typography variant="h6" sx={{ fontWeight: 700 }}>

--- a/packages/frontend/src/components/workflow-runs/index.tsx
+++ b/packages/frontend/src/components/workflow-runs/index.tsx
@@ -15,6 +15,7 @@ import {
   ColumnActionType,
   useActionColumns,
 } from "@/app-components/tables/columns/getColumns";
+import { useTimestampColumns } from "@/app-components/tables/columns/useTimestampColumns";
 import { GenericDataGrid } from "@/app-components/tables/GenericDataGrid";
 import { type Filter } from "@/app-components/tables/GenericFilters";
 import { WorkflowBadgeWithTitle } from "@/app-components/workflow/WorkflowBadgeWithTitle";
@@ -28,7 +29,9 @@ import { useAppRouter } from "@/hooks/useAppRouter";
 import { useQueryState } from "@/hooks/useQueryState";
 import { useTranslate } from "@/hooks/useTranslate";
 import { EntityType, Format } from "@/services/types";
-import { formatDurationMs, getDateTimeFormatter } from "@/utils/date";
+import { formatDurationMs } from "@/utils/date";
+
+const TIMESTAMP_HEADERS = { createdAt: "label.triggered_at" } as const;
 
 export const WorkflowRuns = ({
   hidedColumns = [],
@@ -52,20 +55,15 @@ export const WorkflowRuns = ({
     ],
     t("label.operations"),
   );
+  const timestampColumns = useTimestampColumns<WorkflowRunFull>(
+    "createdAt",
+    TIMESTAMP_HEADERS,
+  );
   const columns = useMemo(
     () =>
       [
-        { field: "id", headerName: "ID", width: 100 },
-        {
-          minWidth: 140,
-          field: "createdAt",
-          headerName: t("label.triggered_at"),
-          disableColumnMenu: true,
-          resizable: false,
-          headerAlign: "left",
-          valueGetter: (value) =>
-            t("datetime.created_at", getDateTimeFormatter(value)),
-        },
+        { field: "id", headerName: "ID" },
+        ...timestampColumns,
         {
           flex: 1,
           minWidth: 200,
@@ -112,7 +110,7 @@ export const WorkflowRuns = ({
           },
         },
         {
-          maxWidth: 120,
+          minWidth: 140,
           field: "status",
           headerName: t("label.status"),
           disableColumnMenu: true,
@@ -124,7 +122,7 @@ export const WorkflowRuns = ({
           ),
         },
         {
-          maxWidth: 100,
+          minWidth: 120,
           field: "duration",
           headerName: t("label.duration"),
           sortable: false,
@@ -144,7 +142,7 @@ export const WorkflowRuns = ({
         },
         actionColumns,
       ] satisfies GridColDef<WorkflowRunFull>[],
-    [t],
+    [t, timestampColumns],
   );
   const [name, setName] = useQueryState("name");
   const [subscriber, setSubscriber] = useQueryState("subscriber");

--- a/packages/frontend/src/layout/AuthenticatedLayout.tsx
+++ b/packages/frontend/src/layout/AuthenticatedLayout.tsx
@@ -59,7 +59,7 @@ export const AuthenticatedLayout: React.FC<
 
   return (
     <WorkflowEventProvider>
-      <Box display="flex">
+      <Box display="flex" width="100%" maxWidth="100vw" overflow="hidden">
         <DashboardHeader
           logo={<HexabotLogo />}
           menuOpen={isDesktopNavigationExpanded}
@@ -79,8 +79,12 @@ export const AuthenticatedLayout: React.FC<
             display: "flex",
             flexDirection: "column",
             flex: 1,
-            overflow: "auto",
-            width: "calc(100% - 88px)",
+            minWidth: 0,
+            maxWidth: "100%",
+            boxSizing: "border-box",
+            overflowX: "hidden",
+            overflowY: "auto",
+            width: 0,
             zIndex: 5,
           }}
         >

--- a/packages/frontend/src/layout/content/PageHeader.tsx
+++ b/packages/frontend/src/layout/content/PageHeader.tsx
@@ -12,28 +12,39 @@ import { Title } from "./Title";
 
 export const PageHeader = ({
   title,
+  description,
   icon,
   chip,
   headerLeftButtons,
   children,
 }: PropsWithChildren<{
   title?: string;
+  description?: string;
   icon?: LucideIcon;
   chip?: ReactNode;
   headerLeftButtons?: React.ReactElement;
 }>) => (
   <Box>
-    {headerLeftButtons ? (
-      <Box alignItems="start">{headerLeftButtons}</Box>
-    ) : null}
+    {headerLeftButtons && <Box alignItems="start">{headerLeftButtons}</Box>}
     <Box
       sx={{
         display: "flex",
-        justifyContent: "space-between",
+        justifyContent: { xs: "center", md: "space-between" },
         alignItems: "flex-end",
+        flexWrap: "wrap",
+        gap: 2,
       }}
     >
-      {(title || icon) && <Title title={title ?? ""} Icon={icon} chip={chip} />}
+      {(title || icon) && (
+        <Box alignSelf="flex-start">
+          <Title
+            title={title || ""}
+            description={description}
+            Icon={icon}
+            chip={chip}
+          />
+        </Box>
+      )}
       {children}
     </Box>
   </Box>

--- a/packages/frontend/src/layout/content/Title.tsx
+++ b/packages/frontend/src/layout/content/Title.tsx
@@ -6,26 +6,53 @@
 
 import { Typography } from "@mui/material";
 import Grid from "@mui/material/Grid";
+import { useTheme } from "@mui/material/styles";
 import { LucideIcon } from "lucide-react";
 import { ReactNode } from "react";
 
+import { Badge } from "@/app-components/displays/Badge";
+
 export const Title = (props: {
   title: string;
+  description?: string;
   Icon?: LucideIcon;
   chip?: ReactNode;
+  gap?: number;
 }) => {
+  const theme = useTheme();
+
   return (
-    <Grid container gap={1} alignContent="center">
-      <Grid sx={{ alignSelf: "center" }}>
-        {props.Icon ? <props.Icon /> : null}
-      </Grid>
+    <Grid container gap={props.gap || 1} alignItems="center">
+      {props.Icon ? (
+        <Badge
+          icon={props.Icon}
+          color={(theme.vars || theme).palette.primary.main}
+          width={theme.spacing(7)}
+          height={theme.spacing(7)}
+          radius={theme.spacing(2)}
+          padding={theme.spacing(1.75)}
+          disableTooltip
+        />
+      ) : null}
       <Grid>
-        <Typography variant="h5" fontWeight={700} height="fit-content">
-          {props.title}
-          {props.chip ? ":" : ""}
-        </Typography>
+        <Grid container alignItems="center" gap={1}>
+          <Typography
+            variant="h5"
+            fontWeight={700}
+            height="fit-content"
+            color="text.secondary"
+          >
+            {props.title}
+            {props.chip ? ":" : ""}
+          </Typography>
+          {props.chip ? <Grid>{props.chip}</Grid> : null}
+        </Grid>
+        {props.description ? (
+          <Typography color="text.secondary" mt={0.5}>
+            {props.description}
+          </Typography>
+        ) : null}
       </Grid>
-      {props.chip ? <Grid>{props.chip}</Grid> : null}
     </Grid>
   );
 };

--- a/packages/frontend/src/layout/theme/customizations/dataGrid.tsx
+++ b/packages/frontend/src/layout/theme/customizations/dataGrid.tsx
@@ -20,110 +20,165 @@ import { gray } from "../themePrimitives";
 
 export const datagridCustomizations: Components<Theme> = {
   MuiDataGrid: {
+    defaultProps: { columnHeaderHeight: 56, rowHeight: 64 },
     styleOverrides: {
-      root: ({ theme }) => ({
-        "--DataGrid-overlayHeight": "300px",
-        overflow: "clip",
-        borderColor: (theme.vars || theme).palette.divider,
-        backgroundColor: (theme.vars || theme).palette.background.default,
-        [`& .${gridClasses.columnHeader}`]: {
-          backgroundColor: (theme.vars || theme).palette.background.paper,
-        },
-        [`& .${gridClasses.footerContainer}`]: {
-          backgroundColor: (theme.vars || theme).palette.background.paper,
-        },
-        [`& .${checkboxClasses.root}`]: {
-          padding: theme.spacing(0.5),
-          "& > svg": {
-            fontSize: "1rem",
+      root: ({ theme }) => {
+        const p = theme.vars || theme;
+        const {
+          divider,
+          text,
+          action,
+          background,
+          primary: pPrimary,
+        } = p.palette;
+        // Use standard theme.palette for alpha() to avoid var() parsing errors
+        const { primary, common } = theme.palette;
+        const st = alpha(primary.main, 0.02);
+        const bdr = `1px solid ${divider}`;
+
+        return {
+          "--DataGrid-overlayHeight": "300px",
+          minWidth: 0,
+          overflow: "clip",
+          borderRadius: theme.spacing(1),
+          borderColor: divider,
+          backgroundColor: background.default,
+          boxShadow: `0 2px 6px ${alpha(common.black, 0.12)}`,
+          ...theme.applyStyles("dark", {
+            boxShadow: `0 0 0 1px ${alpha(common.white, 0.08)}, 0 2px 8px ${alpha(common.white, 0.12)}`,
+          }),
+          [`& .${gridClasses.columnHeaders}, & .${gridClasses.columnHeader}`]: {
+            color: text.secondary,
+            backgroundColor: st,
           },
-        },
-        [`& .${tablePaginationClasses.root}`]: {
-          marginRight: theme.spacing(1),
-          "& .MuiIconButton-root": {
-            maxHeight: 32,
-            maxWidth: 32,
-            "& > svg": {
-              fontSize: "1rem",
-            },
+          [`& .${gridClasses.columnHeader}`]: {
+            paddingInline: theme.spacing(3),
           },
-        },
-        "& .MuiDataGrid-cell": {
-          display: "flex",
-          alignItems: "center",
-        },
-        "& .MuiDataGrid-cell[data-field='actions']": {
-          alignContent: "center",
-          "& button": {
-            ":not(:hover)": {
-              color: theme.palette.common.black,
+          [`& .${gridClasses.columnHeaderTitle}`]: {
+            fontSize: theme.typography.pxToRem(16),
+            fontWeight: theme.typography.fontWeightMedium,
+          },
+          [`& .${gridClasses.footerContainer}`]: {
+            minHeight: theme.spacing(9),
+            paddingInline: theme.spacing(2),
+            backgroundColor: st,
+          },
+          [`& .${checkboxClasses.root}`]: {
+            padding: theme.spacing(0.5),
+            "& > svg": { fontSize: "1rem" },
+          },
+          [`& .${tablePaginationClasses.root}`]: {
+            flex: 1,
+            marginRight: 0,
+            [`& .${tablePaginationClasses.toolbar}`]: { padding: 0 },
+            [`& .${tablePaginationClasses.spacer}`]: { order: 2 },
+            [`& .${tablePaginationClasses.selectLabel}`]: {
+              order: 0,
+              marginLeft: theme.spacing(0.75),
             },
-            ":hover": {
-              stroke: "currenColor",
-              backgroundColor: gray[200],
+            [`& .${tablePaginationClasses.selectRoot}`]: {
+              order: 1,
+              minWidth: theme.spacing(9),
+              minHeight: theme.spacing(5),
+              marginLeft: theme.spacing(1),
+              marginRight: theme.spacing(2),
+              border: bdr,
+              borderRadius: p.shape.borderRadius,
             },
-            ":active": {
-              backgroundColor: gray[200],
-            },
-            ...theme.applyStyles("dark", {
-              ":not(:hover)": {
-                color: theme.palette.common.white,
+            [`& .${tablePaginationClasses.displayedRows}`]: { order: 3 },
+            [`& .${tablePaginationClasses.actions}`]: {
+              order: 4,
+              "& .MuiPaginationItem-root": {
+                width: theme.spacing(5),
+                height: theme.spacing(5),
+                border: bdr,
+                "&.Mui-selected": {
+                  fontWeight: "bold",
+                  color: pPrimary.main,
+                  backgroundColor: action.selected,
+                },
+                "&:hover": {
+                  color: pPrimary.dark,
+                  backgroundColor: action.hover,
+                },
               },
-              ":hover": {
-                backgroundColor: gray[700],
-              },
-            }),
+              "& li:last-of-type > .MuiPaginationItem-root": { marginRight: 0 },
+            },
+            "& .MuiIconButton-root": {
+              maxHeight: theme.spacing(5),
+              maxWidth: theme.spacing(5),
+              "& > svg": { fontSize: "1rem" },
+            },
           },
-          "& .MuiIconButton-root": {
-            boxShadow: "none",
-            borderRadius: (theme.vars || theme).shape.borderRadius,
-            textTransform: "none",
-            letterSpacing: 0,
-            border: `1px solid ${gray[500]}`,
-          },
-          "& .MuiStack-root": {
-            flexDirection: "row",
+          "& .MuiDataGrid-cell": {
             display: "flex",
-            gap: theme.spacing(0.5),
+            alignItems: "center",
+            paddingInline: theme.spacing(3),
+            fontSize: theme.typography.pxToRem(16),
           },
-        },
-      }),
+          "& .MuiDataGrid-cell[data-field='actions']": {
+            alignContent: "center",
+            "& .MuiIconButton-root": {
+              width: theme.spacing(5),
+              height: theme.spacing(5),
+              color: text.primary,
+              backgroundColor: background.paper,
+              border: bdr,
+              borderRadius: p.shape.borderRadius,
+              boxShadow: "none",
+              textTransform: "none",
+              letterSpacing: 0,
+              transition: theme.transitions.create(
+                ["background-color", "border-color", "color"],
+                { duration: theme.transitions.duration.shortest },
+              ),
+              "&:hover": {
+                backgroundColor: action.hover,
+                borderColor: text.secondary,
+              },
+              "&:active": { backgroundColor: action.selected },
+              "&:focus-visible": {
+                outline: `2px solid ${alpha(primary.main, 0.35)}`,
+                outlineOffset: 2,
+              },
+            },
+            "& .MuiStack-root": {
+              flexDirection: "row",
+              display: "flex",
+              gap: theme.spacing(0.5),
+            },
+          },
+        };
+      },
       cell: ({ theme }) => ({
         borderTopColor: (theme.vars || theme).palette.divider,
       }),
-      menu: ({ theme }) => ({
-        borderRadius: theme.shape.borderRadius,
-        backgroundImage: "none",
-        [`& .${paperClasses.root}`]: {
-          border: `1px solid ${(theme.vars || theme).palette.divider}`,
-        },
+      menu: ({ theme }) => {
+        const p = theme.vars || theme;
 
-        [`& .${menuItemClasses.root}`]: {
-          margin: "0 4px",
-        },
-        [`& .${listItemIconClasses.root}`]: {
-          marginRight: 0,
-        },
-        [`& .${listClasses.root}`]: {
-          paddingLeft: 0,
-          paddingRight: 0,
-        },
-      }),
-
-      row: ({ theme }) => ({
-        "&:last-of-type": {
-          borderBottom: `1px solid ${(theme.vars || theme).palette.divider}`,
-        },
-        "&:hover": {
-          backgroundColor: (theme.vars || theme).palette.action.hover,
-        },
-        "&.Mui-selected": {
-          background: (theme.vars || theme).palette.action.selected,
-          "&:hover": {
-            backgroundColor: (theme.vars || theme).palette.action.hover,
+        return {
+          borderRadius: p.shape.borderRadius,
+          backgroundImage: "none",
+          [`& .${paperClasses.root}`]: {
+            border: `1px solid ${p.palette.divider}`,
           },
-        },
-      }),
+          [`& .${menuItemClasses.root}`]: { margin: "0 4px" },
+          [`& .${listItemIconClasses.root}`]: { marginRight: 0 },
+          [`& .${listClasses.root}`]: { padding: 0 },
+        };
+      },
+      row: ({ theme }) => {
+        const { action, divider } = (theme.vars || theme).palette;
+
+        return {
+          "&:last-of-type": { borderBottom: `1px solid ${divider}` },
+          "&:hover": { backgroundColor: action.hover },
+          "&.Mui-selected": {
+            background: action.selected,
+            "&:hover": { backgroundColor: action.hover },
+          },
+        };
+      },
       iconButtonContainer: ({ theme }) => ({
         [`& .${iconButtonClasses.root}`]: {
           border: "none",
@@ -131,37 +186,23 @@ export const datagridCustomizations: Components<Theme> = {
           "&:hover": {
             backgroundColor: alpha(theme.palette.action.selected, 0.3),
           },
-          "&:active": {
-            backgroundColor: gray[200],
-          },
+          "&:active": { backgroundColor: gray[200] },
           ...theme.applyStyles("dark", {
             color: gray[50],
-            "&:hover": {
-              backgroundColor: gray[800],
-            },
-            "&:active": {
-              backgroundColor: gray[900],
-            },
+            "&:hover": { backgroundColor: gray[800] },
+            "&:active": { backgroundColor: gray[900] },
           }),
         },
       }),
       menuIconButton: ({ theme }) => ({
         border: "none",
         backgroundColor: "transparent",
-        "&:hover": {
-          backgroundColor: gray[100],
-        },
-        "&:active": {
-          backgroundColor: gray[200],
-        },
+        "&:hover": { backgroundColor: gray[100] },
+        "&:active": { backgroundColor: gray[200] },
         ...theme.applyStyles("dark", {
           color: gray[50],
-          "&:hover": {
-            backgroundColor: gray[800],
-          },
-          "&:active": {
-            backgroundColor: gray[900],
-          },
+          "&:hover": { backgroundColor: gray[800] },
+          "&:active": { backgroundColor: gray[900] },
         }),
       }),
       filterForm: ({ theme }) => ({
@@ -169,8 +210,7 @@ export const datagridCustomizations: Components<Theme> = {
         alignItems: "flex-end",
       }),
       columnsManagementHeader: ({ theme }) => ({
-        paddingRight: theme.spacing(3),
-        paddingLeft: theme.spacing(3),
+        paddingInline: theme.spacing(3),
       }),
       columnHeaderTitleContainer: {
         flexGrow: 1,

--- a/packages/frontend/src/layout/theme/customizations/inputs.tsx
+++ b/packages/frontend/src/layout/theme/customizations/inputs.tsx
@@ -404,6 +404,7 @@ export const inputsCustomizations: Components<Theme> = {
         [`&.${outlinedInputClasses.focused}:not(.${inputBaseClasses.disabled}):not(.${inputBaseClasses.readOnly}) .${outlinedInputClasses.notchedOutline}`]:
           {
             borderColor: brand[400],
+            borderWidth: 2,
           },
         [`&.${outlinedInputClasses.focused}.${inputBaseClasses.readOnly} .${outlinedInputClasses.notchedOutline}`]:
           {

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -11,6 +11,7 @@ a {
 
 ::-webkit-scrollbar {
   width: 8px;
+  height: 8px;
 }
 ::-webkit-scrollbar-track {
   background: rgb(245, 245, 245);


### PR DESCRIPTION
## Screenshots
- After the update
<img width="2313" height="383" alt="image" src="https://github.com/user-attachments/assets/a33a1f9e-2e75-4fc4-9ba2-17b696e5fc15" />
<img width="2396" height="1236" alt="image" src="https://github.com/user-attachments/assets/de706292-38ba-4353-90ff-f17f1d388d7d" />
<img width="1526" height="1202" alt="image" src="https://github.com/user-attachments/assets/b2dd6a3f-7ec6-4e7c-b381-801ac024c70c" />
<img width="1526" height="1202" alt="image" src="https://github.com/user-attachments/assets/83b23cd1-1f46-42aa-ad16-aa5143676f69" />
<img width="1005" height="1202" alt="image" src="https://github.com/user-attachments/assets/7302139a-9558-401c-ae4e-4b06c4baa5f7" />
<img width="701" height="1207" alt="image" src="https://github.com/user-attachments/assets/f1bfd751-ef23-45f6-b42f-d67b24a61b75" />

- Before the update
<img width="2313" height="383" alt="image" src="https://github.com/user-attachments/assets/2073a947-06ee-4412-93a7-d27891bd49c8" />
<img width="2396" height="1236" alt="image" src="https://github.com/user-attachments/assets/7bbf55be-f6e5-4dc7-a9cc-a2da79717161" />
<img width="1526" height="1202" alt="image" src="https://github.com/user-attachments/assets/68bf5627-37dc-43fa-bc3b-b7d9cee9c9b5" />
<img width="1005" height="1202" alt="image" src="https://github.com/user-attachments/assets/e0061fee-0b27-468c-86bd-fb75806859f6" />
<img width="701" height="1207" alt="image" src="https://github.com/user-attachments/assets/b1d7acbf-c0e5-40c6-a478-6713e3e093fd" />


## Summary
Reworks the frontend list/table experience: the MUI DataGrid theme is restyled (taller rows, tinted headers, rounded container, reworked footer pagination), entity list screens now behave responsively down to mobile, and page headers gain a badged icon plus a descriptive subtitle. Timestamp columns render as a two-line date/time cell, and the actions column gets a deterministic computed width.

## Why
List screens overflowed horizontally on narrow viewports (the authenticated layout forced `width: calc(100% - 88px)` with `overflow: auto`), filters had no place to go on small screens, and page headers gave no context beyond a bare title. The grid styling had also drifted from the design system — inconsistent column widths, hardcoded gray hover states, and a footer that didn't match the rest of the app.

## How to review
- **Layout/overflow correctness** — [AuthenticatedLayout.tsx:62-87](packages/frontend/src/layout/AuthenticatedLayout.tsx#L62-L87) switches to `width: 0; minWidth: 0; flex: 1` with `overflowX: hidden`; the `minWidth={0}` additions in [GenericDataGrid.tsx](packages/frontend/src/app-components/tables/GenericDataGrid.tsx) and [DataGrid.tsx](packages/frontend/src/app-components/tables/DataGrid.tsx) depend on it. This is the change most likely to have side effects on non-grid pages.
- **Column sizing** — [DataGrid.tsx:34-52](packages/frontend/src/app-components/tables/DataGrid.tsx#L34-L52) applies `flex: 0` for explicit-width columns and `flex: 1 + minWidth` otherwise; the actions column width in [getColumns.tsx:145-151](packages/frontend/src/app-components/tables/columns/getColumns.tsx#L145-L151) is derived from constants that mirror values in the theme file — worth confirming they stay in sync.
- **Responsive filters** — the new `ResponsiveGenericFilters` popover in [GenericFilters.tsx](packages/frontend/src/app-components/tables/GenericFilters.tsx), including keyboard/focus behavior when collapsed.
- **i18n coverage** — `GenericDataGrid` derives a description key from the entity name (`message.page_description.${snakeCase(entity)}`); check every entity list screen has a matching key in both `en` and `fr`, since a missing one surfaces as a raw key.
- **Theme diff** — [dataGrid.tsx](packages/frontend/src/layout/theme/customizations/dataGrid.tsx) is the largest file; note the deliberate use of `theme.palette` (not `theme.vars`) for `alpha()` calls to avoid `var()` parsing errors.

## Validation
- Type check / lint pass
- Visual check of list screens (users, roles, subscribers, workflow runs, content, attachments) at desktop, tablet, and mobile widths
- Light and dark mode
- EN and FR locales — no missing `message.page_description.*` keys
- Pagination, sorting, text search, and per-entity filters still functional
