### PR TITLE
refactor(api): share qualifiedName across rag provisioning

### DIFF
--- a/packages/api/src/extensions/helpers/fulltext-search/fulltext.provisioning.ts
+++ b/packages/api/src/extensions/helpers/fulltext-search/fulltext.provisioning.ts
@@ -6,6 +6,8 @@
 
 import { QueryRunner } from 'typeorm';
 
+import { qualifiedName } from '@/helper/lib/content-search.store';
+
 // Schema object names and DDL for the built-in lexical (full-text) RAG helper.
 // This is the single source of truth for provisioning the database-native
 // search structures — a Postgres GIN expression index over `to_tsvector`, or a
@@ -46,17 +48,6 @@ function isSqlite(queryRunner: QueryRunner): boolean {
   const databaseType = queryRunner.connection.options.type;
 
   return databaseType === 'better-sqlite3' || databaseType === 'sqlite';
-}
-
-/**
- * Quotes an object name, prefixing the configured connection schema when one is
- * set so the DDL targets the right namespace under multi-tenant/test schemas.
- */
-export function qualifiedName(queryRunner: QueryRunner, name: string): string {
-  const schema = (queryRunner.connection.options as { schema?: string }).schema;
-  const quotedName = `"${name.replace(/"/g, '""')}"`;
-
-  return schema ? `"${schema.replace(/"/g, '""')}".${quotedName}` : quotedName;
 }
 
 /**

--- a/packages/api/src/extensions/helpers/pgvector/pgvector.provisioning.ts
+++ b/packages/api/src/extensions/helpers/pgvector/pgvector.provisioning.ts
@@ -6,6 +6,8 @@
 
 import { QueryRunner } from 'typeorm';
 
+import { qualifiedName } from '@/helper/lib/content-search.store';
+
 // Schema object names and DDL for the pgvector RAG helper. This is the single
 // source of truth for provisioning, imported by both the v3.4.0 migration
 // (best-effort provisioning at upgrade time) and the runtime store (idempotent
@@ -20,17 +22,6 @@ export const PGVECTOR_JOBS_TABLE = 'rag_pgvector_jobs';
 export const PGVECTOR_TRIGGER = 'contents_enqueue_pgvector_rag';
 
 export const PGVECTOR_TRIGGER_FUNCTION = 'enqueue_pgvector_rag_content';
-
-/**
- * Quotes an object name, prefixing the configured connection schema when one is
- * set so the DDL targets the right namespace under multi-tenant/test schemas.
- */
-export function qualifiedName(queryRunner: QueryRunner, name: string): string {
-  const schema = (queryRunner.connection.options as { schema?: string }).schema;
-  const quotedName = `"${name.replace(/"/g, '""')}"`;
-
-  return schema ? `"${schema.replace(/"/g, '""')}".${quotedName}` : quotedName;
-}
 
 /**
  * Reports whether the pgvector infrastructure is already fully in place: the

--- a/packages/api/src/helper/lib/content-search.store.ts
+++ b/packages/api/src/helper/lib/content-search.store.ts
@@ -4,7 +4,7 @@
  * Full terms: see LICENSE.md.
  */
 
-import { DataSource } from 'typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
 
 import { ContentOrmEntity } from '@/cms/entities/content.entity';
 import { RagHit } from '@/cms/types/rag';
@@ -29,6 +29,20 @@ export const quoteIdentifier = (identifier: string): string =>
 /** Quotes a dotted table path (e.g. `schema.table`) segment by segment. */
 export const quoteTablePath = (path: string): string =>
   path.split('.').map(quoteIdentifier).join('.');
+
+/**
+ * Quotes an object name, prefixing the configured connection schema when one is
+ * set so the DDL targets the right namespace under multi-tenant/test schemas.
+ */
+export const qualifiedName = (
+  queryRunner: QueryRunner,
+  name: string,
+): string => {
+  const schema = (queryRunner.connection.options as { schema?: string }).schema;
+  const quotedName = quoteIdentifier(name);
+
+  return schema ? `${quoteIdentifier(schema)}.${quotedName}` : quotedName;
+};
 
 /**
  * Shared persistence boundary for the content-backed RAG search stores.

--- a/packages/api/src/migration/migrations/1784815200000-v-3-4-0.migration.ts
+++ b/packages/api/src/migration/migrations/1784815200000-v-3-4-0.migration.ts
@@ -20,8 +20,8 @@ import {
   PGVECTOR_TRIGGER,
   PGVECTOR_TRIGGER_FUNCTION,
   provisionPgvectorInfrastructure,
-  qualifiedName,
 } from '@/extensions/helpers/pgvector/pgvector.provisioning';
+import { qualifiedName as table } from '@/helper/lib/content-search.store';
 import { SettingOrmEntity } from '@/setting/entities/setting.entity';
 
 import { MigrationServices } from '../types';
@@ -76,30 +76,24 @@ export default class Migration1784815200000_V3_4_0
     const databaseType = queryRunner.connection.options.type;
 
     if (databaseType === 'postgres') {
-      const contents = this.table(queryRunner, 'contents');
+      const contents = table(queryRunner, 'contents');
       await queryRunner.query(
         `DROP TRIGGER IF EXISTS "${PGVECTOR_TRIGGER}" ON ${contents}`,
       );
       await queryRunner.query(
-        `DROP FUNCTION IF EXISTS ${this.table(
+        `DROP FUNCTION IF EXISTS ${table(
           queryRunner,
           PGVECTOR_TRIGGER_FUNCTION,
         )}()`,
       );
       await queryRunner.query(
-        `DROP TABLE IF EXISTS ${this.table(
-          queryRunner,
-          PGVECTOR_CHUNKS_TABLE,
-        )}`,
+        `DROP TABLE IF EXISTS ${table(queryRunner, PGVECTOR_CHUNKS_TABLE)}`,
       );
       await queryRunner.query(
-        `DROP TABLE IF EXISTS ${this.table(
-          queryRunner,
-          PGVECTOR_DOCUMENTS_TABLE,
-        )}`,
+        `DROP TABLE IF EXISTS ${table(queryRunner, PGVECTOR_DOCUMENTS_TABLE)}`,
       );
       await queryRunner.query(
-        `DROP TABLE IF EXISTS ${this.table(queryRunner, PGVECTOR_JOBS_TABLE)}`,
+        `DROP TABLE IF EXISTS ${table(queryRunner, PGVECTOR_JOBS_TABLE)}`,
       );
     }
 
@@ -392,8 +386,8 @@ export default class Migration1784815200000_V3_4_0
       return undefined;
     }
 
-    const credentials = this.table(queryRunner, 'credentials');
-    const users = this.table(queryRunner, 'users');
+    const credentials = table(queryRunner, 'credentials');
+    const users = table(queryRunner, 'users');
     const placeholder = (index: number) =>
       queryRunner.connection.options.type === 'postgres' ? `$${index}` : '?';
     const existingById = (await queryRunner.query(
@@ -471,9 +465,5 @@ export default class Migration1784815200000_V3_4_0
     const provider = this.asNonEmptyString(value);
 
     return vercelAiSdkProviders.find((candidate) => candidate === provider);
-  }
-
-  private table(queryRunner: QueryRunner, name: string): string {
-    return qualifiedName(queryRunner, name);
   }
 }


### PR DESCRIPTION
## Summary
`qualifiedName` — the helper that quotes a SQL object name and prefixes the
connection's configured schema — existed as three near-identical copies: one in
`pgvector.provisioning.ts`, one in `fulltext.provisioning.ts`, and a private
`table()` wrapper in the v3.4.0 migration. This PR collapses them into a single
definition in `content-search.store.ts`, implemented on top of the existing
`quoteIdentifier`. No behavior change.

## Why
Identifier quoting is correctness-sensitive: it's what keeps DDL pointed at the
right namespace under multi-tenant and test schemas, and it's the escaping
boundary for object names interpolated into raw SQL. Three copies means three
places to fix if the escaping rule ever changes, and they had already started to
drift — each copy re-implemented `name.replace(/"/g, '""')` inline instead of
reusing `quoteIdentifier`, which lived one module away.

It also removes a layering wart: the v3.4.0 migration was importing a completely
generic SQL utility from the *pgvector-specific* provisioning module, coupling a
core migration to an extension's internals.

## How to review
- **`packages/api/src/helper/lib/content-search.store.ts` (+16)** — the only new
  code. Worth confirming the consolidated version is equivalent to what it
  replaced: `quoteIdentifier` is `` `"${identifier.replace(/"/g, '""')}"` ``,
  which is character-for-character what both deleted copies inlined, so
  `quoteIdentifier(schema)` and `quoteIdentifier(name)` produce identical output
  to the old template literals.
- **The two `*.provisioning.ts` files (−13 each)** — pure deletion plus an
  import; call sites are untouched.
- **`1784815200000-v-3-4-0.migration.ts`** — largest diff, but mostly mechanical:
  the private `table()` wrapper is gone and the import is aliased
  (`qualifiedName as table`) so all call sites read the same minus `this.`. A
  few `DROP TABLE` statements collapse back onto one line now that the call is
  shorter. Since this is an already-released migration, the thing to check is
  that the emitted SQL is unchanged — the alias keeps every call site's
  arguments identical.

## Validation
- `pnpm run typecheck` (packages/api) — passes, no errors.
- Targeted Jest run over the affected surface — `src/extensions/helpers/{fulltext-search,pgvector,sqlite-vector}`
  and `1784815200000-v-3-4-0.migration.spec.ts`: **10 suites passed, 97 tests
  passed**.
- Not run: `pgvector.integration.spec.ts` (1 suite, 7 tests) is skipped in this
  environment as it requires a live Postgres instance. Since the pgvector DDL
  path is where `qualifiedName` does the most work, a CI run with Postgres
  available is the meaningful gate here.