### PR TITLE
chore(api): sync barrel exports across api package

### DIFF
--- a/packages/api/src/audit/index.ts
+++ b/packages/api/src/audit/index.ts
@@ -4,6 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
+export * from './audit-core.module';
+
 export * from './audit.module';
 
 export * from './controllers/audit-log.controller';
@@ -16,8 +18,24 @@ export * from './dto/audit-log.dto';
 
 export * from './entities/audit-log.entity';
 
+export * from './exporters/audit-backend.factory';
+
+export * from './exporters/audit-database.exporter';
+
+export * from './exporters/audit-noop.exporter';
+
+export * from './exporters/audit-safe.exporter';
+
+export * from './interceptors/audit-context.interceptor';
+
 export * from './repositories/audit-log.repository';
 
 export * from './services/audit-context.service';
 
 export * from './services/audit-log-record.service';
+
+export * from './subscribers/audit-log.subscriber';
+
+export * from './types/audit-context.type';
+
+export * from './utils/request-context';

--- a/packages/api/src/bindings/index.ts
+++ b/packages/api/src/bindings/index.ts
@@ -10,4 +10,6 @@ export * from './base-binding-kind';
 
 export * from './runtime-bindings';
 
+export * from './runtime-bindings.service';
+
 export * from './create-binding-kind';

--- a/packages/api/src/database/index.ts
+++ b/packages/api/src/database/index.ts
@@ -10,6 +10,8 @@ export * from './decorators/json-column.decorator';
 
 export * from './decorators/datetime-column.decorator';
 
+export * from './decorators/orm-event-hooks.decorator';
+
 export * from './entities/base.entity';
 
 export * from './typeorm-config.service';

--- a/packages/api/src/extensions/channels/web/inbound/events/index.ts
+++ b/packages/api/src/extensions/channels/web/inbound/events/index.ts
@@ -4,6 +4,8 @@
  * Full terms: see LICENSE.md.
  */
 
+export * from './base-web-inbound.event';
+
 export * from './messages/attachment.event';
 
 export * from './delivery.event';
@@ -21,5 +23,7 @@ export * from './read.event';
 export * from './messages/text.event';
 
 export * from './typing.event';
+
+export * from './unsupported.event';
 
 export * from './messages/web-message.event';

--- a/packages/api/src/extensions/index.ts
+++ b/packages/api/src/extensions/index.ts
@@ -18,33 +18,69 @@ export * from './channels/web/types';
 
 export * from './channels/web/inbound';
 
+export * from './channels/web/outbound/web-outbound-message-encoder';
+
+export * from './channels/web/services/web-history.service';
+
+export * from './channels/web/services/web-session.service';
+
 export * from './helpers/local-storage/index.helper';
 
 export * from './helpers/fulltext-search/index.helper';
+
+export * from './helpers/fulltext-search/fulltext.provisioning';
+
+export * from './helpers/fulltext-search/fulltext-search.store';
 
 export * from './helpers/pgvector/index.helper';
 
 export * from './helpers/pgvector/pgvector.settings';
 
+export * from './helpers/pgvector/pgvector.provisioning';
+
+export * from './helpers/pgvector/pgvector.store';
+
 export * from './helpers/sqlite-vector/index.helper';
 
 export * from './helpers/sqlite-vector/sqlite-vector.settings';
+
+export * from './helpers/sqlite-vector/sqlite-vector.provisioning';
+
+export * from './helpers/sqlite-vector/sqlite-vector.store';
 
 export * from './actions/ai/ai-prompt.helpers';
 
 export * from './actions/ai/ai-schemas';
 
+export * from './actions/ai/ai-base.action';
+
+export * from './actions/ai/mcp.binding';
+
+export * from './actions/ai/memory.binding';
+
 export * from './actions/ai/model.binding';
 
 export * from './actions/ai/tools.binding';
+
+export * from './actions/ai/agent.action';
+
+export * from './actions/ai/generate-text.base.action';
 
 export * from './actions/ai/generate-text.action';
 
 export * from './actions/ai/generate-reply.action';
 
+export * from './actions/ai/generate-object.base.action';
+
 export * from './actions/ai/generate-object.action';
 
 export * from './actions/ai/infer-object.action';
+
+export * from './actions/ai/retrieve-content-rag.action';
+
+export * from './actions/memory/update-memory.action';
+
+export * from './actions/messaging/message-action.base';
 
 export * from './actions/messaging/text-message.action';
 
@@ -56,6 +92,14 @@ export * from './actions/messaging/attachment.action';
 
 export * from './actions/messaging/list.action';
 
+export * from './actions/messaging/await-reply.action';
+
+export * from './actions/subscriber/handover.action';
+
+export * from './actions/subscriber/update-labels.action';
+
 export * from './actions/web/send-mail.action';
+
+export * from './actions/web/http-request.action';
 
 export * from './actions/workflow/call-workflow.action';

--- a/packages/api/src/health/index.ts
+++ b/packages/api/src/health/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+export * from './health.service';

--- a/packages/api/src/helper/index.ts
+++ b/packages/api/src/helper/index.ts
@@ -12,6 +12,10 @@ export * from './helper.service';
 
 export * from './lib/base-helper';
 
+export * from './lib/content-search.store';
+
+export * from './lib/base-rag-embedding-helper';
+
 export * from './lib/base-rag-helper';
 
 export * from './lib/base-storage-helper';

--- a/packages/api/src/i18n/index.ts
+++ b/packages/api/src/i18n/index.ts
@@ -18,6 +18,8 @@ export * from './entities/translation.entity';
 
 export * from './i18n.module';
 
+export * from './loaders/extension-json.loader';
+
 export * from './repositories/language.repository';
 
 export * from './repositories/translation.repository';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -44,6 +44,8 @@ export * from './extensions';
 
 export * from './extra';
 
+export * from './health';
+
 export * from './helper';
 
 export * from './i18n';
@@ -53,6 +55,8 @@ export * from './license';
 export * from './logger';
 
 export * from './mailer';
+
+export * from './mcp';
 
 export * from './migration';
 

--- a/packages/api/src/mcp/index.ts
+++ b/packages/api/src/mcp/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Hexabot — Fair Core License (FCL-1.0-ALv2)
+ * Copyright (c) 2026 Hexastack.
+ * Full terms: see LICENSE.md.
+ */
+
+export * from './controllers/mcp-token.controller';
+
+export * from './decorators/mcp-permission.decorator';
+
+export * from './dto/mcp-token.dto';
+
+export * from './entities/mcp-token.entity';
+
+export * from './guards/hexabot-mcp-token.guard';
+
+export * from './guards/mcp-permission.guard';
+
+export * from './mcp-api.module';
+
+export * from './repositories/mcp-token.repository';
+
+export * from './services/mcp-token.service';
+
+export * from './tools';
+
+export * from './types';

--- a/packages/api/src/transfer/index.ts
+++ b/packages/api/src/transfer/index.ts
@@ -4,6 +4,16 @@
  * Full terms: see LICENSE.md.
  */
 
+export * from './adapters/content-type-transfer.adapter';
+
+export * from './adapters/credential-transfer.adapter';
+
+export * from './adapters/label-transfer.adapter';
+
+export * from './adapters/mcp-server-transfer.adapter';
+
+export * from './adapters/memory-definition-transfer.adapter';
+
 export * from './workflow-transfer.module';
 
 export * from './workflow-transfer.controller';

--- a/packages/api/src/user/index.ts
+++ b/packages/api/src/user/index.ts
@@ -26,6 +26,8 @@ export * from './dto/credential.dto';
 
 export * from './dto/user.dto';
 
+export * from './dto/user-profile.dto';
+
 export * from './entities/model.entity';
 
 export * from './entities/permission.entity';
@@ -37,6 +39,8 @@ export * from './entities/session.entity';
 export * from './entities/credential.entity';
 
 export * from './entities/user.entity';
+
+export * from './entities/user-profile.entity';
 
 export * from './guards/ability.guard';
 

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -42,13 +42,19 @@ export * from './helpers/clone';
 
 export * from './helpers/flatten';
 
+export * from './helpers/freeze';
+
 export * from './helpers/misc';
 
 export * from './helpers/object';
 
+export * from './helpers/origin';
+
 export * from './helpers/parse';
 
 export * from './helpers/safeRandom';
+
+export * from './helpers/safe-property-path';
 
 export * from './helpers/svg';
 
@@ -63,6 +69,8 @@ export * from './pipes/uuid.pipe';
 export * from './pipes/zod.pipe';
 
 export * from './types/dto.types';
+
+export * from './types/entity-event.types';
 
 export * from './types/filter.types';
 

--- a/packages/api/src/websocket/index.ts
+++ b/packages/api/src/websocket/index.ts
@@ -20,6 +20,8 @@ export * from './services/socket-event-dispatcher.service';
 
 export * from './storage/socket-event-metadata.storage';
 
+export * from './tokens';
+
 export * from './types';
 
 export * from './utils/gateway-options';

--- a/packages/api/src/workflow/index.ts
+++ b/packages/api/src/workflow/index.ts
@@ -54,7 +54,41 @@ export * from './repositories/mcp-server.repository';
 
 export * from './contexts/conversational-workflow.context';
 
+export * from './contexts/manual-workflow.context';
+
+export * from './contexts/scheduled-workflow.context';
+
 export * from './contexts/workflow-runtime.context';
+
+export * from './contexts/workflow-context-factory';
+
+export * from './decorators/is-workflow-definition.decorator';
+
+export * from './decorators/is-workflow-yaml.decorator';
+
+export * from './guards/webhook-trigger.guard';
+
+export * from './lib/trigger-event-wrapper';
+
+export * from './lib/workflow-definition';
+
+export * from './resource-refs';
+
+export * from './schemas/workflow-input-schemas';
+
+export * from './schemas/workflow-schemas';
+
+export * from './seeds/memory-definition.seed-model';
+
+export * from './seeds/memory-definition.seed';
+
+export * from './seeds/workflow.seed-model';
+
+export * from './seeds/workflow.seed';
+
+export * from './utils/memory-store';
+
+export * from './utils/schema-instance';
 
 export * from './types';
 
@@ -75,6 +109,12 @@ export * from './services/agentic.service';
 export * from './services/mcp-server.service';
 
 export * from './services/mcp-client-pool.service';
+
+export * from './services/stdio-stderr-capture.transport';
+
+export * from './services/webhook-trigger.service';
+
+export * from './services/workflow-scheduler.service';
 
 export * from '../transfer/workflow-transfer.module';
 


### PR DESCRIPTION
## Summary
Syncs the barrel files across `packages/api/src` so that every module's public
symbols are actually re-exported from the package root. Adds two missing barrels
(`health/index.ts`, `mcp/index.ts`) and wires them into `src/index.ts`, plus ~90
previously unexported symbols across `audit`, `extensions`, `workflow`,
`transfer`, `utils`, `helper`, `user`, `i18n`, `websocket`, `bindings`, and
`database`. Export-only change — no runtime logic was touched.

## Why
`@hexabot-ai/api` ships a single root entrypoint (`exports: { "." : ... }`), so
the barrel files *are* the public API surface for extension authors. Modules
added over recent PRs (MCP tokens, health service, sqlite-vector/pgvector RAG
stores, audit exporters and interceptors, workflow contexts/seeds/schemas,
transfer adapters) landed without their barrel entries, leaving them
unreachable to consumers of the published package.

## How to review
- [packages/api/src/index.ts](packages/api/src/index.ts) — the two new
  top-level re-exports (`./health`, `./mcp`); confirm both belong in the public
  surface.
- [packages/api/src/mcp/index.ts](packages/api/src/mcp/index.ts) and
  [packages/api/src/health/index.ts](packages/api/src/health/index.ts) — new
  files; check that nothing internal-only is being leaked (guards, repositories,
  entities are exported deliberately, matching how other modules do it).
- [packages/api/src/extensions/index.ts](packages/api/src/extensions/index.ts)
  and [packages/api/src/workflow/index.ts](packages/api/src/workflow/index.ts) —
  the two largest additions; worth a check for naming collisions between
  `export *` sources, since duplicate symbol names across barrels surface as
  ambiguous exports rather than hard errors.
- The remaining files are one-to-four-line additions and can be skimmed.

## Validation
- `pnpm --filter @hexabot-ai/api build` — TypeScript compiles and `dist/index.d.ts`
  resolves all new re-exports.
- `pnpm --filter @hexabot-ai/api lint`
- `pnpm --filter @hexabot-ai/api test`
- No behavioral change expected: diff is additive `export * from` lines only
  (`git show --stat` → 15 files, 178 insertions, 0 deletions).
