### PR TITLE
chore(cli): remove CLI unused packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,13 +32,10 @@
     "axios": "^1.18.1",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "degit": "^2.8.4",
-    "dotenv": "^16.4.5",
     "figlet": "^1.7.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@types/degit": "^2.8.6",
     "@types/figlet": "^1.5.8",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,12 +506,6 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
-      degit:
-        specifier: ^2.8.4
-        version: 2.8.4
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
       figlet:
         specifier: ^1.7.0
         version: 1.9.4
@@ -519,9 +513,6 @@ importers:
       '@jest/globals':
         specifier: ^30.4.1
         version: 30.4.1
-      '@types/degit':
-        specifier: ^2.8.6
-        version: 2.8.6
       '@types/figlet':
         specifier: ^1.5.8
         version: 1.7.0
@@ -4128,9 +4119,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/degit@2.8.6':
-    resolution: {integrity: sha512-y0M7sqzsnHB6cvAeTCBPrCQNQiZe8U4qdzf8uBVmOWYap5MMTN/gB2iEqrIqFiYcsyvP74GnGD5tgsHttielFw==}
-
   '@types/emoji-js@3.5.2':
     resolution: {integrity: sha512-qPR85yjSPk2UEbdjYYNHfcOjVod7DCARSrJlPcL+cwaDFwdnmOFhPyYUvP5GaW0YZEy8mU93ZjTNgsVWz1zzlg==}
 
@@ -5733,11 +5721,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  degit@2.8.4:
-    resolution: {integrity: sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==}
-    engines: {node: '>=8.0.0'}
-    hasBin: true
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
@@ -13760,8 +13743,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/degit@2.8.6': {}
-
   '@types/emoji-js@3.5.2': {}
 
   '@types/eslint-scope@3.7.7':
@@ -15539,8 +15520,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  degit@2.8.4: {}
 
   delaunator@5.0.1:
     dependencies:


### PR DESCRIPTION
## Summary: 
Remove the unused `degit`, `dotenv`, and `@types/degit` dependencies from the CLI package, along with their lockfile entries.

## Why: 
The CLI no longer uses `degit`, and it does not import or preload `dotenv`. Removing these packages reduces unnecessary dependencies.

## How to review: 
Review the dependency removals in `packages/cli/package.json` and the corresponding updates in `pnpm-lock.yaml`.

## Validation: 
Searched the CLI source, tests, scripts, and configuration for references to these packages and confirmed that none remain.
