### PR TITLE
chore(frontend): align development configuration

### DIFF
--- a/packages/frontend/AGENTS.md
+++ b/packages/frontend/AGENTS.md
@@ -17,7 +17,7 @@ Use this file as the entrypoint for AI coding agents working on the Hexabot admi
 - Theme: `packages/frontend/src/layout/theme/index.ts`, `packages/frontend/src/layout/theme/AppTheme.tsx`
 
 ## Tooling and commands
-- Node.js >= 24.17.0; PNPM workspace (run commands from repo root).
+- Node.js `^24.17.0`; PNPM workspace (run commands from repo root).
 - Dev server: `pnpm --filter @hexabot-ai/frontend dev` (Vite on :8080).
 - Build: `pnpm --filter @hexabot-ai/frontend build` (typecheck + Vite build).
 - Typecheck: `pnpm --filter @hexabot-ai/frontend typecheck`.

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -51,7 +51,7 @@ Hexabot also provides a live chat widget package that can be launched in paralle
 pnpm --filter @hexabot-ai/widget run dev
 ```
 
-To run all workspace dev tasks (including `@hexabot-ai/frontend` and `@hexabot-ai/graph`), use `pnpm dev` from the repository root.
+To run all workspace dev tasks (including `@hexabot-ai/frontend` and `@hexabot-ai/graph`), use `pnpm dev:all` from the repository root.
 
 The chat widget development server listens on http://localhost:5173.
 
@@ -60,7 +60,7 @@ The chat widget development server listens on http://localhost:5173.
 Create a `.env.local` (or `.env`) file inside `packages/frontend/` to override defaults that are read at build-time:
 
 ```
-VITE_API_ORIGIN=http://localhost:4000
+VITE_API_ORIGIN=http://localhost:3000/api
 VITE_SSO_ENABLED=false
 VITE_UPLOAD_MAX_SIZE_IN_BYTES=20971520
 VITE_DEFAULT_LANGUAGE=en


### PR DESCRIPTION
## Summary
Aligned the frontend documentation with the current workspace scripts, API configuration, and Node.js engine requirement. Updated the all-workspace development command, API origin example, and documented Node range.

## Why
The README incorrectly stated that `pnpm dev` includes the graph package and used an API port inconsistent with the local backend. The agent guide also documented a broader Node.js range than the frontend manifest permits.

## How to review
Focus on:

- `pnpm dev:all` as the command for running every workspace development task.
- `VITE_API_ORIGIN=http://localhost:3000/api`.
- The `^24.17.0` Node.js requirement in `packages/frontend/AGENTS.md`.

## Validation
- Compared commands with the root `package.json`.
- Compared the API origin with the Vite proxy and frontend configuration.
- Compared the Node range with `packages/frontend/package.json`.
- Ran `git diff --check`.
- Verified all internal Markdown links resolve.