### PR TITLE
chore(graph): standardize license notice

### DIFF
--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -278,7 +278,7 @@ Current Vitest suites cover:
 
 ## License
 
-Copyright (c) 2026 Hexastack.
+Copyright (c) 2025 Hexastack.
 
 This project is licensed under the **Fair Core License, Version 1.0**, with **Apache License 2.0** as the future license (abbrev. **FCL-1.0-ALv2**).
 


### PR DESCRIPTION
## Summary
Standardized the copyright year in the graph package README to match the repository-wide license notice.

## Why
The graph README used 2026 while the root license and all other package documentation use 2025, creating an inconsistent license notice across the monorepo.

## How to review
Confirm the copyright notice in `packages/graph/README.md` now matches `LICENSE.md` and the other package READMEs.

## Validation
- Compared copyright notices across the root and package documentation.
- Ran `git diff --check`.
- Verified all internal Markdown links resolve.