### PR TITLE
chore(cli): remove stale documentation reference

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -148,7 +148,7 @@ That’s it—`create → cd → dev` is the happy path for a new Hexabot v3 aut
 
 ## Documentation
 
-For detailed information on how to get started, as well as in-depth user and developer guides, please refer to our full documentation available in the docs folder or visit the [Documentation](https://docs.hexabot.ai).
+For detailed information on how to get started, see the repository README files below or visit the [Documentation](https://docs.hexabot.ai).
 
 You can also find specific documentation for different components of the project in the following locations:
 


### PR DESCRIPTION
## Summary
Updated the CLI README to remove the reference to a nonexistent local documentation folder. It now directs readers to the repository README files and the official documentation website.

## Why
The previous guidance told users to consult a `docs` directory that does not exist in the repository, making the documentation path misleading.

## How to review
Review the Documentation section in `packages/cli/README.md` and confirm its references accurately reflect the available documentation sources.

## Validation
- Confirmed there is no repository `docs` directory.
- Verified the referenced package README files exist.
- Ran `git diff --check`.
- Verified all internal Markdown links resolve.