### PR TITLE
fix(settings): require storage helper selection

### DIFF
--- a/packages/api/src/setting/default.settings.ts
+++ b/packages/api/src/setting/default.settings.ts
@@ -21,19 +21,16 @@ export const globalSettingsSchema = z
         'Provide the license key associated with your subscription. Learn more about available plans at https://hexabot.ai/pricing#pricing.',
       'ui:widget': 'password',
     }),
-    default_storage_helper: z
-      .string()
-      .default('local-storage')
-      .meta({
-        title: 'Default storage helper',
-        description: 'Helper used to persist workflow data by default.',
-        'ui:widget': 'AutoCompleteWidget',
-        'ui:options': {
-          entity: 'StorageHelper',
-          valueKey: 'name',
-          labelKey: 'name',
-        },
-      }),
+    default_storage_helper: z.string().meta({
+      title: 'Default storage helper',
+      description: 'Helper used to persist workflow data by default.',
+      'ui:widget': 'AutoCompleteWidget',
+      'ui:options': {
+        entity: 'StorageHelper',
+        valueKey: 'name',
+        labelKey: 'name',
+      },
+    }),
     default_rag_helper: z
       .string()
       .default('fulltext-search')

--- a/packages/api/src/setting/default.settings.ts
+++ b/packages/api/src/setting/default.settings.ts
@@ -21,16 +21,19 @@ export const globalSettingsSchema = z
         'Provide the license key associated with your subscription. Learn more about available plans at https://hexabot.ai/pricing#pricing.',
       'ui:widget': 'password',
     }),
-    default_storage_helper: z.string().meta({
-      title: 'Default storage helper',
-      description: 'Helper used to persist workflow data by default.',
-      'ui:widget': 'AutoCompleteWidget',
-      'ui:options': {
-        entity: 'StorageHelper',
-        valueKey: 'name',
-        labelKey: 'name',
-      },
-    }),
+    default_storage_helper: z
+      .string()
+      .min(1)
+      .meta({
+        title: 'Default storage helper',
+        description: 'Helper used to persist workflow data by default.',
+        'ui:widget': 'AutoCompleteWidget',
+        'ui:options': {
+          entity: 'StorageHelper',
+          valueKey: 'name',
+          labelKey: 'name',
+        },
+      }),
     default_rag_helper: z
       .string()
       .default('fulltext-search')

--- a/packages/api/src/setting/runtime-settings.seed.spec.ts
+++ b/packages/api/src/setting/runtime-settings.seed.spec.ts
@@ -31,6 +31,21 @@ describe('runtime-settings.seed', () => {
     ]);
   });
 
+  it('seeds defaulted settings while leaving required settings for user setup', () => {
+    const schema = z.strictObject({
+      defaulted: z.string().default('automatic'),
+      required: z.string(),
+    });
+
+    expect(buildSettingSeedsFromSchema('settings', schema)).toEqual([
+      {
+        group: 'settings',
+        label: 'defaulted',
+        value: 'automatic',
+      },
+    ]);
+  });
+
   it('adds subgroup marker for helper extension groups from runtime registry', () => {
     const registry: RuntimeSettingRegistryMap = {
       ollama: {

--- a/packages/api/src/setting/runtime-settings.seed.ts
+++ b/packages/api/src/setting/runtime-settings.seed.ts
@@ -16,30 +16,19 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
 };
 const resolveGroupDefaultValues = (
   schema: RuntimeSettingGroupSchema,
-  context: string,
+  _context: string,
 ): Record<string, unknown> => {
-  const parsed = schema.safeParse({});
+  const parsed = schema.partial().safeParse({});
 
   if (!parsed.success || parsed.data === undefined) {
     throw new Error(
-      `Setting group "${context}" must define default values in its zod schema.`,
+      `Setting group "${_context}" must define default values in its zod schema.`,
     );
   }
 
   if (!isPlainObject(parsed.data)) {
     throw new Error(
-      `Setting group "${context}" default values must resolve to an object.`,
-    );
-  }
-
-  const expectedKeys = schema.keyof().options;
-  const missingDefaultKeys = expectedKeys.filter(
-    (key) => !(key in parsed.data),
-  );
-
-  if (missingDefaultKeys.length > 0) {
-    throw new Error(
-      `Setting group "${context}" is missing default values for: ${missingDefaultKeys.join(', ')}.`,
+      `Setting group "${_context}" default values must resolve to an object.`,
     );
   }
 

--- a/packages/api/src/utils/helpers/zod.spec.ts
+++ b/packages/api/src/utils/helpers/zod.spec.ts
@@ -7,6 +7,7 @@
 import { z } from 'zod';
 
 import type { I18nService } from '@/i18n/services/i18n.service';
+import { globalSettingsSchema } from '@/setting/default.settings';
 
 import { toDraft07JsonSchema } from './zod';
 
@@ -81,5 +82,13 @@ describe('toDraft07JsonSchema', () => {
       lang: 'fr',
       defaultValue: 'Field description',
     });
+  });
+
+  it('requires the storage helper without generating a default value', () => {
+    const result = toDraft07JsonSchema(globalSettingsSchema);
+    const storageHelper = result.properties?.default_storage_helper;
+
+    expect(result.required).toContain('default_storage_helper');
+    expect(storageHelper).not.toHaveProperty('default');
   });
 });

--- a/packages/api/src/utils/helpers/zod.spec.ts
+++ b/packages/api/src/utils/helpers/zod.spec.ts
@@ -90,5 +90,8 @@ describe('toDraft07JsonSchema', () => {
 
     expect(result.required).toContain('default_storage_helper');
     expect(storageHelper).not.toHaveProperty('default');
+    expect(
+      globalSettingsSchema.safeParse({ default_storage_helper: '' }).success,
+    ).toBe(false);
   });
 });

--- a/packages/api/src/utils/helpers/zod.ts
+++ b/packages/api/src/utils/helpers/zod.ts
@@ -18,7 +18,6 @@ export type JsonSchemaLocalizationOptions = {
 type ToDraft07JsonSchemaOptions = {
   localize?: JsonSchemaLocalizationOptions;
 };
-
 const localizeSchemaNodeMetadata = (
   schemaNode: Record<string, unknown>,
   options: JsonSchemaLocalizationOptions,
@@ -49,8 +48,7 @@ export const toDraft07JsonSchema = <TSchema extends z.ZodTypeAny>(
   options?: ToDraft07JsonSchemaOptions,
 ): JsonSchema => {
   const localize = options?.localize;
-
-  return schema.toJSONSchema({
+  const jsonSchema = schema.toJSONSchema({
     target: 'draft-07',
     ...(localize
       ? {
@@ -63,4 +61,6 @@ export const toDraft07JsonSchema = <TSchema extends z.ZodTypeAny>(
         }
       : {}),
   }) as JsonSchema;
+
+  return jsonSchema;
 };


### PR DESCRIPTION
## Summary

- Remove the implicit `local-storage` default from the `default_storage_helper` setting so the settings UI requires an explicit helper selection.
- Keep seeding defaults for optional settings while allowing required settings to remain unset until configured.
- Add regression coverage for the JSON Schema and seed behavior.

Closes #1961

## Validation

- API lint ✅
- API typecheck ✅
- Targeted settings/Zod tests: **6 passed** ✅
- Settings test suite: **42 passed** ✅
- Full API Jest run: **1227 passed, 3 failed, 3 skipped**. The 3 failures are existing Windows path-separator assertions in migration and attachment tests; unrelated to this change.

The repository Husky hook could not run its test command on Windows because it uses POSIX syntax (`NODE_OPTIONS=...`). The equivalent Jest command was run directly and produced the results above. Local Node is 22.16.0 while the repository declares Node 24.17+; pnpm reports this as an engine warning.