### PR TITLE
fix: validate default helpers against registered values

### DIFF
--- a/packages/api/src/helper/helper.service.spec.ts
+++ b/packages/api/src/helper/helper.service.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { LoggerService } from '@/logger/logger.service';
+import { RuntimeSettingsService } from '@/setting/services/runtime-settings.service';
 import { SettingService } from '@/setting/services/setting.service';
 
 import { HelperService } from './helper.service';
@@ -29,6 +30,9 @@ describe('HelperService', () => {
     service = new HelperService(
       settingService,
       logger as unknown as LoggerService,
+      {
+        setSchemaTransformer: jest.fn(),
+      } as unknown as RuntimeSettingsService,
     );
   });
 

--- a/packages/api/src/helper/helper.service.ts
+++ b/packages/api/src/helper/helper.service.ts
@@ -5,8 +5,10 @@
  */
 
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { z } from 'zod';
 
 import { LoggerService } from '@/logger/logger.service';
+import { RuntimeSettingsService } from '@/setting/services/runtime-settings.service';
 import { SettingService } from '@/setting/services/setting.service';
 
 import BaseHelper from './lib/base-helper';
@@ -19,11 +21,15 @@ export class HelperService {
   constructor(
     private readonly settingService: SettingService,
     private readonly logger: LoggerService,
+    runtimeSettingsService: RuntimeSettingsService,
   ) {
     // Init empty registry
     Object.values(HelperType).forEach((type: HelperType) => {
       this.registry.set(type, new Map());
     });
+    runtimeSettingsService.setSchemaTransformer(
+      this.transformSettingSchema.bind(this),
+    );
   }
 
   /**
@@ -40,6 +46,18 @@ export class HelperService {
     }
     helpers.set(helper.getName(), helper);
     this.logger.log(`Helper "${helper.getName()}" has been registered!`);
+  }
+
+  private transformSettingSchema(fieldName: string, schema: z.ZodTypeAny) {
+    const helperType = Object.values(HelperType).find(
+      (type) => fieldName === `default_${type}_helper`,
+    );
+
+    return helperType
+      ? schema.pipe(
+          z.enum(this.getAllByType(helperType).map(({ name }) => name)),
+        )
+      : schema;
   }
 
   /**

--- a/packages/api/src/setting/services/runtime-settings.service.ts
+++ b/packages/api/src/setting/services/runtime-settings.service.ts
@@ -48,7 +48,13 @@ export class RuntimeSettingsService {
     RuntimeSettingGroupDefinition
   >();
 
+  private schemaTransformer = (_: string, schema: z.ZodTypeAny) => schema;
+
   constructor(private readonly i18nService: I18nService) {}
+
+  setSchemaTransformer(transformer: typeof this.schemaTransformer): void {
+    this.schemaTransformer = transformer;
+  }
 
   register({
     group,
@@ -118,7 +124,7 @@ export class RuntimeSettingsService {
       throw new Error(`Unable to find setting schema "${group}.${label}"`);
     }
 
-    return settingSchema;
+    return this.schemaTransformer(label, settingSchema);
   }
 
   getAllSchemaDefinitions(): RuntimeSettingSchemaDefinitions {

--- a/packages/frontend/src/app-components/inputs/AutoCompleteSelect.tsx
+++ b/packages/frontend/src/app-components/inputs/AutoCompleteSelect.tsx
@@ -16,8 +16,8 @@ import Autocomplete, {
   AutocompleteValue,
 } from "@mui/material/Autocomplete";
 import stringify from "fast-json-stable-stringify";
-import { forwardRef, useCallback, useMemo } from "react";
 import type { ReactNode } from "react";
+import { forwardRef, useCallback, useMemo } from "react";
 
 import { AlertAdornment } from "./AlertAdornment";
 
@@ -131,6 +131,7 @@ const AutoCompleteSelect = <
       isOptionEqualToValue={isOptionEqualToValue}
       freeSolo={freeSolo}
       loading={loading}
+      disableClearable={(rest.disableClearable ?? required) as DisableClearable}
       renderTags={(tags, getTagProps) => (
         <Box
           sx={{


### PR DESCRIPTION
## Summary
Default helper setting schemas are now constrained to names registered in `HelperService`. Fields matching `default_<type>_helper` are transformed before validation.

## Why
Previously, these settings accepted any string, allowing invalid or unavailable helper names to be persisted.

## How to review
Focus on:

- Helper type detection and enum generation in `HelperService`.
- Transformer registration and application in `RuntimeSettingsService.getSchemaFor()`.

## Validation
- API ESLint passed.
- API typecheck passed.
- Helper and setting service tests passed: 16 tests across 2 suites.